### PR TITLE
feat: add point-in-time replay for kshrk open

### DIFF
--- a/cmd/open.go
+++ b/cmd/open.go
@@ -20,7 +20,7 @@ func init() {
 	rootCmd.AddCommand(openCmd)
 	openCmd.Flags().String("port", "0", "port for the mock API server (0 = random available port)")
 	openCmd.Flags().String("kubeconfig-out", "", "where to write the generated kubeconfig (default: ~/.kube/k8shark-<id>)")
-	openCmd.Flags().String("at", "", "pin replay to a specific timestamp (RFC3339, e.g. 2026-04-09T10:00:00Z)")
+	openCmd.Flags().String("at", "", "pin replay to a specific timestamp (RFC3339) or relative duration like -5m")
 }
 
 func runOpen(cmd *cobra.Command, args []string) error {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -206,9 +206,15 @@ Every captured record is timestamped. `--at` lets you replay the capture as it l
 
 ```sh
 kshrk open capture.tar.gz --at 2026-04-09T10:30:00Z
+kshrk open capture.tar.gz --at -5m
 ```
 
-The timestamp must be in RFC3339 format. Use UTC (`Z`) or include an offset (`+05:30`).
+`--at` accepts either:
+
+- an RFC3339 timestamp, using UTC (`Z`) or an explicit offset (`+05:30`)
+- a relative duration such as `-5m` or `-1h`, interpreted relative to the capture end time
+
+If the requested time is outside the capture window, `kshrk open` exits with a clear error.
 
 This is useful when you have a long capture (e.g. 1h) and want to compare cluster state before and after an incident.
 

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -5,9 +5,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/phenixblue/k8shark/internal/capture"
 )
 
 func TestHandler_Version(t *testing.T) {
@@ -292,6 +296,59 @@ func TestHandler_FieldSelector(t *testing.T) {
 	names := itemNames(t, rw.Body.Bytes())
 	if len(names) != 1 || names[0] != "nginx" {
 		t.Errorf("expected [nginx], got %v", names)
+	}
+}
+
+func TestHandler_ReplayAtTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	recDir := filepath.Join(dir, "k8shark-capture", "records")
+	if err := os.MkdirAll(recDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	path := "/api/v1/namespaces/default/pods"
+	t1 := time.Date(2026, 4, 9, 10, 40, 0, 0, time.UTC)
+	t2 := t1.Add(2 * time.Minute)
+	records := []capture.Record{
+		{ID: "rec-1", CapturedAt: t1, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(`{"apiVersion":"v1","kind":"PodList","items":[{"metadata":{"name":"before"}}]}`)},
+		{ID: "rec-2", CapturedAt: t2, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(`{"apiVersion":"v1","kind":"PodList","items":[{"metadata":{"name":"after"}}]}`)},
+	}
+	for _, rec := range records {
+		data, err := json.Marshal(rec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(recDir, rec.ID+".json"), data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	metaJSON, _ := json.Marshal(capture.CaptureMetadata{CaptureID: "test-capture-id", CapturedAt: t1, CapturedUntil: t2, RecordCount: len(records)})
+	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "metadata.json"), metaJSON, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idxJSON, _ := json.Marshal(capture.Index{
+		path: {APIPath: path, RecordIDs: []string{"rec-1", "rec-2"}, Times: []time.Time{t1, t2}},
+	})
+	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "index.json"), idxJSON, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := LoadStore(dir)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	h := newHandler(store, t1.Add(time.Minute), false)
+
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rw.Code)
+	}
+	if !strings.Contains(rw.Body.String(), "before") {
+		t.Fatalf("expected point-in-time replay to return first record, got %s", rw.Body.String())
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
 )
 
 // OpenOptions holds parameters for opening a capture archive.
@@ -55,13 +56,10 @@ func Open(opts OpenOptions) (*Server, error) {
 	}
 
 	// Parse optional replay timestamp.
-	var at time.Time
-	if opts.At != "" {
-		at, err = time.Parse(time.RFC3339, opts.At)
-		if err != nil {
-			_ = os.RemoveAll(tmpDir)
-			return nil, fmt.Errorf("parsing --at timestamp %q: %w", opts.At, err)
-		}
+	at, err := parseReplayAt(store.Metadata, opts.At)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, err
 	}
 
 	// Generate a self-signed TLS certificate.
@@ -153,4 +151,28 @@ func (s *Server) Wait() error {
 	}
 	_ = os.RemoveAll(s.tmpDir)
 	return nil
+}
+
+func parseReplayAt(meta capture.CaptureMetadata, raw string) (time.Time, error) {
+	if raw == "" {
+		return time.Time{}, nil
+	}
+
+	at, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		d, derr := time.ParseDuration(raw)
+		if derr != nil {
+			return time.Time{}, fmt.Errorf("parsing --at %q: must be RFC3339 or a relative duration like -5m", raw)
+		}
+		at = meta.CapturedUntil.Add(d)
+	}
+
+	if !meta.CapturedAt.IsZero() && at.Before(meta.CapturedAt) {
+		return time.Time{}, fmt.Errorf("parsing --at %q: requested replay time %s is before capture start %s", raw, at.Format(time.RFC3339), meta.CapturedAt.Format(time.RFC3339))
+	}
+	if !meta.CapturedUntil.IsZero() && at.After(meta.CapturedUntil) {
+		return time.Time{}, fmt.Errorf("parsing --at %q: requested replay time %s is after capture end %s", raw, at.Format(time.RFC3339), meta.CapturedUntil.Format(time.RFC3339))
+	}
+
+	return at, nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -135,3 +135,64 @@ func TestServer_Open_EndToEnd(t *testing.T) {
 		t.Errorf("expected pod name=nginx, got %v", meta["name"])
 	}
 }
