### PR TITLE
feat(capture): streaming record sink; NDJSON stdout mode (#13)

### DIFF
--- a/docs/archive-format.md
+++ b/docs/archive-format.md
@@ -145,3 +145,19 @@ and types, but all values will be `REDACTED`.
 ```sh
 kshrk redact --in capture.tar.gz --out capture-redacted.tar.gz
 ```
+
+## Streaming mode (NDJSON stdout)
+
+When `output: "-"` is set in the configuration (or `--output -` on the command line), k8shark writes records to stdout in **newline-delimited JSON (NDJSON)** format instead of writing a `.tar.gz` file. Each line is a complete JSON record object identical to the individual record files described above.
+
+```sh
+kshrk capture --config capture.yaml --output - | jq 'select(.api_path == "/api/v1/namespaces/default/pods")'
+```
+
+No `metadata.json` or `index.json` is written in streaming mode — only the raw record stream. Pipe to a file or processing tool:
+
+```sh
+kshrk capture --config capture.yaml --output - > records.ndjson
+```
+
+In streaming mode, SIGTERM or SIGINT causes the engine to stop polling and flush all in-flight records before exiting. Every line in the stream is a complete JSON object.

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -8,7 +8,121 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 )
+
+// RecordSink accepts individual capture records as they arrive.
+// It decouples the engine from the specific output format (tar.gz vs NDJSON).
+type RecordSink interface {
+	WriteRecord(rec any) error
+	Finish(meta, index any) error
+	RecordCount() int
+}
+
+// StreamWriter streams each record directly into a .tar.gz archive as it
+// arrives. metadata.json and index.json are written by Finish(). Thread-safe.
+type StreamWriter struct {
+	mu sync.Mutex
+	f  *os.File
+	gw *gzip.Writer
+	tw *tar.Writer
+	n  int
+}
+
+// NewStreamWriter creates a new StreamWriter writing to outputPath.
+func NewStreamWriter(outputPath string) (*StreamWriter, error) {
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return nil, fmt.Errorf("creating output file %q: %w", outputPath, err)
+	}
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	return &StreamWriter{f: f, gw: gw, tw: tw}, nil
+}
+
+// WriteRecord marshals rec to JSON and appends it to the tar archive.
+func (w *StreamWriter) WriteRecord(rec any) error {
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("marshalling record: %w", err)
+	}
+	var idHolder struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(data, &idHolder); err != nil || idHolder.ID == "" {
+		return fmt.Errorf("record missing id field")
+	}
+	path := filepath.Join("k8shark-capture", "records", idHolder.ID+".json")
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if err := writeBytesToTar(w.tw, path, data); err != nil {
+		return err
+	}
+	w.n++
+	return nil
+}
+
+// Finish writes metadata.json and index.json then closes the archive.
+func (w *StreamWriter) Finish(meta, index any) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if err := writeJSON(w.tw, "k8shark-capture/metadata.json", meta); err != nil {
+		return err
+	}
+	if err := writeJSON(w.tw, "k8shark-capture/index.json", index); err != nil {
+		return err
+	}
+	if err := w.tw.Close(); err != nil {
+		return fmt.Errorf("closing tar: %w", err)
+	}
+	if err := w.gw.Close(); err != nil {
+		return fmt.Errorf("closing gzip: %w", err)
+	}
+	return w.f.Close()
+}
+
+// RecordCount returns the number of records written so far.
+func (w *StreamWriter) RecordCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.n
+}
+
+// NDJSONWriter writes each record as a newline-delimited JSON object to an
+// io.Writer (typically os.Stdout). Finish is a no-op. Thread-safe.
+type NDJSONWriter struct {
+	mu  sync.Mutex
+	w   io.Writer
+	enc *json.Encoder
+	n   int
+}
+
+// NewNDJSONWriter creates an NDJSONWriter writing to w.
+func NewNDJSONWriter(w io.Writer) *NDJSONWriter {
+	return &NDJSONWriter{w: w, enc: json.NewEncoder(w)}
+}
+
+// WriteRecord encodes rec as a single JSON line.
+func (w *NDJSONWriter) WriteRecord(rec any) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if err := w.enc.Encode(rec); err != nil {
+		return err
+	}
+	w.n++
+	return nil
+}
+
+// Finish is a no-op for NDJSONWriter.
+func (w *NDJSONWriter) Finish(_, _ any) error { return nil }
+
+// RecordCount returns the number of records written so far.
+func (w *NDJSONWriter) RecordCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.n
+}
 
 // Writable is anything that can provide records, index, and metadata for writing.
 // We use concrete types from capture to avoid circular imports by defining them as

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -33,8 +35,8 @@ type Engine struct {
 	httpClient *http.Client
 	baseURL    string
 	mu         sync.Mutex
-	records    []*Record
 	index      Index
+	sink       archive.RecordSink // set by Run(); exposed for tests
 }
 
 // NewEngine creates a capture Engine from validated config.
