### PR TITLE
feat: kubectl logs support via opt-in capture + mock server stub

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -234,8 +234,40 @@ The mock server is designed to be a drop-in replacement for `kubectl`'s real ser
 | Watch (`-w`) | ✅ synthetic event stream |
 | Write operations (`apply`, `delete`, `edit`, …) | ⛔ returns `405 Method Not Allowed` — mock server is read-only |
 | `kubectl exec` / `kubectl cp` / `kubectl port-forward` / `kubectl attach` | ⛔ returns `405 Method Not Allowed` with a clear error referencing k8shark capture replay |
-| `kubectl logs` | ❌ not yet captured |
+| `kubectl logs` | ✅ if captured via `logs: N` in capture config; helpful stub returned when not captured |
 | `kubectl top` | ❌ metrics API not captured |
+
+---
+
+## Capturing pod logs
+
+To capture pod logs alongside resource state, add a `logs` field to a `pods` resource entry in your capture config. The value is the number of tail lines to capture per pod:
+
+```yaml
+resources:
+  - version: v1
+    resource: pods
+    namespaces: [production, staging]
+    interval: 30s
+    logs: 200       # capture last 200 lines from each pod
+```
+
+Log content is fetched once at the end of the capture run and stored in the archive. When you open the archive with `kshrk open`, `kubectl logs` returns the captured output:
+
+```sh
+kubectl logs my-app-pod-abc123 -n production
+# outputs the captured tail log
+```
+
+If a pod's logs were not captured (e.g. `logs` was omitted or set to `0`), `kubectl logs` returns a clear stub message instead of an error:
+
+```
+# k8shark capture replay: logs were not captured for this pod.
+# To capture logs, add 'logs: 200' (or another line count) to the
+# pods entry in your k8shark capture config and re-run the capture.
+```
+
+> **Note:** Large log volumes increase archive size. Use a reasonable tail-line limit (e.g. 100–500 lines). Previous-container logs (`kubectl logs --previous`) are not captured.
 
 ### Resources not in the capture
 

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -102,6 +102,17 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 	}
 	wg.Wait()
 
