### PR TITLE
feat(capture): support wildcard namespace expansion (#18)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -28,6 +28,24 @@ k8shark reads a YAML config file that controls what gets captured, from which na
 
 > **Warning**: if you include `namespaces:` for a cluster-scoped resource, k8shark will warn during capture and automatically fall back to the correct cluster-scoped path.
 
+### Wildcard namespaces
+
+Use `"*"` as a namespace value to automatically capture from all namespaces discoverable at capture start:
+
+```yaml
+- group: apps
+  version: v1
+  resource: deployments
+  namespaces: ["*"]
+  interval: 30s
+```
+
+**Behaviour:**
+- `namespaces: ["*"]` expands to every namespace present at the start of the capture. Namespaces created _during_ the capture are not included.
+- Mixed lists such as `namespaces: ["production", "*"]` are supported — explicit namespaces appear first, then all remaining discovered namespaces are appended, deduplicated.
+- If namespace discovery fails (e.g. RBAC permissions), the capture exits with a clear error.
+- A well-known cluster-scoped resource (nodes, persistentvolumes, etc.) with `namespaces: ["*"]` emits a warning and falls back to a cluster-scoped fetch.
+
 ## Example configs
 
 ### Minimal: just pods in one namespace

--- a/examples/k8shark.yaml
+++ b/examples/k8shark.yaml
@@ -19,7 +19,7 @@ resources:
   - group: ""
     version: v1
     resource: pods
-    namespaces: [default, kube-system, k8shark-test, k8shark-jobs]
+    namespaces: ["*"]          # capture pods from ALL namespaces
     interval: 30s
 
   - group: ""
@@ -30,7 +30,7 @@ resources:
   - group: ""
     version: v1
     resource: events
-    namespaces: [default, k8shark-test, k8shark-jobs]
+    namespaces: ["*"]
     interval: 10s
 
   # ── Controllers ──────────────────────────────────────────────────────────────
@@ -38,19 +38,19 @@ resources:
   - group: apps
     version: v1
     resource: deployments
-    namespaces: [default, k8shark-test, k8shark-jobs]
+    namespaces: ["*"]
     interval: 30s
 
   - group: apps
     version: v1
     resource: daemonsets
-    namespaces: [default, kube-system, k8shark-test, k8shark-jobs]
+    namespaces: ["*"]
     interval: 60s
 
   - group: apps
     version: v1
     resource: statefulsets
-    namespaces: [default, k8shark-test, k8shark-jobs]
+    namespaces: ["*"]
     interval: 30s
 
   # ── Jobs ─────────────────────────────────────────────────────────────────────
@@ -58,7 +58,7 @@ resources:
   - group: batch
     version: v1
     resource: jobs
-    namespaces: [default, k8shark-test, k8shark-jobs]
+    namespaces: ["*"]
     interval: 30s
 
   # ── Networking ───────────────────────────────────────────────────────────────
@@ -66,7 +66,7 @@ resources:
   - group: ""
     version: v1
     resource: services
-    namespaces: [default, k8shark-test, k8shark-jobs]
+    namespaces: ["*"]
     interval: 60s
 
   # ── Storage ──────────────────────────────────────────────────────────────────
@@ -74,7 +74,7 @@ resources:
   - group: ""
     version: v1
     resource: persistentvolumeclaims
-    namespaces: [default, k8shark-test, k8shark-jobs]
+    namespaces: ["*"]
     interval: 30s
 
   - group: ""

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -113,6 +114,11 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 				return nil, err
 			}
 		}
+	}
+
+	// Expand wildcard namespaces before polling begins.
+	if err := e.expandWildcardNamespaces(ctx); err != nil {
+		return nil, err
 	}
 
 	// Collect server version for metadata.
