### PR TITLE
feat: add watch-based capture alongside polling

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -21,6 +21,7 @@ k8shark reads a YAML config file that controls what gets captured, from which na
 | `namespaces` | list of strings | no | Namespaces to poll. **Omit entirely for cluster-scoped resources** (nodes, persistentvolumes, storageclasses, etc.). |
 | `interval` | duration string | `30s` | How often to re-poll this resource during the capture window. |
 | `dedup` | bool | `true` | Skip writing a record when the response body is identical to the previous poll for the same API path. Set `false` to force writing every poll. |
+| `watch` | bool | `false` | Start a Kubernetes watch stream (`?watch=1`) for this resource in addition to polling. Watch events are recorded with an `event_type` field. |
 
 ### Namespaced vs. cluster-scoped resources
 
@@ -63,6 +64,27 @@ Use `dedup: false` on a resource when every poll must be preserved:
   interval: 10s
   dedup: false
 ```
+
+### Watch streaming alongside polling
+
+Set `watch: true` to supplement polling with watch events. This captures
+short-lived changes that may occur between poll intervals.
+
+```yaml
+- group: ""
+  version: v1
+  resource: pods
+  namespaces: [default]
+  interval: 30s
+  watch: true
+```
+
+Behavior:
+
+- poll-based capture remains active (first poll + interval polling)
+- watch events are recorded with `event_type` values such as `ADDED`,
+  `MODIFIED`, and `DELETED`
+- watch streams reconnect automatically when disconnected
 
 ## Example configs
 

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -147,6 +148,13 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 			defer wg.Done()
 			e.pollResource(ctx, r)
 		}(res)
+		if res.Watch {
+			wg.Add(1)
+			go func(r config.Resource) {
+				defer wg.Done()
+				e.watchResource(ctx, r)
+			}(res)
+		}
 	}
 	wg.Wait()
 
@@ -210,6 +218,150 @@ func (e *Engine) pollResource(ctx context.Context, res config.Resource) {
 			e.fetchResource(ctx, res)
 		}
 	}
+}
+
+// watchResource starts one watch loop per configured namespace for the given
+// resource. For cluster-scoped resources, a single watch loop is used.
+func (e *Engine) watchResource(ctx context.Context, res config.Resource) {
+	namespaces := res.Namespaces
+	if len(namespaces) == 0 {
+		namespaces = []string{""}
+	}
+
+	var wg sync.WaitGroup
+	for _, ns := range namespaces {
+		wg.Add(1)
+		go func(namespace string) {
+			defer wg.Done()
+			e.watchResourcePath(ctx, res, namespace)
+		}(ns)
+	}
+	wg.Wait()
+}
+
+func (e *Engine) watchResourcePath(ctx context.Context, res config.Resource, namespace string) {
+	apiPath := buildAPIPath(res.Group, res.Version, res.Resource, namespace)
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		resourceVersion := ""
+		if body, code := e.doFetch(ctx, apiPath, "", res.DedupEnabled()); code == http.StatusOK && body != nil {
+			resourceVersion = extractResourceVersion(body)
+		}
+
+		if err := e.streamWatch(ctx, apiPath, resourceVersion); err != nil && ctx.Err() == nil && e.verbose {
+			fmt.Fprintf(os.Stderr, "  [watch] %s: %v\n", apiPath, err)
+		}
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		// Brief backoff before reconnecting after a disconnect/error.
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+func (e *Engine) streamWatch(ctx context.Context, apiPath, resourceVersion string) error {
+	q := url.Values{}
+	q.Set("watch", "1")
+	if resourceVersion != "" {
+		q.Set("resourceVersion", resourceVersion)
+	}
+
+	watchURL := e.baseURL + apiPath + "?" + q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, watchURL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("watch status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	if e.verbose {
+		fmt.Fprintf(os.Stdout, "  [watch] %s connected\n", apiPath)
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	for {
+		var event struct {
+			Type   string          `json:"type"`
+			Object json.RawMessage `json:"object"`
+		}
+		if err := dec.Decode(&event); err != nil {
+			if err == io.EOF || ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+
+		switch event.Type {
+		case "ADDED", "MODIFIED", "DELETED":
+			// Keep these event types.
+		default:
+			continue
+		}
+		if len(event.Object) == 0 {
+			continue
+		}
+
+		rec := &Record{
+			ID:           uuid.New().String(),
+			CapturedAt:   time.Now().UTC(),
+			APIPath:      apiPath,
+			EventType:    event.Type,
+			HTTPMethod:   http.MethodGet,
+			ResponseCode: http.StatusOK,
+			ResponseBody: event.Object,
+		}
+
+		if e.sink != nil {
+			if err := e.sink.WriteRecord(rec); err != nil {
+				if e.verbose {
+					fmt.Fprintf(os.Stderr, "  [warn] writing watch record %s: %v\n", apiPath, err)
+				}
+				continue
+			}
+		}
+
+		e.mu.Lock()
+		if _, ok := e.index[apiPath]; !ok {
+			e.index[apiPath] = &IndexEntry{APIPath: apiPath}
+		}
+		e.index[apiPath].RecordIDs = append(e.index[apiPath].RecordIDs, rec.ID)
+		e.index[apiPath].Times = append(e.index[apiPath].Times, rec.CapturedAt)
+		e.mu.Unlock()
+	}
+}
+
+func extractResourceVersion(body []byte) string {
+	var meta struct {
+		Metadata struct {
+			ResourceVersion string `json:"resourceVersion"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(body, &meta); err != nil {
+		return ""
+	}
+	return meta.Metadata.ResourceVersion
 }
 
 // tableIndexKey is the virtual index key used to store Table-format responses

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -803,5 +805,142 @@ func TestEngine_DedupPerResourceOptOut(t *testing.T) {
 	}
 	if got := len(eventsEntry.RecordIDs); got <= 1 {
 		t.Fatalf("events with dedup:false should keep multiple polls, got %d", got)
+	}
+}
+
+func TestWatchResource_RecordsEvents(t *testing.T) {
+	var watchHits int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/namespaces/default/pods":
+			if r.URL.Query().Get("watch") == "1" {
+				atomic.AddInt32(&watchHits, 1)
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, `{"type":"ADDED","object":{"metadata":{"name":"p1"}}}`+"\n")
+				_, _ = io.WriteString(w, `{"type":"DELETED","object":{"metadata":{"name":"p2"}}}`+"\n")
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+				return
+			}
+			fmt.Fprint(w, `{"kind":"PodList","metadata":{"resourceVersion":"10"},"items":[]}`)
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+		default:
+			fmt.Fprint(w, `{"kind":"List","items":[]}`)
+		}
+	}))
+	defer srv.Close()
+
+	eng := newEngineWith(&config.Config{}, srv.Client(), srv.URL, false)
+	ss := &sliceSink{}
+	eng.sink = ss
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	res := config.Resource{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, Watch: true}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		eng.watchResource(ctx, res)
+	}()
+
+	deadline := time.Now().Add(1500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		ss.mu.Lock()
+		count := len(ss.records)
+		ss.mu.Unlock()
+		if count >= 2 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	if atomic.LoadInt32(&watchHits) == 0 {
+		t.Fatal("expected at least one watch connection")
+	}
+
+	seen := map[string]bool{}
+	for _, rec := range ss.records {
+		if rec.APIPath != "/api/v1/namespaces/default/pods" {
+			continue
+		}
+		if rec.EventType != "" {
+			seen[rec.EventType] = true
+		}
+	}
+	if !seen["ADDED"] || !seen["DELETED"] {
+		t.Fatalf("expected ADDED and DELETED watch event types, got %v", seen)
+	}
+}
+
+func TestWatchResource_Reconnects(t *testing.T) {
+	var watchConn int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/namespaces/default/pods":
+			if r.URL.Query().Get("watch") == "1" {
+				n := atomic.AddInt32(&watchConn, 1)
+				w.WriteHeader(http.StatusOK)
+				if n == 1 {
+					_, _ = io.WriteString(w, `{"type":"ADDED","object":{"metadata":{"name":"first"}}}`+"\n")
+				} else {
+					_, _ = io.WriteString(w, `{"type":"MODIFIED","object":{"metadata":{"name":"second"}}}`+"\n")
+				}
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+				return
+			}
+			fmt.Fprint(w, `{"kind":"PodList","metadata":{"resourceVersion":"22"},"items":[]}`)
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+		default:
+			fmt.Fprint(w, `{"kind":"List","items":[]}`)
+		}
+	}))
+	defer srv.Close()
+
+	eng := newEngineWith(&config.Config{}, srv.Client(), srv.URL, false)
+	ss := &sliceSink{}
+	eng.sink = ss
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	res := config.Resource{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, Watch: true}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		eng.watchResource(ctx, res)
+	}()
+
+	deadline := time.Now().Add(2500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&watchConn) >= 2 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	if atomic.LoadInt32(&watchConn) < 2 {
+		t.Fatalf("expected watch reconnect (>=2 watch connections), got %d", watchConn)
+	}
+
+	seen := map[string]bool{}
+	for _, rec := range ss.records {
+		if rec.EventType != "" {
+			seen[rec.EventType] = true
+		}
+	}
+	if !seen["ADDED"] || !seen["MODIFIED"] {
+		t.Fatalf("expected ADDED and MODIFIED watch events across reconnects, got %v", seen)
 	}
 }