+	// Fetch pod logs for any pods resource entry with logs > 0. This runs after
+	// all polling so we capture the most recent log state. A short background
+	// context is used because the main capture context has already expired.
+	for _, res := range e.cfg.Resources {
+		if res.Logs > 0 && res.Resource == "pods" {
+			logCtx, logCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			e.fetchPodsLogs(logCtx, res)
+			logCancel()
+		}
+	}
+
 	meta := &CaptureMetadata{
 		CaptureID:         uuid.New().String(),
 		CapturedAt:        time.Now().UTC().Add(-e.cfg.Duration),
@@ -275,6 +286,13 @@ func (e *Engine) doFetch(ctx context.Context, apiPath, tableKeySuffix string) ([
 	if tableKeySuffix == "" && resp.StatusCode == http.StatusForbidden {
 		fmt.Fprintf(os.Stderr, "  [warn] RBAC denied: %s (check cluster permissions)\n", apiPath)
 	}
+
+	// Skip records with an empty body — storing json.RawMessage("") would
+	// produce invalid JSON in the archive and corrupt serialisation.
+	if len(body) == 0 {
+		return nil, resp.StatusCode
+	}
+
 	if e.verbose {
 		label := apiPath
 		if tableKeySuffix != "" {
@@ -343,4 +361,90 @@ func buildAPIPath(group, version, resource, namespace string) string {
 		return base + "/" + resource
 	}
 	return base + "/namespaces/" + namespace + "/" + resource
+}
+
+// fetchPodsLogs fetches the tail log for each pod found in res across all
+// configured namespaces. Each log is stored under the clean
+// /api/v1/namespaces/<ns>/pods/<name>/log path so the mock server can serve
+// it verbatim when kubectl logs is run against the replay server.
+func (e *Engine) fetchPodsLogs(ctx context.Context, res config.Resource) {
+	namespaces := res.Namespaces
+	if len(namespaces) == 0 {
+		namespaces = []string{""}
+	}
+	for _, ns := range namespaces {
+		listPath := buildAPIPath(res.Group, res.Version, res.Resource, ns)
+		listBody, code := e.doFetch(ctx, listPath, "")
+		if code != 200 || listBody == nil {
+			continue
+		}
+		var list struct {
+			Items []struct {
+				Metadata struct {
+					Name      string `json:"name"`
+					Namespace string `json:"namespace"`
+				} `json:"metadata"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal(listBody, &list); err != nil {
+			continue
+		}
+		for _, item := range list.Items {
+			podNS := item.Metadata.Namespace
+			if podNS == "" {
+				podNS = ns
+			}
+			e.fetchOnePodLog(ctx, podNS, item.Metadata.Name, res.Logs)
+		}
+	}
+}
+
+// fetchOnePodLog fetches the last tailLines lines of a pod's log and stores
+// the plain-text content as a JSON-encoded string under the clean log path.
+// Storing as a JSON string ensures the record is valid JSON for the archive.
+func (e *Engine) fetchOnePodLog(ctx context.Context, namespace, podName string, tailLines int) {
+	logPath := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/log", namespace, podName)
+	fetchURL := fmt.Sprintf("%s%s?tailLines=%d", e.baseURL, logPath, tailLines)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, nil)
+	if err != nil {
+		return
+	}
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return
+	}
+
+	// Encode plain-text log body as a JSON string so it can be stored in the
+	// JSON archive without breaking serialisation.
+	jsonBody, err := json.Marshal(string(body))
+	if err != nil {
+		return
+	}
+
+	if e.verbose {
+		fmt.Fprintf(os.Stdout, "  [capture] %s -> %d (%d bytes)\n", logPath, resp.StatusCode, len(body))
+	}
+
+	rec := &Record{
+		ID:           uuid.New().String(),
+		CapturedAt:   time.Now().UTC(),
+		APIPath:      logPath,
+		HTTPMethod:   http.MethodGet,
+		ResponseCode: http.StatusOK,
+		ResponseBody: json.RawMessage(jsonBody),
+	}
+	e.mu.Lock()
+	e.records = append(e.records, rec)
+	if _, ok := e.index[logPath]; !ok {
+		e.index[logPath] = &IndexEntry{APIPath: logPath}
+	}
+	e.index[logPath].RecordIDs = append(e.index[logPath].RecordIDs, rec.ID)
+	e.index[logPath].Times = append(e.index[logPath].Times, rec.CapturedAt)
+	e.mu.Unlock()
 }

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -95,5 +96,124 @@ func TestEngine_CaptureToArchive(t *testing.T) {
 	}
 	if _, ok := eng.index["/api/v1/nodes"]; !ok {
 		t.Error("nodes path missing from index")
+	}
+}
+
+func TestEngine_FetchPodsLogs(t *testing.T) {
+	podList := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[` +
+		`{"metadata":{"name":"nginx","namespace":"default"}},` +
+		`{"metadata":{"name":"redis","namespace":"default"}}]}`
+	nginxLog := "nginx log line 1\nnginx log line 2\n"
+	redisLog := "redis log line 1\n"
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+		case "/api/v1/namespaces/default/pods":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, podList)
+		case "/api/v1/namespaces/default/pods/nginx/log":
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprint(w, nginxLog)
+		case "/api/v1/namespaces/default/pods/redis/log":
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprint(w, redisLog)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw: "1s",
+		Duration:    1 * time.Second,
+		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Resources: []config.Resource{
+			{
+				Version: "v1", Resource: "pods",
+				Namespaces:  []string{"default"},
+				IntervalRaw: "500ms", Interval: 500 * time.Millisecond,
+				Logs: 50,
+			},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	// Both log paths must be in the index.
+	nginxLogPath := "/api/v1/namespaces/default/pods/nginx/log"
+	redisLogPath := "/api/v1/namespaces/default/pods/redis/log"
+	if _, ok := eng.index[nginxLogPath]; !ok {
+		t.Errorf("nginx log path %q missing from index", nginxLogPath)
+	}
+	if _, ok := eng.index[redisLogPath]; !ok {
+		t.Errorf("redis log path %q missing from index", redisLogPath)
+	}
+
+	// Log records must be stored as JSON strings encoding the plain-text body.
+	for _, rec := range eng.records {
+		if rec.APIPath != nginxLogPath && rec.APIPath != redisLogPath {
+			continue
+		}
+		var text string
+		if err := json.Unmarshal(rec.ResponseBody, &text); err != nil {
+			t.Errorf("log record at %q has invalid JSON body: %v", rec.APIPath, err)
+			continue
+		}
+		want := nginxLog
+		if rec.APIPath == redisLogPath {
+			want = redisLog
+		}
+		if text != want {
+			t.Errorf("%q: got %q, want %q", rec.APIPath, text, want)
+		}
+	}
+}
+
+func TestEngine_NoLogsWhenDisabled(t *testing.T) {
+	logCalled := false
+	podList := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/log") {
+			logCalled = true
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "some log")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+		case "/api/v1/namespaces/default/pods":
+			fmt.Fprint(w, podList)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw: "1s",
+		Duration:    1 * time.Second,
+		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Resources: []config.Resource{
+			// Logs: 0 (default) — log capture disabled.
+			{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "500ms", Interval: 500 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+	if logCalled {
+		t.Error("log endpoint was called even though Logs=0")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,10 @@ type Resource struct {
 	IntervalRaw string `mapstructure:"interval"`
 	// Interval is parsed from IntervalRaw.
 	Interval time.Duration `mapstructure:"-"`
+	// Logs is the number of tail lines to capture from each pod's log when this
+	// resource is "pods". 0 (default) disables log capture. For example, set
+	// logs: 200 to capture the last 200 lines from every pod at capture time.
+	Logs int `mapstructure:"logs"`
 }
 
 // Config holds the full capture configuration.
@@ -99,6 +103,9 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("resources[%d] (%s): invalid interval %q: %w", i, r.Resource, r.IntervalRaw, err)
 		}
 		r.Interval = iv
+		if r.Logs < 0 {
+			return fmt.Errorf("resources[%d] (%s): 'logs' must be >= 0", i, r.Resource)
+		}
 	}
 
 	return nil

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -102,6 +102,9 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if !h.tryServeFromStore(w, path, replayAt) {
 			h.serveGroupResourceList(w, path)
 		}
+	case strings.HasSuffix(path, "/log"):
+		// Pod log sub-resource: serve captured content or a helpful stub.
+		h.serveLog(w, path, replayAt)
 	default:
 		h.serveResource(w, r, path, replayAt)
 	}
@@ -624,6 +627,36 @@ func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path strin
 	case <-r.Context().Done():
 	case <-timer:
 	}
+}
+
+// serveLog serves a pod log sub-resource (e.g. /api/v1/namespaces/<ns>/pods/<name>/log).
+// If the log was captured (logs: N in the resource config), it is served as
+// plain text. Otherwise a helpful stub message is returned so kubectl logs does
+// not error out against the mock server.
+func (h *handler) serveLog(w http.ResponseWriter, path string, at time.Time) {
+	body, code, err := h.store.Latest(path, at)
+	if err == nil && code == 200 {
+		// Logs are stored as JSON strings; decode to recover the original plain text.
+		var text string
+		if json.Unmarshal(body, &text) == nil {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, text)
+			return
+		}
+		// Fallback: body is already plain text (should not normally happen).
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+		return
+	}
+	// Log was not captured — return a readable stub so kubectl logs exits cleanly.
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprint(w,
+		"# k8shark capture replay: logs were not captured for this pod.\n"+
+			"# To capture logs, add 'logs: 200' (or another line count) to the\n"+
+			"# pods entry in your k8shark capture config and re-run the capture.\n")
 }
 
 func (h *handler) writeStatus(w http.ResponseWriter, code int, msg string) {

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -424,3 +424,50 @@ func TestHandler_InteractiveSubResourcesReturn405(t *testing.T) {
 		}
 	}
 }
+
+func TestHandler_ServeLog_Captured(t *testing.T) {
+	// Log bodies are stored as JSON strings in the archive.
+	logContent := "line1\nline2\nline3\n"
+	logJSON, _ := json.Marshal(logContent)
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/pods/mypod/log": logJSON,
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/mypod/log", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rw.Code)
+	}
+	if ct := rw.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("expected text/plain Content-Type, got %q", ct)
+	}
+	if got := rw.Body.String(); got != logContent {
+		t.Errorf("expected log body %q, got %q", logContent, got)
+	}
+}
+
+func TestHandler_ServeLog_NotCaptured(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/pods": []byte(`{"kind":"PodList","items":[]}`),
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/mypod/log", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	// Should return 200 with a stub message — not 404 or an error.
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rw.Code)
+	}
+	body := rw.Body.String()
+	if !strings.Contains(body, "k8shark") {
+		t.Errorf("expected stub message to mention k8shark, got: %q", body)
+	}
+	if !strings.Contains(body, "not captured") {
+		t.Errorf("expected stub to mention 'not captured', got: %q", body)
+	}
+}

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -670,8 +670,10 @@ else
 fi
 
 # A pod whose logs were not captured should return the k8shark stub message.
