### PR TITLE
fix(server): apply label/field selectors to Table-format responses

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -305,10 +305,25 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 	}
 
 	// Apply label/field selectors if present.
-	body, err = applySelectors(body, r.URL.Query().Get("labelSelector"), r.URL.Query().Get("fieldSelector"))
+	labelSel := r.URL.Query().Get("labelSelector")
+	fieldSel := r.URL.Query().Get("fieldSelector")
+	body, err = applySelectors(body, labelSel, fieldSel)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, statusObj(500, err.Error()))
 		return
+	}
+
+	// tableFiltered applies label/field selectors to a stored Table-format body,
+	// removing rows whose embedded object does not match. Returns tb unchanged
+	// when selectors are empty or if filtering fails (best-effort).
+	tableFiltered := func(tb []byte) []byte {
+		if labelSel == "" && fieldSel == "" {
+			return tb
+		}
+		if out, ferr := filterTableRows(tb, labelSel, fieldSel); ferr == nil {
+			return out
+		}
+		return tb
 	}
 
 	// If kubectl requests Table format, try the captured Table response first
@@ -319,10 +334,12 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		if tb, tbCode, _ := h.store.Latest(path+"?as=Table", at); tbCode == 200 {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(200)
-			_, _ = w.Write(tb)
+			_, _ = w.Write(tableFiltered(tb))
 			return
 		}
 		// Single-item GET: extract the matching row from the parent list's Table.
