### PR TITLE
feat: return 405 Method Not Allowed for all write operations on the mock server

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -145,7 +145,7 @@ The mock server is designed to be a drop-in replacement for `kubectl`'s real ser
 | Label selectors (`-l app=foo`) | ✅ |
 | Field selectors (`--field-selector status.phase=Running`) | ✅ |
 | Watch (`-w`) | ✅ synthetic event stream |
-| Write operations (`apply`, `delete`, `edit`, …) | ❌ read-only |
+| Write operations (`apply`, `delete`, `edit`, …) | ⛔ returns `405 Method Not Allowed` — mock server is read-only |
 | `kubectl exec` / `kubectl logs` | ❌ |
 | `kubectl top` | ❌ metrics API not captured |
 

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -35,10 +35,12 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Reject all write operations — k8shark replay is read-only.
+	// RFC 7231 §6.5.5 requires an Allow header with a 405 response.
 	switch r.Method {
 	case http.MethodGet, http.MethodHead:
 		// allowed
 	default:
+		w.Header().Set("Allow", "GET, HEAD")
 		h.writeStatus(w, http.StatusMethodNotAllowed,
 			"k8shark replay server is read-only; write operations are not supported")
 		return

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -34,6 +34,16 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("  --> %s %s\n", r.Method, path)
 	}
 
+	// Reject all write operations — k8shark replay is read-only.
+	switch r.Method {
+	case http.MethodGet, http.MethodHead:
+		// allowed
+	default:
+		h.writeStatus(w, http.StatusMethodNotAllowed,
+			"k8shark replay server is read-only; write operations are not supported")
+		return
+	}
+
 	// Watch requests get a synthetic event stream.
 	if r.URL.Query().Get("watch") == "1" || r.URL.Query().Get("watch") == "true" {
 		h.handleWatch(w, r, path, replayAt)

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -341,3 +341,50 @@ func TestHandler_Watch_TimeoutSeconds(t *testing.T) {
 		t.Error("expected a BOOKMARK event")
 	}
 }
+
+// TestHandler_WriteMethodsReturn405 verifies that POST, PUT, PATCH, and DELETE
+// all receive a 405 Method Not Allowed response with a Status JSON body, while
+// a regular GET to the same path is not blocked.
+func TestHandler_WriteMethodsReturn405(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/pods": []byte(`{"kind":"PodList","items":[]}`),
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	writeMethods := []string{
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodPatch,
+		http.MethodDelete,
+	}
+	path := "/api/v1/namespaces/default/pods"
+
+	for _, method := range writeMethods {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, path, nil)
+			rw := httptest.NewRecorder()
+			h.ServeHTTP(rw, req)
+
+			if rw.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("expected 405, got %d", rw.Code)
+			}
+			var body map[string]any
+			if err := json.Unmarshal(rw.Body.Bytes(), &body); err != nil {
+				t.Fatalf("expected JSON body: %v", err)
+			}
+			if code, _ := body["code"].(float64); int(code) != http.StatusMethodNotAllowed {
+				t.Errorf("expected body.code=405, got %v", body["code"])
+			}
+		})
+	}
+
+	// GET must still work normally.
+	t.Run("GET_allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+		if rw.Code == http.StatusMethodNotAllowed {
+			t.Fatalf("GET should not return 405")
+		}
+	})
+}

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -368,6 +368,10 @@ func TestHandler_WriteMethodsReturn405(t *testing.T) {
 			if rw.Code != http.StatusMethodNotAllowed {
 				t.Fatalf("expected 405, got %d", rw.Code)
 			}
+			// RFC 7231 §6.5.5 requires Allow header on 405 responses.
+			if allow := rw.Header().Get("Allow"); allow == "" {
+				t.Error("expected Allow header, got none")
+			}
 			var body map[string]any
 			if err := json.Unmarshal(rw.Body.Bytes(), &body); err != nil {
 				t.Fatalf("expected JSON body: %v", err)


### PR DESCRIPTION
## Summary

The k8shark mock server is read-only, but until now write operations (POST, PUT, PATCH, DELETE) received no explicit response — leaving `kubectl apply`, `kubectl delete`, etc. hanging or getting unexpected results. This PR adds a router-level guard that returns a well-formed Kubernetes `Status` JSON body with HTTP 405 for all write verbs.

Closes #6, closes #12.

## Changes

- **`internal/server/handler.go`** — add an 8-line guard at the top of `ServeHTTP` that rejects non-GET/non-HEAD methods with a `405` + `Status` JSON response. GET and HEAD pass through; watch requests (`GET + ?watch=1`) are unaffected.
- **`internal/server/handler_test.go`** — `TestHandler_WriteMethodsReturn405` covers POST, PUT, PATCH, DELETE (each expects 405 + `code: 405` in body) and a GET sanity check.
- **`docs/usage.md`** — kubectl compatibility table entry for write operations updated from "❌ read-only" to "⛔ returns 405 (read-only)".
- **`planning/write-op-405-handler.md`** — implementation plan.

## Testing

```
go test ./internal/server/...
```

All existing tests continue to pass.