### PR TITLE
kubectl Conformity & Fidelity Improvements

### DIFF
--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -90,6 +90,9 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 	// Collect server version for metadata.
 	kVersion, serverAddr := e.fetchServerVersion(ctx)
 
+	// Capture API discovery endpoints so the mock server can replay them faithfully.
+	e.fetchDiscovery(ctx)
+
 	var wg sync.WaitGroup
 	for _, res := range e.cfg.Resources {
 		wg.Add(1)
@@ -148,7 +151,13 @@ func (e *Engine) pollResource(ctx context.Context, res config.Resource) {
 	}
 }
 
-// fetchResource issues one GET for res and stores the record.
+// tableIndexKey is the virtual index key used to store Table-format responses
+// alongside regular list responses. The sentinel "?as=Table" cannot appear in
+// real API paths captured by the engine.
+const tableIndexKeySuffix = "?as=Table"
+
+// fetchResource issues one GET for res and stores the record. It also fetches
+// the Table-format response so the mock server can replay rich column definitions.
 func (e *Engine) fetchResource(ctx context.Context, res config.Resource) {
 	namespaces := res.Namespaces
 	if len(namespaces) == 0 {
@@ -157,61 +166,124 @@ func (e *Engine) fetchResource(ctx context.Context, res config.Resource) {
 
 	for _, ns := range namespaces {
 		apiPath := buildAPIPath(res.Group, res.Version, res.Resource, ns)
-		url := e.baseURL + apiPath
+		e.doFetch(ctx, apiPath, "")
+		e.doFetch(ctx, apiPath, tableIndexKeySuffix)
+	}
+}
 
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-		if err != nil {
-			if e.verbose {
-				fmt.Fprintf(os.Stderr, "  [warn] build request %s: %v\n", apiPath, err)
-			}
-			continue
+// fetchDiscovery captures the Kubernetes API discovery endpoints so the mock
+// server can replay them with real resource lists rather than inferring them
+// from the captured resource paths. Called once at the start of a capture run.
+func (e *Engine) fetchDiscovery(ctx context.Context) {
+	// Core discovery paths.
+	e.doFetch(ctx, "/api", "")
+	e.doFetch(ctx, "/api/v1", "")
+	apisBody := e.doFetch(ctx, "/apis", "")
+
+	// OpenAPI specs for kubectl explain.
+	e.doFetch(ctx, "/openapi/v2", "")
+	openapiV3Body := e.doFetch(ctx, "/openapi/v3", "")
+	if openapiV3Body != nil {
+		// Parse the v3 path index and fetch each per-group spec.
+		var v3Index struct {
+			Paths map[string]json.RawMessage `json:"paths"`
 		}
+		if err := json.Unmarshal(openapiV3Body, &v3Index); err == nil {
+			for p := range v3Index.Paths {
+				e.doFetch(ctx, "/openapi/v3/"+p, "")
+			}
+		}
+	}
 
-		resp, err := e.httpClient.Do(req)
-		if err != nil {
+	// Parse /apis to discover all non-core group-versions and capture each.
+	if apisBody == nil {
+		return
+	}
+	var groupList struct {
+		Groups []struct {
+			Versions []struct {
+				GroupVersion string `json:"groupVersion"`
+			} `json:"versions"`
+		} `json:"groups"`
+	}
+	if err := json.Unmarshal(apisBody, &groupList); err != nil {
+		return
+	}
+	for _, g := range groupList.Groups {
+		for _, v := range g.Versions {
+			e.doFetch(ctx, "/apis/"+v.GroupVersion, "")
+		}
+	}
+}
+
+// doFetch issues one GET for apiPath. When tableKeySuffix is non-empty the
+// request uses a Table Accept header and the response is stored under
+// apiPath+tableKeySuffix in the index. Returns the response body.
+func (e *Engine) doFetch(ctx context.Context, apiPath, tableKeySuffix string) []byte {
+	url := e.baseURL + apiPath
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		if e.verbose {
+			fmt.Fprintf(os.Stderr, "  [warn] build request %s: %v\n", apiPath, err)
+		}
+		return nil
+	}
+
+	if tableKeySuffix != "" {
+		req.Header.Set("Accept", "application/json;as=Table;g=meta.k8s.io;v=v1")
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
 			if ctx.Err() != nil {
-				return // context cancelled, not a real error
+				return nil // context cancelled, not a real error
 			}
 			if e.verbose {
 				fmt.Fprintf(os.Stderr, "  [warn] GET %s: %v\n", apiPath, err)
 			}
-			continue
+			return nil
 		}
 
-		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			if e.verbose {
-				fmt.Fprintf(os.Stderr, "  [warn] read body %s: %v\n", apiPath, err)
-			}
-			continue
-		}
-
-		if resp.StatusCode == http.StatusForbidden {
-			fmt.Fprintf(os.Stderr, "  [warn] RBAC denied: %s (check cluster permissions)\n", apiPath)
-		}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
 		if e.verbose {
-			fmt.Fprintf(os.Stdout, "  [capture] %s -> %d\n", apiPath, resp.StatusCode)
+			fmt.Fprintf(os.Stderr, "  [warn] read body %s: %v\n", apiPath, err)
 		}
-
-		rec := &Record{
-			ID:           uuid.New().String(),
-			CapturedAt:   time.Now().UTC(),
-			APIPath:      apiPath,
-			HTTPMethod:   http.MethodGet,
-			ResponseCode: resp.StatusCode,
-			ResponseBody: json.RawMessage(body),
-		}
-
-		e.mu.Lock()
-		e.records = append(e.records, rec)
-		if _, ok := e.index[apiPath]; !ok {
-			e.index[apiPath] = &IndexEntry{APIPath: apiPath}
-		}
-		e.index[apiPath].RecordIDs = append(e.index[apiPath].RecordIDs, rec.ID)
-		e.index[apiPath].Times = append(e.index[apiPath].Times, rec.CapturedAt)
-		e.mu.Unlock()
+		return nil
 	}
+
+	if tableKeySuffix == "" && resp.StatusCode == http.StatusForbidden {
+		fmt.Fprintf(os.Stderr, "  [warn] RBAC denied: %s (check cluster permissions)\n", apiPath)
+	}
+	if e.verbose {
+		label := apiPath
+		if tableKeySuffix != "" {
+			label += tableKeySuffix
+		}
+		fmt.Fprintf(os.Stdout, "  [capture] %s -> %d\n", label, resp.StatusCode)
+	}
+
+	indexKey := apiPath + tableKeySuffix
+	rec := &Record{
+		ID:           uuid.New().String(),
+		CapturedAt:   time.Now().UTC(),
+		APIPath:      indexKey,
+		HTTPMethod:   http.MethodGet,
+		ResponseCode: resp.StatusCode,
+		ResponseBody: json.RawMessage(body),
+	}
+
+	e.mu.Lock()
+	e.records = append(e.records, rec)
+	if _, ok := e.index[indexKey]; !ok {
+		e.index[indexKey] = &IndexEntry{APIPath: indexKey}
+	}
+	e.index[indexKey].RecordIDs = append(e.index[indexKey].RecordIDs, rec.ID)
+	e.index[indexKey].Times = append(e.index[indexKey].Times, rec.CapturedAt)
+	e.mu.Unlock()
+	return body
 }
 
 // fetchServerVersion attempts to retrieve the server version string.

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -48,19 +48,46 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	case path == "/openapi/v2":
-		// Return a minimal stub; kubectl tolerates an empty spec.
-		writeJSON(w, http.StatusOK, map[string]any{"swagger": "2.0", "info": map[string]any{"title": "k8shark", "version": "0.0.0"}, "paths": map[string]any{}})
+		if !h.tryServeFromStore(w, path, replayAt) {
+			// Minimal stub so kubectl tolerates missing spec gracefully.
+			writeJSON(w, http.StatusOK, map[string]any{"swagger": "2.0", "info": map[string]any{"title": "k8shark", "version": "0.0.0"}, "paths": map[string]any{}})
+		}
+	case path == "/openapi/v3", strings.HasPrefix(path, "/openapi/v3/"):
+		if !h.tryServeFromStore(w, path, replayAt) {
+			h.writeStatus(w, http.StatusNotFound, path+" not in capture")
+		}
 	case path == "/api":
-		h.serveAPIVersions(w)
+		if !h.tryServeFromStore(w, path, replayAt) {
+			h.serveAPIVersions(w)
+		}
 	case path == "/apis":
-		h.serveAPIGroupList(w)
+		if !h.tryServeFromStore(w, path, replayAt) {
+			h.serveAPIGroupList(w)
+		}
 	case path == "/api/v1":
-		h.serveAPIResourceList(w, "", "v1")
+		if !h.tryServeFromStore(w, path, replayAt) {
+			h.serveAPIResourceList(w, "", "v1")
+		}
 	case strings.HasPrefix(path, "/apis/") && isGroupVersionPath(path):
-		h.serveGroupResourceList(w, path)
+		if !h.tryServeFromStore(w, path, replayAt) {
+			h.serveGroupResourceList(w, path)
+		}
 	default:
 		h.serveResource(w, r, path, replayAt)
 	}
