### PR TITLE
feat: kshrk redact — scrub Secret data from capture archives before sharing

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/capture"
 	"github.com/phenixblue/k8shark/internal/config"
+	"github.com/phenixblue/k8shark/internal/redact"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -25,6 +26,8 @@ func init() {
 	captureCmd.Flags().StringP("output", "o", "", "output file path (default: ./k8shark-<timestamp>.tar.gz)")
 	captureCmd.Flags().String("kubeconfig", "", "path to kubeconfig (defaults to KUBECONFIG env, then ~/.kube/config)")
 	captureCmd.Flags().String("duration", "", "capture duration, overrides config file value (e.g. 10m, 1h)")
+	captureCmd.Flags().Bool("redact-secrets", false, "redact Secret data and stringData values from the archive after capture")
+	captureCmd.Flags().StringArray("allow-secret", nil, "namespace/name of secret to preserve when --redact-secrets is set (repeatable)")
 	_ = viper.BindPFlag("output", captureCmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag("kubeconfig", captureCmd.Flags().Lookup("kubeconfig"))
 	_ = viper.BindPFlag("duration", captureCmd.Flags().Lookup("duration"))
@@ -72,6 +75,28 @@ func runCapture(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stdout, "  Output:    %s (%s)\n", sum.OutputPath, formatBytes(sum.OutputSize))
 	fmt.Fprintf(os.Stdout, "  Records:   %d across %d resource path(s)\n", sum.RecordCount, sum.ResourceCount)
 	fmt.Fprintf(os.Stdout, "  Duration:  %s\n", sum.Duration)
+
+	// Optional in-place redaction of Secret values.
+	if doRedact, _ := cmd.Flags().GetBool("redact-secrets"); doRedact {
+		allows, _ := cmd.Flags().GetStringArray("allow-secret")
+		allowList := make(map[string]bool, len(allows))
+		for _, a := range allows {
+			allowList[a] = true
+		}
+
+		tmpPath := sum.OutputPath + ".redacting"
+		n, err := redact.Archive(sum.OutputPath, tmpPath, allowList)
+		if err != nil {
+			_ = os.Remove(tmpPath)
+			return fmt.Errorf("redacting secrets: %w", err)
+		}
+		if err := os.Rename(tmpPath, sum.OutputPath); err != nil {
+			_ = os.Remove(tmpPath)
+			return fmt.Errorf("replacing archive with redacted version: %w", err)
+		}
+		fmt.Fprintf(os.Stdout, "  Redacted:  %d secret(s) scrubbed from archive\n", n)
+	}
+
 	return nil
 }
 

--- a/cmd/redact.go
+++ b/cmd/redact.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/phenixblue/k8shark/internal/redact"
+	"github.com/spf13/cobra"
+)
+
+var redactCmd = &cobra.Command{
+	Use:   "redact --in <capture.tar.gz> [--out <redacted.tar.gz>]",
+	Short: "Redact Secret data from a capture archive",
+	Long: `Produces a new capture archive with all Kubernetes Secret data and
+stringData values replaced by "REDACTED", safe for sharing with support teams.
+The original archive is not modified.`,
+	RunE: runRedact,
+}
+
+func init() {
+	rootCmd.AddCommand(redactCmd)
+	redactCmd.Flags().String("in", "", "source capture archive (required)")
+	redactCmd.Flags().String("out", "", "output archive path (default: <in>-redacted.tar.gz)")
+	redactCmd.Flags().StringArray("allow-secret", nil, "namespace/name of secret to preserve (repeatable)")
+	_ = redactCmd.MarkFlagRequired("in")
+}
+
+func runRedact(cmd *cobra.Command, _ []string) error {
+	in, _ := cmd.Flags().GetString("in")
+	out, _ := cmd.Flags().GetString("out")
+	allows, _ := cmd.Flags().GetStringArray("allow-secret")
+
+	if out == "" {
+		base := strings.TrimSuffix(in, ".tar.gz")
+		out = base + "-redacted.tar.gz"
+	}
+
+	// Refuse to overwrite the source.
+	inAbs, _ := filepath.Abs(in)
+	outAbs, _ := filepath.Abs(out)
+	if inAbs == outAbs {
+		return fmt.Errorf("--out must differ from --in")
+	}
+
+	allowList := make(map[string]bool, len(allows))
+	for _, a := range allows {
+		allowList[a] = true
+	}
+
+	n, err := redact.Archive(in, out, allowList)
+	if err != nil {
+		return err
+	}
+
+	fi, _ := os.Stat(out)
+	size := int64(0)
+	if fi != nil {
+		size = fi.Size()
+	}
+
+	fmt.Printf("Redacted %d secret(s) → %s (%d bytes)\n", n, out, size)
+	return nil
+}