--- a/internal/capture/record.go
+++ b/internal/capture/record.go
@@ -10,6 +10,7 @@ type Record struct {
 	ID           string            `json:"id"`
 	CapturedAt   time.Time         `json:"captured_at"`
 	APIPath      string            `json:"api_path"`
+	EventType    string            `json:"event_type,omitempty"`
 	HTTPMethod   string            `json:"http_method"`
 	QueryParams  map[string]string `json:"query_params,omitempty"`
 	ResponseCode int               `json:"response_code"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,9 @@ type Resource struct {
 	// Dedup controls response-body deduplication for this resource. Nil means
 	// enabled by default; set dedup: false to force writing every poll.
 	Dedup *bool `mapstructure:"dedup"`
+	// Watch enables a Kubernetes watch stream for this resource in addition to
+	// polling. Watch events are captured with low-latency timestamps.
+	Watch bool `mapstructure:"watch"`
 }
 
 // DedupEnabled reports whether polling responses for this resource should be


### PR DESCRIPTION
Implements Issue #31.

## What changed

- add `watch: true` as a per-resource config option (default false)
- start watch loops alongside poll loops for watch-enabled resources
- run watch loops per namespace (or single cluster-scoped loop)
- relist to refresh resourceVersion and reconnect watch streams on disconnect
- record watch events with `event_type` (`ADDED`, `MODIFIED`, `DELETED`)
- keep existing poll-only behavior unchanged when `watch` is not enabled
- document the `watch` field and behavior in config docs

## Tests

- add watch event recording test coverage
- add reconnect behavior test coverage
- preserve existing capture/config/server test coverage

## Validation

- `make fmt`
- `go test ./internal/capture ./internal/config`
- `go test ./...`

Closes #31