+
+func TestParseReplayAt(t *testing.T) {
+	meta := capture.CaptureMetadata{
+		CapturedAt:    time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC),
+		CapturedUntil: time.Date(2026, 4, 9, 11, 0, 0, 0, time.UTC),
+	}
+
+	t.Run("rfc3339", func(t *testing.T) {
+		got, err := parseReplayAt(meta, "2026-04-09T10:30:00Z")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := time.Date(2026, 4, 9, 10, 30, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Fatalf("got %s, want %s", got, want)
+		}
+	})
+
+	t.Run("relative duration", func(t *testing.T) {
+		got, err := parseReplayAt(meta, "-5m")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := time.Date(2026, 4, 9, 10, 55, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Fatalf("got %s, want %s", got, want)
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		_, err := parseReplayAt(meta, "not-a-time")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("before capture", func(t *testing.T) {
+		_, err := parseReplayAt(meta, "2026-04-09T09:59:59Z")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err != nil && err.Error() == "" {
+			t.Fatal("expected clear error message")
+		}
+	})
+
+	t.Run("after capture", func(t *testing.T) {
+		_, err := parseReplayAt(meta, "1m")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestServer_Open_RejectsOutOfRangeAt(t *testing.T) {
+	archivePath := buildTestArchive(t)
+	_, err := Open(OpenOptions{ArchivePath: archivePath, At: "1900-01-01T00:00:00Z"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -110,13 +111,14 @@ func (s *CaptureStore) Latest(apiPath string, at time.Time) ([]byte, int, error)
 
 	// Default to the most recent record.
 	id := entry.RecordIDs[len(entry.RecordIDs)-1]
-	if !at.IsZero() {
-		// Walk forward; keep the latest ID whose time is <= at.
-		for i, t := range entry.Times {
-			if !t.After(at) {
-				id = entry.RecordIDs[i]
-			}
+	if !at.IsZero() && len(entry.Times) == len(entry.RecordIDs) && len(entry.Times) > 0 {
+		idx := sort.Search(len(entry.Times), func(i int) bool {
+			return entry.Times[i].After(at)
+		})
+		if idx == 0 {
+			return nil, 404, nil
 		}
+		id = entry.RecordIDs[idx-1]
 	}
 
 	data, err := os.ReadFile(filepath.Join(s.Dir, "k8shark-capture", "records", id+".json"))

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -143,3 +144,85 @@ func TestStore_Latest_NotFound(t *testing.T) {
 		t.Errorf("expected 404, got %d", code)
 	}
 }
+
+func TestStore_Latest_AtTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	recDir := filepath.Join(dir, "k8shark-capture", "records")
+	if err := os.MkdirAll(recDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	path := "/api/v1/namespaces/default/pods"
+	t1 := time.Date(2026, 4, 9, 10, 40, 0, 0, time.UTC)
+	t2 := t1.Add(2 * time.Minute)
+	records := []capture.Record{
+		{ID: "rec-1", CapturedAt: t1, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(`{"kind":"PodList","items":[{"metadata":{"name":"before"}}]}`)},
+		{ID: "rec-2", CapturedAt: t2, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(`{"kind":"PodList","items":[{"metadata":{"name":"after"}}]}`)},
+	}
+	for _, rec := range records {
+		data, err := json.Marshal(rec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(recDir, rec.ID+".json"), data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	metaJSON, _ := json.Marshal(capture.CaptureMetadata{
+		CaptureID:     "test-capture-id",
+		CapturedAt:    t1,
+		CapturedUntil: t2,
+		RecordCount:   len(records),
+	})
+	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "metadata.json"), metaJSON, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idxJSON, _ := json.Marshal(capture.Index{
+		path: {
+			APIPath:   path,
+			RecordIDs: []string{"rec-1", "rec-2"},
+			Times:     []time.Time{t1, t2},
+		},
+	})
+	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "index.json"), idxJSON, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := LoadStore(dir)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+
+	body, code, err := store.Latest(path, t1.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if string(body) == "" || !containsString(string(body), "before") {
+		t.Fatalf("expected first record body, got %s", string(body))
+	}
+
+	body, code, err = store.Latest(path, t2.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if !containsString(string(body), "after") {
+		t.Fatalf("expected second record body, got %s", string(body))
+	}
+
+	_, code, err = store.Latest(path, t1.Add(-time.Second))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 404 {
+		t.Fatalf("expected 404 before first record, got %d", code)
+	}
+}
+
+func containsString(s, sub string) bool { return strings.Contains(s, sub) }


### PR DESCRIPTION
Implements Issue #28.

## What changed

- accept `kshrk open --at` as either RFC3339 timestamps or relative durations like `-5m`
- validate that the requested replay time is inside the capture window
- use time-based record selection so replay returns the latest record at or before the requested time
- return not found for a path when the requested time is earlier than that path's first captured sample
- add tests for replay timestamp parsing, range validation, and point-in-time store/handler selection
- document absolute and relative `--at` usage in the usage guide

## Validation

- `make fmt`
- `go test ./internal/server ./cmd`
- `go test ./...`

Closes #28