@@ -86,6 +88,33 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), e.cfg.Duration)
 	defer cancel()
 
+	// Install SIGTERM/SIGINT handler so the capture can be wound down gracefully:
+	// the context is cancelled, polling stops, and Finish() still writes a valid
+	// (partial) archive.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
+	go func() {
+		select {
+		case <-sigCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	// Create the record sink (only if not pre-set by tests).
+	var err error
+	if e.sink == nil {
+		if e.cfg.Output == "-" {
+			e.sink = archive.NewNDJSONWriter(os.Stdout)
+		} else {
+			e.sink, err = archive.NewStreamWriter(e.cfg.Output)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	// Collect server version for metadata.
 	kVersion, serverAddr := e.fetchServerVersion(ctx)
 
@@ -119,26 +148,28 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 		CapturedUntil:     time.Now().UTC(),
 		KubernetesVersion: kVersion,
 		ServerAddress:     serverAddr,
-		RecordCount:       len(e.records),
+		RecordCount:       e.sink.RecordCount(),
 	}
 
 	if e.verbose {
-		fmt.Fprintf(os.Stdout, "  captured %d records\n", len(e.records))
+		fmt.Fprintf(os.Stdout, "  captured %d records\n", e.sink.RecordCount())
 	}
 
-	if err := archive.Write(e.cfg.Output, meta, e.records, e.index); err != nil {
+	if err := e.sink.Finish(meta, e.index); err != nil {
 		return nil, err
 	}
 
 	var outputSize int64
-	if fi, err := os.Stat(e.cfg.Output); err == nil {
-		outputSize = fi.Size()
+	if e.cfg.Output != "-" {
+		if fi, err := os.Stat(e.cfg.Output); err == nil {
+			outputSize = fi.Size()
+		}
 	}
 
 	return &CaptureSummary{
 		OutputPath:    e.cfg.Output,
 		OutputSize:    outputSize,
-		RecordCount:   len(e.records),
+		RecordCount:   e.sink.RecordCount(),
 		ResourceCount: len(e.index),
 		Duration:      time.Since(start).Truncate(time.Second),
 	}, nil
@@ -311,8 +342,14 @@ func (e *Engine) doFetch(ctx context.Context, apiPath, tableKeySuffix string) ([
 		ResponseBody: json.RawMessage(body),
 	}
 
+	// Stream the record to the sink immediately — no in-memory buffer.
+	if e.sink != nil {
+		if err := e.sink.WriteRecord(rec); err != nil && e.verbose {
+			fmt.Fprintf(os.Stderr, "  [warn] writing record %s: %v\n", indexKey, err)
+		}
+	}
+
 	e.mu.Lock()
-	e.records = append(e.records, rec)
 	if _, ok := e.index[indexKey]; !ok {
 		e.index[indexKey] = &IndexEntry{APIPath: indexKey}
 	}
@@ -439,8 +476,12 @@ func (e *Engine) fetchOnePodLog(ctx context.Context, namespace, podName string, 
 		ResponseCode: http.StatusOK,
 		ResponseBody: json.RawMessage(jsonBody),
 	}
+	if e.sink != nil {
+		if err := e.sink.WriteRecord(rec); err != nil && e.verbose {
+			fmt.Fprintf(os.Stderr, "  [warn] writing log record %s: %v\n", logPath, err)
+		}
+	}
 	e.mu.Lock()
-	e.records = append(e.records, rec)
 	if _, ok := e.index[logPath]; !ok {
 		e.index[logPath] = &IndexEntry{APIPath: logPath}
 	}

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -1,6 +1,7 @@
 package capture
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -8,11 +9,36 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/config"
 )
+
+// sliceSink is a test RecordSink that accumulates records in memory.
+type sliceSink struct {
+	mu      sync.Mutex
+	records []*Record
+}
+
+func (s *sliceSink) WriteRecord(rec any) error {
+	r, ok := rec.(*Record)
+	if !ok {
+		return nil
+	}
+	s.mu.Lock()
+	s.records = append(s.records, r)
+	s.mu.Unlock()
+	return nil
+}
+func (s *sliceSink) Finish(_, _ any) error { return nil }
+func (s *sliceSink) RecordCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.records)
+}
 
 // fakeK8sServer returns an httptest.TLSServer that responds to the paths used by
 // a minimal capture config (pods in default, nodes cluster-scoped).
@@ -69,27 +95,21 @@ func TestEngine_CaptureToArchive(t *testing.T) {
 		t.Fatal("output archive is empty")
 	}
 
-	// Must have captured at least one record per resource.
-	if len(eng.records) == 0 {
-		t.Fatal("no records captured")
+	// Extract the archive and verify its contents.
+	extractDir := t.TempDir()
+	if err := archive.Open(outFile, extractDir); err != nil {
+		t.Fatalf("failed to open archive: %v", err)
 	}
-	// Verify at least one pod record exists.
-	foundPod := false
-	for _, rec := range eng.records {
-		if rec.APIPath == "/api/v1/namespaces/default/pods" && rec.ResponseCode == 200 {
-			var podList map[string]any
-			if err := json.Unmarshal(rec.ResponseBody, &podList); err != nil {
-				t.Errorf("pod response not valid JSON: %v", err)
-			}
-			if podList["kind"] != "PodList" {
-				t.Errorf("expected kind=PodList, got %v", podList["kind"])
-			}
-			foundPod = true
-		}
+
+	// metadata.json must exist.
+	if _, err := os.Stat(filepath.Join(extractDir, "k8shark-capture", "metadata.json")); err != nil {
+		t.Error("metadata.json missing from archive")
 	}
-	if !foundPod {
-		t.Error("no pod records found in capture")
+	// index.json must exist.
+	if _, err := os.Stat(filepath.Join(extractDir, "k8shark-capture", "index.json")); err != nil {
+		t.Error("index.json missing from archive")
 	}
+
 	// Verify index contains the captured paths.
 	if _, ok := eng.index["/api/v1/namespaces/default/pods"]; !ok {
 		t.Error("pod path missing from index")
@@ -141,6 +161,8 @@ func TestEngine_FetchPodsLogs(t *testing.T) {
 	}
 
 	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	ss := &sliceSink{}
+	eng.sink = ss
 	if _, err := eng.Run(); err != nil {
 		t.Fatalf("engine.Run() error: %v", err)
 	}
@@ -156,7 +178,7 @@ func TestEngine_FetchPodsLogs(t *testing.T) {
 	}
 
 	// Log records must be stored as JSON strings encoding the plain-text body.
-	for _, rec := range eng.records {
+	for _, rec := range ss.records {
 		if rec.APIPath != nginxLogPath && rec.APIPath != redisLogPath {
 			continue
 		}
@@ -215,5 +237,37 @@ func TestEngine_NoLogsWhenDisabled(t *testing.T) {
 	}
 	if logCalled {
 		t.Error("log endpoint was called even though Logs=0")
+	}
+}
+
+func TestEngine_NDJSONOutput(t *testing.T) {
+	srv := fakeK8sServer(t)
+	defer srv.Close()
+
+	cfg := &config.Config{
+		DurationRaw: "500ms",
+		Duration:    500 * time.Millisecond,
+		Output:      "-",
+		Resources: []config.Resource{
+			{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+		},
+	}
+
+	var buf bytes.Buffer
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	eng.sink = archive.NewNDJSONWriter(&buf)
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	output := strings.TrimSpace(buf.String())
+	if output == "" {
+		t.Fatal("expected NDJSON output, got empty buffer")
+	}
+	for i, line := range strings.Split(output, "\n") {
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			t.Errorf("line %d is not valid JSON: %v\nline: %s", i, err, line)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #13

Replaces the in-memory `records` slice with a `RecordSink` interface that receives records as they arrive. Archives are written incrementally to disk (no full in-memory buffer). Passing `output: "-"` writes newline-delimited JSON to stdout instead.

## Changes

- **`internal/archive/archive.go`** — added `RecordSink` interface, `StreamWriter` (streaming tar.gz, thread-safe), and `NDJSONWriter` (JSON lines to any `io.Writer`)
- **`internal/capture/engine.go`** — removed `records []*Record` field; added `sink archive.RecordSink`; `Run()` creates the appropriate sink based on `cfg.Output`; added SIGTERM/SIGINT handler that cancels the context and completes the archive gracefully
- **`internal/capture/engine_test.go`** — added `sliceSink` test helper; updated existing tests to use sink injection; added `TestEngine_NDJSONOutput`
- **`docs/archive-format.md`** — added "Streaming mode (NDJSON stdout)" section

## Design notes

- `if e.sink == nil` guard in `Run()` allows tests to pre-inject a sink without it being overwritten
- On SIGTERM: context is cancelled → polls drain via `ctx.Done()` → `wg.Wait()` → `sink.Finish()` writes `metadata.json` + `index.json` → valid partial archive
- `StreamWriter` holds the tar/gzip writers open and appends each record as an individual tar entry immediately; `Finish()` writes the two manifest files and closes all writers