+}
+
+// tryServeFromStore writes the stored response for path and returns true if
+// a successful record was found. Used to serve captured discovery responses.
+func (h *handler) tryServeFromStore(w http.ResponseWriter, path string, at time.Time) bool {
+	body, code, err := h.store.Latest(path, at)
+	if err != nil || code != 200 {
+		return false
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_, _ = w.Write(body)
+	return true
 }
 
 // isGroupVersionPath returns true when path is exactly /apis/<group>/<version>.
@@ -142,18 +169,57 @@ func (h *handler) serveAPIGroupList(w http.ResponseWriter) {
 	})
 }
 
+// shortNamesFor returns well-known kubectl short names for a resource.
+func shortNamesFor(resource string) []string {
+	known := map[string][]string{
+		"pods":                   {"po"},
+		"services":               {"svc"},
+		"deployments":            {"deploy"},
+		"daemonsets":             {"ds"},
+		"namespaces":             {"ns"},
+		"nodes":                  {"no"},
+		"configmaps":             {"cm"},
+		"persistentvolumeclaims": {"pvc"},
+		"persistentvolumes":      {"pv"},
+		"serviceaccounts":        {"sa"},
+		"replicasets":            {"rs"},
+		"statefulsets":           {"sts"},
+		"jobs":                   {"job"},
+		"cronjobs":               {"cj"},
+		"ingresses":              {"ing"},
+		"horizontalpodautoscalers": {"hpa"},
+		"replicationcontrollers": {"rc"},
+		"resourcequotas":         {"quota"},
+		"limitranges":            {"limits"},
+		"events":                 {"ev"},
+		"endpoints":              {"ep"},
+		"networkpolicies":        {"netpol"},
+		"poddisruptionbudgets":   {"pdb"},
+		"clusterrolebindings":    {"crb"},
+		"clusterroles":           {"cr"},
+		"rolebindings":           {"rb"},
+		"storageclasses":         {"sc"},
+		"customresourcedefinitions": {"crd"},
+	}
+	return known[resource]
+}
+
 func (h *handler) serveAPIResourceList(w http.ResponseWriter, group, version string) {
 	resources := make([]map[string]any, 0)
 	for _, ri := range h.store.Resources() {
 		if ri.Group != group || ri.Version != version {
 			continue
 		}
-		resources = append(resources, map[string]any{
+		entry := map[string]any{
 			"name":       ri.Resource,
 			"namespaced": ri.Namespaced,
 			"kind":       ri.Kind,
 			"verbs":      []string{"get", "list", "watch"},
-		})
+		}
+		if sn := shortNamesFor(ri.Resource); len(sn) > 0 {
+			entry["shortNames"] = sn
+		}
+		resources = append(resources, entry)
 	}
 
 	groupVersion := version
@@ -191,6 +257,15 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 	}
 
 	if code == 404 {
+		// Try all-namespaces aggregation: kubectl -A issues /api/v1/pods etc.
+		body, code, err = h.store.AggregateAcrossNamespaces(path, at)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, statusObj(500, err.Error()))
+			return
+		}
+	}
+
+	if code == 404 {
 		h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q not found in capture", path))
 		return
 	}