-stub_out=$(kubectl --kubeconfig "$E2E_KUBECONFIG" --request-timeout=10s \
-  logs nonexistent-pod -n k8shark-test 2>&1) || true
+# kubectl logs first fetches the pod (which would 404 for a nonexistent pod),
+# so we hit the /log sub-resource directly via curl to test the stub path.
+SERVER_ADDR=$(grep -E '^\s+server:' "$E2E_KUBECONFIG" | awk '{print $2}')
+stub_out=$(curl -s "${SERVER_ADDR}/api/v1/namespaces/k8shark-test/pods/nonexistent-pod/log" 2>&1) || true
 assert_contains "kubectl logs: stub message mentions k8shark"       "$stub_out" "k8shark"
 assert_contains "kubectl logs: stub message mentions not captured" "$stub_out" "not captured"
 

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -672,8 +672,10 @@ fi
 # A pod whose logs were not captured should return the k8shark stub message.
 # kubectl logs first fetches the pod (which would 404 for a nonexistent pod),
 # so we hit the /log sub-resource directly via curl to test the stub path.
-SERVER_ADDR=$(grep -E '^\s+server:' "$E2E_KUBECONFIG" | awk '{print $2}')
-stub_out=$(curl -s "${SERVER_ADDR}/api/v1/namespaces/k8shark-test/pods/nonexistent-pod/log" 2>&1) || true
+# Use -k because the mock server uses a self-signed TLS cert.
+SERVER_ADDR=$(kubectl config --kubeconfig "$E2E_KUBECONFIG" view \
+  --minify -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null || echo "")
+stub_out=$(curl -sk "${SERVER_ADDR}/api/v1/namespaces/k8shark-test/pods/nonexistent-pod/log" 2>&1) || true
 assert_contains "kubectl logs: stub message mentions k8shark"       "$stub_out" "k8shark"
 assert_contains "kubectl logs: stub message mentions not captured" "$stub_out" "not captured"
 

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -290,6 +290,7 @@ resources:
     resource: pods
     namespaces: [k8shark-test, k8shark-jobs]
     interval: 5s