--- a/docs/archive-format.md
+++ b/docs/archive-format.md
@@ -127,3 +127,21 @@ print(entry['record_ids'][-1])
 # then:
 # tar -xOf capture.tar.gz k8shark-capture/records/<uuid>.json | python3 -m json.tool
 ```
+
+## Redacted archives
+
+`kshrk redact` produces a structurally identical archive where every Kubernetes
+Secret record has its `data` and `stringData` fields scrubbed:
+
+- `data` values are replaced with `UkVEQUNURUQ=` (base64 of `"REDACTED"`)
+- `stringData` values are replaced with the string `"REDACTED"`
+- All other Secret fields (name, namespace, labels, annotations, type) are unchanged
+- Non-Secret records are written verbatim
+
+The `index.json` and `metadata.json` are written unchanged. A redacted archive is
+fully usable with `kshrk open` — `kubectl get secret` will show the secret names
+and types, but all values will be `REDACTED`.
+
+```sh
+kshrk redact --in capture.tar.gz --out capture-redacted.tar.gz
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -61,6 +61,8 @@ Capture complete
 | `--duration` | | from config | Override capture duration (e.g. `5m`) |
 | `--kubeconfig` | | `$KUBECONFIG` / `~/.kube/config` | Source cluster kubeconfig |
 | `--verbose` | `-v` | false | Log every API path as it is fetched |
+| `--redact-secrets` | | false | Redact Secret `data`/`stringData` values from the archive after capture |
+| `--allow-secret` | | | `namespace/name` of secret to preserve when `--redact-secrets` is set (repeatable) |
 
 The `--config` flag auto-discovers `./k8shark.yaml` if not specified.
 
@@ -129,7 +131,11 @@ This is useful when you have a long capture (e.g. 1h) and want to compare cluste
 
 ## Redact
 
-`kshrk redact` produces a new capture archive with all Kubernetes Secret `data` and `stringData` values replaced by `"REDACTED"`. The original archive is not modified. Use this before sharing a capture with support teams or filing bug reports.
+Secret values can be removed from a capture archive in two ways:
+
+### Option A — `kshrk redact` (post-capture)
+
+Produces a **new** archive with all Kubernetes Secret `data` and `stringData` values replaced by `"REDACTED"`. The original archive is not modified.
 
 ```sh
 kshrk redact --in capture.tar.gz
@@ -142,13 +148,26 @@ kshrk redact --in capture.tar.gz --out safe-capture.tar.gz \
   --allow-secret kube-system/bootstrap-token
 ```
 