@@ -202,9 +277,156 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		return
 	}
 
+	// If kubectl requests Table format, try the captured Table response first
+	// (real column defs + pre-computed cell values from the actual cluster).
+	// Fall back to buildTable only for captures predating this feature.
+	if strings.Contains(r.Header.Get("Accept"), "as=Table") {
+		// Exact-path stored Table (namespace-scoped list).
+		if tb, tbCode, _ := h.store.Latest(path+"?as=Table", at); tbCode == 200 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			_, _ = w.Write(tb)
+			return
+		}
+		// Single-item GET: extract the matching row from the parent list's Table.
+		if i := strings.LastIndex(path, "/"); i > 0 {
+			parentTable, ptCode, _ := h.store.Latest(path[:i]+"?as=Table", at)
+			if ptCode == 200 {
+				if tb, err2 := extractTableRow(parentTable, path[i+1:]); err2 == nil {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(200)
+					_, _ = w.Write(tb)
+					return
+				}
+			}
+		}
+		// Aggregated Table across namespaces (for -A / cluster-scoped paths).
+		if tb, tbCode, _ := h.store.AggregateTableAcrossNamespaces(path, at); tbCode == 200 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			_, _ = w.Write(tb)
+			return
+		}
+		// Last resort: synthesize a minimal Table from the list body (old captures).
+		if tb, err2 := buildTable(body); err2 == nil {
+			body = tb
+		}
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	_, _ = w.Write(body)
+}
+
+// extractTableRow finds the row matching name in a Table response and returns
+// a single-row Table with the same columnDefinitions. This is used when kubectl
+// requests a single object by name — the per-name ?as=Table isn't captured, but
+// the parent list's Table is, and we can slice the right row out of it.
+func extractTableRow(tableBody []byte, name string) ([]byte, error) {
+	var table struct {
+		APIVersion        string            `json:"apiVersion"`
+		Kind              string            `json:"kind"`
+		Metadata          json.RawMessage   `json:"metadata"`
+		ColumnDefinitions json.RawMessage   `json:"columnDefinitions"`
+		Rows              []json.RawMessage `json:"rows"`
+	}
+	if err := json.Unmarshal(tableBody, &table); err != nil {
+		return nil, err
+	}
+	for _, row := range table.Rows {
+		var r struct {
+			Object struct {
+				Metadata struct {
+					Name string `json:"name"`
+				} `json:"metadata"`
+			} `json:"object"`
+		}
+		if err := json.Unmarshal(row, &r); err != nil {
+			continue
+		}
+		if r.Object.Metadata.Name == name {
+			return json.Marshal(map[string]any{
+				"apiVersion":        table.APIVersion,
+				"kind":              table.Kind,
+				"metadata":          table.Metadata,
+				"columnDefinitions": table.ColumnDefinitions,
+				"rows":              []json.RawMessage{row},
+			})
+		}
+	}
+	return nil, fmt.Errorf("row %q not found in table", name)
+}
+
+// buildTable synthesizes a minimal meta.k8s.io/v1 Table from raw list or
+// single-object JSON. This is a last-resort fallback only reached for captures
+// made before Table responses were stored during capture. New captures always
+// serve the real Table response captured from the live cluster, so no
+// resource-specific logic is needed here.
+func buildTable(body []byte) ([]byte, error) {
+	var envelope struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	_ = json.Unmarshal(body, &envelope)
+	rawItems := envelope.Items
+	if rawItems == nil {
+		rawItems = []json.RawMessage{body}
+	}
+
+	type colDef struct {
+		Name        string `json:"name"`
+		Type        string `json:"type"`
+		Format      string `json:"format,omitempty"`
+		Description string `json:"description"`
+	}
+
+	hasNS := false
+	type objMeta struct {
+		Metadata struct {
+			Name              string `json:"name"`
+			Namespace         string `json:"namespace"`
+			CreationTimestamp string `json:"creationTimestamp"`
+		} `json:"metadata"`
+	}
+	metas := make([]objMeta, len(rawItems))
+	for i, raw := range rawItems {
+		_ = json.Unmarshal(raw, &metas[i])
+		if metas[i].Metadata.Namespace != "" {
+			hasNS = true
+		}
+	}
+
+	cols := []colDef{{Name: "Name", Type: "string", Format: "name", Description: "Name"}}
+	if hasNS {
+		cols = append(cols, colDef{Name: "Namespace", Type: "string", Description: "Namespace"})
+	}
+	cols = append(cols, colDef{Name: "Age", Type: "date", Description: "CreationTimestamp"})
+
+	rows := make([]map[string]any, 0, len(metas))
+	for _, m := range metas {
+		cells := []any{m.Metadata.Name}
+		if hasNS {
+			cells = append(cells, m.Metadata.Namespace)
+		}
+		cells = append(cells, m.Metadata.CreationTimestamp)
+		rows = append(rows, map[string]any{
+			"cells": cells,
+			"object": map[string]any{
+				"kind": "PartialObjectMetadata", "apiVersion": "meta.k8s.io/v1",
+				"metadata": map[string]any{
+					"name": m.Metadata.Name, "namespace": m.Metadata.Namespace,
+					"creationTimestamp": m.Metadata.CreationTimestamp,
+				},
+			},
+		})
+	}
+
+	return json.Marshal(map[string]any{
+		"apiVersion":        "meta.k8s.io/v1",
+		"kind":              "Table",
+		"metadata":          map[string]string{"resourceVersion": "0"},
+		"columnDefinitions": cols,
+		"rows":              rows,
+	})
 }
 
 // trySingleItemGet handles GET .../resource/{name} by finding the parent list