+    logs: 50
   - group: apps
     version: v1
     resource: deployments
@@ -653,6 +654,26 @@ if [[ -n "$REDACTED_SERVER_PID" ]]; then
   wait "$REDACTED_SERVER_PID" 2>/dev/null || true
 fi
 rm -f "$REDACTED_FILE" "$REDACTED_SERVER_LOG" "$REDACTED_KC"
+
+# ── Phase 8c: kubectl logs ────────────────────────────────────────────────────
+log "Testing kubectl logs via mock server"
+
+# Get the name of one nginx pod from the mock server.
+NGINX_POD=$(kubectl "${EKC[@]}" get pods -n k8shark-test -l app=nginx \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+if [[ -z "$NGINX_POD" ]]; then
+  fail "kubectl logs: could not find an nginx pod in mock server"
+else
+  log_out=$(kubectl --kubeconfig "$E2E_KUBECONFIG" --request-timeout=10s \
+    logs "$NGINX_POD" -n k8shark-test 2>&1) || true
+  assert_not_empty "kubectl logs: captured nginx pod log is non-empty" "$log_out"
+fi
+
+# A pod whose logs were not captured should return the k8shark stub message.
+stub_out=$(kubectl --kubeconfig "$E2E_KUBECONFIG" --request-timeout=10s \
+  logs nonexistent-pod -n k8shark-test 2>&1) || true
+assert_contains "kubectl logs: stub message mentions k8shark"       "$stub_out" "k8shark"
+assert_contains "kubectl logs: stub message mentions not captured" "$stub_out" "not captured"
 
 # ── Phase 9: Round-trip comparison (live cluster vs. mock server) ─────────────
 log "Round-trip comparison: live cluster vs. mock server"


### PR DESCRIPTION
Closes #4

## What

Implements Option B from the issue (tail snapshot) with Option C as fallback.

### Capture config

Add `logs: N` to a `pods` resource entry to capture the last N lines from every pod at the end of the capture run:

```yaml
resources:
  - version: v1
    resource: pods
    namespaces: [production]
    interval: 30s
    logs: 200
```

### Mock server

- If logs were captured: `kubectl logs <pod> -n <ns>` returns the captured tail as `text/plain`
- If logs were **not** captured: returns a helpful `200 OK` stub message (no error) explaining how to enable log capture

## Changes

| File | Change |
|------|--------|
| `internal/config/config.go` | Add `Logs int` to `Resource`; validate `>= 0` |
| `internal/capture/engine.go` | Add `fetchPodsLogs` + `fetchOnePodLog`; call after `wg.Wait()`; guard `doFetch` against empty-body records |
| `internal/server/handler.go` | Route `/log` suffix to new `serveLog` handler |
| `docs/usage.md` | Update compat table; add "Capturing pod logs" section |

## Tests (4 new)
- `TestEngine_FetchPodsLogs`
- `TestEngine_NoLogsWhenDisabled`
- `TestHandler_ServeLog_Captured`
- `TestHandler_ServeLog_NotCaptured`