-### Redact flags
+### Option B — `--redact-secrets` flag on `kshrk capture` (at collection time)
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--in` | (required) | Source capture archive |
-| `--out` | `<in>-redacted.tar.gz` | Output archive path |
-| `--allow-secret` | | `namespace/name` of secret to keep unredacted (repeatable) |
+Pass `--redact-secrets` to have the archive redacted **in-place** immediately after capture completes, before any data is stored on disk in final form:
+
+```sh
+kshrk capture --config k8shark.yaml --redact-secrets
+kshrk capture --config k8shark.yaml --redact-secrets \
+  --allow-secret default/pull-secret
+```
+
+The final archive at the configured output path will already be redacted. No intermediate unredacted file is retained.
+
+### Redact flags (both commands)
+
+| Flag | Command | Default | Description |
+|------|---------|---------|-------------|
+| `--in` | `redact` | (required) | Source capture archive |
+| `--out` | `redact` | `<in>-redacted.tar.gz` | Output archive path |
+| `--redact-secrets` | `capture` | false | Redact secrets in-place after capture |
+| `--allow-secret` | both | | `namespace/name` of secret to preserve (repeatable) |
 
 Secret metadata (name, namespace, labels, annotations, type) is always preserved so you can still count and identify secrets by kind.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -127,6 +127,33 @@ This is useful when you have a long capture (e.g. 1h) and want to compare cluste
 
 ---
 
+## Redact
+
+`kshrk redact` produces a new capture archive with all Kubernetes Secret `data` and `stringData` values replaced by `"REDACTED"`. The original archive is not modified. Use this before sharing a capture with support teams or filing bug reports.
+
+```sh
+kshrk redact --in capture.tar.gz
+# writes capture-redacted.tar.gz by default
+```
+
+```sh
+kshrk redact --in capture.tar.gz --out safe-capture.tar.gz \
+  --allow-secret default/pull-secret \
+  --allow-secret kube-system/bootstrap-token
+```
+
+### Redact flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--in` | (required) | Source capture archive |
+| `--out` | `<in>-redacted.tar.gz` | Output archive path |
+| `--allow-secret` | | `namespace/name` of secret to keep unredacted (repeatable) |
+
+Secret metadata (name, namespace, labels, annotations, type) is always preserved so you can still count and identify secrets by kind.
+
+---
+
 ## kubectl compatibility
 
 The mock server is designed to be a drop-in replacement for `kubectl`'s real server. Supported behaviours:

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,169 @@
+package redact
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// redactedB64 is "REDACTED" base64-encoded.  Kubernetes Secret data values are
+// base64 strings, so we replace with another valid base64 string.
+var redactedB64 = base64.StdEncoding.EncodeToString([]byte("REDACTED"))
+
+// Archive reads srcPath, redacts all Secret records, and writes to dstPath.
+// allowList is a set of "namespace/name" keys whose data is preserved unchanged.
+func Archive(srcPath, dstPath string, allowList map[string]bool) (int, error) {
+	// Extract the source archive to a temp dir.
+	tmpDir, err := os.MkdirTemp("", "k8shark-redact-*")
+	if err != nil {
+		return 0, fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err := archive.Open(srcPath, tmpDir); err != nil {
+		return 0, fmt.Errorf("opening archive: %w", err)
+	}
+
+	// Load metadata and index.
+	metaBytes, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "metadata.json"))
+	if err != nil {
+		return 0, fmt.Errorf("reading metadata: %w", err)
+	}
+	var meta capture.CaptureMetadata
+	if err := json.Unmarshal(metaBytes, &meta); err != nil {
+		return 0, fmt.Errorf("parsing metadata: %w", err)
+	}
+
+	idxBytes, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "index.json"))
+	if err != nil {
+		return 0, fmt.Errorf("reading index: %w", err)
+	}
+	var idx capture.Index
+	if err := json.Unmarshal(idxBytes, &idx); err != nil {
+		return 0, fmt.Errorf("parsing index: %w", err)
+	}
+
+	// Walk all records, collect unique IDs, and redact as needed.
+	seen := map[string]bool{}
+	for _, entry := range idx {
+		for _, id := range entry.RecordIDs {
+			seen[id] = true
+		}
+	}
+
+	var records []*capture.Record
+	redactedCount := 0
+
+	for id := range seen {
+		recPath := filepath.Join(tmpDir, "k8shark-capture", "records", id+".json")
+		data, err := os.ReadFile(recPath)
+		if err != nil {
+			return 0, fmt.Errorf("reading record %s: %w", id, err)
+		}
+		var rec capture.Record
+		if err := json.Unmarshal(data, &rec); err != nil {
+			return 0, fmt.Errorf("parsing record %s: %w", id, err)
+		}
+
+		redacted, err := redactRecord(&rec, allowList)
+		if err != nil {
+			return 0, fmt.Errorf("redacting record %s: %w", id, err)
+		}
+		if redacted {
+			redactedCount++
+		}
+		records = append(records, &rec)
+	}
+
+	if err := archive.Write(dstPath, &meta, records, idx); err != nil {
+		return 0, fmt.Errorf("writing redacted archive: %w", err)
+	}
+
+	return redactedCount, nil
+}
+
+// redactRecord modifies rec in-place if it is a Secret not in the allowList.
+// Returns true if the record was redacted.
+func redactRecord(rec *capture.Record, allowList map[string]bool) (bool, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+		// Not JSON (e.g. Table format) — leave as-is.
+		return false, nil
+	}
+
+	kindRaw, ok := obj["kind"]
+	if !ok {
+		return false, nil
+	}
+	var kind string
+	if err := json.Unmarshal(kindRaw, &kind); err != nil || kind != "Secret" {
+		return false, nil
+	}
+
+	// Check allowlist.
+	metaKey := secretKey(obj)
+	if allowList[metaKey] {
+		return false, nil
+	}
+
+	modified := false
+
+	if dataRaw, ok := obj["data"]; ok {
+		var dataMap map[string]string
+		if err := json.Unmarshal(dataRaw, &dataMap); err == nil {
+			for k := range dataMap {
+				dataMap[k] = redactedB64
+			}
+			newData, _ := json.Marshal(dataMap)
+			obj["data"] = newData
+			modified = true
+		}
+	}
+
+	if sdRaw, ok := obj["stringData"]; ok {
+		var sdMap map[string]string
+		if err := json.Unmarshal(sdRaw, &sdMap); err == nil {
+			for k := range sdMap {
+				sdMap[k] = "REDACTED"
+			}
+			newSD, _ := json.Marshal(sdMap)
+			obj["stringData"] = newSD
+			modified = true
+		}
+	}
+
+	if modified {
+		newBody, err := json.Marshal(obj)
+		if err != nil {
+			return false, fmt.Errorf("re-marshalling secret: %w", err)
+		}
+		rec.ResponseBody = newBody
+	}
+
+	return modified, nil
+}
+
+// secretKey returns "namespace/name" for a Secret object map, for allowlist lookup.
+func secretKey(obj map[string]json.RawMessage) string {
+	metaRaw, ok := obj["metadata"]
+	if !ok {
+		return ""
+	}
+	var meta struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	}
+	if err := json.Unmarshal(metaRaw, &meta); err != nil {
+		return ""
+	}
+	if meta.Namespace == "" {
+		return meta.Name
+	}
+	return strings.Join([]string{meta.Namespace, meta.Name}, "/")
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -88,8 +88,10 @@ func Archive(srcPath, dstPath string, allowList map[string]bool) (int, error) {
 	return redactedCount, nil
 }
 
