### PR TITLE
feat: add kshrk diff command for capture comparisons

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	diffpkg "github.com/phenixblue/k8shark/internal/diff"
+	"github.com/spf13/cobra"
+)
+
+type exitError struct {
+	msg  string
+	code int
+}
+
+func (e exitError) Error() string { return e.msg }
+func (e exitError) ExitCode() int { return e.code }
+
+var diffCmd = &cobra.Command{
+	Use:   "diff",
+	Short: "Compare two capture snapshots",
+	Long: `Compares resource state between two capture archives, or between two
+points in time within the same archive, and prints a diff.`,
+	Args: cobra.NoArgs,
+	RunE: runDiff,
+}
+
+func init() {
+	rootCmd.AddCommand(diffCmd)
+	diffCmd.Flags().String("before", "", "before archive path")
+	diffCmd.Flags().String("after", "", "after archive path")
+	diffCmd.Flags().String("archive", "", "single archive path for intra-archive diff")
+	diffCmd.Flags().String("before-at", "", "time for the before snapshot (RFC3339 or relative duration like -5m)")
+	diffCmd.Flags().String("after-at", "", "time for the after snapshot (RFC3339 or relative duration like -1m)")
+	diffCmd.Flags().String("resource", "", "limit diff to one resource type, e.g. pods")
+	diffCmd.Flags().String("namespace", "", "limit diff to one namespace")
+	diffCmd.Flags().StringP("output", "o", "text", "output format: text or json")
+}
+
+func runDiff(cmd *cobra.Command, _ []string) error {
+	beforeArchive, _ := cmd.Flags().GetString("before")
+	afterArchive, _ := cmd.Flags().GetString("after")
+	archivePath, _ := cmd.Flags().GetString("archive")
+	beforeAt, _ := cmd.Flags().GetString("before-at")
+	afterAt, _ := cmd.Flags().GetString("after-at")
+	resource, _ := cmd.Flags().GetString("resource")
+	namespace, _ := cmd.Flags().GetString("namespace")
+	output, _ := cmd.Flags().GetString("output")
+
+	result, err := diffpkg.Run(diffpkg.Options{
+		BeforeArchive: beforeArchive,
+		AfterArchive:  afterArchive,
+		Archive:       archivePath,
+		BeforeAt:      beforeAt,
+		AfterAt:       afterAt,
+		Resource:      resource,
+		Namespace:     namespace,
+	})
+	if err != nil {
+		return err
+	}
+
+	hasDiff := len(result.Changes) > 0
+	switch strings.ToLower(output) {
+	case "json":
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(result); err != nil {
+			return err
+		}
+	default:
+		color := isColorTerminal(cmd.OutOrStdout())
+		text, err := diffpkg.RenderText(result, color)
+		if err != nil {
+			return err
+		}
+		if text != "" {
+			_, _ = fmt.Fprint(cmd.OutOrStdout(), text)
+		}
+	}
+
+	if hasDiff {
+		return exitError{code: 1}
+	}
+	return nil
+}
+
+func isColorTerminal(f any) bool {
+	out, ok := f.(*os.File)
+	if !ok {
+		return false
+	}
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	fi, err := out.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	archivepkg "github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/spf13/cobra"
+)
+
+func TestRunDiff_ExitCodeOnDiff(t *testing.T) {
+	before := buildDiffArchive(t, `{"kind":"PodList","items":[{"metadata":{"name":"before"}}]}`)
+	after := buildDiffArchive(t, `{"kind":"PodList","items":[{"metadata":{"name":"after"}}]}`)
+
+	cmd := newTestDiffCommand()
+	cmd.Flags().Set("before", before)
+	cmd.Flags().Set("after", after)
+
+	err := runDiff(cmd, nil)
+	if err == nil {
+		t.Fatal("expected diff exit error, got nil")
+	}
+	exitErr, ok := err.(exitError)
+	if !ok {
+		t.Fatalf("expected exitError, got %T", err)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Fatalf("expected exit code 1, got %d", exitErr.ExitCode())
+	}
+}
+
+func TestRunDiff_JSONOutputNoDiff(t *testing.T) {
+	archivePath := buildDiffArchive(t, `{"kind":"PodList","items":[]}`)
+	cmd := newTestDiffCommand()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.Flags().Set("before", archivePath)
+	cmd.Flags().Set("after", archivePath)
+	cmd.Flags().Set("output", "json")
+
+	err := runDiff(cmd, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var result struct {
+		Changes []any `json:"changes"`
+	}
+	if jerr := json.Unmarshal(buf.Bytes(), &result); jerr != nil {
+		t.Fatalf("invalid json output: %v", jerr)
+	}
+	if len(result.Changes) != 0 {
+		t.Fatalf("expected no changes, got %d", len(result.Changes))
+	}
+}
+
+func newTestDiffCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("before", "", "")
+	cmd.Flags().String("after", "", "")
+	cmd.Flags().String("archive", "", "")
+	cmd.Flags().String("before-at", "", "")
+	cmd.Flags().String("after-at", "", "")
+	cmd.Flags().String("resource", "", "")
+	cmd.Flags().String("namespace", "", "")
+	cmd.Flags().StringP("output", "o", "text", "")
+	return cmd
+}
+
+func buildDiffArchive(t *testing.T, body string) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "capture.tar.gz")
+	now := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	rec := &capture.Record{ID: "rec-1", CapturedAt: now, APIPath: "/api/v1/namespaces/default/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body)}
+	meta := &capture.CaptureMetadata{CaptureID: "test-capture", CapturedAt: now, CapturedUntil: now, RecordCount: 1}
+	index := capture.Index{
+		"/api/v1/namespaces/default/pods": {APIPath: "/api/v1/namespaces/default/pods", RecordIDs: []string{"rec-1"}, Times: []time.Time{now}},
+	}
+	if err := archivepkg.Write(out, meta, []*capture.Record{rec}, index); err != nil {
+		t.Fatalf("archive.Write: %v", err)
+	}
+	return out
+}

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -17,8 +17,12 @@ func TestRunDiff_ExitCodeOnDiff(t *testing.T) {
 	after := buildDiffArchive(t, `{"kind":"PodList","items":[{"metadata":{"name":"after"}}]}`)
 
 	cmd := newTestDiffCommand()
-	cmd.Flags().Set("before", before)
-	cmd.Flags().Set("after", after)
+	if err := cmd.Flags().Set("before", before); err != nil {
+		t.Fatalf("set before flag: %v", err)
+	}
+	if err := cmd.Flags().Set("after", after); err != nil {
+		t.Fatalf("set after flag: %v", err)
+	}
 
 	err := runDiff(cmd, nil)
 	if err == nil {
@@ -38,9 +42,15 @@ func TestRunDiff_JSONOutputNoDiff(t *testing.T) {
 	cmd := newTestDiffCommand()
 	buf := &bytes.Buffer{}
 	cmd.SetOut(buf)
-	cmd.Flags().Set("before", archivePath)
-	cmd.Flags().Set("after", archivePath)
-	cmd.Flags().Set("output", "json")
+	if err := cmd.Flags().Set("before", archivePath); err != nil {
+		t.Fatalf("set before flag: %v", err)
+	}
+	if err := cmd.Flags().Set("after", archivePath); err != nil {
+		t.Fatalf("set after flag: %v", err)
+	}
+	if err := cmd.Flags().Set("output", "json"); err != nil {
+		t.Fatalf("set output flag: %v", err)
+	}
 
 	err := runDiff(cmd, nil)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -21,6 +22,13 @@ environment without direct connectivity.`,
 // Execute is the entry point called from main.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		var exitErr interface{ ExitCode() int }
+		if errors.As(err, &exitErr) {
+			if err.Error() != "" {
+				fmt.Fprintln(os.Stderr, err)
+			}
+			os.Exit(exitErr.ExitCode())
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -214,6 +214,57 @@ This is useful when you have a long capture (e.g. 1h) and want to compare cluste
 
 ---
 
+## Diff
+
+`kshrk diff` compares either two capture archives or two points in time within the same archive.
+
+Compare two archives:
+
+```sh
+kshrk diff --before before.tar.gz --after after.tar.gz
+```
+
+Compare two points within one archive:
+
+```sh
+kshrk diff --archive capture.tar.gz \
+  --before-at 2026-04-09T10:40:00Z \
+  --after-at -1m
+```
+
+Scope the output:
+
+```sh
+kshrk diff --before before.tar.gz --after after.tar.gz \
+  --resource pods --namespace default
+```
+
+Emit machine-readable JSON instead of unified diff text:
+
+```sh
+kshrk diff --before before.tar.gz --after after.tar.gz --output json
+```
+
+### Diff flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--before` | | Before archive path |
+| `--after` | | After archive path |
+| `--archive` | | Single archive path for intra-archive diff |
+| `--before-at` | | Before snapshot time (RFC3339 or relative duration) |
+| `--after-at` | | After snapshot time (RFC3339 or relative duration) |
+| `--resource` | | Limit diff to one resource type |
+| `--namespace` | | Limit diff to one namespace |
+| `--output`, `-o` | `text` | Output format: `text` or `json` |
+
+Exit codes follow the usual diff convention:
+
+- `0` when no differences are found
+- `1` when differences are found
+
+---
+
 ## Redact
 
 Secret values can be removed from a capture archive in two ways:

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.1
 
 require (
 	github.com/google/uuid v1.6.0
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -22,7 +23,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,0 +1,346 @@
+package diff
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	archivepkg "github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+type Options struct {
+	BeforeArchive string
+	AfterArchive  string
+	Archive       string
+	BeforeAt      string
+	AfterAt       string
+	Resource      string
+	Namespace     string
+}
+
+type Result struct {
+	Changes []Change `json:"changes"`
+}
+
+type Change struct {
+	Path      string          `json:"path"`
+	Group     string          `json:"group,omitempty"`
+	Version   string          `json:"version,omitempty"`
+	Resource  string          `json:"resource,omitempty"`
+	Namespace string          `json:"namespace,omitempty"`
+	Before    json.RawMessage `json:"before,omitempty"`
+	After     json.RawMessage `json:"after,omitempty"`
+}
+
+func Run(opts Options) (*Result, error) {
+	before, after, err := loadSnapshots(opts)
+	if err != nil {
+		return nil, err
+	}
+	defer before.cleanup()
+	if after.dir != before.dir {
+		defer after.cleanup()
+	}
+
+	pathSet := make(map[string]struct{}, len(before.snapshot)+len(after.snapshot))
+	for path := range before.snapshot {
+		pathSet[path] = struct{}{}
+	}
+	for path := range after.snapshot {
+		pathSet[path] = struct{}{}
+	}
+
+	paths := make([]string, 0, len(pathSet))
+	for path := range pathSet {
+		if !matchesFilters(path, opts.Resource, opts.Namespace) {
+			continue
+		}
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	changes := make([]Change, 0)
+	for _, path := range paths {
+		beforeBody := before.snapshot[path]
+		afterBody := after.snapshot[path]
+		if jsonEqual(beforeBody, afterBody) {
+			continue
+		}
+		g, v, r, ns := parseAPIPath(path)
+		changes = append(changes, Change{
+			Path:      path,
+			Group:     g,
+			Version:   v,
+			Resource:  r,
+			Namespace: ns,
+			Before:    beforeBody,
+			After:     afterBody,
+		})
+	}
+
+	return &Result{Changes: changes}, nil
+}
+
+func RenderText(result *Result, color bool) (string, error) {
+	if len(result.Changes) == 0 {
+		return "", nil
+	}
+
+	var out strings.Builder
+	for i, change := range result.Changes {
+		beforePretty := prettyJSON(change.Before)
+		afterPretty := prettyJSON(change.After)
+		text, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+			A:        difflib.SplitLines(beforePretty),
+			B:        difflib.SplitLines(afterPretty),
+			FromFile: "before" + change.Path,
+			ToFile:   "after" + change.Path,
+			Context:  3,
+		})
+		if err != nil {
+			return "", err
+		}
+		if i > 0 {
+			out.WriteString("\n")
+		}
+		out.WriteString("Path: ")
+		out.WriteString(change.Path)
+		out.WriteString("\n")
+		if color {
+			out.WriteString(colorizeDiff(text))
+		} else {
+			out.WriteString(text)
+		}
+		if !strings.HasSuffix(text, "\n") {
+			out.WriteString("\n")
+		}
+	}
+	return out.String(), nil
+}
+
+type archiveSnapshot struct {
+	dir      string
+	meta     capture.CaptureMetadata
+	snapshot map[string]json.RawMessage
+}
+
+func (s *archiveSnapshot) cleanup() {
+	if s == nil || s.dir == "" {
+		return
+	}
+	_ = os.RemoveAll(s.dir)
+}
+
+func loadSnapshots(opts Options) (*archiveSnapshot, *archiveSnapshot, error) {
+	switch {
+	case opts.BeforeArchive != "" || opts.AfterArchive != "":
+		if opts.BeforeArchive == "" || opts.AfterArchive == "" {
+			return nil, nil, fmt.Errorf("both --before and --after are required when comparing two archives")
+		}
+		if opts.Archive != "" || opts.BeforeAt != "" || opts.AfterAt != "" {
+			return nil, nil, fmt.Errorf("use either --before/--after or --archive with --before-at/--after-at")
+		}
+		before, err := loadArchiveSnapshot(opts.BeforeArchive, time.Time{})
+		if err != nil {
+			return nil, nil, err
+		}
+		after, err := loadArchiveSnapshot(opts.AfterArchive, time.Time{})
+		if err != nil {
+			before.cleanup()
+			return nil, nil, err
+		}
+		return before, after, nil
+	case opts.Archive != "":
+		if opts.BeforeAt == "" || opts.AfterAt == "" {
+			return nil, nil, fmt.Errorf("--before-at and --after-at are required with --archive")
+		}
+		base, err := loadArchiveSnapshot(opts.Archive, time.Time{})
+		if err != nil {
+			return nil, nil, err
+		}
+		beforeAt, err := parseSnapshotTime(base.meta, opts.BeforeAt)
+		if err != nil {
+			base.cleanup()
+			return nil, nil, err
+		}
+		afterAt, err := parseSnapshotTime(base.meta, opts.AfterAt)
+		if err != nil {
+			base.cleanup()
+			return nil, nil, err
+		}
+		before, err := loadArchiveSnapshot(opts.Archive, beforeAt)
+		if err != nil {
+			base.cleanup()
+			return nil, nil, err
+		}
+		after, err := loadArchiveSnapshot(opts.Archive, afterAt)
+		if err != nil {
+			base.cleanup()
+			before.cleanup()
+			return nil, nil, err
+		}
+		base.cleanup()
+		return before, after, nil
+	default:
+		return nil, nil, fmt.Errorf("provide either --before and --after, or --archive with --before-at and --after-at")
+	}
+}
+
+func loadArchiveSnapshot(archivePath string, at time.Time) (*archiveSnapshot, error) {
+	dir, err := os.MkdirTemp("", "k8shark-diff-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp dir: %w", err)
+	}
+	if err := archivepkg.Open(archivePath, dir); err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("opening archive %q: %w", archivePath, err)
+	}
+	store, err := server.LoadStore(dir)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("loading archive %q: %w", archivePath, err)
+	}
+	shot := &archiveSnapshot{
+		dir:      dir,
+		meta:     store.Metadata,
+		snapshot: make(map[string]json.RawMessage, len(store.Index)),
+	}
+	for path := range store.Index {
+		if strings.Contains(path, "?as=Table") {
+			continue
+		}
+		body, code, err := store.Latest(path, at)
+		if err != nil {
+			shot.cleanup()
+			return nil, fmt.Errorf("reading %s from %q: %w", path, filepath.Base(archivePath), err)
+		}
+		if code != 200 {
+			continue
+		}
+		shot.snapshot[path] = append(json.RawMessage(nil), body...)
+	}
+	return shot, nil
+}
+
+func parseSnapshotTime(meta capture.CaptureMetadata, raw string) (time.Time, error) {
+	at, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		d, derr := time.ParseDuration(raw)
+		if derr != nil {
+			return time.Time{}, fmt.Errorf("parsing time %q: must be RFC3339 or a relative duration like -5m", raw)
+		}
+		at = meta.CapturedUntil.Add(d)
+	}
+	if !meta.CapturedAt.IsZero() && at.Before(meta.CapturedAt) {
+		return time.Time{}, fmt.Errorf("parsing time %q: requested time %s is before capture start %s", raw, at.Format(time.RFC3339), meta.CapturedAt.Format(time.RFC3339))
+	}
+	if !meta.CapturedUntil.IsZero() && at.After(meta.CapturedUntil) {
+		return time.Time{}, fmt.Errorf("parsing time %q: requested time %s is after capture end %s", raw, at.Format(time.RFC3339), meta.CapturedUntil.Format(time.RFC3339))
+	}
+	return at, nil
+}
+
+func matchesFilters(path, resource, namespace string) bool {
+	_, _, r, ns := parseAPIPath(path)
+	if resource != "" && r != resource {
+		return false
+	}
+	if namespace != "" && ns != namespace {
+		return false
+	}
+	if resource != "" || namespace != "" {
+		return r != ""
+	}
+	return true
+}
+
+func parseAPIPath(path string) (group, version, resource, namespace string) {
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	switch {
+	case len(parts) >= 3 && parts[0] == "api":
+		version = parts[1]
+		if len(parts) == 3 {
+			resource = parts[2]
+		} else if len(parts) == 5 && parts[2] == "namespaces" {
+			namespace = parts[3]
+			resource = parts[4]
+		}
+	case len(parts) >= 4 && parts[0] == "apis":
+		group = parts[1]
+		version = parts[2]
+		if len(parts) == 4 {
+			resource = parts[3]
+		} else if len(parts) == 6 && parts[3] == "namespaces" {
+			namespace = parts[4]
+			resource = parts[5]
+		}
+	}
+	return
+}
+
+func prettyJSON(body []byte) string {
+	if len(body) == 0 {
+		return "null\n"
+	}
+	var out bytes.Buffer
+	if err := json.Indent(&out, body, "", "  "); err == nil {
+		out.WriteByte('\n')
+		return out.String()
+	}
+	return string(body) + "\n"
+}
+
+func jsonEqual(a, b []byte) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	var av any
+	if err := json.Unmarshal(a, &av); err != nil {
+		return string(a) == string(b)
+	}
+	var bv any
+	if err := json.Unmarshal(b, &bv); err != nil {
+		return string(a) == string(b)
+	}
+	aj, _ := json.Marshal(av)
+	bj, _ := json.Marshal(bv)
+	return string(aj) == string(bj)
+}
+
+func colorizeDiff(in string) string {
+	const (
+		red   = "\x1b[31m"
+		green = "\x1b[32m"
+		cyan  = "\x1b[36m"
+		reset = "\x1b[0m"
+	)
+	lines := strings.SplitAfter(in, "\n")
+	var out strings.Builder
+	for _, line := range lines {
+		switch {
+		case strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") || strings.HasPrefix(line, "@@"):
+			out.WriteString(cyan)
+			out.WriteString(line)
+			out.WriteString(reset)
+		case strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++"):
+			out.WriteString(green)
+			out.WriteString(line)
+			out.WriteString(reset)
+		case strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---"):
+			out.WriteString(red)
+			out.WriteString(line)
+			out.WriteString(reset)
+		default:
+			out.WriteString(line)
+		}
+	}
+	return out.String()
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,0 +1,162 @@
+package diff
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	archivepkg "github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+func TestRun_TwoArchives(t *testing.T) {
+	before := buildArchive(t, map[string][]capture.Record{
+		"/api/v1/namespaces/default/pods": {
+			newRecord("rec-1", "/api/v1/namespaces/default/pods", time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC), `{"kind":"PodList","items":[{"metadata":{"name":"nginx"}}]}`),
+		},
+	})
+	after := buildArchive(t, map[string][]capture.Record{
+		"/api/v1/namespaces/default/pods": {
+			newRecord("rec-2", "/api/v1/namespaces/default/pods", time.Date(2026, 4, 9, 10, 5, 0, 0, time.UTC), `{"kind":"PodList","items":[{"metadata":{"name":"redis"}}]}`),
+		},
+	})
+
+	result, err := Run(Options{BeforeArchive: before, AfterArchive: after})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if len(result.Changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(result.Changes))
+	}
+	if result.Changes[0].Path != "/api/v1/namespaces/default/pods" {
+		t.Fatalf("unexpected path %q", result.Changes[0].Path)
+	}
+	if !strings.Contains(string(result.Changes[0].Before), "nginx") || !strings.Contains(string(result.Changes[0].After), "redis") {
+		t.Fatalf("unexpected before/after bodies: before=%s after=%s", result.Changes[0].Before, result.Changes[0].After)
+	}
+	text, err := RenderText(result, false)
+	if err != nil {
+		t.Fatalf("RenderText() error: %v", err)
+	}
+	if !strings.Contains(text, "Path: /api/v1/namespaces/default/pods") {
+		t.Fatalf("expected path header in text output, got %s", text)
+	}
+	if !strings.Contains(text, "--- before/api/v1/namespaces/default/pods") {
+		t.Fatalf("expected unified diff header, got %s", text)
+	}
+	if !strings.Contains(text, "+        \"name\": \"redis\"") {
+		t.Fatalf("expected added line in diff, got %s", text)
+	}
+}
+
+func TestRun_SameArchiveAtTimes(t *testing.T) {
+	archivePath := buildArchive(t, map[string][]capture.Record{
+		"/api/v1/namespaces/default/pods": {
+			newRecord("rec-1", "/api/v1/namespaces/default/pods", time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC), `{"kind":"PodList","items":[{"metadata":{"name":"before"}}]}`),
+			newRecord("rec-2", "/api/v1/namespaces/default/pods", time.Date(2026, 4, 9, 10, 5, 0, 0, time.UTC), `{"kind":"PodList","items":[{"metadata":{"name":"after"}}]}`),
+		},
+	})
+
+	result, err := Run(Options{Archive: archivePath, BeforeAt: "2026-04-09T10:01:00Z", AfterAt: "0s"})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if len(result.Changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(result.Changes))
+	}
+	if !strings.Contains(string(result.Changes[0].Before), "before") || !strings.Contains(string(result.Changes[0].After), "after") {
+		t.Fatalf("unexpected before/after bodies: before=%s after=%s", result.Changes[0].Before, result.Changes[0].After)
+	}
+}
+
+func TestRun_Filters(t *testing.T) {
+	before := buildArchive(t, map[string][]capture.Record{
+		"/api/v1/namespaces/default/pods": {
+			newRecord("rec-1", "/api/v1/namespaces/default/pods", time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC), `{"kind":"PodList","items":[]}`),
+		},
+		"/api/v1/namespaces/kube-system/pods": {
+			newRecord("rec-2", "/api/v1/namespaces/kube-system/pods", time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC), `{"kind":"PodList","items":[]}`),
+		},
+	})
+	after := buildArchive(t, map[string][]capture.Record{
+		"/api/v1/namespaces/default/pods": {
+			newRecord("rec-3", "/api/v1/namespaces/default/pods", time.Date(2026, 4, 9, 10, 5, 0, 0, time.UTC), `{"kind":"PodList","items":[{"metadata":{"name":"changed"}}]}`),
+		},
+		"/api/v1/namespaces/kube-system/pods": {
+			newRecord("rec-4", "/api/v1/namespaces/kube-system/pods", time.Date(2026, 4, 9, 10, 5, 0, 0, time.UTC), `{"kind":"PodList","items":[{"metadata":{"name":"ignored"}}]}`),
+		},
+	})
+
+	result, err := Run(Options{BeforeArchive: before, AfterArchive: after, Resource: "pods", Namespace: "default"})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if len(result.Changes) != 1 {
+		t.Fatalf("expected 1 filtered change, got %d", len(result.Changes))
+	}
+	if result.Changes[0].Namespace != "default" {
+		t.Fatalf("expected default namespace, got %q", result.Changes[0].Namespace)
+	}
+}
+
+func TestRun_NoDiff(t *testing.T) {
+	before := buildArchive(t, map[string][]capture.Record{
+		"/api/v1/namespaces/default/pods": {
+			newRecord("rec-1", "/api/v1/namespaces/default/pods", time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC), `{"kind":"PodList","items":[]}`),
+		},
+	})
+	after := buildArchive(t, map[string][]capture.Record{
+		"/api/v1/namespaces/default/pods": {
+			newRecord("rec-2", "/api/v1/namespaces/default/pods", time.Date(2026, 4, 9, 10, 5, 0, 0, time.UTC), `{"items":[],"kind":"PodList"}`),
+		},
+	})
+
+	result, err := Run(Options{BeforeArchive: before, AfterArchive: after})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if len(result.Changes) != 0 {
+		t.Fatalf("expected no changes, got %d", len(result.Changes))
+	}
+}
+
+func buildArchive(t *testing.T, entries map[string][]capture.Record) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "capture.tar.gz")
+	ids := make([]string, 0)
+	all := make([]capture.Record, 0)
+	index := make(capture.Index)
+	var capturedAt, capturedUntil time.Time
+	for path, records := range entries {
+		entry := &capture.IndexEntry{APIPath: path}
+		for _, rec := range records {
+			if capturedAt.IsZero() || rec.CapturedAt.Before(capturedAt) {
+				capturedAt = rec.CapturedAt
+			}
+			if capturedUntil.IsZero() || rec.CapturedAt.After(capturedUntil) {
+				capturedUntil = rec.CapturedAt
+			}
+			ids = append(ids, rec.ID)
+			all = append(all, rec)
+			entry.RecordIDs = append(entry.RecordIDs, rec.ID)
+			entry.Times = append(entry.Times, rec.CapturedAt)
+		}
+		index[path] = entry
+	}
+	meta := capture.CaptureMetadata{CaptureID: "test-capture", CapturedAt: capturedAt, CapturedUntil: capturedUntil, RecordCount: len(all)}
+	recs := make([]*capture.Record, 0, len(all))
+	for i := range all {
+		recs = append(recs, &all[i])
+	}
+	if err := archivepkg.Write(out, &meta, recs, index); err != nil {
+		t.Fatalf("archive.Write: %v", err)
+	}
+	_ = ids
+	return out
+}
+
+func newRecord(id, path string, capturedAt time.Time, body string) capture.Record {
+	return capture.Record{ID: id, CapturedAt: capturedAt, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body)}
+}


### PR DESCRIPTION
Implements Issue #29.

## What changed

- add `kshrk diff` subcommand for comparing:
  - two archives (`--before` + `--after`)
  - two timestamps in one archive (`--archive` + `--before-at` + `--after-at`)
- add `--resource` and `--namespace` filters
- add `--output json` for machine-readable results (default is unified diff text)
- return exit code `0` when no differences are found and `1` when differences are found
- add coverage for diff engine behavior and CLI exit/output behavior
- document command usage and flags in the usage guide

## Validation

- `make fmt`
- `go test ./internal/diff ./cmd`
- `go test ./...`

Closes #29