@@ -488,4 +494,98 @@ func (e *Engine) fetchOnePodLog(ctx context.Context, namespace, podName string, 
 	e.index[logPath].RecordIDs = append(e.index[logPath].RecordIDs, rec.ID)
 	e.index[logPath].Times = append(e.index[logPath].Times, rec.CapturedAt)
 	e.mu.Unlock()
+}
+
+// expandWildcardNamespaces replaces "*" in any resource's Namespaces list with
+// the full list of namespaces discovered from the source cluster. If no
+// resource mentions "*" the method is a no-op. Expansion happens once before
+// polling begins; namespaces created during the capture are not included.
+//
+// Cluster-scoped resources with "*" emit a warning and fall back to a
+// cluster-scoped (no namespace) fetch.
+func (e *Engine) expandWildcardNamespaces(ctx context.Context) error {
+	// Fast path: check whether any resource actually uses "*".
+	needsExpansion := false
+	for _, r := range e.cfg.Resources {
+		for _, ns := range r.Namespaces {
+			if ns == "*" {
+				needsExpansion = true
+				break
+			}
+		}
+		if needsExpansion {
+			break
+		}
+	}
+	if !needsExpansion {
+		return nil
+	}
+
+	// Fetch the namespace list from the cluster.
+	nsBody, code := e.doFetch(ctx, "/api/v1/namespaces", "")
+	if code != http.StatusOK || nsBody == nil {
+		return fmt.Errorf("namespace discovery failed (HTTP %d): check cluster permissions", code)
+	}
+	var nsList struct {
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(nsBody, &nsList); err != nil {
+		return fmt.Errorf("parsing namespace list: %w", err)
+	}
+	allNS := make([]string, 0, len(nsList.Items))
+	for _, item := range nsList.Items {
+		allNS = append(allNS, item.Metadata.Name)
+	}
+
+	// Expand each resource entry that contains "*".
+	for i := range e.cfg.Resources {
+		r := &e.cfg.Resources[i]
+		hasWildcard := false
+		for _, ns := range r.Namespaces {
+			if ns == "*" {
+				hasWildcard = true
+				break
+			}
+		}
+		if !hasWildcard {
+			continue
+		}
+
+		if config.IsClusterScoped(r.Resource) {
+			fmt.Fprintf(os.Stderr,
+				"  [warn] %s: cluster-scoped resource with namespaces: [\"*\"] — ignoring namespaces\n",
+				r.Resource)
+			r.Namespaces = nil
+			continue
+		}
+
+		// Build expanded list: explicit (non-wildcard) namespaces first, then
+		// all discovered, deduplicated while preserving order.
+		seen := make(map[string]bool)
+		expanded := make([]string, 0, len(allNS))
+		for _, ns := range r.Namespaces {
+			if ns != "*" && !seen[ns] {
+				seen[ns] = true
+				expanded = append(expanded, ns)
+			}
+		}
+		for _, ns := range allNS {
+			if !seen[ns] {
+				seen[ns] = true
+				expanded = append(expanded, ns)
+			}
+		}
+		r.Namespaces = expanded
+
+		if e.verbose {
+			fmt.Fprintf(os.Stdout,
+				"  [info] %s: expanded '*' to %d namespaces: %s\n",
+				r.Resource, len(expanded), strings.Join(expanded, ", "))
+		}
+	}
+	return nil
 }

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -271,3 +271,197 @@ func TestEngine_NDJSONOutput(t *testing.T) {
 		}
 	}
 }
