### PR TITLE
feat(bench): add benchmarks and CI tracking with GitHub Pages

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,39 @@
+name: bench
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Tidy
+        run: go mod tidy
+
+      - name: Run benchmarks
+        run: go test -bench=. -benchmem -run=^$ -count=5 ./... | tee bench-output.txt
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: k8shark benchmarks
+          tool: go
+          output-file-path: bench-output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: benchmarks
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false
+          alert-comment-cc-users: '@phenixblue'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-race test-cover fmt lint e2e kind-up kind-down release-snapshot release-local clean help
+.PHONY: build test test-race test-cover bench fmt lint e2e kind-up kind-down release-snapshot release-local clean help
 
 BINARY  := kshrk
 VERSION ?= dev
@@ -17,6 +17,9 @@ test-race: ## Run unit tests with the race detector
 test-cover: ## Run unit tests and generate an HTML coverage report
 	go test -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out -o coverage.html
+
+bench: ## Run all benchmarks (use BENCH=<regexp> to filter)
+	go test -bench=${BENCH:-.} -benchmem -run=^$$ ./...
 
 fmt: ## Format Go source files
 	gofmt -w .

--- a/internal/archive/bench_test.go
+++ b/internal/archive/bench_test.go
@@ -1,0 +1,82 @@
+package archive
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+// sampleRecord is a minimal JSON object with an id field — the minimum
+// WriteRecord requires.
+func sampleRecord(i int) any {
+	return map[string]any{
+		"id":            fmt.Sprintf("record-%04d", i),
+		"captured_at":   "2026-04-10T10:00:00Z",
+		"api_path":      "/api/v1/namespaces/default/pods",
+		"http_method":   "GET",
+		"response_code": 200,
+		"response_body": map[string]any{
+			"kind":       "PodList",
+			"apiVersion": "v1",
+			"items":      []any{},
+		},
+	}
+}
+
+// BenchmarkStreamWriter_WriteRecord measures throughput of writing individual
+// records to a streaming tar.gz archive.
+func BenchmarkStreamWriter_WriteRecord(b *testing.B) {
+	dir := b.TempDir()
+	w, err := NewStreamWriter(dir + "/capture.tar.gz")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := w.WriteRecord(sampleRecord(i)); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	_ = w.Finish(nil, nil)
+}
+
+// BenchmarkStreamWriter_RoundTrip measures the full write→finish→open cycle
+// for archives of increasing record counts.
+func BenchmarkStreamWriter_RoundTrip(b *testing.B) {
+	for _, n := range []int{10, 100, 500} {
+		n := n
+		b.Run(fmt.Sprintf("%d_records", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				dir := b.TempDir()
+				path := dir + "/capture.tar.gz"
+				w, err := NewStreamWriter(path)
+				if err != nil {
+					b.Fatal(err)
+				}
+				for j := 0; j < n; j++ {
+					if err := w.WriteRecord(sampleRecord(j)); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if err := w.Finish(map[string]any{"capture_id": "bench"}, map[string]any{}); err != nil {
+					b.Fatal(err)
+				}
+				if err := Open(path, b.TempDir()); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkNDJSONWriter_WriteRecord measures throughput of NDJSON output.
+func BenchmarkNDJSONWriter_WriteRecord(b *testing.B) {
+	w := NewNDJSONWriter(&bytes.Buffer{})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := w.WriteRecord(sampleRecord(i)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/capture/bench_test.go
+++ b/internal/capture/bench_test.go
@@ -1,0 +1,89 @@
+package capture
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/config"
+)
+
+// fakeCaptureServer returns a TLS server with realistic responses for
+// benchmark use. It serves pods, nodes, and a /version endpoint.
+func fakeCaptureServer(b *testing.B) *httptest.Server {
+	b.Helper()
+	podList := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[` +
+		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"nginx","namespace":"default"}},` +
+		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"redis","namespace":"default"}}]}`
+	nodeList := `{"apiVersion":"v1","kind":"NodeList","metadata":{},"items":[` +
+		`{"apiVersion":"v1","kind":"Node","metadata":{"name":"node1"}},` +
+		`{"apiVersion":"v1","kind":"Node","metadata":{"name":"node2"}}]}`
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+		case "/api/v1/namespaces/default/pods":
+			fmt.Fprint(w, podList)
+		case "/api/v1/nodes":
+			fmt.Fprint(w, nodeList)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"kind":"Status","code":404}`)
+		}
+	}))
+	return srv
+}
+
+// BenchmarkEngine_CaptureToArchive measures a full capture run writing to a
+// tar.gz archive.
+func BenchmarkEngine_CaptureToArchive(b *testing.B) {
+	srv := fakeCaptureServer(b)
+	defer srv.Close()
+
+	for i := 0; i < b.N; i++ {
+		cfg := &config.Config{
+			DurationRaw: "500ms",
+			Duration:    500 * time.Millisecond,
+			Output:      filepath.Join(b.TempDir(), "capture.tar.gz"),
+			Resources: []config.Resource{
+				{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+				{Version: "v1", Resource: "nodes", IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+			},
+		}
+		eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+		if _, err := eng.Run(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkEngine_CaptureToNDJSON measures a full capture run writing to NDJSON
+// (no I/O bottleneck from gzip compression).
+func BenchmarkEngine_CaptureToNDJSON(b *testing.B) {
+	srv := fakeCaptureServer(b)
+	defer srv.Close()
+
+	for i := 0; i < b.N; i++ {
+		cfg := &config.Config{
+			DurationRaw: "500ms",
+			Duration:    500 * time.Millisecond,
+			Output:      "-",
+			Resources: []config.Resource{
+				{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+				{Version: "v1", Resource: "nodes", IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+			},
+		}
+		eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+		eng.sink = archive.NewNDJSONWriter(&bytes.Buffer{})
+		if _, err := eng.Run(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/server/bench_test.go
+++ b/internal/server/bench_test.go
@@ -1,0 +1,132 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	capture "github.com/phenixblue/k8shark/internal/capture"
+)
+
+// buildBenchStore builds a CaptureStore with n pod list records for
+// benchmarking. It bypasses buildTestStore because that helper only accepts
+// *testing.T.
+func buildBenchStore(b *testing.B, n int) *CaptureStore {
+	b.Helper()
+	dir := b.TempDir()
+	recDir := filepath.Join(dir, "k8shark-capture", "records")
+	if err := os.MkdirAll(recDir, 0o750); err != nil {
+		b.Fatal(err)
+	}
+
+	index := make(capture.Index)
+	for i := 0; i < n; i++ {
+		apiPath := fmt.Sprintf("/api/v1/namespaces/ns%d/pods", i)
+		body := json.RawMessage(fmt.Sprintf(
+			`{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"pod%d","namespace":"ns%d"}}]}`,
+			i, i))
+		recID := fmt.Sprintf("bench-rec-%04d", i)
+		rec := capture.Record{
+			ID:           recID,
+			CapturedAt:   time.Now().UTC(),
+			APIPath:      apiPath,
+			HTTPMethod:   "GET",
+			ResponseCode: 200,
+			ResponseBody: body,
+		}
+		data, _ := json.Marshal(rec)
+		if err := os.WriteFile(filepath.Join(recDir, recID+".json"), data, 0o644); err != nil {
+			b.Fatal(err)
+		}
+		index[apiPath] = &capture.IndexEntry{
+			APIPath:   apiPath,
+			RecordIDs: []string{recID},
+			Times:     []time.Time{rec.CapturedAt},
+		}
+	}
+
+	metaJSON, _ := json.Marshal(capture.CaptureMetadata{
+		CaptureID:         "bench-capture",
+		KubernetesVersion: "v1.29.0",
+		CapturedAt:        time.Now().UTC().Add(-time.Minute),
+		CapturedUntil:     time.Now().UTC(),
+		RecordCount:       n,
+	})
+	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "metadata.json"), metaJSON, 0o644); err != nil {
+		b.Fatal(err)
+	}
+	idxJSON, _ := json.Marshal(index)
+	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "index.json"), idxJSON, 0o644); err != nil {
+		b.Fatal(err)
+	}
+
+	store, err := LoadStore(dir)
+	if err != nil {
+		b.Fatalf("LoadStore: %v", err)
+	}
+	return store
+}
+
+// BenchmarkHandler_GetList measures handler latency for a list request
+// served from the in-memory store.
+func BenchmarkHandler_GetList(b *testing.B) {
+	store := buildBenchStore(b, 1)
+	h := newHandler(store, time.Time{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/ns0/pods", nil)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+		if rw.Code != http.StatusOK {
+			b.Fatalf("unexpected status %d", rw.Code)
+		}
+	}
+}
+
+// BenchmarkHandler_GetList_LargeStore measures list request latency when the
+// store holds many distinct paths (simulates a large capture).
+func BenchmarkHandler_GetList_LargeStore(b *testing.B) {
+	for _, size := range []int{10, 100, 500} {
+		size := size
+		b.Run(fmt.Sprintf("store_%d_paths", size), func(b *testing.B) {
+			store := buildBenchStore(b, size)
+			h := newHandler(store, time.Time{}, false)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/ns0/pods", nil)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				rw := httptest.NewRecorder()
+				h.ServeHTTP(rw, req)
+			}
+		})
+	}
+}
+
+// BenchmarkHandler_GetVersion measures the fast-path /version handler.
+func BenchmarkHandler_GetVersion(b *testing.B) {
+	store := buildBenchStore(b, 1)
+	h := newHandler(store, time.Time{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/version", nil)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+	}
+}
+
+// BenchmarkHandler_NotFound measures handler latency when the path is absent
+// from the store — exercises the full routing path without a store hit.
+func BenchmarkHandler_NotFound(b *testing.B) {
+	store := buildBenchStore(b, 1)
+	h := newHandler(store, time.Time{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/missing/widgets", nil)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive benchmark suite across the core packages and a CI workflow that stores results over time on GitHub Pages.

## Changes

### Benchmark tests
- `internal/archive/bench_test.go` — `StreamWriter` write throughput, round-trip (10/100/500 records), `NDJSONWriter` write throughput
- `internal/capture/bench_test.go` — full `Engine` capture runs to archive and NDJSON
- `internal/server/bench_test.go` — handler request latency, store-size scaling (10/100/500 paths), fast-path handlers

### Makefile
- New `make bench` target (filterable via `BENCH=<regexp>`)

### CI
- `.github/workflows/bench.yml` — triggers only on `push: main`; runs benchmarks with `-count=5` and publishes results to `gh-pages` via `benchmark-action/github-action-benchmark@v1`

## GitHub Pages setup (post-merge)
After the first merge to main triggers the workflow and creates the `gh-pages` branch, enable Pages in **Settings → Pages → Source: Deploy from branch → `gh-pages`** to activate the benchmark chart dashboard.