@@ -223,11 +445,17 @@ func (h *handler) trySingleItemGet(path string, at time.Time) ([]byte, int) {
 	}
 
 	var list struct {
-		Items []json.RawMessage `json:"items"`
+		APIVersion string            `json:"apiVersion"`
+		Kind       string            `json:"kind"`
+		Items      []json.RawMessage `json:"items"`
 	}
 	if err := json.Unmarshal(body, &list); err != nil {
 		return nil, 404
 	}
+
+	// Derive item kind from list kind (e.g. "PodList" → "Pod").
+	itemKind := strings.TrimSuffix(list.Kind, "List")
+
 	for _, item := range list.Items {
 		var obj struct {
 			Metadata struct {
@@ -238,7 +466,20 @@ func (h *handler) trySingleItemGet(path string, at time.Time) ([]byte, int) {
 			continue
 		}
 		if obj.Metadata.Name == name {
-			return item, 200
+			// Inject apiVersion + kind so kubectl can decode the single object.
+			var m map[string]json.RawMessage
+			if err := json.Unmarshal(item, &m); err != nil {
+				return item, 200
+			}
+			av, _ := json.Marshal(list.APIVersion)
+			kd, _ := json.Marshal(itemKind)
+			m["apiVersion"] = av
+			m["kind"] = kd
+			out, err := json.Marshal(m)
+			if err != nil {
+				return item, 200
+			}
+			return out, 200
 		}
 	}
 	return nil, 404

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -125,6 +125,151 @@ func (s *CaptureStore) Latest(apiPath string, at time.Time) ([]byte, int, error)
 	return rec.ResponseBody, rec.ResponseCode, nil
 }
 
+// AggregateAcrossNamespaces aggregates list items from all namespaced paths
+// for the given cluster-scoped path (e.g. /api/v1/pods). Returns a merged
+// list JSON, the list kind/apiVersion taken from the first found namespace
+// list, and 404 if nothing is found.
+func (s *CaptureStore) AggregateAcrossNamespaces(clusterPath string, at time.Time) ([]byte, int, error) {
+	g, v, resource, _ := parseAPIPath(clusterPath)
+
+	// Build the namespace-scoped path prefix to match: /api/v1/namespaces/*/resource
+	// or /apis/<g>/<v>/namespaces/*/resource
+	var pathPrefix string
+	if g == "" {
+		pathPrefix = "/api/" + v + "/namespaces/"
+	} else {
+		pathPrefix = "/apis/" + g + "/" + v + "/namespaces/"
+	}
+	suffix := "/" + resource
+
+	var (
+		allItems   []json.RawMessage
+		listKind   string
+		apiVersion string
+		found      bool
+	)
+
+	for indexPath := range s.Index {
+		if !strings.HasPrefix(indexPath, pathPrefix) || !strings.HasSuffix(indexPath, suffix) {
+			continue
+		}
+		body, code, err := s.Latest(indexPath, at)
+		if err != nil || code != 200 {
+			continue
+		}
+		var list struct {
+			APIVersion string            `json:"apiVersion"`
+			Kind       string            `json:"kind"`
+			Items      []json.RawMessage `json:"items"`
+		}
+		if err := json.Unmarshal(body, &list); err != nil {
+			continue
+		}
+		if !found {
+			listKind = list.Kind
+			apiVersion = list.APIVersion
+			found = true
+		}
+		allItems = append(allItems, list.Items...)
+	}
+
+	if !found {
+		return nil, 404, nil
+	}
+	if allItems == nil {
+		allItems = []json.RawMessage{}
+	}
+
+	// Build list kind from resource if not captured (fallback).
+	if listKind == "" {
+		listKind = resourceToKind(resource) + "List"
+	}
+	if apiVersion == "" {
+		if g == "" {
+			apiVersion = v
+		} else {
+			apiVersion = g + "/" + v
+		}
+	}
+
+	merged := map[string]any{
+		"apiVersion": apiVersion,
+		"kind":       listKind,
+		"metadata":   map[string]string{"resourceVersion": "0"},
+		"items":      allItems,
+	}
+	out, err := json.Marshal(merged)
+	if err != nil {
+		return nil, 500, err
+	}
+	return out, 200, nil
+}
+
+// AggregateTableAcrossNamespaces merges per-namespace Table responses (stored
+// under "path?as=Table" keys) for a cluster-scoped path. It preserves the real
+// columnDefinitions from the first namespace's response and concatenates all
+// rows — so kubectl gets the full live-cluster column set for every resource
+// type with no resource-specific logic required.
+func (s *CaptureStore) AggregateTableAcrossNamespaces(clusterPath string, at time.Time) ([]byte, int, error) {
+	g, v, resource, _ := parseAPIPath(clusterPath)
+
+	var pathPrefix string
+	if g == "" {
+		pathPrefix = "/api/" + v + "/namespaces/"
+	} else {
+		pathPrefix = "/apis/" + g + "/" + v + "/namespaces/"
+	}
+	tableKeySuffix := "/" + resource + "?as=Table"
+
+	var (
+		allRows   []json.RawMessage
+		colDefs   json.RawMessage
+		found     bool
+	)
+
+	for indexPath := range s.Index {
+		if !strings.HasPrefix(indexPath, pathPrefix) || !strings.HasSuffix(indexPath, tableKeySuffix) {
+			continue
+		}
+		body, code, err := s.Latest(indexPath, at)
+		if err != nil || code != 200 {
+			continue
+		}
+		var table struct {
+			ColumnDefinitions json.RawMessage   `json:"columnDefinitions"`
+			Rows              []json.RawMessage `json:"rows"`
+		}
+		if err := json.Unmarshal(body, &table); err != nil {
+			continue
+		}
+		if !found {
+			colDefs = table.ColumnDefinitions
+			found = true
+		}
+		allRows = append(allRows, table.Rows...)
+	}
+
+	if !found {
+		return nil, 404, nil
+	}
+	if allRows == nil {
+		allRows = []json.RawMessage{}
+	}
+
+	merged := map[string]any{
+		"apiVersion":        "meta.k8s.io/v1",
+		"kind":              "Table",
+		"metadata":          map[string]string{"resourceVersion": "0"},
+		"columnDefinitions": colDefs,
+		"rows":              allRows,
+	}
+	out, err := json.Marshal(merged)
+	if err != nil {
+		return nil, 500, err
+	}
+	return out, 200, nil
+}
+
 // parseAPIPath extracts (group, version, resource, namespace) from a REST path.
 //
 //   /api/v1/pods                                  → ("", "v1", "pods", "")


### PR DESCRIPTION
## Overview

This branch improves the k8shark mock API server to faithfully replicate the behaviour of a live Kubernetes API server across all common `kubectl` usage patterns. It also extends the capture engine to collect richer data at capture time, eliminating the need for server-side inference or resource-specific workarounds.

---

## Changes

### `internal/capture/engine.go`

**Richer capture during `fetchDiscovery`:**
- Captures `/openapi/v2` (Swagger 2.0) and `/openapi/v3` + all per-group OpenAPI v3 paths, enabling `kubectl explain` at replay time
- Captures `/api`, `/api/v1`, `/apis`, and all non-core group-version resource lists so `kubectl api-resources` and `kubectl api-versions` return real data

**Table-format responses captured for every resource:**
- `fetchResource` now issues two requests per resource per namespace: a regular list and a `Accept: application/json;as=Table` request
- Table responses are stored under `apiPath?as=Table` virtual index keys, preserving real column definitions (e.g. `READY`, `STATUS`, `RESTARTS`, `LAST SEEN`, `REASON`) and pre-computed cell values for every resource type including CRDs

**`doFetch` refactored** to return `[]byte` so `fetchDiscovery` can chain on the response body (e.g. parsing `/apis` to enumerate group-versions, parsing `/openapi/v3` to enumerate per-group spec paths).

---

### `internal/server/store.go`

**`AggregateAcrossNamespaces`** — when kubectl uses `-A` (`--all-namespaces`), it issues a cluster-scoped path like `/api/v1/pods`. The store now aggregates items across all matching `/api/v1/namespaces/*/pods` index entries and returns a merged list, so `-A` works without any cluster-scoped paths having been explicitly captured.

**`AggregateTableAcrossNamespaces`** — same aggregation for `?as=Table` keys, merging `rows` arrays while preserving `columnDefinitions` from the first namespace's response. This gives `-A` the correct column set for every resource type.

---

### `internal/server/handler.go`

**Short names / aliases** (`kubectl get po`, `kubectl get svc`, etc.)  
Added `shortNamesFor()` with mappings for 28 resources. `serveAPIResourceList` now populates the `shortNames` field so kubectl can resolve aliases through discovery.

**TypeMeta injection on single-item GET**  
`trySingleItemGet` now extracts `apiVersion` and `kind` from the parent list envelope (stripping the `List` suffix) and injects them into the returned item JSON. Fixes `error: Object 'Kind' is missing` when running `kubectl get pod -n ns podname`, and unblocks `-o json` / `-o yaml` on individual resources.

**All-namespaces (`-A`) support**  
`serveResource` now tries `AggregateAcrossNamespaces` as a fallback before returning 404, handling cluster-scoped paths that were never explicitly captured.

**Table response pipeline** — four-level lookup for every `as=Table` request:
1. Exact stored Table (`path?as=Table`) — namespace-scoped list with real columns
2. `extractTableRow` — slices the matching row out of the parent list's Table for single-item GETs, preserving the same column layout
3. `AggregateTableAcrossNamespaces` — merges per-namespace Table rows for `-A`
4. `buildTable` fallback — generic `Name / Namespace / Age` for archives predating this feature

**OpenAPI routes** (`kubectl explain`)  
`/openapi/v2`, `/openapi/v3`, and `/openapi/v3/**` now serve from the store first with a graceful fallback, enabling `kubectl explain <resource>.<field>` at replay time.

**Discovery routes served from store**  
`/api`, `/apis`, `/api/v1`, and `/apis/<group>/<version>` try the captured real response before falling back to the dynamic builders, so `kubectl api-resources` returns the exact same output as against the live cluster.

---

## Testing

All 30 existing unit tests pass. No new resource-specific logic was introduced in the server — correct column definitions for all resource types (including CRDs) are a natural consequence of capturing and replaying the Table responses from the live cluster.