+
+// ── Wildcard namespace expansion tests ──────────────────────────────────────
+
+func nsList(namespaces ...string) string {
+	items := make([]string, 0, len(namespaces))
+	for _, ns := range namespaces {
+		items = append(items, fmt.Sprintf(`{"metadata":{"name":%q}}`, ns))
+	}
+	return `{"kind":"NamespaceList","items":[` + strings.Join(items, ",") + `]}`
+}
+
+func wildcardServer(t *testing.T, discoveredNS []string, reqPaths chan<- string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if reqPaths != nil {
+			select {
+			case reqPaths <- r.URL.Path:
+			default:
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+		case "/api/v1/namespaces":
+			fmt.Fprint(w, nsList(discoveredNS...))
+		default:
+			// Return a minimal list for any resource path so engine doesn't warn.
+			fmt.Fprintf(w, `{"kind":"List","items":[]}`)
+		}
+	}))
+	return srv
+}
+
+func TestExpandWildcard_NoWildcard(t *testing.T) {
+	paths := make(chan string, 100)
+	srv := wildcardServer(t, []string{"default", "kube-system"}, paths)
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw: "500ms",
+		Duration:    500 * time.Millisecond,
+		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Resources: []config.Resource{
+			{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	// /api/v1/namespaces (discovery) must NOT have been called.
+	close(paths)
+	for p := range paths {
+		if p == "/api/v1/namespaces" {
+			t.Error("namespace discovery endpoint was called even though no '*' was configured")
+		}
+	}
+
+	// Namespaces must be unchanged.
+	if got := cfg.Resources[0].Namespaces; len(got) != 1 || got[0] != "default" {
+		t.Errorf("expected namespaces unchanged, got %v", got)
+	}
+}
+
+func TestExpandWildcard_AllNamespaces(t *testing.T) {
+	discovered := []string{"default", "kube-system", "production"}
+	srv := wildcardServer(t, discovered, nil)
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw: "500ms",
+		Duration:    500 * time.Millisecond,
+		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Resources: []config.Resource{
+			{Version: "v1", Resource: "pods", Namespaces: []string{"*"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	got := cfg.Resources[0].Namespaces
+	if len(got) != len(discovered) {
+		t.Fatalf("expected %d namespaces after expansion, got %d: %v", len(discovered), len(got), got)
+	}
+	for i, want := range discovered {
+		if got[i] != want {
+			t.Errorf("namespace[%d]: want %q, got %q", i, want, got[i])
+		}
+	}
+}
+
+func TestExpandWildcard_Mixed(t *testing.T) {
+	discovered := []string{"default", "kube-system", "production"}
+	srv := wildcardServer(t, discovered, nil)
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw: "500ms",
+		Duration:    500 * time.Millisecond,
+		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Resources: []config.Resource{
+			// "production" explicit first, then wildcard — production must not be duplicated.
+			{Version: "v1", Resource: "pods", Namespaces: []string{"production", "*"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	got := cfg.Resources[0].Namespaces
+	// Expect: production (explicit), default, kube-system — no duplicate production.
+	wantLen := len(discovered) // 3 unique namespaces
+	if len(got) != wantLen {
+		t.Fatalf("expected %d namespaces (deduped), got %d: %v", wantLen, len(got), got)
+	}
+	if got[0] != "production" {
+		t.Errorf("expected 'production' first (explicit), got %q", got[0])
+	}
+	seen := make(map[string]bool)
+	for _, ns := range got {
+		if seen[ns] {
+			t.Errorf("duplicate namespace %q in expanded list %v", ns, got)
+		}
+		seen[ns] = true
+	}
+}
+
+func TestExpandWildcard_ClusterScoped(t *testing.T) {
+	srv := wildcardServer(t, []string{"default"}, nil)
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw: "500ms",
+		Duration:    500 * time.Millisecond,
+		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Resources: []config.Resource{
+			{Version: "v1", Resource: "nodes", Namespaces: []string{"*"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	// Namespaces must be cleared (cluster-scoped fetch).
+	if got := cfg.Resources[0].Namespaces; len(got) != 0 {
+		t.Errorf("expected nil/empty Namespaces for cluster-scoped resource, got %v", got)
+	}
+}
+
+func TestExpandWildcard_DiscoveryFailure(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/namespaces" {
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprint(w, `{"kind":"Status","code":403}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+	}))
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw: "500ms",
+		Duration:    500 * time.Millisecond,
+		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Resources: []config.Resource{
+			{Version: "v1", Resource: "pods", Namespaces: []string{"*"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	_, err := eng.Run()
+	if err == nil {
+		t.Fatal("expected error from discovery failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "namespace discovery failed") {
+		t.Errorf("expected 'namespace discovery failed' in error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #18

Adds support for `namespaces: ["*"]` in capture configs. At runtime the engine expands `*` to the full list of namespaces on the cluster before polling begins.

## Changes

- **`internal/capture/engine.go`** — added `expandWildcardNamespaces()` method called at the start of `Run()`; fetches `/api/v1/namespaces`, replaces `*` entries with the concrete list, deduplicates, and warns on cluster-scoped resources
- **`internal/config/config.go`** — added `IsClusterScoped()` and `knownClusterScoped` map
- **`internal/capture/engine_test.go`** — 5 new tests: no-wildcard passthrough, all-namespaces expansion, mixed explicit+wildcard, cluster-scoped warning, discovery failure
- **`docs/config.md`** — added "Wildcard namespaces" subsection
- **`examples/k8shark.yaml`** — updated to use `["*"]`