### PR TITLE
feat(server): stub exec/cp/port-forward with clear 405 responses

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -233,7 +233,8 @@ The mock server is designed to be a drop-in replacement for `kubectl`'s real ser
 | Field selectors (`--field-selector status.phase=Running`) | ✅ |
 | Watch (`-w`) | ✅ synthetic event stream |
 | Write operations (`apply`, `delete`, `edit`, …) | ⛔ returns `405 Method Not Allowed` — mock server is read-only |
-| `kubectl exec` / `kubectl logs` | ❌ |
+| `kubectl exec` / `kubectl cp` / `kubectl port-forward` / `kubectl attach` | ⛔ returns `405 Method Not Allowed` with a clear error referencing k8shark capture replay |
+| `kubectl logs` | ❌ not yet captured |
 | `kubectl top` | ❌ metrics API not captured |
 
 ### Resources not in the capture

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -34,6 +34,24 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("  --> %s %s\n", r.Method, path)
 	}
 
+	// Intercept interactive sub-resources that can never work against a capture
+	// replay. Doing this before the method check ensures we return a specific,
+	// actionable error instead of the generic "write operations are not
+	// supported" message — and we don't hang waiting for a protocol upgrade.
+	//   kubectl exec / kubectl cp  → POST .../pods/<name>/exec
+	//   kubectl port-forward       → POST .../pods/<name>/portforward
+	//   kubectl attach             → POST .../pods/<name>/attach
+	if strings.HasSuffix(path, "/exec") ||
+		strings.HasSuffix(path, "/portforward") ||
+		strings.HasSuffix(path, "/attach") {
+		w.Header().Set("Allow", "")
+		h.writeStatus(w, http.StatusMethodNotAllowed,
+			"k8shark capture replay: exec, cp, and port-forward are not supported — "+
+				"this mock server replays a captured snapshot and cannot run commands "+
+				"or open connections on pods")
+		return
+	}
+
 	// Reject all write operations — k8shark replay is read-only.
 	// RFC 7231 §6.5.5 requires an Allow header with a 405 response.
 	switch r.Method {

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -392,3 +392,35 @@ func TestHandler_WriteMethodsReturn405(t *testing.T) {
 		}
 	})
 }
+
+func TestHandler_InteractiveSubResourcesReturn405(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/pods": []byte(`{"kind":"PodList","items":[]}`),
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	// These sub-resource paths must always return 405 regardless of method,
+	// with a message that explicitly references k8shark capture replay.
+	subResources := []string{
+		"/api/v1/namespaces/default/pods/mypod/exec",
+		"/api/v1/namespaces/default/pods/mypod/portforward",
+		"/api/v1/namespaces/default/pods/mypod/attach",
+	}
+	for _, sr := range subResources {
+		for _, method := range []string{http.MethodGet, http.MethodPost} {
+			t.Run(method+"_"+sr, func(t *testing.T) {
+				req := httptest.NewRequest(method, sr, nil)
+				rw := httptest.NewRecorder()
+				h.ServeHTTP(rw, req)
+
+				if rw.Code != http.StatusMethodNotAllowed {
+					t.Fatalf("%s %s: expected 405, got %d", method, sr, rw.Code)
+				}
+				body := rw.Body.String()
+				if !strings.Contains(body, "k8shark") {
+					t.Errorf("%s %s: expected error message to mention k8shark, got: %s", method, sr, body)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
Closes #8

## What
`kubectl exec`, `kubectl cp`, and `kubectl port-forward` previously returned a generic write-op error or potentially hung waiting for a protocol upgrade (SPDY/WebSocket). The error message gave no indication this was a capture replay limitation.

## Fix
Intercept paths ending in `/exec`, `/portforward`, or `/attach` **before** the method check in `ServeHTTP`, so:
- The server rejects them immediately with `405 Method Not Allowed` before any protocol negotiation
- The error message explicitly says *"k8shark capture replay: exec, cp, and port-forward are not supported"*
- Both GET and POST methods are rejected (covers any pre-flight requests)

## Also
- Updated `docs/usage.md` kubectl compatibility table
- Added `TestHandler_InteractiveSubResourcesReturn405` covering all three sub-resources × GET and POST