-// redactRecord modifies rec in-place if it is a Secret not in the allowList.
-// Returns true if the record was redacted.
+// redactRecord modifies rec in-place if it contains Secret data.
+// Handles both individual Secret objects ("kind":"Secret") and list responses
+// ("kind":"SecretList") since the capture engine stores list-level responses.
+// Returns true if any redaction was performed.
 func redactRecord(rec *capture.Record, allowList map[string]bool) (bool, error) {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
@@ -102,13 +104,24 @@ func redactRecord(rec *capture.Record, allowList map[string]bool) (bool, error) 
 		return false, nil
 	}
 	var kind string
-	if err := json.Unmarshal(kindRaw, &kind); err != nil || kind != "Secret" {
+	if err := json.Unmarshal(kindRaw, &kind); err != nil {
 		return false, nil
 	}
 
-	// Check allowlist.
-	metaKey := secretKey(obj)
-	if allowList[metaKey] {
+	switch kind {
+	case "Secret":
+		return redactSecretObj(obj, allowList, &rec.ResponseBody)
+	case "SecretList":
+		return redactSecretList(obj, allowList, &rec.ResponseBody)
+	default:
+		return false, nil
+	}
+}
+
+// redactSecretObj redacts data/stringData on a single Secret map.
+// Writes back to dest if modified.
+func redactSecretObj(obj map[string]json.RawMessage, allowList map[string]bool, dest *json.RawMessage) (bool, error) {
+	if allowList[secretKey(obj)] {
 		return false, nil
 	}
 
@@ -116,7 +129,7 @@ func redactRecord(rec *capture.Record, allowList map[string]bool) (bool, error) 
 
 	if dataRaw, ok := obj["data"]; ok {
 		var dataMap map[string]string
-		if err := json.Unmarshal(dataRaw, &dataMap); err == nil {
+		if err := json.Unmarshal(dataRaw, &dataMap); err == nil && len(dataMap) > 0 {
 			for k := range dataMap {
 				dataMap[k] = redactedB64
 			}
@@ -128,7 +141,7 @@ func redactRecord(rec *capture.Record, allowList map[string]bool) (bool, error) 
 
 	if sdRaw, ok := obj["stringData"]; ok {
 		var sdMap map[string]string
-		if err := json.Unmarshal(sdRaw, &sdMap); err == nil {
+		if err := json.Unmarshal(sdRaw, &sdMap); err == nil && len(sdMap) > 0 {
 			for k := range sdMap {
 				sdMap[k] = "REDACTED"
 			}
@@ -143,9 +156,52 @@ func redactRecord(rec *capture.Record, allowList map[string]bool) (bool, error) 
 		if err != nil {
 			return false, fmt.Errorf("re-marshalling secret: %w", err)
 		}
-		rec.ResponseBody = newBody
+		*dest = newBody
+	}
+	return modified, nil
+}
+
+// redactSecretList redacts all items in a SecretList response.
+func redactSecretList(obj map[string]json.RawMessage, allowList map[string]bool, dest *json.RawMessage) (bool, error) {
+	itemsRaw, ok := obj["items"]
+	if !ok {
+		return false, nil
 	}
 
+	var items []json.RawMessage
+	if err := json.Unmarshal(itemsRaw, &items); err != nil || len(items) == 0 {
+		return false, nil
+	}
+
+	modified := false
+	for i, itemRaw := range items {
+		var itemObj map[string]json.RawMessage
+		if err := json.Unmarshal(itemRaw, &itemObj); err != nil {
+			continue
+		}
+		var newBody json.RawMessage = itemRaw
+		changed, err := redactSecretObj(itemObj, allowList, &newBody)
+		if err != nil {
+			return false, err
+		}
+		if changed {
+			items[i] = newBody
+			modified = true
+		}
+	}
+
+	if modified {
+		newItems, err := json.Marshal(items)
+		if err != nil {
+			return false, fmt.Errorf("re-marshalling secret list items: %w", err)
+		}
+		obj["items"] = newItems
+		newBody, err := json.Marshal(obj)
+		if err != nil {
+			return false, fmt.Errorf("re-marshalling secret list: %w", err)
+		}
+		*dest = newBody
+	}
 	return modified, nil
 }
 

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,212 @@
+package redact
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// buildTestArchive writes a minimal k8shark archive containing the given records
+// and returns its file path (inside a temp dir cleaned up by t.Cleanup).
+func buildTestArchive(t *testing.T, records []*capture.Record) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	idx := capture.Index{}
+	for _, r := range records {
+		e := &capture.IndexEntry{
+			APIPath:   r.APIPath,
+			RecordIDs: []string{r.ID},
+			Times:     []time.Time{r.CapturedAt},
+		}
+		idx[r.APIPath] = e
+	}
+
+	meta := &capture.CaptureMetadata{
+		CaptureID:         "test-id",
+		CapturedAt:        time.Now().Add(-time.Minute),
+		CapturedUntil:     time.Now(),
+		KubernetesVersion: "v1.29.0",
+		ServerAddress:     "https://127.0.0.1:6443",
+		RecordCount:       len(records),
+	}
+
+	outPath := filepath.Join(dir, "test.tar.gz")
+	if err := archive.Write(outPath, meta, records, idx); err != nil {
+		t.Fatalf("buildTestArchive: %v", err)
+	}
+	return outPath
+}
+
+func secretRecord(id, ns, name string, data map[string]string, stringData map[string]string) *capture.Record {
+	obj := map[string]any{
+		"kind":       "Secret",
+		"apiVersion": "v1",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": ns,
+		},
+	}
+	if data != nil {
+		obj["data"] = data
+	}
+	if stringData != nil {
+		obj["stringData"] = stringData
+	}
+	body, _ := json.Marshal(obj)
+	apiPath := "/api/v1/namespaces/" + ns + "/secrets"
+	return &capture.Record{
+		ID:           id,
+		APIPath:      apiPath,
+		CapturedAt:   time.Now(),
+		ResponseCode: 200,
+		ResponseBody: body,
+	}
+}
+
+func podRecord(id, ns string) *capture.Record {
+	obj := map[string]any{
+		"kind":       "PodList",
+		"apiVersion": "v1",
+		"items":      []any{},
+	}
+	body, _ := json.Marshal(obj)
+	apiPath := "/api/v1/namespaces/" + ns + "/pods"
+	return &capture.Record{
+		ID:           id,
+		APIPath:      apiPath,
+		CapturedAt:   time.Now(),
+		ResponseCode: 200,
+		ResponseBody: body,
+	}
+}
+
+func TestRedact_SecretDataRedacted(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("my-password"))
+	src := buildTestArchive(t, []*capture.Record{
+		secretRecord("r1", "default", "db-creds", map[string]string{"password": encoded}, nil),
+	})
+	dst := src + "-redacted.tar.gz"
+	t.Cleanup(func() { os.Remove(dst) })
+
+	n, err := Archive(src, dst, nil)
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 redacted record, got %d", n)
+	}
+
+	// Verify the output archive has the value replaced.
+	tmpDir := t.TempDir()
+	if err := archive.Open(dst, tmpDir); err != nil {
+		t.Fatalf("opening redacted archive: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "records", "r1.json"))
+	if err != nil {
+		t.Fatalf("reading record: %v", err)
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatalf("parsing record: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	_ = json.Unmarshal(rec.ResponseBody, &obj)
+	var dataMap map[string]string
+	_ = json.Unmarshal(obj["data"], &dataMap)
+
+	want := base64.StdEncoding.EncodeToString([]byte("REDACTED"))
+	if dataMap["password"] != want {
+		t.Errorf("expected data[password]=%q, got %q", want, dataMap["password"])
+	}
+}
+
+func TestRedact_StringDataRedacted(t *testing.T) {
+	src := buildTestArchive(t, []*capture.Record{
+		secretRecord("r2", "default", "plain-secret", nil, map[string]string{"token": "s3cr3t"}),
+	})
+	dst := src + "-redacted.tar.gz"
+	t.Cleanup(func() { os.Remove(dst) })
+
+	_, err := Archive(src, dst, nil)
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	if err := archive.Open(dst, tmpDir); err != nil {
+		t.Fatalf("opening redacted archive: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "records", "r2.json"))
+	if err != nil {
+		t.Fatalf("reading record: %v", err)
+	}
+	var rec capture.Record
+	_ = json.Unmarshal(data, &rec)
+	var obj map[string]json.RawMessage
+	_ = json.Unmarshal(rec.ResponseBody, &obj)
+	var sdMap map[string]string
+	_ = json.Unmarshal(obj["stringData"], &sdMap)
+
+	if sdMap["token"] != "REDACTED" {
+		t.Errorf("expected stringData[token]=REDACTED, got %q", sdMap["token"])
+	}
+}
+
+func TestRedact_AllowList(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("keep-me"))
+	src := buildTestArchive(t, []*capture.Record{
+		secretRecord("r3", "default", "allowed-secret", map[string]string{"key": encoded}, nil),
+	})
+	dst := src + "-redacted.tar.gz"
+	t.Cleanup(func() { os.Remove(dst) })
+
+	n, err := Archive(src, dst, map[string]bool{"default/allowed-secret": true})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 redacted records (all allowlisted), got %d", n)
+	}
+
+	tmpDir := t.TempDir()
+	if err := archive.Open(dst, tmpDir); err != nil {
+		t.Fatalf("opening redacted archive: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "records", "r3.json"))
+	if err != nil {
+		t.Fatalf("reading record: %v", err)
+	}
+	var rec capture.Record
+	_ = json.Unmarshal(data, &rec)
+	var obj map[string]json.RawMessage
+	_ = json.Unmarshal(rec.ResponseBody, &obj)
+	var dataMap map[string]string
+	_ = json.Unmarshal(obj["data"], &dataMap)
+
+	if dataMap["key"] != encoded {
+		t.Errorf("expected original value preserved for allowlisted secret, got %q", dataMap["key"])
+	}
+}
+
+func TestRedact_NonSecretUnchanged(t *testing.T) {
+	src := buildTestArchive(t, []*capture.Record{
+		podRecord("r4", "default"),
+	})
+	dst := src + "-redacted.tar.gz"
+	t.Cleanup(func() { os.Remove(dst) })
+
+	n, err := Archive(src, dst, nil)
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 redacted (no secrets), got %d", n)
+	}
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -87,6 +87,26 @@ func podRecord(id, ns string) *capture.Record {
 	}
 }
 
+// secretListRecord creates a record whose response body is a SecretList — the real
+// format stored by the capture engine (it GETs the list endpoint, not individual items).
+func secretListRecord(id, ns string, items []map[string]any) *capture.Record {
+	obj := map[string]any{
+		"kind":       "SecretList",
+		"apiVersion": "v1",
+		"metadata":   map[string]any{},
+		"items":      items,
+	}
+	body, _ := json.Marshal(obj)
+	apiPath := "/api/v1/namespaces/" + ns + "/secrets"
+	return &capture.Record{
+		ID:           id,
+		APIPath:      apiPath,
+		CapturedAt:   time.Now(),
+		ResponseCode: 200,
+		ResponseBody: body,
+	}
+}
+
 func TestRedact_SecretDataRedacted(t *testing.T) {
 	encoded := base64.StdEncoding.EncodeToString([]byte("my-password"))
 	src := buildTestArchive(t, []*capture.Record{
@@ -208,5 +228,104 @@ func TestRedact_NonSecretUnchanged(t *testing.T) {
 	}
 	if n != 0 {
 		t.Errorf("expected 0 redacted (no secrets), got %d", n)
+	}
+}
+
+func TestRedact_SecretListRedacted(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("hunter2"))
+	item := map[string]any{
+		"kind":       "Secret",
+		"apiVersion": "v1",
+		"metadata":   map[string]any{"name": "app-secret", "namespace": "k8shark-test"},
+		"data":       map[string]string{"password": encoded},
+	}
+	src := buildTestArchive(t, []*capture.Record{
+		secretListRecord("r5", "k8shark-test", []map[string]any{item}),
+	})
+	dst := src + "-redacted.tar.gz"
+	t.Cleanup(func() { os.Remove(dst) })
+
+	n, err := Archive(src, dst, nil)
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 redacted record, got %d", n)
+	}
+
+	tmpDir := t.TempDir()
+	if err := archive.Open(dst, tmpDir); err != nil {
+		t.Fatalf("opening redacted archive: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "records", "r5.json"))
+	if err != nil {
+		t.Fatalf("reading record: %v", err)
+	}
+	var rec capture.Record
+	_ = json.Unmarshal(data, &rec)
+	var obj map[string]json.RawMessage
+	_ = json.Unmarshal(rec.ResponseBody, &obj)
+	var items []json.RawMessage
+	_ = json.Unmarshal(obj["items"], &items)
+	if len(items) == 0 {
+		t.Fatal("expected items array in SecretList response")
+	}
+	var itemObj map[string]json.RawMessage
+	_ = json.Unmarshal(items[0], &itemObj)
+	var dataMap map[string]string
+	_ = json.Unmarshal(itemObj["data"], &dataMap)
+
+	want := base64.StdEncoding.EncodeToString([]byte("REDACTED"))
+	if dataMap["password"] != want {
+		t.Errorf("expected data[password]=%q, got %q", want, dataMap["password"])
+	}
+}
+
+func TestRedact_SecretList_AllowList(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("keep-me"))
+	item := map[string]any{
+		"kind":       "Secret",
+		"apiVersion": "v1",
+		"metadata":   map[string]any{"name": "allowed-secret", "namespace": "default"},
+		"data":       map[string]string{"key": encoded},
+	}
+	src := buildTestArchive(t, []*capture.Record{
+		secretListRecord("r6", "default", []map[string]any{item}),
+	})
+	dst := src + "-redacted.tar.gz"
+	t.Cleanup(func() { os.Remove(dst) })
+
+	n, err := Archive(src, dst, map[string]bool{"default/allowed-secret": true})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 redacted records (allowlisted), got %d", n)
+	}
+
+	tmpDir := t.TempDir()
+	if err := archive.Open(dst, tmpDir); err != nil {
+		t.Fatalf("opening redacted archive: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "records", "r6.json"))
+	if err != nil {
+		t.Fatalf("reading record: %v", err)
+	}
+	var rec capture.Record
+	_ = json.Unmarshal(data, &rec)
+	var obj map[string]json.RawMessage
+	_ = json.Unmarshal(rec.ResponseBody, &obj)
+	var items []json.RawMessage
+	_ = json.Unmarshal(obj["items"], &items)
+	if len(items) == 0 {
+		t.Fatal("expected items array in SecretList response")
+	}
+	var itemObj map[string]json.RawMessage
+	_ = json.Unmarshal(items[0], &itemObj)
+	var dataMap map[string]string
+	_ = json.Unmarshal(itemObj["data"], &dataMap)
+
+	if dataMap["key"] != encoded {
+		t.Errorf("expected original value preserved for allowlisted secret in list, got %q", dataMap["key"])
 	}
 }


### PR DESCRIPTION
## Summary

Adds a `kshrk redact` subcommand that produces a new capture archive with all Kubernetes Secret `data` and `stringData` values replaced by `"REDACTED"`. The original archive is never modified. Intended for safely sharing captures with support teams or attaching to bug reports.

Closes #11.

## Changes

- **`internal/redact/redact.go`** — new package. `Archive(src, dst, allowList)` extracts the source archive to a temp dir, walks every record, replaces Secret field values, and writes a new archive.
  - `data` values → `UkVEQUNURUQ=` (base64 of `"REDACTED"`) so `kubectl get secret -o yaml` remains valid
  - `stringData` values → `"REDACTED"`
  - Non-Secret records written verbatim
  - `allowList map[string]bool` keyed by `namespace/name` exempts named secrets
- **`internal/redact/redact_test.go`** — 4 unit tests: `data` redaction, `stringData` redaction, allowlist, non-secret unchanged.
- **`cmd/redact.go`** — cobra subcommand: `kshrk redact --in <src> [--out <dst>] [--allow-secret ns/name]...`
  - `--out` defaults to `<basename>-redacted.tar.gz`
  - Refuses to overwrite source (`--in == --out` check)
- **`docs/usage.md`** — new `## Redact` section with flags table.
- **`docs/archive-format.md`** — note explaining the redacted archive format.
- **`planning/secret-redaction.md`** — implementation plan.

## Testing

```
go test ./internal/redact/...
```

## Usage

```sh
# Redact all secrets
kshrk redact --in capture.tar.gz

# Preserve a specific secret
kshrk redact --in capture.tar.gz --allow-secret default/pull-secret
```