+		// Selectors on single-item GETs are resolved by name, not labels — no
+		// row filtering needed here.
 		if i := strings.LastIndex(path, "/"); i > 0 {
 			parentTable, ptCode, _ := h.store.Latest(path[:i]+"?as=Table", at)
 			if ptCode == 200 {
@@ -338,10 +355,11 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		if tb, tbCode, _ := h.store.AggregateTableAcrossNamespaces(path, at); tbCode == 200 {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(200)
-			_, _ = w.Write(tb)
+			_, _ = w.Write(tableFiltered(tb))
 			return
 		}
 		// Last resort: synthesize a minimal Table from the list body (old captures).
+		// body is already selector-filtered above, so buildTable sees filtered items.
 		if tb, err2 := buildTable(body); err2 == nil {
 			body = tb
 		}

--- a/internal/server/selector.go
+++ b/internal/server/selector.go
@@ -229,6 +229,49 @@ func matchesFields(obj *k8sObject, reqs []fieldSelectorReq) bool {
 	return true
 }
 
+// filterTableRows applies label/field selectors to a Table-format response,
+// keeping only rows whose embedded object satisfies both selectors. Returns the
+// original body unchanged if selectors are empty, the body cannot be decoded as
+// a Table, or the rows array is absent.
+func filterTableRows(tableBody []byte, labelSelector, fieldSelector string) ([]byte, error) {
+	if labelSelector == "" && fieldSelector == "" {
+		return tableBody, nil
+	}
+
+	labelReqs, err := parseRequirements(labelSelector)
+	if err != nil {
+		return tableBody, nil // malformed selector — serve unfiltered (best-effort)
+	}
+	fieldReqs := parseFieldSelector(fieldSelector)
+
+	var table struct {
+		APIVersion        json.RawMessage   `json:"apiVersion"`
+		Kind              json.RawMessage   `json:"kind"`
+		Metadata          json.RawMessage   `json:"metadata"`
+		ColumnDefinitions json.RawMessage   `json:"columnDefinitions"`
+		Rows              []json.RawMessage `json:"rows"`
+	}
+	if err := json.Unmarshal(tableBody, &table); err != nil || table.Rows == nil {
+		return tableBody, nil
+	}
+
+	filtered := make([]json.RawMessage, 0, len(table.Rows))
+	for _, row := range table.Rows {
+		var r struct {
+			Object k8sObject `json:"object"`
+		}
+		if err := json.Unmarshal(row, &r); err != nil {
+			filtered = append(filtered, row) // can't inspect — include to avoid data loss
+			continue
+		}
+		if matchesLabels(&r.Object, labelReqs) && matchesFields(&r.Object, fieldReqs) {
+			filtered = append(filtered, row)
+		}
+	}
+	table.Rows = filtered
+	return json.Marshal(table)
+}
+
 // applySelectors filters a JSON list body keeping only items that match both
 // labelSelector and fieldSelector. Returns the original body unchanged if
 // both selectors are empty or if the body is not a list.

--- a/internal/server/selector_test.go
+++ b/internal/server/selector_test.go
@@ -217,3 +217,145 @@ func stringSliceEqual(a, b []string) bool {
 	}
 	return true
 }
+
+// ── filterTableRows tests ─────────────────────────────────────────────────────
+
+// tableWithPods builds a meta.k8s.io/v1 Table JSON from a slice of podSpecs,
+// mirroring the structure the mock server stores from a real cluster capture.
+func tableWithPods(pods []podSpec) []byte {
+	rows := make([]map[string]any, 0, len(pods))
+	for _, p := range pods {
+		ns := p.namespace
+		if ns == "" {
+			ns = "default"
+		}
+		rows = append(rows, map[string]any{
+			"cells": []any{p.name, ns, "1d"},
+			"object": map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]any{
+					"name":      p.name,
+					"namespace": ns,
+					"labels":    p.labels,
+				},
+			},
+		})
+	}
+	body, _ := json.Marshal(map[string]any{
+		"apiVersion": "meta.k8s.io/v1",
+		"kind":       "Table",
+		"metadata":   map[string]any{"resourceVersion": "1"},
+		"columnDefinitions": []map[string]any{
+			{"name": "Name", "type": "string"},
+			{"name": "Namespace", "type": "string"},
+			{"name": "Age", "type": "date"},
+		},
+		"rows": rows,
+	})
+	return body
+}
+
+// tableRowNames extracts metadata.name from each row's embedded object.
+func tableRowNames(t *testing.T, body []byte) []string {
+	t.Helper()
+	var table struct {
+		Rows []struct {
+			Object struct {
+				Metadata struct {
+					Name string `json:"name"`
+				} `json:"metadata"`
+			} `json:"object"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal(body, &table); err != nil {
+		t.Fatalf("tableRowNames unmarshal: %v\nbody: %s", err, body)
+	}
+	names := make([]string, 0, len(table.Rows))
+	for _, r := range table.Rows {
+		names = append(names, r.Object.Metadata.Name)
+	}
+	return names
+}
+
+func TestFilterTableRows_LabelFilter(t *testing.T) {
+	table := tableWithPods([]podSpec{
+		{name: "nginx-1", labels: map[string]string{"app": "nginx", "env": "prod"}},
+		{name: "redis-1", labels: map[string]string{"app": "redis", "env": "prod"}},
+		{name: "nginx-dev", labels: map[string]string{"app": "nginx", "env": "dev"}},
+	})
+
+	cases := []struct {
+		sel       string
+		wantNames []string
+	}{
+		{"app=nginx", []string{"nginx-1", "nginx-dev"}},
+		{"app=redis", []string{"redis-1"}},
+		{"app!=nginx", []string{"redis-1"}},
+		{"env in (prod)", []string{"nginx-1", "redis-1"}},
+		{"app notin (nginx,redis)", []string{}},
+		{"app", []string{"nginx-1", "redis-1", "nginx-dev"}},
+		{"!missing", []string{"nginx-1", "redis-1", "nginx-dev"}},
+		{"app=nginx,env=prod", []string{"nginx-1"}},
+	}
+
+	for _, tc := range cases {
+		filtered, err := filterTableRows(table, tc.sel, "")
+		if err != nil {
+			t.Fatalf("[%q] error: %v", tc.sel, err)
+		}
+		names := tableRowNames(t, filtered)
+		if !stringSliceEqual(names, tc.wantNames) {
+			t.Errorf("[%q] got %v, want %v", tc.sel, names, tc.wantNames)
+		}
+	}
+}
+
+func TestFilterTableRows_FieldFilter(t *testing.T) {
+	table := tableWithPods([]podSpec{
+		{name: "nginx", namespace: "default"},
+		{name: "redis", namespace: "kube-system"},
+	})
+
+	cases := []struct {
+		sel       string
+		wantNames []string
+	}{
+		{"metadata.name=nginx", []string{"nginx"}},
+		{"metadata.name!=nginx", []string{"redis"}},
+		{"metadata.namespace=kube-system", []string{"redis"}},
+	}
+
+	for _, tc := range cases {
+		filtered, err := filterTableRows(table, "", tc.sel)
+		if err != nil {
+			t.Fatalf("[%q] error: %v", tc.sel, err)
+		}
+		names := tableRowNames(t, filtered)
+		if !stringSliceEqual(names, tc.wantNames) {
+			t.Errorf("[%q] got %v, want %v", tc.sel, names, tc.wantNames)
+		}
+	}
+}
+
+func TestFilterTableRows_EmptySelector(t *testing.T) {
+	table := tableWithPods([]podSpec{{name: "nginx", labels: map[string]string{"app": "nginx"}}})
+	out, err := filterTableRows(table, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(table) {
+		t.Error("empty selectors should return body unchanged")
+	}
+}
+
+func TestFilterTableRows_NotATable(t *testing.T) {
+	body := []byte(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"nginx"}}`)
+	out, err := filterTableRows(body, "app=nginx", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(body) {
+		t.Error("non-Table body should be returned unchanged")
+	}
+}


### PR DESCRIPTION
Closes #3

## What
When `kubectl get pods -l app=foo` is run, kubectl sends `Accept: application/json;as=Table` with `?labelSelector=app%3Dfoo`. The handler was serving the full captured Table without filtering its rows, so the selector had no effect on the default terminal output.

## Fix
- Add `filterTableRows` to `selector.go`: walks the Table `rows` array and removes rows whose embedded `object` doesn't match the selector — mirrors `applySelectors` for JSON list bodies
- Hoist `labelSel`/`fieldSel` in `serveResource` and apply `filterTableRows` to all three Table-serving paths (exact-path, aggregated across namespaces)
- The `buildTable` fallback is already correct since it builds from the already-filtered JSON list body

## Tests
4 new unit tests in `selector_test.go` covering label filter, field filter, empty selector (no-op), and non-Table body (no-op).