### PR TITLE
feat: CRD auto-discovery, proxy 405, and client compat docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -243,3 +243,161 @@ Both `duration` and `interval` accept Go duration strings:
 | `90s` | 90 seconds |
 
 The first poll for each resource happens immediately when the capture starts; subsequent polls fire on the interval.
+
+---
+
+## Capturing CRD-backed resources
+
+Custom Resource Definitions (CRDs) — Istio, cert-manager, Flux, ArgoCD,
+Crossplane, Kyverno, etc. — are captured exactly like built-in resources. Use
+the `group`, `version`, and `resource` fields from `kubectl api-resources`.
+
+### Finding group / version / resource values
+
+```bash
+kubectl api-resources --api-group=networking.istio.io
+# NAME              SHORTNAMES   APIVERSION                         NAMESPACED
+# destinationrules  dr           networking.istio.io/v1beta1        true
+# gateways          gw           networking.istio.io/v1beta1        true
+# virtualservices   vs           networking.istio.io/v1beta1        true
+```
+
+### Explicit CRD entries
+
+```yaml
+duration: 10m
+output: ./istio-capture.tar.gz
+
+resources:
+  - group: ""
+    version: v1
+    resource: pods
+    namespaces: ["*"]
+    interval: 30s
+
+  # Istio networking
+  - group: networking.istio.io
+    version: v1beta1
+    resource: virtualservices
+    namespaces: ["*"]
+    interval: 30s
+
+  - group: networking.istio.io
+    version: v1beta1
+    resource: destinationrules
+    namespaces: ["*"]
+    interval: 30s
+
+  - group: networking.istio.io
+    version: v1beta1
+    resource: gateways
+    namespaces: ["*"]
+    interval: 30s
+
+  # cert-manager — cluster-scoped CRD (no namespaces:)
+  - group: cert-manager.io
+    version: v1
+    resource: clusterissuers
+    interval: 60s
+
+  # cert-manager — namespaced CRD
+  - group: cert-manager.io
+    version: v1
+    resource: certificates
+    namespaces: ["*"]
+    interval: 60s
+```
+
+> **Tip**: `kshrk validate --config <file>` warns when a non-core resource has
+> `namespaces:` set for what might be a cluster-scoped CRD (e.g. `ClusterIssuer`).
+> Remove `namespaces:` from those entries.
+
+### Auto-discovery (capture all installed CRDs automatically)
+
+Instead of enumerating every CRD in the config, set `auto_discover: true` to
+have k8shark walk the cluster's `/apis` endpoint at capture time and
+automatically add every non-core resource type it finds.
+
+```yaml
+duration: 10m
+output: ./full-capture.tar.gz
+auto_discover: true
+
+# Explicit entries are still captured and take precedence over auto-discovered
+# duplicates.  You can combine the two approaches.
+resources:
+  - group: ""
+    version: v1
+    resource: pods
+    namespaces: ["*"]
+    interval: 30s
+    logs: 100
+
+  - group: ""
+    version: v1
+    resource: nodes
+    interval: 60s
+```
+
+**Auto-discovery behaviour:**
+- Walks `/apis` once at the start of the capture.
+- For each discovered non-core group-version, reads the resource list and adds
+  an entry for every non-sub-resource type.
+- Namespaced resources automatically use `namespaces: ["*"]` (wildcard
+  expansion applies).
+- Cluster-scoped resources are captured without a namespace.
+- The following system groups are excluded by default:
+
+  | Group | Reason |
+  |-------|--------|
+  | `metrics.k8s.io` | Live-only metrics, not persistent state |
+  | `apiregistration.k8s.io` | API aggregation layer internals |
+  | `apiextensions.k8s.io` | CRD definitions themselves (not instances) |
+  | `authentication.k8s.io` | Token review — live-only |
+  | `authorization.k8s.io` | Access review — live-only |
+
+- Add your own exclusions with `auto_discover_exclude_groups`:
+
+```yaml
+auto_discover: true
+auto_discover_exclude_groups:
+  - metrics.k8s.io
+  - my-internal.company.io
+```
+
+### Ecosystem-specific examples
+
+#### Flux CD
+
+```yaml
+auto_discover: true
+auto_discover_exclude_groups:
+  - metrics.k8s.io
+
+resources:
+  - group: ""
+    version: v1
+    resource: pods
+    namespaces: ["*"]
+    interval: 30s
+```
+
+Flux CRDs (`kustomizations.kustomize.toolkit.fluxcd.io`,
+`helmreleases.helm.toolkit.fluxcd.io`, etc.) will be picked up automatically
+by `auto_discover: true`.
+
+#### ArgoCD
+
+```yaml
+auto_discover: true
+
+resources:
+  - group: ""
+    version: v1
+    resource: pods
+    namespaces: [argocd]
+    interval: 30s
+```
+
+ArgoCD CRDs (`applications.argoproj.io`, `appprojects.argoproj.io`) are
+captured automatically via `auto_discover`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -323,3 +323,82 @@ Warning: persistentvolumeclaims not found in capture; was it included in the cap
 ```
 
 This is intentional — it avoids confusing `Error from server:` output for resources that simply weren't captured.
+
+---
+
+## Client compatibility
+
+The k8shark mock API server is designed to work with any read-only Kubernetes
+client, not just `kubectl`. This section documents what is supported, what
+requires special capture config, and what is intentionally unsupported.
+
+### Works out of the box
+
+These operations work against any k8shark archive with no special config:
+
+| Client / Command | Notes |
+|-----------------|-------|
+| `kubectl get`, `kubectl describe` | Full support |
+| `kubectl logs` | Requires `logs: N` in capture config — see above |
+| `kubectl api-resources` | Synthesised from index if discovery wasn't captured |
+| `kubectl explain` | Works if OpenAPI spec was captured (always attempted) |
+| `kubectl get --watch` | Synthetic watch stream; emits ADDED + BOOKMARK |
+| `helm list`, `helm status` | Reads Secrets for release state — works if captured |
+| `k9s` (read-only browsing) | Full support — API discovery + resource listing |
+
+### Requires CRD resources to be captured
+
+These tools or commands require CRD-backed resources to be present in the
+archive. Use `auto_discover: true` or explicit config entries (see
+[Capturing CRD-backed resources](config.md#capturing-crd-backed-resources)).
+
+| Client / Command | Required resources |
+|-----------------|--------------------|
+| `istioctl analyze` | `networking.istio.io`, `security.istio.io` CRDs |
+| `istioctl describe pod` | pods, services, VirtualServices, DestinationRules |
+| `istioctl x precheck` | Resource lists + RBAC resources |
+| `argocd app get` | `applications.argoproj.io`, `appprojects.argoproj.io` |
+| `flux get all` | Flux toolkit CRDs (`kustomize.toolkit.fluxcd.io`, etc.) |
+
+### Intentionally unsupported (always 405)
+
+These operations require a live cluster and cannot be replayed from a snapshot.
+The server returns `405 Method Not Allowed` with a clear message rather than
+hanging or returning a confusing error.
+
+| Operation | Why unsupported |
+|-----------|----------------|
+| `kubectl exec` / `kubectl cp` | Requires a running container |
+| `kubectl port-forward` | Requires a running pod |
+| `kubectl attach` | Requires a running container |
+| Pod/service proxy (`/proxy/`) | Requires a running in-cluster service |
+| `istioctl proxy-status` | Requires gRPC connection to Istiod |
+| Istiod xDS / gRPC endpoints | Out of scope for a replay server |
+| All write operations (POST/PUT/PATCH/DELETE) | Replay is read-only |
+
+### Using non-kubectl clients with kshrk open
+
+`kshrk open` writes a kubeconfig file (`kubectl config view`) that points at
+the mock server. Any tool that can be configured with a kubeconfig or a
+`--kubeconfig` flag will work:
+
+```sh
+# Start the mock server
+kshrk open capture.tar.gz
+# Note the printed kubeconfig path, e.g. /tmp/k8shark-kubeconfig-1234
+
+# Use with istioctl
+istioctl analyze --kubeconfig /tmp/k8shark-kubeconfig-1234
+
+# Use with helm
+helm list --kubeconfig /tmp/k8shark-kubeconfig-1234 --all-namespaces
+
+# Use with flux
+flux get all --kubeconfig /tmp/k8shark-kubeconfig-1234
+
+# Use with k9s
+k9s --kubeconfig /tmp/k8shark-kubeconfig-1234
+```
+
+> **Tip:** Export `KUBECONFIG=/tmp/k8shark-kubeconfig-1234` to make all tools
+> in your shell session use the mock server automatically.

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -31,13 +31,14 @@ type CaptureSummary struct {
 
 // Engine orchestrates the capture loop.
 type Engine struct {
-	cfg        *config.Config
-	verbose    bool
-	httpClient *http.Client
-	baseURL    string
-	mu         sync.Mutex
-	index      Index
-	sink       archive.RecordSink // set by Run(); exposed for tests
+	cfg            *config.Config
+	verbose        bool
+	httpClient     *http.Client
+	baseURL        string
+	mu             sync.Mutex
+	index          Index
+	sink           archive.RecordSink // set by Run(); exposed for tests
+	discoveryCache map[string][]byte  // bodies saved by fetchDiscovery for autoDiscoverResources
 }
 
 // NewEngine creates a capture Engine from validated config.
@@ -63,11 +64,12 @@ func NewEngine(cfg *config.Config, verbose bool) (*Engine, error) {
 	}
 
 	return &Engine{
-		cfg:        cfg,
-		verbose:    verbose,
-		httpClient: httpClient,
-		baseURL:    restCfg.Host,
-		index:      make(Index),
+		cfg:            cfg,
+		verbose:        verbose,
+		httpClient:     httpClient,
+		baseURL:        restCfg.Host,
+		index:          make(Index),
+		discoveryCache: make(map[string][]byte),
 	}, nil
 }
 
@@ -75,11 +77,12 @@ func NewEngine(cfg *config.Config, verbose bool) (*Engine, error) {
 // Used in tests to inject a fake API server.
 func newEngineWith(cfg *config.Config, client *http.Client, baseURL string, verbose bool) *Engine {
 	return &Engine{
-		cfg:        cfg,
-		verbose:    verbose,
-		httpClient: client,
-		baseURL:    baseURL,
-		index:      make(Index),
+		cfg:            cfg,
+		verbose:        verbose,
+		httpClient:     client,
+		baseURL:        baseURL,
+		index:          make(Index),
+		discoveryCache: make(map[string][]byte),
 	}
 }
 
@@ -126,6 +129,11 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 
 	// Capture API discovery endpoints so the mock server can replay them faithfully.
 	e.fetchDiscovery(ctx)
+
+	// Auto-discover CRD-backed and non-core resources from /apis if requested.
+	if e.cfg.AutoDiscover {
+		e.autoDiscoverResources(ctx)
+	}
 
 	var wg sync.WaitGroup
 	for _, res := range e.cfg.Resources {
@@ -236,14 +244,141 @@ func (e *Engine) fetchResource(ctx context.Context, res config.Resource) {
 	}
 }
 
+// defaultAutoDiscoverExcludeGroups are API groups that produce no useful
+// captures (internal machinery, aggregated metrics, etc.) and are always
+// excluded during auto-discovery regardless of user config.
+var defaultAutoDiscoverExcludeGroups = map[string]bool{
+	"metrics.k8s.io":         true,
+	"apiregistration.k8s.io": true,
+	"apiextensions.k8s.io":   true,
+	"authentication.k8s.io":  true,
+	"authorization.k8s.io":   true,
+}
+
+// autoDiscoverResources reads the already-cached /apis discovery documents
+// from e.discoveryCache (populated earlier in the same run by fetchDiscovery)
+// and appends one config.Resource entry per group-version-resource tuple that
+// is not already covered by an explicit config entry. The appended entries are
+// then picked up by the standard poll loop in Run().
+func (e *Engine) autoDiscoverResources(ctx context.Context) {
+	// Build the exclude set: defaults + user overrides.
+	exclude := make(map[string]bool, len(defaultAutoDiscoverExcludeGroups))
+	for g := range defaultAutoDiscoverExcludeGroups {
+		exclude[g] = true
+	}
+	for _, g := range e.cfg.AutoDiscoverExcludeGroups {
+		exclude[g] = true
+	}
+
+	// Build a set of already-configured (group, version, resource) triples so
+	// we don't add duplicates.
+	type gvr struct{ group, version, resource string }
+	configured := make(map[gvr]bool, len(e.cfg.Resources))
+	for _, r := range e.cfg.Resources {
+		configured[gvr{r.Group, r.Version, r.Resource}] = true
+	}
+
+	apisBody := e.discoveryCache["/apis"]
+	if apisBody == nil {
+		if e.verbose {
+			fmt.Fprintln(os.Stderr, "  [auto-discover] /apis not in discovery cache; skipping")
+		}
+		return
+	}
+
+	var groupList struct {
+		Groups []struct {
+			Name     string `json:"name"`
+			Versions []struct {
+				GroupVersion string `json:"groupVersion"`
+				Version      string `json:"version"`
+			} `json:"versions"`
+		} `json:"groups"`
+	}
+	if err := json.Unmarshal(apisBody, &groupList); err != nil {
+		return
+	}
+
+	added := 0
+	for _, g := range groupList.Groups {
+		if exclude[g.Name] {
+			continue
+		}
+		for _, gv := range g.Versions {
+			gvPath := "/apis/" + gv.GroupVersion
+			gvBody := e.discoveryCache[gvPath]
+			if gvBody == nil {
+				// Not in cache (e.g. an older capture); skip — we never fetch
+				// again here to avoid duplicate records in the archive.
+				continue
+			}
+
+			var resList struct {
+				Resources []struct {
+					Name       string `json:"name"`
+					Namespaced bool   `json:"namespaced"`
+				} `json:"resources"`
+			}
+			if err := json.Unmarshal(gvBody, &resList); err != nil {
+				continue
+			}
+
+			parts := strings.SplitN(gv.GroupVersion, "/", 2)
+			group := parts[0]
+			version := gv.Version
+			if len(parts) == 2 {
+				version = parts[1]
+			}
+
+			for _, res := range resList.Resources {
+				// Skip sub-resources (contain a slash, e.g. "pods/status").
+				if strings.Contains(res.Name, "/") {
+					continue
+				}
+				key := gvr{group, version, res.Name}
+				if configured[key] {
+					continue
+				}
+				newRes := config.Resource{
+					Group:       group,
+					Version:     version,
+					Resource:    res.Name,
+					IntervalRaw: "30s",
+					Interval:    30 * time.Second,
+				}
+				if res.Namespaced {
+					newRes.Namespaces = []string{"*"}
+				}
+				e.cfg.Resources = append(e.cfg.Resources, newRes)
+				configured[key] = true
+				added++
+				if e.verbose {
+					fmt.Fprintf(os.Stdout, "  [auto-discover] added %s/%s/%s (namespaced=%v)\n",
+						group, version, res.Name, res.Namespaced)
+				}
+			}
+		}
+	}
+
+	if e.verbose {
+		fmt.Fprintf(os.Stdout, "  [auto-discover] added %d resource types\n", added)
+	}
+}
+
 // fetchDiscovery captures the Kubernetes API discovery endpoints so the mock
 // server can replay them with real resource lists rather than inferring them
 // from the captured resource paths. Called once at the start of a capture run.
+// Bodies for /apis and each /apis/<group>/<version> are saved into
+// e.discoveryCache so that autoDiscoverResources can use them without issuing
+// a second round of HTTP requests to the live cluster.
 func (e *Engine) fetchDiscovery(ctx context.Context) {
 	// Core discovery paths.
 	e.doFetch(ctx, "/api", "")
 	e.doFetch(ctx, "/api/v1", "")
 	apisBody, _ := e.doFetch(ctx, "/apis", "")
+	if apisBody != nil {
+		e.discoveryCache["/apis"] = apisBody
+	}
 
 	// OpenAPI specs for kubectl explain.
 	e.doFetch(ctx, "/openapi/v2", "")
@@ -276,7 +411,11 @@ func (e *Engine) fetchDiscovery(ctx context.Context) {
 	}
 	for _, g := range groupList.Groups {
 		for _, v := range g.Versions {
-			e.doFetch(ctx, "/apis/"+v.GroupVersion, "")
+			gvPath := "/apis/" + v.GroupVersion
+			gvBody, _ := e.doFetch(ctx, gvPath, "")
+			if gvBody != nil {
+				e.discoveryCache[gvPath] = gvBody
+			}
 		}
 	}
 }

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -465,3 +465,159 @@ func TestExpandWildcard_DiscoveryFailure(t *testing.T) {
 		t.Errorf("expected 'namespace discovery failed' in error, got: %v", err)
 	}
 }
+
+// ── Auto-discover CRD resource tests ────────────────────────────────────────
+
+// autoDiscoverServer returns a fake API server that serves minimal /apis and
+// /apis/<group>/<version> responses for one CRD group (networking.istio.io)
+// with two resources: virtualservices (namespaced) and gateways (namespaced).
+// It also serves a metrics.k8s.io group which should be excluded by default.
+func autoDiscoverServer(t *testing.T, reqPaths chan<- string) *httptest.Server {
+	t.Helper()
+	apisBody := `{
+		"kind":"APIGroupList","apiVersion":"v1",
+		"groups":[
+			{"name":"networking.istio.io","versions":[{"groupVersion":"networking.istio.io/v1beta1","version":"v1beta1"}]},
+			{"name":"metrics.k8s.io","versions":[{"groupVersion":"metrics.k8s.io/v1beta1","version":"v1beta1"}]}
+		]
+	}`
+	istioGVBody := `{
+		"kind":"APIResourceList","apiVersion":"v1",
+		"groupVersion":"networking.istio.io/v1beta1",
+		"resources":[
+			{"name":"virtualservices","namespaced":true,"kind":"VirtualService"},
+			{"name":"gateways","namespaced":true,"kind":"Gateway"},
+			{"name":"virtualservices/status","namespaced":true,"kind":"VirtualService"}
+		]
+	}`
+	metricsGVBody := `{
+		"kind":"APIResourceList","apiVersion":"v1",
+		"groupVersion":"metrics.k8s.io/v1beta1",
+		"resources":[{"name":"pods","namespaced":true,"kind":"PodMetrics"}]
+	}`
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if reqPaths != nil {
+			select {
+			case reqPaths <- r.URL.Path:
+			default:
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+		case "/apis":
+			fmt.Fprint(w, apisBody)
+		case "/apis/networking.istio.io/v1beta1":
+			fmt.Fprint(w, istioGVBody)
+		case "/apis/metrics.k8s.io/v1beta1":
+			fmt.Fprint(w, metricsGVBody)
+		default:
+			fmt.Fprint(w, `{"kind":"List","apiVersion":"v1","items":[]}`)
+		}
+	}))
+	return srv
+}
+
+func TestAutoDiscover_AddsResources(t *testing.T) {
+	srv := autoDiscoverServer(t, nil)
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw:  "500ms",
+		Duration:     500 * time.Millisecond,
+		Output:       filepath.Join(outDir, "capture.tar.gz"),
+		AutoDiscover: true,
+		// No explicit resources — auto-discover should populate them.
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	ss := &sliceSink{}
+	eng.sink = ss
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	// virtualservices and gateways should have been added; metrics.k8s.io excluded.
+	resourceNames := make(map[string]bool)
+	for _, r := range cfg.Resources {
+		resourceNames[r.Resource] = true
+		if r.Group == "metrics.k8s.io" {
+			t.Errorf("metrics.k8s.io/%s should be excluded by default", r.Resource)
+		}
+	}
+	for _, want := range []string{"virtualservices", "gateways"} {
+		if !resourceNames[want] {
+			t.Errorf("expected resource %q to be auto-discovered, got resources: %v", want, cfg.Resources)
+		}
+	}
+	// Sub-resources (virtualservices/status) must NOT be added.
+	if resourceNames["virtualservices/status"] {
+		t.Error("sub-resource 'virtualservices/status' should not be added as a resource entry")
+	}
+}
+
+func TestAutoDiscover_SkipsAlreadyConfigured(t *testing.T) {
+	srv := autoDiscoverServer(t, nil)
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw:  "500ms",
+		Duration:     500 * time.Millisecond,
+		Output:       filepath.Join(outDir, "capture.tar.gz"),
+		AutoDiscover: true,
+		Resources: []config.Resource{
+			// Pre-configured virtualservices — must not be duplicated.
+			{Group: "networking.istio.io", Version: "v1beta1", Resource: "virtualservices",
+				Namespaces: []string{"default"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	ss := &sliceSink{}
+	eng.sink = ss
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	// Count virtualservices entries — must be exactly 1.
+	count := 0
+	for _, r := range cfg.Resources {
+		if r.Resource == "virtualservices" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 virtualservices entry, got %d", count)
+	}
+}
+
+func TestAutoDiscover_ExcludeGroupsOverride(t *testing.T) {
+	srv := autoDiscoverServer(t, nil)
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw:               "500ms",
+		Duration:                  500 * time.Millisecond,
+		Output:                    filepath.Join(outDir, "capture.tar.gz"),
+		AutoDiscover:              true,
+		AutoDiscoverExcludeGroups: []string{"networking.istio.io"},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	ss := &sliceSink{}
+	eng.sink = ss
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	for _, r := range cfg.Resources {
+		if r.Group == "networking.istio.io" {
+			t.Errorf("networking.istio.io should be excluded via AutoDiscoverExcludeGroups, but found %v", r)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,15 @@ type Config struct {
 	Kubeconfig string `mapstructure:"kubeconfig"`
 	// Resources is the list of resources to capture.
 	Resources []Resource `mapstructure:"resources"`
+	// AutoDiscover, when true, causes the capture engine to walk /apis at
+	// capture time and automatically add every discovered non-core resource
+	// type to the poll loop, supplementing any explicit Resources entries.
+	AutoDiscover bool `mapstructure:"auto_discover"`
+	// AutoDiscoverExcludeGroups is an optional list of API groups to skip
+	// during auto-discovery (e.g. "metrics.k8s.io"). System groups that
+	// produce noisy or unusable data are excluded by default regardless of
+	// this setting; see defaultAutoDiscoverExcludeGroups.
+	AutoDiscoverExcludeGroups []string `mapstructure:"auto_discover_exclude_groups"`
 }
 
 // Load reads k8shark capture config. If configFile is empty, viper uses
@@ -83,8 +92,8 @@ func (c *Config) Validate() error {
 		// empty string is fine — client-go will use ~/.kube/config
 	}
 
-	if len(c.Resources) == 0 {
-		return fmt.Errorf("no resources defined in config; add at least one entry under 'resources:'")
+	if len(c.Resources) == 0 && !c.AutoDiscover {
+		return fmt.Errorf("no resources defined in config; add at least one entry under 'resources:' or set 'auto_discover: true'")
 	}
 
 	for i := range c.Resources {
@@ -164,6 +173,15 @@ func Warnings(cfg *Config) []string {
 		if knownClusterScoped[r.Resource] && len(r.Namespaces) > 0 {
 			ws = append(ws, fmt.Sprintf(
 				"resources[%d] (%s): cluster-scoped resource has 'namespaces:' set — this will be ignored at capture time",
+				i, r.Resource))
+		}
+		// For non-core (CRD-backed) resources we cannot determine cluster-scope
+		// offline. Warn when 'namespaces:' is set so the user knows to verify.
+		if r.Group != "" && !knownClusterScoped[r.Resource] && len(r.Namespaces) > 0 {
+			ws = append(ws, fmt.Sprintf(
+				"resources[%d] (%s): non-core resource with 'namespaces:' set — "+
+					"if this is a cluster-scoped CRD (e.g. ClusterIssuer, ClusterPolicy) "+
+					"remove 'namespaces:' so the cluster-scoped path is captured instead",
 				i, r.Resource))
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -125,3 +125,32 @@ func contains(s, sub string) bool {
 			return false
 		}())
 }
+
+func TestWarnings_CRDWithNamespaces(t *testing.T) {
+	cfg := validatedCfg(t, "10m", []Resource{
+		{Group: "cert-manager.io", Version: "v1", Resource: "clusterissuers", IntervalRaw: "30s", Namespaces: []string{"default"}},
+	})
+	ws := Warnings(cfg)
+	found := false
+	for _, w := range ws {
+		if contains(w, "non-core resource") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected non-core CRD namespace advisory warning, got: %v", ws)
+	}
+}
+
+func TestWarnings_CRDNoNamespaces_NoWarn(t *testing.T) {
+	// A non-core resource without namespaces set should NOT trigger the advisory.
+	cfg := validatedCfg(t, "10m", []Resource{
+		{Group: "cert-manager.io", Version: "v1", Resource: "clusterissuers", IntervalRaw: "30s"},
+	})
+	ws := Warnings(cfg)
+	for _, w := range ws {
+		if contains(w, "non-core resource") {
+			t.Errorf("unexpected non-core advisory for resource without namespaces: %s", w)
+		}
+	}
+}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -41,14 +41,18 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	//   kubectl exec / kubectl cp  → POST .../pods/<name>/exec
 	//   kubectl port-forward       → POST .../pods/<name>/portforward
 	//   kubectl attach             → POST .../pods/<name>/attach
+	//   istioctl proxy-status      → GET/POST .../pods/<name>/proxy/...
+	//                                GET/POST .../services/<name>/proxy/...
 	if strings.HasSuffix(path, "/exec") ||
 		strings.HasSuffix(path, "/portforward") ||
-		strings.HasSuffix(path, "/attach") {
+		strings.HasSuffix(path, "/attach") ||
+		strings.HasSuffix(path, "/proxy") ||
+		strings.Contains(path, "/proxy/") {
 		w.Header().Set("Allow", "")
 		h.writeStatus(w, http.StatusMethodNotAllowed,
-			"k8shark capture replay: exec, cp, and port-forward are not supported — "+
+			"k8shark capture replay: exec, cp, port-forward, and proxy are not supported — "+
 				"this mock server replays a captured snapshot and cannot run commands "+
-				"or open connections on pods")
+				"or proxy connections to pods/services")
 		return
 	}
 

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -471,3 +471,89 @@ func TestHandler_ServeLog_NotCaptured(t *testing.T) {
 		t.Errorf("expected stub to mention 'not captured', got: %q", body)
 	}
 }
+
+// TestHandler_GroupResourceList_FallbackFromIndex verifies that the mock server
+// returns a valid APIResourceList for a CRD API group even when the
+// /apis/<group>/<version> discovery document was never captured — as long as
+// resource records for that group exist in the archive index.
+//
+// This covers the case where an older capture missed the discovery call but
+// has real VirtualService/Gateway records.
+func TestHandler_GroupResourceList_FallbackFromIndex(t *testing.T) {
+	// Store only resource-level records — no discovery doc for the group.
+	store := buildTestStore(t, map[string][]byte{
+		"/apis/networking.istio.io/v1beta1/namespaces/default/virtualservices": []byte(
+			`{"kind":"VirtualServiceList","apiVersion":"networking.istio.io/v1beta1","items":[]}`),
+		"/apis/networking.istio.io/v1beta1/namespaces/default/gateways": []byte(
+			`{"kind":"GatewayList","apiVersion":"networking.istio.io/v1beta1","items":[]}`),
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/apis/networking.istio.io/v1beta1", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d\nbody: %s", rw.Code, rw.Body.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(rw.Body.Bytes(), &result); err != nil {
+		t.Fatalf("expected JSON body: %v", err)
+	}
+	if result["kind"] != "APIResourceList" {
+		t.Errorf("expected kind=APIResourceList, got %v", result["kind"])
+	}
+	if result["groupVersion"] != "networking.istio.io/v1beta1" {
+		t.Errorf("expected groupVersion=networking.istio.io/v1beta1, got %v", result["groupVersion"])
+	}
+	resources, _ := result["resources"].([]any)
+	if len(resources) == 0 {
+		t.Fatalf("expected non-empty resources list in synthesised APIResourceList")
+	}
+	// Both virtualservices and gateways should appear.
+	names := make(map[string]bool)
+	for _, r := range resources {
+		if rm, ok := r.(map[string]any); ok {
+			if name, ok := rm["name"].(string); ok {
+				names[name] = true
+			}
+		}
+	}
+	for _, want := range []string{"virtualservices", "gateways"} {
+		if !names[want] {
+			t.Errorf("expected %q in synthesised resource list, got: %v", want, names)
+		}
+	}
+}
+
+// TestHandler_ProxySubResource405 verifies that requests to pod proxy
+// sub-resources (/pods/<name>/proxy/...) return 405 with a clear message,
+// rather than silently returning 404.
+func TestHandler_ProxySubResource405(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/istio-system/pods": []byte(`{"kind":"PodList","items":[]}`),
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	proxyPaths := []string{
+		"/api/v1/namespaces/istio-system/services/istiod:15014/proxy/debug/syncz",
+		"/api/v1/namespaces/istio-system/pods/istiod-abc/proxy/stats/prometheus",
+	}
+	for _, path := range proxyPaths {
+		for _, method := range []string{http.MethodGet, http.MethodPost} {
+			t.Run(method+"_"+path, func(t *testing.T) {
+				req := httptest.NewRequest(method, path, nil)
+				rw := httptest.NewRecorder()
+				h.ServeHTTP(rw, req)
+
+				if rw.Code != http.StatusMethodNotAllowed {
+					t.Fatalf("%s %s: expected 405, got %d\nbody: %s", method, path, rw.Code, rw.Body.String())
+				}
+				body := rw.Body.String()
+				if !strings.Contains(body, "k8shark") {
+					t.Errorf("expected k8shark mention in error message, got: %s", body)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
Implements issues #33 and #34.

## #34 — CRD support improvements

- **config**: add `auto_discover` and `auto_discover_exclude_groups` fields; relax `Validate` to allow empty `resources` when `auto_discover: true`
- **engine**: add `discoveryCache`; `fetchDiscovery` stores `/apis` and each `/apis/<group>/<version>` body for reuse without extra HTTP calls
- **engine**: add `autoDiscoverResources` — walks cached discovery at capture start, appends one `config.Resource` per group-version-resource tuple not already in explicit config; namespaced → `namespaces: ['*']`; cluster-scoped → no namespaces; default exclude list for system groups (`metrics.k8s.io`, `apiregistration.k8s.io`, `apiextensions.k8s.io`, etc.)
- **config**: `Warnings()` now emits an advisory for non-core resources that have `namespaces:` set, noting scope cannot be verified offline
- **server**: add test confirming fallback `APIResourceList` synthesis from index entries when the discovery doc was never captured

## #33 — Non-kubectl client interoperability

- **server**: intercept `/proxy/` sub-resource paths before the method check; return 405 with a clear k8shark message (previously GET returned 404)
- **docs/config.md**: new "Capturing CRD-backed resources" section — explicit entries, `auto_discover` usage, ecosystem examples (Istio, cert-manager, Flux, ArgoCD)
- **docs/usage.md**: new "Client compatibility" section — supported tools matrix, intentionally unsupported operations, kubeconfig usage for istioctl / helm / flux / k9s

## Tests added

- `TestAutoDiscover_AddsResources`
- `TestAutoDiscover_SkipsAlreadyConfigured`
- `TestAutoDiscover_ExcludeGroupsOverride`
- `TestWarnings_CRDWithNamespaces`
- `TestWarnings_CRDNoNamespaces_NoWarn`
- `TestHandler_GroupResourceList_FallbackFromIndex`
- `TestHandler_ProxySubResource405`

Closes #34
Closes #33