### PR TITLE
feat: add initial kshrk ui web explorer (v1)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,13 @@
         "/usr/local/go/bin/go": true,
         "/usr/bin/go": true,
         "brew": true,
-        },
-        "mkdir": true
+        "mkdir": true,
+        "git push": true,
+        "git rebase": true,
+        "make": true,
+        "git add": true,
+        "git commit": true,
+        "gh": true,
+        "git rev-parse": true
     }
 }

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -2,7 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 
+	"github.com/phenixblue/k8shark/internal/server"
 	"github.com/phenixblue/k8shark/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -10,8 +14,8 @@ import (
 var uiCmd = &cobra.Command{
 	Use:   "ui <capture.tar.gz>",
 	Short: "Open an interactive web explorer for a capture archive",
-	Long: `Starts a local web UI for browsing a k8shark capture without kubectl,
-including hierarchy navigation, filters, and raw JSON/YAML detail views.`,
+	Long: `Starts a local web UI for browsing a k8shark capture and also runs
+the mock Kubernetes API server with generated kubeconfig output.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runUI,
 }
@@ -19,28 +23,57 @@ including hierarchy navigation, filters, and raw JSON/YAML detail views.`,
 func init() {
 	rootCmd.AddCommand(uiCmd)
 	uiCmd.Flags().String("port", "0", "port for the local UI server (0 = random available port)")
+	uiCmd.Flags().String("api-port", "0", "port for the mock API server (0 = random available port)")
+	uiCmd.Flags().String("kubeconfig-out", "", "where to write the generated kubeconfig (default: ~/.kube/k8shark-<id>)")
 	uiCmd.Flags().String("at", "", "pin UI data to a specific timestamp (RFC3339 or relative duration like -5m)")
 }
 
 func runUI(cmd *cobra.Command, args []string) error {
 	archivePath := args[0]
-	port, _ := cmd.Flags().GetString("port")
+	uiPort, _ := cmd.Flags().GetString("port")
+	apiPort, _ := cmd.Flags().GetString("api-port")
+	kubeconfigOut, _ := cmd.Flags().GetString("kubeconfig-out")
 	at, _ := cmd.Flags().GetString("at")
 	verbose, _ := cmd.Root().PersistentFlags().GetBool("verbose")
 
-	srv, err := ui.Open(ui.OpenOptions{
+	mockSrv, err := server.Open(server.OpenOptions{
+		ArchivePath:   archivePath,
+		Port:          apiPort,
+		KubeconfigOut: kubeconfigOut,
+		At:            at,
+		Verbose:       verbose,
+	})
+	if err != nil {
+		return fmt.Errorf("opening mock API: %w", err)
+	}
+
+	uiSrv, err := ui.Open(ui.OpenOptions{
 		ArchivePath: archivePath,
-		Port:        port,
+		Port:        uiPort,
 		At:          at,
 		Verbose:     verbose,
 	})
 	if err != nil {
+		mockSrv.Shutdown()
 		return fmt.Errorf("opening UI: %w", err)
 	}
 
+	fmt.Printf("k8shark mock server running\n")
+	fmt.Printf("  Address:    %s\n", mockSrv.Address())
+	fmt.Printf("  Kubeconfig: %s\n", mockSrv.KubeconfigPath())
+	fmt.Printf("\nRun: export KUBECONFIG=%s\n", mockSrv.KubeconfigPath())
+	fmt.Printf("Then use kubectl normally against the capture.\n\n")
+
 	fmt.Printf("k8shark UI running\n")
-	fmt.Printf("  Address: %s\n", srv.Address())
+	fmt.Printf("  Address: %s\n", uiSrv.Address())
 	fmt.Printf("\nOpen this URL in your browser. Press Ctrl+C to stop.\n")
 
-	return srv.Wait()
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	<-sigCh
+
+	uiSrv.Shutdown()
+	mockSrv.Shutdown()
+
+	return nil
 }

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/phenixblue/k8shark/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var uiCmd = &cobra.Command{
+	Use:   "ui <capture.tar.gz>",
+	Short: "Open an interactive web explorer for a capture archive",
+	Long: `Starts a local web UI for browsing a k8shark capture without kubectl,
+including hierarchy navigation, filters, and raw JSON/YAML detail views.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runUI,
+}
+
+func init() {
+	rootCmd.AddCommand(uiCmd)
+	uiCmd.Flags().String("port", "0", "port for the local UI server (0 = random available port)")
+	uiCmd.Flags().String("at", "", "pin UI data to a specific timestamp (RFC3339 or relative duration like -5m)")
+}
+
+func runUI(cmd *cobra.Command, args []string) error {
+	archivePath := args[0]
+	port, _ := cmd.Flags().GetString("port")
+	at, _ := cmd.Flags().GetString("at")
+	verbose, _ := cmd.Root().PersistentFlags().GetBool("verbose")
+
+	srv, err := ui.Open(ui.OpenOptions{
+		ArchivePath: archivePath,
+		Port:        port,
+		At:          at,
+		Verbose:     verbose,
+	})
+	if err != nil {
+		return fmt.Errorf("opening UI: %w", err)
+	}
+
+	fmt.Printf("k8shark UI running\n")
+	fmt.Printf("  Address: %s\n", srv.Address())
+	fmt.Printf("\nOpen this URL in your browser. Press Ctrl+C to stop.\n")
+
+	return srv.Wait()
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -216,7 +216,7 @@ This is useful when you have a long capture (e.g. 1h) and want to compare cluste
 
 ## UI
 
-`kshrk ui` starts a local web-based explorer for a capture archive.
+`kshrk ui` starts a local web-based explorer and the mock Kubernetes API server for a capture archive.
 
 ```sh
 kshrk ui capture.tar.gz
@@ -225,6 +225,13 @@ kshrk ui capture.tar.gz
 Example output:
 
 ```
+k8shark mock server running
+  Address:    https://127.0.0.1:51325
+  Kubeconfig: ~/.kube/k8shark-abc123def456.yaml
+
+Run: export KUBECONFIG=~/.kube/k8shark-abc123def456.yaml
+Then use kubectl normally against the capture.
+
 k8shark UI running
   Address: http://127.0.0.1:53421
 
@@ -245,6 +252,8 @@ Open this URL in your browser. Press Ctrl+C to stop.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--port` | random | Port for the local UI server |
+| `--api-port` | random | Port for the mock API server |
+| `--kubeconfig-out` | `~/.kube/k8shark-<id>.yaml` | Where to write the generated kubeconfig |
 | `--at` | latest records | Pin UI data to a specific timestamp (RFC3339 or relative duration) |
 
 ---

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -214,6 +214,41 @@ This is useful when you have a long capture (e.g. 1h) and want to compare cluste
 
 ---
 
+## UI
+
+`kshrk ui` starts a local web-based explorer for a capture archive.
+
+```sh
+kshrk ui capture.tar.gz
+```
+
+Example output:
+
+```
+k8shark UI running
+  Address: http://127.0.0.1:53421
+
+Open this URL in your browser. Press Ctrl+C to stop.
+```
+
+### UI features (v1)
+
+- Cluster and namespace drill-down
+- Workload, pod, and container navigation
+- Cluster-scoped resources at top level
+- Sidebar toggles by resource type
+- Search by name or label text
+- Click for detail panel with JSON/YAML views
+
+### UI flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--port` | random | Port for the local UI server |
+| `--at` | latest records | Pin UI data to a specific timestamp (RFC3339 or relative duration) |
+
+---
+
 ## Redact
 
 Secret values can be removed from a capture archive in two ways:

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1011,8 +1011,12 @@ const indexHTML = `<!doctype html>
     body { margin:0; font-family: ui-sans-serif, -apple-system, Segoe UI, sans-serif; background:linear-gradient(145deg,#0b0f14,#0f172a); color:var(--text); }
 	header { padding:14px 18px; border-bottom:1px solid var(--line); display:flex; justify-content:space-between; align-items:center; gap:12px; }
 	.head-right { display:flex; align-items:center; gap:10px; }
+	.snapshot-nav { display:flex; align-items:center; gap:6px; }
 	.snapshot-select { min-width:220px; max-width:340px; box-sizing:border-box; padding:6px 8px; border:1px solid #334155; border-radius:8px; background:#0f172a; color:var(--text); }
 	.snapshot-label { color:var(--muted); font-size:12px; }
+	.snapshot-btn { padding:6px 10px; border-radius:8px; border:1px solid #334155; background:#0f172a; color:#cbd5e1; cursor:pointer; font-size:12px; }
+	.snapshot-btn:hover { border-color:#64748b; }
+	.snapshot-btn:disabled { opacity:.45; cursor:not-allowed; border-color:#1f2937; }
     .layout { display:grid; grid-template-columns:260px 1fr 40%; min-height:calc(100vh - 56px); }
     .panel { border-right:1px solid var(--line); overflow:auto; }
     .panel:last-child { border-right:none; border-left:1px solid var(--line); }
@@ -1075,7 +1079,11 @@ const indexHTML = `<!doctype html>
     <div><strong>kshrk capture explorer</strong></div>
 		<div class="head-right">
 			<span class="snapshot-label">Snapshot</span>
-			<select id="snapshotAt" class="snapshot-select" title="Select capture timestamp"></select>
+			<div class="snapshot-nav">
+				<button id="snapshotPrev" class="snapshot-btn" type="button" title="Jump to older snapshot">Prev</button>
+				<select id="snapshotAt" class="snapshot-select" title="Select capture timestamp"></select>
+				<button id="snapshotNext" class="snapshot-btn" type="button" title="Jump to newer snapshot">Next</button>
+			</div>
 			<div id="meta" class="muted"></div>
 		</div>
   </header>
@@ -1150,7 +1158,9 @@ const indexHTML = `<!doctype html>
 			toggleNone: document.getElementById('toggleNone'),
 			expandAll: document.getElementById('expandAll'),
 			collapseAll: document.getElementById('collapseAll'),
+			snapshotPrev: document.getElementById('snapshotPrev'),
 			snapshotAt: document.getElementById('snapshotAt'),
+			snapshotNext: document.getElementById('snapshotNext'),
 			toasts: document.getElementById('toasts')
     };
 
@@ -1163,11 +1173,14 @@ const indexHTML = `<!doctype html>
 		el.toggleNone.onclick = () => setAllKinds(false);
 	el.expandAll.onclick = () => setAllTreeDetails(true);
 	el.collapseAll.onclick = () => setAllTreeDetails(false);
+	el.snapshotPrev.onclick = () => stepSnapshot(1);
 	el.snapshotAt.onchange = () => {
 		currentAt = el.snapshotAt.value || '';
+		syncSnapshotButtons();
 		syncAtInURL();
 		refreshTree();
 	};
+	el.snapshotNext.onclick = () => stepSnapshot(-1);
 	document.addEventListener('keydown', onTreeKeyDown);
 
 	function syncAtInURL() {
@@ -1202,6 +1215,38 @@ const indexHTML = `<!doctype html>
 		return d.toISOString();
 	}
 
+	function snapshotSequence() {
+		return Array.from(el.snapshotAt.options).map((opt) => opt.value);
+	}
+
+	function syncSnapshotButtons() {
+		const sequence = snapshotSequence();
+		const idx = sequence.indexOf(currentAt || 'latest');
+		el.snapshotPrev.disabled = idx < 0 || idx >= sequence.length - 1;
+		el.snapshotNext.disabled = idx <= 0;
+	}
+
+	function stepSnapshot(delta) {
+		const sequence = snapshotSequence();
+		if (sequence.length === 0) {
+			return;
+		}
+		const current = currentAt || 'latest';
+		const idx = sequence.indexOf(current);
+		if (idx < 0) {
+			return;
+		}
+		const nextIdx = Math.max(0, Math.min(sequence.length - 1, idx + delta));
+		if (nextIdx === idx) {
+			return;
+		}
+		currentAt = sequence[nextIdx];
+		el.snapshotAt.value = currentAt;
+		syncSnapshotButtons();
+		syncAtInURL();
+		refreshTree();
+	}
+
 	function updateMetaLine() {
 		if (!treeData) {
 			el.meta.textContent = 'capture unavailable';
@@ -1214,7 +1259,7 @@ const indexHTML = `<!doctype html>
 	}
 
 	function renderSnapshotSelector(times, defaultAt) {
-		const opts = Array.isArray(times) ? times.slice() : [];
+		const opts = Array.isArray(times) ? times.slice().reverse() : [];
 		const unique = [];
 		const seen = new Set();
 		for (const ts of opts) {
@@ -1249,6 +1294,7 @@ const indexHTML = `<!doctype html>
 			el.snapshotAt.appendChild(opt);
 		}
 		el.snapshotAt.value = currentAt;
+		syncSnapshotButtons();
 	}
 
     function setTab(tab) {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -892,6 +892,9 @@ const indexHTML = `<!doctype html>
 	.toggle-actions button:hover { border-color:#64748b; }
     .toggle-list { margin-top:10px; display:grid; gap:6px; }
     .tree { padding:12px; }
+	.tree-head { display:flex; justify-content:space-between; align-items:center; margin-bottom:8px; }
+	.tree-actions button { margin-left:6px; padding:3px 8px; border-radius:6px; border:1px solid #334155; background:#0f172a; color:#cbd5e1; font-size:11px; cursor:pointer; }
+	.tree-actions button:hover { border-color:#64748b; }
     .crumbs { color:var(--muted); font-size:13px; margin-bottom:8px; }
     details { border:1px solid #1f2937; border-radius:8px; margin-bottom:8px; background:rgba(2,6,23,.45); }
     summary { cursor:pointer; padding:8px 10px; }
@@ -944,6 +947,13 @@ const indexHTML = `<!doctype html>
       <div class="toggle-list" id="toggles"></div>
     </aside>
     <main class="panel tree">
+			<div class="tree-head">
+				<span class="toggle-head-title">Tree</span>
+				<span class="tree-actions">
+					<button id="expandAll" type="button">Expand All</button>
+					<button id="collapseAll" type="button">Collapse All</button>
+				</span>
+			</div>
       <div class="crumbs" id="crumbs">Cluster</div>
       <div id="tree"></div>
     </main>
@@ -977,6 +987,8 @@ const indexHTML = `<!doctype html>
 			tabYaml: document.getElementById('tabYaml'),
 			toggleAll: document.getElementById('toggleAll'),
 			toggleNone: document.getElementById('toggleNone'),
+			expandAll: document.getElementById('expandAll'),
+			collapseAll: document.getElementById('collapseAll'),
 			toasts: document.getElementById('toasts')
     };
 
@@ -985,6 +997,8 @@ const indexHTML = `<!doctype html>
     el.search.oninput = render;
 		el.toggleAll.onclick = () => setAllKinds(true);
 		el.toggleNone.onclick = () => setAllKinds(false);
+	el.expandAll.onclick = () => setAllTreeDetails(true);
+	el.collapseAll.onclick = () => setAllTreeDetails(false);
 	document.addEventListener('keydown', onTreeKeyDown);
 
     function setTab(tab) {
@@ -1243,6 +1257,12 @@ const indexHTML = `<!doctype html>
 				activeKinds = new Set();
 			}
 			render();
+		}
+
+		function setAllTreeDetails(open) {
+			for (const details of el.tree.querySelectorAll('details')) {
+				details.open = open;
+			}
 		}
 
     async function init() {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -224,7 +224,7 @@ func (h *explorerHandler) serveDetail(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	normalizedBody, err := normalizeDetailBody(body, path)
+	normalizedBody, inferred, err := normalizeDetailBody(body, path)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "invalid object body"})
 		return
@@ -248,25 +248,28 @@ func (h *explorerHandler) serveDetail(w http.ResponseWriter, r *http.Request) {
 		"status_code": code,
 		"json":        string(prettyJSON),
 		"yaml":        string(yml),
+		"inferred":    inferred,
 	})
 }
 
-func normalizeDetailBody(body []byte, path string) ([]byte, error) {
+func normalizeDetailBody(body []byte, path string) ([]byte, map[string]bool, error) {
+	inferred := map[string]bool{"apiVersion": false, "kind": false}
 	var obj map[string]any
 	if err := json.Unmarshal(body, &obj); err != nil {
-		return nil, err
+		return nil, inferred, err
 	}
 
 	// Keep list/table/detail envelopes as-is.
 	if _, hasItems := obj["items"]; hasItems {
-		return body, nil
+		return body, inferred, nil
 	}
 	if strings.HasSuffix(asString(obj["kind"]), "Table") {
-		return body, nil
+		return body, inferred, nil
 	}
 
 	group, version, resource, _, _ := parseAPIPath(path)
 	if asString(obj["apiVersion"]) == "" {
+		inferred["apiVersion"] = true
 		if group == "" {
 			obj["apiVersion"] = version
 		} else {
@@ -274,14 +277,15 @@ func normalizeDetailBody(body []byte, path string) ([]byte, error) {
 		}
 	}
 	if asString(obj["kind"]) == "" {
+		inferred["kind"] = true
 		obj["kind"] = kindFromResource(resource)
 	}
 
 	b, err := json.Marshal(obj)
 	if err != nil {
-		return nil, err
+		return nil, inferred, err
 	}
-	return b, nil
+	return b, inferred, nil
 }
 
 func (h *explorerHandler) buildTree() (*treeResponse, error) {
@@ -1174,12 +1178,17 @@ const indexHTML = `<!doctype html>
 			const refs = meta.ownerReferences || [];
 			const owner = refs.length > 0 ? (refs[0].kind + '/' + refs[0].name) : '';
 			const labels = meta.labels ? Object.keys(meta.labels).length : 0;
+			const inferred = data.inferred || {};
+			const completeness = (inferred.apiVersion || inferred.kind)
+				? ('inferred: ' + [inferred.apiVersion ? 'apiVersion' : '', inferred.kind ? 'kind' : ''].filter(Boolean).join(', '))
+				: 'inferred: none';
 			const chips = [
 				['kind', obj.kind || node.kind || ''],
 				['name', meta.name || node.name || ''],
 				['ns', meta.namespace || '-'],
 				['labels', String(labels)],
-				['owner', owner || '-']
+				['owner', owner || '-'],
+				['raw', completeness]
 			];
 			for (const [k, v] of chips) {
 				const chip = document.createElement('span');

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1,0 +1,805 @@
+package ui
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/server"
+	"gopkg.in/yaml.v3"
+)
+
+type OpenOptions struct {
+	ArchivePath string
+	Port        string
+	At          string
+	Verbose     bool
+}
+
+type Server struct {
+	address    string
+	tmpDir     string
+	httpServer *http.Server
+	done       chan struct{}
+}
+
+type explorerHandler struct {
+	store   *server.CaptureStore
+	at      time.Time
+	verbose bool
+}
+
+type treeResponse struct {
+	CapturedAt    time.Time       `json:"captured_at"`
+	CapturedUntil time.Time       `json:"captured_until"`
+	Namespaces    []namespaceNode `json:"namespaces"`
+	ClusterScoped []resourceNode  `json:"cluster_scoped"`
+	ResourceKinds []string        `json:"resource_kinds"`
+}
+
+type namespaceNode struct {
+	Name      string         `json:"name"`
+	Workloads []workloadNode `json:"workloads"`
+	Pods      []podNode      `json:"pods"`
+	Resources []resourceNode `json:"resources"`
+}
+
+type workloadNode struct {
+	Kind     string            `json:"kind"`
+	Name     string            `json:"name"`
+	Status   string            `json:"status,omitempty"`
+	Age      string            `json:"age,omitempty"`
+	ListPath string            `json:"list_path"`
+	Labels   map[string]string `json:"labels,omitempty"`
+	Pods     []podNode         `json:"pods,omitempty"`
+}
+
+type podNode struct {
+	Kind       string            `json:"kind"`
+	Name       string            `json:"name"`
+	Status     string            `json:"status,omitempty"`
+	Age        string            `json:"age,omitempty"`
+	ListPath   string            `json:"list_path"`
+	Labels     map[string]string `json:"labels,omitempty"`
+	OwnerKind  string            `json:"owner_kind,omitempty"`
+	OwnerName  string            `json:"owner_name,omitempty"`
+	Containers []containerNode   `json:"containers,omitempty"`
+}
+
+type containerNode struct {
+	Name string `json:"name"`
+}
+
+type resourceNode struct {
+	Kind     string            `json:"kind"`
+	Name     string            `json:"name"`
+	Status   string            `json:"status,omitempty"`
+	Age      string            `json:"age,omitempty"`
+	ListPath string            `json:"list_path"`
+	Labels   map[string]string `json:"labels,omitempty"`
+}
+
+func Open(opts OpenOptions) (*Server, error) {
+	tmpDir, err := os.MkdirTemp("", "k8shark-ui-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp dir: %w", err)
+	}
+
+	if err := archive.Open(opts.ArchivePath, tmpDir); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("extracting archive: %w", err)
+	}
+
+	store, err := server.LoadStore(tmpDir)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("loading capture: %w", err)
+	}
+
+	at, err := parseReplayAt(store.Metadata.CapturedAt, store.Metadata.CapturedUntil, opts.At)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, err
+	}
+
+	port := opts.Port
+	if port == "" || port == "0" {
+		port = "0"
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:"+port)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("listening: %w", err)
+	}
+
+	h := &explorerHandler{store: store, at: at, verbose: opts.Verbose}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", h.serveIndex)
+	mux.HandleFunc("/api/ui/tree", h.serveTree)
+	mux.HandleFunc("/api/ui/detail", h.serveDetail)
+
+	httpSrv := &http.Server{Handler: mux}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = httpSrv.Serve(ln)
+	}()
+
+	addr := fmt.Sprintf("http://127.0.0.1:%d", ln.Addr().(*net.TCPAddr).Port)
+	return &Server{address: addr, tmpDir: tmpDir, httpServer: httpSrv, done: done}, nil
+}
+
+func (s *Server) Address() string { return s.address }
+
+func (s *Server) Shutdown() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = s.httpServer.Shutdown(ctx)
+	<-s.done
+	_ = os.RemoveAll(s.tmpDir)
+}
+
+func (s *Server) Wait() error {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	select {
+	case <-s.done:
+	case <-sigCh:
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = s.httpServer.Shutdown(ctx)
+		<-s.done
+	}
+	_ = os.RemoveAll(s.tmpDir)
+	return nil
+}
+
+func (h *explorerHandler) serveIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte(indexHTML))
+}
+
+func (h *explorerHandler) serveTree(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.buildTree()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *explorerHandler) serveDetail(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Query().Get("path")
+	if path == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing path query parameter"})
+		return
+	}
+
+	body, code, err := h.store.Latest(path, h.at)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if code == http.StatusNotFound {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "path not found in capture"})
+		return
+	}
+
+	name := r.URL.Query().Get("name")
+	if name != "" {
+		item, ok := findListItemByName(body, name)
+		if !ok {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "item not found in list response"})
+			return
+		}
+		body = item
+	}
+
+	prettyJSON := body
+	var out bytes.Buffer
+	if err := json.Indent(&out, body, "", "  "); err == nil {
+		prettyJSON = []byte(out.String())
+	}
+	var obj any
+	if err := json.Unmarshal(body, &obj); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "invalid json body"})
+		return
+	}
+	yml, _ := yaml.Marshal(obj)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"path":        path,
+		"status_code": code,
+		"json":        string(prettyJSON),
+		"yaml":        string(yml),
+	})
+}
+
+func (h *explorerHandler) buildTree() (*treeResponse, error) {
+	nsMap := map[string]*namespaceNode{}
+	clusterScoped := make([]resourceNode, 0)
+	kindSet := map[string]bool{}
+
+	workloadKinds := map[string]bool{
+		"deployments":  true,
+		"statefulsets": true,
+		"daemonsets":   true,
+		"jobs":         true,
+		"replicasets":  true,
+	}
+
+	for path := range h.store.Index {
+		if strings.Contains(path, "?") {
+			continue
+		}
+		group, version, resource, ns := parseAPIPath(path)
+		if resource == "" {
+			continue
+		}
+
+		listBody, code, err := h.store.Latest(path, h.at)
+		if err != nil || code != http.StatusOK {
+			continue
+		}
+		items, err := parseListItems(listBody)
+		if err != nil {
+			continue
+		}
+
+		if ns == "" {
+			for _, item := range items {
+				node := toResourceNode(resource, path, item)
+				clusterScoped = append(clusterScoped, node)
+				kindSet[node.Kind] = true
+			}
+			continue
+		}
+
+		node, ok := nsMap[ns]
+		if !ok {
+			node = &namespaceNode{Name: ns}
+			nsMap[ns] = node
+		}
+
+		if workloadKinds[resource] {
+			for _, item := range items {
+				w := workloadNode{
+					Kind:     firstNonEmpty(asString(item["kind"]), kindFromResource(resource)),
+					Name:     getMetaName(item),
+					Status:   summarizeStatus(item),
+					Age:      summarizeAge(item),
+					ListPath: path,
+					Labels:   getMetaLabels(item),
+				}
+				node.Workloads = append(node.Workloads, w)
+				kindSet[w.Kind] = true
+			}
+			continue
+		}
+
+		if resource == "pods" {
+			for _, item := range items {
+				p := toPodNode(path, item)
+				node.Pods = append(node.Pods, p)
+				kindSet[p.Kind] = true
+			}
+			continue
+		}
+
+		for _, item := range items {
+			rn := toResourceNode(resource, path, item)
+			node.Resources = append(node.Resources, rn)
+			kindSet[rn.Kind] = true
+		}
+
+		_ = group
+		_ = version
+	}
+
+	for ns := range nsMap {
+		attachPodsToWorkloads(nsMap[ns])
+	}
+
+	namespaces := make([]namespaceNode, 0, len(nsMap))
+	for _, ns := range nsMap {
+		sort.Slice(ns.Workloads, func(i, j int) bool {
+			if ns.Workloads[i].Kind == ns.Workloads[j].Kind {
+				return ns.Workloads[i].Name < ns.Workloads[j].Name
+			}
+			return ns.Workloads[i].Kind < ns.Workloads[j].Kind
+		})
+		sort.Slice(ns.Pods, func(i, j int) bool { return ns.Pods[i].Name < ns.Pods[j].Name })
+		sort.Slice(ns.Resources, func(i, j int) bool {
+			if ns.Resources[i].Kind == ns.Resources[j].Kind {
+				return ns.Resources[i].Name < ns.Resources[j].Name
+			}
+			return ns.Resources[i].Kind < ns.Resources[j].Kind
+		})
+		namespaces = append(namespaces, *ns)
+	}
+	sort.Slice(namespaces, func(i, j int) bool { return namespaces[i].Name < namespaces[j].Name })
+	sort.Slice(clusterScoped, func(i, j int) bool {
+		if clusterScoped[i].Kind == clusterScoped[j].Kind {
+			return clusterScoped[i].Name < clusterScoped[j].Name
+		}
+		return clusterScoped[i].Kind < clusterScoped[j].Kind
+	})
+
+	kinds := make([]string, 0, len(kindSet))
+	for k := range kindSet {
+		kinds = append(kinds, k)
+	}
+	sort.Strings(kinds)
+
+	return &treeResponse{
+		CapturedAt:    h.store.Metadata.CapturedAt,
+		CapturedUntil: h.store.Metadata.CapturedUntil,
+		Namespaces:    namespaces,
+		ClusterScoped: clusterScoped,
+		ResourceKinds: kinds,
+	}, nil
+}
+
+func toResourceNode(resource, listPath string, item map[string]any) resourceNode {
+	return resourceNode{
+		Kind:     firstNonEmpty(asString(item["kind"]), kindFromResource(resource)),
+		Name:     getMetaName(item),
+		Status:   summarizeStatus(item),
+		Age:      summarizeAge(item),
+		ListPath: listPath,
+		Labels:   getMetaLabels(item),
+	}
+}
+
+func toPodNode(listPath string, item map[string]any) podNode {
+	containers := make([]containerNode, 0)
+	spec, _ := item["spec"].(map[string]any)
+	if cList, ok := spec["containers"].([]any); ok {
+		for _, c := range cList {
+			if cm, ok := c.(map[string]any); ok {
+				containers = append(containers, containerNode{Name: asString(cm["name"])})
+			}
+		}
+	}
+
+	ownKind, ownName := getOwner(item)
+	return podNode{
+		Kind:       firstNonEmpty(asString(item["kind"]), "Pod"),
+		Name:       getMetaName(item),
+		Status:     summarizeStatus(item),
+		Age:        summarizeAge(item),
+		ListPath:   listPath,
+		Labels:     getMetaLabels(item),
+		OwnerKind:  ownKind,
+		OwnerName:  ownName,
+		Containers: containers,
+	}
+}
+
+func attachPodsToWorkloads(ns *namespaceNode) {
+	byOwner := map[string]*workloadNode{}
+	for i := range ns.Workloads {
+		k := ns.Workloads[i].Kind + "/" + ns.Workloads[i].Name
+		byOwner[k] = &ns.Workloads[i]
+	}
+
+	remaining := make([]podNode, 0)
+	for _, p := range ns.Pods {
+		if p.OwnerKind != "" && p.OwnerName != "" {
+			if w := byOwner[p.OwnerKind+"/"+p.OwnerName]; w != nil {
+				w.Pods = append(w.Pods, p)
+				continue
+			}
+		}
+		remaining = append(remaining, p)
+	}
+	ns.Pods = remaining
+}
+
+func parseListItems(body []byte) ([]map[string]any, error) {
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, err
+	}
+	itemsAny, ok := raw["items"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("no items array")
+	}
+	items := make([]map[string]any, 0, len(itemsAny))
+	for _, it := range itemsAny {
+		if m, ok := it.(map[string]any); ok {
+			items = append(items, m)
+		}
+	}
+	return items, nil
+}
+
+func findListItemByName(body []byte, name string) ([]byte, bool) {
+	items, err := parseListItems(body)
+	if err != nil {
+		return nil, false
+	}
+	for _, item := range items {
+		if getMetaName(item) == name {
+			b, err := json.Marshal(item)
+			return b, err == nil
+		}
+	}
+	return nil, false
+}
+
+func getMetaName(item map[string]any) string {
+	meta, _ := item["metadata"].(map[string]any)
+	return asString(meta["name"])
+}
+
+func getMetaLabels(item map[string]any) map[string]string {
+	meta, _ := item["metadata"].(map[string]any)
+	labelsAny, _ := meta["labels"].(map[string]any)
+	out := make(map[string]string, len(labelsAny))
+	for k, v := range labelsAny {
+		out[k] = asString(v)
+	}
+	return out
+}
+
+func summarizeStatus(item map[string]any) string {
+	status, _ := item["status"].(map[string]any)
+	if phase := asString(status["phase"]); phase != "" {
+		return phase
+	}
+	if conds, ok := status["conditions"].([]any); ok {
+		for _, c := range conds {
+			if cm, ok := c.(map[string]any); ok {
+				if asString(cm["status"]) == "True" {
+					return firstNonEmpty(asString(cm["type"]), "Ready")
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func summarizeAge(item map[string]any) string {
+	meta, _ := item["metadata"].(map[string]any)
+	ts := asString(meta["creationTimestamp"])
+	if ts == "" {
+		return ""
+	}
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return ""
+	}
+	d := time.Since(t)
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	}
+	return fmt.Sprintf("%dd", int(d.Hours()/24))
+}
+
+func getOwner(item map[string]any) (string, string) {
+	meta, _ := item["metadata"].(map[string]any)
+	refs, _ := meta["ownerReferences"].([]any)
+	for _, r := range refs {
+		if rm, ok := r.(map[string]any); ok {
+			return asString(rm["kind"]), asString(rm["name"])
+		}
+	}
+	return "", ""
+}
+
+func kindFromResource(resource string) string {
+	known := map[string]string{
+		"pods":         "Pod",
+		"deployments":  "Deployment",
+		"statefulsets": "StatefulSet",
+		"daemonsets":   "DaemonSet",
+		"jobs":         "Job",
+		"replicasets":  "ReplicaSet",
+		"services":     "Service",
+		"nodes":        "Node",
+	}
+	if k, ok := known[resource]; ok {
+		return k
+	}
+	s := strings.TrimSuffix(resource, "s")
+	if s == "" {
+		return resource
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func parseAPIPath(path string) (group, version, resource, namespace string) {
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	switch {
+	case len(parts) >= 3 && parts[0] == "api":
+		version = parts[1]
+		if len(parts) == 3 {
+			resource = parts[2]
+		} else if len(parts) == 5 && parts[2] == "namespaces" {
+			namespace = parts[3]
+			resource = parts[4]
+		}
+	case len(parts) >= 4 && parts[0] == "apis":
+		group = parts[1]
+		version = parts[2]
+		if len(parts) == 4 {
+			resource = parts[3]
+		} else if len(parts) == 6 && parts[3] == "namespaces" {
+			namespace = parts[4]
+			resource = parts[5]
+		}
+	}
+	return
+}
+
+func asString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func parseReplayAt(start, end time.Time, raw string) (time.Time, error) {
+	if raw == "" {
+		return time.Time{}, nil
+	}
+	at, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		d, derr := time.ParseDuration(raw)
+		if derr != nil {
+			return time.Time{}, fmt.Errorf("parsing --at %q: must be RFC3339 or a relative duration like -5m", raw)
+		}
+		at = end.Add(d)
+	}
+	if !start.IsZero() && at.Before(start) {
+		return time.Time{}, fmt.Errorf("parsing --at %q: requested time %s is before capture start %s", raw, at.Format(time.RFC3339), start.Format(time.RFC3339))
+	}
+	if !end.IsZero() && at.After(end) {
+		return time.Time{}, fmt.Errorf("parsing --at %q: requested time %s is after capture end %s", raw, at.Format(time.RFC3339), end.Format(time.RFC3339))
+	}
+	return at, nil
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+const indexHTML = `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>kshrk UI</title>
+  <style>
+    :root { --bg:#0b0f14; --panel:#111827; --text:#e5e7eb; --muted:#94a3b8; --line:#1f2937; --ok:#16a34a; --warn:#f59e0b; --bad:#dc2626; --accent:#22c55e; }
+    body { margin:0; font-family: ui-sans-serif, -apple-system, Segoe UI, sans-serif; background:linear-gradient(145deg,#0b0f14,#0f172a); color:var(--text); }
+    header { padding:14px 18px; border-bottom:1px solid var(--line); display:flex; justify-content:space-between; align-items:center; }
+    .layout { display:grid; grid-template-columns:260px 1fr 40%; min-height:calc(100vh - 56px); }
+    .panel { border-right:1px solid var(--line); overflow:auto; }
+    .panel:last-child { border-right:none; border-left:1px solid var(--line); }
+    .side { padding:12px; background:rgba(17,24,39,.85); }
+    .search { width:100%; box-sizing:border-box; padding:8px 10px; border:1px solid #334155; border-radius:8px; background:#0f172a; color:var(--text); }
+    .toggle-list { margin-top:10px; display:grid; gap:6px; }
+    .tree { padding:12px; }
+    .crumbs { color:var(--muted); font-size:13px; margin-bottom:8px; }
+    details { border:1px solid #1f2937; border-radius:8px; margin-bottom:8px; background:rgba(2,6,23,.45); }
+    summary { cursor:pointer; padding:8px 10px; }
+    .node { padding:6px 10px; cursor:pointer; border-radius:6px; margin:3px 8px; border:1px solid transparent; }
+    .node:hover { border-color:#334155; background:#0f172a; }
+    .muted { color:var(--muted); font-size:12px; }
+    .badge { display:inline-block; font-size:11px; padding:2px 6px; border-radius:999px; margin-left:6px; background:#1f2937; }
+    .ok { background:rgba(22,163,74,.2); color:#86efac; }
+    .warn { background:rgba(245,158,11,.2); color:#fcd34d; }
+    .bad { background:rgba(220,38,38,.2); color:#fca5a5; }
+    .detail { padding:12px; background:rgba(17,24,39,.9); }
+    pre { white-space:pre-wrap; background:#020617; border:1px solid #1f2937; padding:10px; border-radius:8px; }
+    .tabs button { margin-right:6px; padding:6px 10px; border-radius:7px; border:1px solid #334155; background:#0f172a; color:var(--text); cursor:pointer; }
+    .tabs button.active { border-color:var(--accent); color:#86efac; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>kshrk capture explorer</strong></div>
+    <div id="meta" class="muted"></div>
+  </header>
+  <div class="layout">
+    <aside class="panel side">
+      <input class="search" id="search" placeholder="Search name or label..."/>
+      <div class="toggle-list" id="toggles"></div>
+    </aside>
+    <main class="panel tree">
+      <div class="crumbs" id="crumbs">Cluster</div>
+      <div id="tree"></div>
+    </main>
+    <section class="detail">
+      <h3 id="detailTitle">Select a resource</h3>
+      <div class="tabs">
+        <button id="tabJson" class="active">JSON</button>
+        <button id="tabYaml">YAML</button>
+      </div>
+      <pre id="detailBody">Click a node in the tree to inspect details.</pre>
+    </section>
+  </div>
+  <script>
+    let treeData = null;
+    let activeKinds = new Set();
+    let selected = null;
+    let activeTab = 'json';
+
+    const el = {
+      tree: document.getElementById('tree'),
+      search: document.getElementById('search'),
+      toggles: document.getElementById('toggles'),
+      crumbs: document.getElementById('crumbs'),
+      meta: document.getElementById('meta'),
+      detailTitle: document.getElementById('detailTitle'),
+      detailBody: document.getElementById('detailBody'),
+      tabJson: document.getElementById('tabJson'),
+      tabYaml: document.getElementById('tabYaml')
+    };
+
+    el.tabJson.onclick = () => setTab('json');
+    el.tabYaml.onclick = () => setTab('yaml');
+    el.search.oninput = render;
+
+    function setTab(tab) {
+      activeTab = tab;
+      el.tabJson.classList.toggle('active', tab === 'json');
+      el.tabYaml.classList.toggle('active', tab === 'yaml');
+      if (selected && selected.detail) {
+        el.detailBody.textContent = selected.detail[activeTab] || '';
+      }
+    }
+
+    function statusClass(status) {
+      const s = (status || '').toLowerCase();
+      if (s.includes('running') || s.includes('ready') || s.includes('active')) return 'ok';
+      if (s.includes('pending') || s.includes('containercreating')) return 'warn';
+      if (s.includes('failed') || s.includes('error') || s.includes('crash')) return 'bad';
+      return '';
+    }
+
+    function nodeMatches(node, q) {
+      if (!q) return true;
+      const hay = [node.name, ...(Object.entries(node.labels || {}).map(([k,v]) => k + '=' + v))].join(' ').toLowerCase();
+      return hay.includes(q);
+    }
+
+    function kindEnabled(kind) {
+      return activeKinds.size === 0 || activeKinds.has(kind);
+    }
+
+    function mkNode(label, node, crumbs) {
+      const d = document.createElement('div');
+      d.className = 'node';
+      d.title = [node.kind, node.status, node.age, Object.entries(node.labels || {}).slice(0,5).map(([k,v]) => k + '=' + v).join(', ')].filter(Boolean).join(' | ');
+      const badge = node.status ? '<span class="badge ' + statusClass(node.status) + '">' + node.status + '</span>' : '';
+      d.innerHTML = '<strong>' + label + '</strong>' + badge + (node.age ? ' <span class="muted">' + node.age + '</span>' : '');
+      d.onclick = () => showDetail(node, crumbs);
+      return d;
+    }
+
+    async function showDetail(node, crumbs) {
+      selected = { node, crumbs };
+      el.crumbs.textContent = crumbs.join(' / ');
+      el.detailTitle.textContent = node.kind + ' ' + node.name;
+      const q = new URLSearchParams({ path: node.list_path, name: node.name });
+      const res = await fetch('/api/ui/detail?' + q.toString());
+      const data = await res.json();
+      selected.detail = data;
+      el.detailBody.textContent = data[activeTab] || JSON.stringify(data, null, 2);
+    }
+
+    function render() {
+      if (!treeData) return;
+      el.tree.innerHTML = '';
+      const q = el.search.value.trim().toLowerCase();
+
+      const cs = document.createElement('details');
+      cs.open = true;
+      cs.innerHTML = '<summary>Cluster-scoped resources</summary>';
+      for (const node of treeData.cluster_scoped) {
+        if (!kindEnabled(node.kind) || !nodeMatches(node, q)) continue;
+        cs.appendChild(mkNode(node.kind + ' ' + node.name, node, ['Cluster', node.kind, node.name]));
+      }
+      el.tree.appendChild(cs);
+
+      for (const ns of treeData.namespaces) {
+        const ds = document.createElement('details');
+        ds.open = true;
+        ds.innerHTML = '<summary>Namespace: <strong>' + ns.name + '</strong></summary>';
+
+        for (const w of ns.workloads) {
+          if (!kindEnabled(w.kind) || !nodeMatches(w, q)) continue;
+          ds.appendChild(mkNode(w.kind + ' ' + w.name, w, ['Cluster', ns.name, w.kind, w.name]));
+          for (const p of (w.pods || [])) {
+            if (!kindEnabled(p.kind) || !nodeMatches(p, q)) continue;
+            ds.appendChild(mkNode('  Pod ' + p.name, p, ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name]));
+            for (const c of (p.containers || [])) {
+              const fake = {kind:'Container',name:c.name,status:'',age:'',labels:{},list_path:p.list_path};
+              if (!kindEnabled('Container') || !nodeMatches(fake, q)) continue;
+              ds.appendChild(mkNode('    Container ' + c.name, fake, ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name, 'Container', c.name]));
+            }
+          }
+        }
+
+        for (const p of ns.pods) {
+          if (!kindEnabled(p.kind) || !nodeMatches(p, q)) continue;
+          ds.appendChild(mkNode('Pod ' + p.name, p, ['Cluster', ns.name, 'Pod', p.name]));
+          for (const c of (p.containers || [])) {
+            const fake = {kind:'Container',name:c.name,status:'',age:'',labels:{},list_path:p.list_path};
+            if (!kindEnabled('Container') || !nodeMatches(fake, q)) continue;
+            ds.appendChild(mkNode('  Container ' + c.name, fake, ['Cluster', ns.name, 'Pod', p.name, 'Container', c.name]));
+          }
+        }
+
+        for (const r of ns.resources) {
+          if (!kindEnabled(r.kind) || !nodeMatches(r, q)) continue;
+          ds.appendChild(mkNode(r.kind + ' ' + r.name, r, ['Cluster', ns.name, r.kind, r.name]));
+        }
+        el.tree.appendChild(ds);
+      }
+    }
+
+    function renderToggles(kinds) {
+      activeKinds = new Set(kinds);
+      el.toggles.innerHTML = '';
+      for (const kind of kinds) {
+        const row = document.createElement('label');
+        row.className = 'muted';
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.checked = true;
+        cb.onchange = () => {
+          if (cb.checked) activeKinds.add(kind); else activeKinds.delete(kind);
+          render();
+        };
+        row.appendChild(cb);
+        row.appendChild(document.createTextNode(' ' + kind));
+        el.toggles.appendChild(row);
+      }
+    }
+
+    async function init() {
+      const res = await fetch('/api/ui/tree');
+      treeData = await res.json();
+      el.meta.textContent = 'capture ' + new Date(treeData.captured_at).toISOString() + ' to ' + new Date(treeData.captured_until).toISOString();
+      renderToggles(treeData.resource_kinds.concat(['Container']));
+      render();
+    }
+    init();
+  </script>
+</body>
+</html>`

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -916,6 +916,8 @@ const indexHTML = `<!doctype html>
     .warn { background:rgba(245,158,11,.2); color:#fcd34d; }
     .bad { background:rgba(220,38,38,.2); color:#fca5a5; }
     .detail { padding:12px; background:rgba(17,24,39,.9); }
+	.detail-summary { display:flex; flex-wrap:wrap; gap:6px; margin:8px 0 10px; }
+	.summary-chip { font-size:11px; line-height:1; padding:5px 8px; border-radius:999px; border:1px solid #334155; color:#cbd5e1; background:#0f172a; }
 	.tree-state { margin:8px; padding:10px 12px; border-radius:8px; border:1px solid #334155; background:rgba(15,23,42,.7); }
 	.tree-state.error { border-color:rgba(220,38,38,.55); color:#fecaca; background:rgba(127,29,29,.25); }
 	.tree-state.empty { border-color:rgba(148,163,184,.45); color:#cbd5e1; }
@@ -962,6 +964,7 @@ const indexHTML = `<!doctype html>
     </main>
     <section class="detail">
       <h3 id="detailTitle">Select a resource</h3>
+			<div id="detailSummary" class="detail-summary"></div>
       <div class="tabs">
         <button id="tabJson" class="active">JSON</button>
         <button id="tabYaml">YAML</button>
@@ -990,6 +993,7 @@ const indexHTML = `<!doctype html>
       crumbs: document.getElementById('crumbs'),
       meta: document.getElementById('meta'),
       detailTitle: document.getElementById('detailTitle'),
+	detailSummary: document.getElementById('detailSummary'),
       detailBody: document.getElementById('detailBody'),
       tabJson: document.getElementById('tabJson'),
 			tabYaml: document.getElementById('tabYaml'),
@@ -1043,6 +1047,34 @@ const indexHTML = `<!doctype html>
 			el.toasts.appendChild(toast);
 			const ttl = timeoutMs || (type === 'error' ? 7000 : 3000);
 			window.setTimeout(() => toast.remove(), ttl);
+		}
+
+		function updateDetailSummary(data, node) {
+			el.detailSummary.innerHTML = '';
+			if (!data || !data.json) return;
+			let obj = null;
+			try {
+				obj = JSON.parse(data.json);
+			} catch (_) {
+				return;
+			}
+			const meta = obj.metadata || {};
+			const refs = meta.ownerReferences || [];
+			const owner = refs.length > 0 ? (refs[0].kind + '/' + refs[0].name) : '';
+			const labels = meta.labels ? Object.keys(meta.labels).length : 0;
+			const chips = [
+				['kind', obj.kind || node.kind || ''],
+				['name', meta.name || node.name || ''],
+				['ns', meta.namespace || '-'],
+				['labels', String(labels)],
+				['owner', owner || '-']
+			];
+			for (const [k, v] of chips) {
+				const chip = document.createElement('span');
+				chip.className = 'summary-chip';
+				chip.textContent = k + ': ' + v;
+				el.detailSummary.appendChild(chip);
+			}
 		}
 
 		function loadPreferences() {
@@ -1197,9 +1229,11 @@ const indexHTML = `<!doctype html>
 					throw new Error(msg);
 				}
 				selected.detail = data;
+				updateDetailSummary(data, node);
 				el.detailBody.textContent = data[activeTab] || JSON.stringify(data, null, 2);
 			} catch (err) {
 				selected.detail = null;
+				el.detailSummary.innerHTML = '';
 				const msg = (err && err.message ? err.message : String(err));
 				el.detailBody.textContent = 'Failed to load detail: ' + msg;
 				showToast('error', 'Detail request failed: ' + msg);

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -907,6 +907,10 @@ const indexHTML = `<!doctype html>
     .warn { background:rgba(245,158,11,.2); color:#fcd34d; }
     .bad { background:rgba(220,38,38,.2); color:#fca5a5; }
     .detail { padding:12px; background:rgba(17,24,39,.9); }
+	.tree-state { margin:8px; padding:10px 12px; border-radius:8px; border:1px solid #334155; background:rgba(15,23,42,.7); }
+	.tree-state.error { border-color:rgba(220,38,38,.55); color:#fecaca; background:rgba(127,29,29,.25); }
+	.tree-state.empty { border-color:rgba(148,163,184,.45); color:#cbd5e1; }
+	.tree-state.loading { border-color:rgba(59,130,246,.45); color:#bfdbfe; }
     pre { white-space:pre-wrap; background:#020617; border:1px solid #1f2937; padding:10px; border-radius:8px; }
     .tabs button { margin-right:6px; padding:6px 10px; border-radius:7px; border:1px solid #334155; background:#0f172a; color:var(--text); cursor:pointer; }
     .tabs button.active { border-color:var(--accent); color:#86efac; }
@@ -966,6 +970,14 @@ const indexHTML = `<!doctype html>
       }
     }
 
+		function setTreeState(type, message) {
+			el.tree.innerHTML = '';
+			const box = document.createElement('div');
+			box.className = 'tree-state ' + type;
+			box.textContent = message;
+			el.tree.appendChild(box);
+		}
+
     function statusClass(status) {
       const s = (status || '').toLowerCase();
       if (s.includes('running') || s.includes('ready') || s.includes('active')) return 'ok';
@@ -1011,17 +1023,31 @@ const indexHTML = `<!doctype html>
       selected = { node, crumbs };
       el.crumbs.textContent = crumbs.join(' / ');
       el.detailTitle.textContent = node.kind + ' ' + node.name;
-      const q = new URLSearchParams({ path: node.list_path, name: node.name });
-      const res = await fetch('/api/ui/detail?' + q.toString());
-      const data = await res.json();
-      selected.detail = data;
-      el.detailBody.textContent = data[activeTab] || JSON.stringify(data, null, 2);
+			el.detailBody.textContent = 'Loading detail...';
+			try {
+				const q = new URLSearchParams({ path: node.list_path, name: node.name });
+				const res = await fetch('/api/ui/detail?' + q.toString());
+				const data = await res.json();
+				if (!res.ok) {
+					const msg = (data && data.error) ? data.error : ('request failed with status ' + res.status);
+					throw new Error(msg);
+				}
+				selected.detail = data;
+				el.detailBody.textContent = data[activeTab] || JSON.stringify(data, null, 2);
+			} catch (err) {
+				selected.detail = null;
+				el.detailBody.textContent = 'Failed to load detail: ' + (err && err.message ? err.message : String(err));
+			}
     }
 
     function render() {
-      if (!treeData) return;
+			if (!treeData) {
+				setTreeState('loading', 'Loading captured resources...');
+				return;
+			}
       el.tree.innerHTML = '';
       const q = el.search.value.trim().toLowerCase();
+			let renderedNodes = 0;
 
       const cs = document.createElement('details');
       cs.open = true;
@@ -1029,6 +1055,7 @@ const indexHTML = `<!doctype html>
       for (const node of treeData.cluster_scoped) {
         if (!kindEnabled(node.kind) || !nodeMatches(node, q)) continue;
 				cs.appendChild(mkNode(node, ['Cluster', node.kind, node.name], 0, ''));
+				renderedNodes++;
       }
       el.tree.appendChild(cs);
 
@@ -1041,13 +1068,16 @@ const indexHTML = `<!doctype html>
 			for (const w of (ns.workloads || [])) {
           if (!kindEnabled(w.kind) || !nodeMatches(w, q)) continue;
 					ds.appendChild(mkNode(w, ['Cluster', ns.name, w.kind, w.name], 0, ''));
+					renderedNodes++;
           for (const p of (w.pods || [])) {
             if (!kindEnabled(p.kind) || !nodeMatches(p, q)) continue;
 						ds.appendChild(mkNode(p, ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name], 1, ''));
+						renderedNodes++;
             for (const c of (p.containers || [])) {
               const fake = {kind:'Container',name:c.name,status:'',age:'',labels:{},list_path:p.list_path};
               if (!kindEnabled('Container') || !nodeMatches(fake, q)) continue;
 							ds.appendChild(mkNode(fake, ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name, 'Container', c.name], 2, ''));
+							renderedNodes++;
             }
           }
         }
@@ -1055,19 +1085,29 @@ const indexHTML = `<!doctype html>
 			for (const p of (ns.pods || [])) {
           if (!kindEnabled(p.kind) || !nodeMatches(p, q)) continue;
 					ds.appendChild(mkNode(p, ['Cluster', ns.name, 'Pod', p.name], 0, ''));
+					renderedNodes++;
           for (const c of (p.containers || [])) {
             const fake = {kind:'Container',name:c.name,status:'',age:'',labels:{},list_path:p.list_path};
             if (!kindEnabled('Container') || !nodeMatches(fake, q)) continue;
 						ds.appendChild(mkNode(fake, ['Cluster', ns.name, 'Pod', p.name, 'Container', c.name], 1, ''));
+						renderedNodes++;
           }
         }
 
 			for (const r of (ns.resources || [])) {
           if (!kindEnabled(r.kind) || !nodeMatches(r, q)) continue;
 					ds.appendChild(mkNode(r, ['Cluster', ns.name, r.kind, r.name], 0, ''));
+					renderedNodes++;
         }
         el.tree.appendChild(ds);
       }
+
+			if (renderedNodes === 0) {
+				const msg = q
+					? 'No resources match the current search/filter selection.'
+					: 'No resources were found in this capture at the selected time.';
+				setTreeState('empty', msg);
+			}
     }
 
     function renderToggles(kinds) {
@@ -1090,11 +1130,22 @@ const indexHTML = `<!doctype html>
     }
 
     async function init() {
-      const res = await fetch('/api/ui/tree');
-      treeData = await res.json();
-      el.meta.textContent = 'capture ' + new Date(treeData.captured_at).toISOString() + ' to ' + new Date(treeData.captured_until).toISOString();
-      renderToggles(treeData.resource_kinds.concat(['Container']));
-      render();
+			setTreeState('loading', 'Loading captured resources...');
+			try {
+				const res = await fetch('/api/ui/tree');
+				const data = await res.json();
+				if (!res.ok) {
+					const msg = (data && data.error) ? data.error : ('request failed with status ' + res.status);
+					throw new Error(msg);
+				}
+				treeData = data;
+				el.meta.textContent = 'capture ' + new Date(treeData.captured_at).toISOString() + ' to ' + new Date(treeData.captured_until).toISOString();
+				renderToggles((treeData.resource_kinds || []).concat(['Container']));
+				render();
+			} catch (err) {
+				setTreeState('error', 'Failed to load capture tree: ' + (err && err.message ? err.message : String(err)));
+				el.meta.textContent = 'capture unavailable';
+			}
     }
     init();
   </script>

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -967,6 +967,7 @@ const indexHTML = `<!doctype html>
 	.tabs-left button { margin-right:6px; padding:6px 10px; border-radius:7px; border:1px solid #334155; background:#0f172a; color:var(--text); cursor:pointer; }
 	.copy-btn { padding:6px 10px; border-radius:7px; border:1px solid #334155; background:#0f172a; color:#cbd5e1; cursor:pointer; font-size:12px; }
 	.copy-btn:hover { border-color:#64748b; }
+	.detail-actions { display:flex; gap:6px; }
     .tabs button.active { border-color:var(--accent); color:#86efac; }
 		.toast-stack { position:fixed; right:14px; bottom:14px; display:grid; gap:8px; z-index:40; pointer-events:none; }
 		.toast { pointer-events:auto; max-width:420px; border:1px solid #334155; border-radius:8px; padding:10px 12px; background:rgba(15,23,42,.92); box-shadow:0 8px 28px rgba(2,6,23,.45); font-size:13px; }
@@ -1013,7 +1014,10 @@ const indexHTML = `<!doctype html>
 					<button id="tabJson" class="active">JSON</button>
 					<button id="tabYaml">YAML</button>
 				</span>
-				<button id="copyDetail" class="copy-btn" type="button">Copy JSON</button>
+				<span class="detail-actions">
+					<button id="copyDetail" class="copy-btn" type="button">Copy JSON</button>
+					<button id="downloadDetail" class="copy-btn" type="button">Download JSON</button>
+				</span>
       </div>
       <pre id="detailBody">Click a node in the tree to inspect details.</pre>
     </section>
@@ -1044,6 +1048,7 @@ const indexHTML = `<!doctype html>
       tabJson: document.getElementById('tabJson'),
 			tabYaml: document.getElementById('tabYaml'),
 			copyDetail: document.getElementById('copyDetail'),
+			downloadDetail: document.getElementById('downloadDetail'),
 			toggleAll: document.getElementById('toggleAll'),
 			toggleNone: document.getElementById('toggleNone'),
 			expandAll: document.getElementById('expandAll'),
@@ -1054,6 +1059,7 @@ const indexHTML = `<!doctype html>
     el.tabJson.onclick = () => setTab('json');
     el.tabYaml.onclick = () => setTab('yaml');
 	el.copyDetail.onclick = () => copyActiveDetail();
+	el.downloadDetail.onclick = () => downloadActiveDetail();
     el.search.oninput = render;
 		el.toggleAll.onclick = () => setAllKinds(true);
 		el.toggleNone.onclick = () => setAllKinds(false);
@@ -1066,10 +1072,40 @@ const indexHTML = `<!doctype html>
       el.tabJson.classList.toggle('active', tab === 'json');
       el.tabYaml.classList.toggle('active', tab === 'yaml');
 			el.copyDetail.textContent = tab === 'yaml' ? 'Copy YAML' : 'Copy JSON';
+			el.downloadDetail.textContent = tab === 'yaml' ? 'Download YAML' : 'Download JSON';
       if (selected && selected.detail) {
         el.detailBody.textContent = selected.detail[activeTab] || '';
       }
     }
+
+		function sanitizeFilenamePart(v) {
+			return String(v || 'resource').replace(/[^a-zA-Z0-9._-]+/g, '-');
+		}
+
+		function downloadActiveDetail() {
+			if (!selected || !selected.detail) {
+				showToast('info', 'Select a resource first.');
+				return;
+			}
+			const text = selected.detail[activeTab] || '';
+			if (!text) {
+				showToast('info', 'No content available to download.');
+				return;
+			}
+			const ext = activeTab === 'yaml' ? 'yaml' : 'json';
+			const mime = activeTab === 'yaml' ? 'application/yaml' : 'application/json';
+			const name = sanitizeFilenamePart(selected.node && selected.node.name) + '.' + ext;
+			const blob = new Blob([text], { type: mime });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = name;
+			document.body.appendChild(a);
+			a.click();
+			a.remove();
+			URL.revokeObjectURL(url);
+			showToast('info', (activeTab === 'yaml' ? 'YAML' : 'JSON') + ' downloaded as ' + name + '.');
+		}
 
 		async function copyActiveDetail() {
 			if (!selected || !selected.detail) {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -221,7 +221,7 @@ func (h *explorerHandler) serveDetail(w http.ResponseWriter, r *http.Request) {
 	name := r.URL.Query().Get("name")
 	var (
 		body []byte
-		code = http.StatusOK
+		code int
 		err  error
 	)
 	if name != "" {
@@ -256,7 +256,7 @@ func (h *explorerHandler) serveDetail(w http.ResponseWriter, r *http.Request) {
 	prettyJSON := body
 	var out bytes.Buffer
 	if err := json.Indent(&out, body, "", "  "); err == nil {
-		prettyJSON = []byte(out.String())
+		prettyJSON = out.Bytes()
 	}
 	var obj any
 	if err := json.Unmarshal(body, &obj); err != nil {
@@ -643,41 +643,6 @@ func kindFromResource(resource string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
 }
 
-func buildPathCandidates(index map[string]*capture.IndexEntry) map[string][]string {
-	pathsByBase := make(map[string][]string)
-	for path := range index {
-		base := baseAPIPath(path)
-		if _, _, resource, _, _ := parseAPIPath(base); resource == "" {
-			continue
-		}
-		pathsByBase[base] = append(pathsByBase[base], path)
-	}
-	for base := range pathsByBase {
-		sort.Slice(pathsByBase[base], func(i, j int) bool {
-			pi := pathPriority(pathsByBase[base][i])
-			pj := pathPriority(pathsByBase[base][j])
-			if pi == pj {
-				return pathsByBase[base][i] < pathsByBase[base][j]
-			}
-			return pi < pj
-		})
-	}
-	return pathsByBase
-}
-
-func sortedKeys(m map[string][]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
-}
-
-func (h *explorerHandler) loadResourceItems(candidates []string) ([]listItem, bool) {
-	return h.loadResourceItemsAt(candidates, h.at)
-}
-
 func (h *explorerHandler) loadResourceItemsAt(candidates []string, at time.Time) ([]listItem, bool) {
 	sorted := append([]string(nil), candidates...)
 	sort.Slice(sorted, func(i, j int) bool {
@@ -803,10 +768,6 @@ func itemIdentityKey(item map[string]any) string {
 	return firstNonEmpty(asString(item["kind"]), "?") + "/" + asString(meta["namespace"]) + "/" + asString(meta["name"])
 }
 
-func (h *explorerHandler) findResourceBody(path, name string) ([]byte, int, error) {
-	return h.findResourceBodyAt(path, name, h.at)
-}
-
 func (h *explorerHandler) findResourceBodyAt(path, name string, at time.Time) ([]byte, int, error) {
 	bodies, ok := h.responseBodiesAt(path, at)
 	if !ok {
@@ -822,10 +783,6 @@ func (h *explorerHandler) findResourceBodyAt(path, name string, at time.Time) ([
 		}
 	}
 	return nil, http.StatusNotFound, nil
-}
-
-func (h *explorerHandler) responseBodies(path string) ([][]byte, bool) {
-	return h.responseBodiesAt(path, h.at)
 }
 
 func (h *explorerHandler) responseBodiesAt(path string, at time.Time) ([][]byte, bool) {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -891,8 +891,10 @@ const indexHTML = `<!doctype html>
     .crumbs { color:var(--muted); font-size:13px; margin-bottom:8px; }
     details { border:1px solid #1f2937; border-radius:8px; margin-bottom:8px; background:rgba(2,6,23,.45); }
     summary { cursor:pointer; padding:8px 10px; }
-	.node { display:flex; align-items:center; gap:8px; padding:7px 10px; cursor:pointer; border-radius:6px; margin:3px 8px; border:1px solid transparent; }
+	.node { display:flex; align-items:center; gap:8px; padding:7px 10px; cursor:pointer; border-radius:6px; margin:3px 8px; border:1px solid transparent; outline:none; }
     .node:hover { border-color:#334155; background:#0f172a; }
+	.node:focus-visible { border-color:#22c55e; box-shadow:0 0 0 2px rgba(34,197,94,.2); }
+	.node.selected { border-color:#22c55e; background:rgba(34,197,94,.12); }
 	.node-name { font-weight:600; letter-spacing:.1px; }
 	.kind-chip { display:inline-block; min-width:68px; text-align:center; font-size:10px; font-weight:700; letter-spacing:.4px; text-transform:uppercase; padding:2px 6px; border-radius:999px; border:1px solid transparent; }
 	.tone-core { background:rgba(59,130,246,.18); color:#bfdbfe; border-color:rgba(59,130,246,.45); }
@@ -944,6 +946,8 @@ const indexHTML = `<!doctype html>
     let activeKinds = new Set();
     let selected = null;
     let activeTab = 'json';
+	let visibleNodes = [];
+	let activeNodeIdx = -1;
 
     const el = {
       tree: document.getElementById('tree'),
@@ -960,6 +964,7 @@ const indexHTML = `<!doctype html>
     el.tabJson.onclick = () => setTab('json');
     el.tabYaml.onclick = () => setTab('yaml');
     el.search.oninput = render;
+	document.addEventListener('keydown', onTreeKeyDown);
 
     function setTab(tab) {
       activeTab = tab;
@@ -1009,15 +1014,68 @@ const indexHTML = `<!doctype html>
 		function mkNode(node, crumbs, depth, namePrefix) {
       const d = document.createElement('div');
       d.className = 'node';
+			d.tabIndex = 0;
+			d.setAttribute('role', 'button');
 			d.style.paddingLeft = (10 + (depth * 16)) + 'px';
       d.title = [node.kind, node.status, node.age, Object.entries(node.labels || {}).slice(0,5).map(([k,v]) => k + '=' + v).join(', ')].filter(Boolean).join(' | ');
       const badge = node.status ? '<span class="badge ' + statusClass(node.status) + '">' + node.status + '</span>' : '';
 			const kindChip = '<span class="kind-chip ' + kindTone(node.kind) + '">' + (node.kind || 'Resource') + '</span>';
 			const nodeName = '<span class="node-name">' + (namePrefix ? namePrefix + node.name : node.name) + '</span>';
 			d.innerHTML = kindChip + nodeName + badge + (node.age ? ' <span class="muted">' + node.age + '</span>' : '');
-      d.onclick = () => showDetail(node, crumbs);
+			d._node = node;
+			d._crumbs = crumbs;
+      d.onclick = () => activateNodeElement(d, true);
+			d.onkeydown = (ev) => {
+				if (ev.key === 'Enter' || ev.key === ' ') {
+					ev.preventDefault();
+					activateNodeElement(d, false);
+				}
+			};
       return d;
     }
+
+		function clearNodeSelection() {
+			for (const n of visibleNodes) n.classList.remove('selected');
+		}
+
+		function selectNodeAt(index, focusNode) {
+			if (visibleNodes.length === 0) {
+				activeNodeIdx = -1;
+				return;
+			}
+			activeNodeIdx = Math.max(0, Math.min(index, visibleNodes.length - 1));
+			clearNodeSelection();
+			const nodeEl = visibleNodes[activeNodeIdx];
+			nodeEl.classList.add('selected');
+			if (focusNode) nodeEl.focus();
+			nodeEl.scrollIntoView({ block: 'nearest' });
+		}
+
+		function activateNodeElement(nodeEl, keepFocus) {
+			const idx = visibleNodes.indexOf(nodeEl);
+			if (idx >= 0) selectNodeAt(idx, keepFocus);
+			showDetail(nodeEl._node, nodeEl._crumbs);
+		}
+
+		function onTreeKeyDown(ev) {
+			if (visibleNodes.length === 0) return;
+			const tag = (document.activeElement && document.activeElement.tagName) || '';
+			if (tag === 'INPUT' || tag === 'TEXTAREA' || (document.activeElement && document.activeElement.isContentEditable)) return;
+			if (ev.key === 'ArrowDown') {
+				ev.preventDefault();
+				selectNodeAt(activeNodeIdx < 0 ? 0 : activeNodeIdx + 1, true);
+				return;
+			}
+			if (ev.key === 'ArrowUp') {
+				ev.preventDefault();
+				selectNodeAt(activeNodeIdx < 0 ? 0 : activeNodeIdx - 1, true);
+				return;
+			}
+			if ((ev.key === 'Enter' || ev.key === ' ') && activeNodeIdx >= 0) {
+				ev.preventDefault();
+				activateNodeElement(visibleNodes[activeNodeIdx], false);
+			}
+		}
 
     async function showDetail(node, crumbs) {
       selected = { node, crumbs };
@@ -1107,7 +1165,20 @@ const indexHTML = `<!doctype html>
 					? 'No resources match the current search/filter selection.'
 					: 'No resources were found in this capture at the selected time.';
 				setTreeState('empty', msg);
+				visibleNodes = [];
+				activeNodeIdx = -1;
+				return;
 			}
+
+			visibleNodes = Array.from(el.tree.querySelectorAll('.node'));
+			if (visibleNodes.length === 0) {
+				activeNodeIdx = -1;
+				return;
+			}
+			if (activeNodeIdx < 0 || activeNodeIdx >= visibleNodes.length) {
+				activeNodeIdx = 0;
+			}
+			selectNodeAt(activeNodeIdx, false);
     }
 
     function renderToggles(kinds) {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1060,6 +1060,8 @@ const indexHTML = `<!doctype html>
 	.snapshot-btn { padding:6px 10px; border-radius:8px; border:1px solid #334155; background:#0f172a; color:#cbd5e1; cursor:pointer; font-size:12px; }
 	.snapshot-btn:hover { border-color:#64748b; }
 	.snapshot-btn:disabled { opacity:.45; cursor:not-allowed; border-color:#1f2937; }
+	body.loading-snapshot .snapshot-select,
+	body.loading-snapshot .snapshot-btn { opacity:.7; }
     .layout { display:grid; grid-template-columns:260px 1fr 40%; min-height:calc(100vh - 56px); }
     .panel { border-right:1px solid var(--line); overflow:auto; }
     .panel:last-child { border-right:none; border-left:1px solid var(--line); }
@@ -1322,7 +1324,7 @@ const indexHTML = `<!doctype html>
 		for (const ts of unique) {
 			const opt = document.createElement('option');
 			opt.value = ts;
-			opt.textContent = formatAtLabel(ts);
+			opt.textContent = sampled ? (formatAtLabel(ts) + ' (sampled)') : formatAtLabel(ts);
 			el.snapshotAt.appendChild(opt);
 		}
 
@@ -1335,7 +1337,7 @@ const indexHTML = `<!doctype html>
 		if (currentAt !== 'latest' && !seen.has(currentAt)) {
 			const opt = document.createElement('option');
 			opt.value = currentAt;
-			opt.textContent = formatAtLabel(currentAt);
+			opt.textContent = formatAtLabel(currentAt) + ' (custom)';
 			el.snapshotAt.appendChild(opt);
 		}
 		el.snapshotAt.value = currentAt;
@@ -1441,6 +1443,16 @@ const indexHTML = `<!doctype html>
 			el.toasts.appendChild(toast);
 			const ttl = timeoutMs || (type === 'error' ? 7000 : 3000);
 			window.setTimeout(() => toast.remove(), ttl);
+		}
+
+		function setSnapshotLoading(loading) {
+			document.body.classList.toggle('loading-snapshot', !!loading);
+			el.snapshotAt.disabled = !!loading;
+			el.snapshotPrev.disabled = !!loading || el.snapshotPrev.disabled;
+			el.snapshotNext.disabled = !!loading || el.snapshotNext.disabled;
+			if (loading) {
+				el.snapshotHint.textContent = 'loading snapshot...';
+			}
 		}
 
 		function updateDetailSummary(data, node) {
@@ -1561,6 +1573,7 @@ const indexHTML = `<!doctype html>
 			d.innerHTML = kindChip + nodeName + badge + (node.age ? ' <span class="muted">' + node.age + '</span>' : '');
 			d._node = node;
 			d._crumbs = crumbs;
+			d._nodeKey = nodeIdentity(node);
       d.onclick = () => activateNodeElement(d, true);
 			d.onkeydown = (ev) => {
 				if (ev.key === 'Enter' || ev.key === ' ') {
@@ -1592,6 +1605,19 @@ const indexHTML = `<!doctype html>
 			const idx = visibleNodes.indexOf(nodeEl);
 			if (idx >= 0) selectNodeAt(idx, keepFocus);
 			showDetail(nodeEl._node, nodeEl._crumbs);
+		}
+
+		function nodeIdentity(node) {
+			if (!node) return '';
+			return [node.list_path || '', node.kind || '', node.name || ''].join('|');
+		}
+
+		function restoreSelectionByKey(nodeKey) {
+			if (!nodeKey || visibleNodes.length === 0) return false;
+			const idx = visibleNodes.findIndex((n) => n._nodeKey === nodeKey);
+			if (idx < 0) return false;
+			selectNodeAt(idx, false);
+			return true;
 		}
 
 		function onTreeKeyDown(ev) {
@@ -1644,6 +1670,7 @@ const indexHTML = `<!doctype html>
 				setTreeState('loading', 'Loading captured resources...');
 				return;
 			}
+		const desiredKey = selected && selected.node ? nodeIdentity(selected.node) : '';
       el.tree.innerHTML = '';
       const q = el.search.value.trim().toLowerCase();
 			let renderedNodes = 0;
@@ -1739,6 +1766,9 @@ const indexHTML = `<!doctype html>
 			if (activeNodeIdx < 0 || activeNodeIdx >= visibleNodes.length) {
 				activeNodeIdx = 0;
 			}
+			if (restoreSelectionByKey(desiredKey)) {
+				return;
+			}
 			selectNodeAt(activeNodeIdx, false);
     }
 
@@ -1809,21 +1839,35 @@ const indexHTML = `<!doctype html>
 		}
 
 		async function refreshTree() {
+			const previousSelectionKey = selected && selected.node ? nodeIdentity(selected.node) : '';
 			setTreeState('loading', 'Loading captured resources...');
+			setSnapshotLoading(true);
 			const q = withAtQuery(new URLSearchParams());
 			const url = q.toString() ? ('/api/ui/tree?' + q.toString()) : '/api/ui/tree';
-			const res = await fetch(url);
-			const data = await res.json();
-			if (!res.ok) {
-				const msg = (data && data.error) ? data.error : ('request failed with status ' + res.status);
-				throw new Error(msg);
-			}
-			treeData = data;
-			updateMetaLine();
-			renderToggles((treeData.resource_kinds || []).concat(['Container']));
-			render();
-			if (selected && selected.node) {
-				showDetail(selected.node, selected.crumbs || ['Cluster']);
+			try {
+				const res = await fetch(url);
+				const data = await res.json();
+				if (!res.ok) {
+					const msg = (data && data.error) ? data.error : ('request failed with status ' + res.status);
+					throw new Error(msg);
+				}
+				treeData = data;
+				updateMetaLine();
+				renderToggles((treeData.resource_kinds || []).concat(['Container']));
+				render();
+				if (restoreSelectionByKey(previousSelectionKey)) {
+					const nodeEl = visibleNodes[activeNodeIdx];
+					if (nodeEl) {
+						showDetail(nodeEl._node, nodeEl._crumbs || ['Cluster']);
+						return;
+					}
+				}
+				if (selected && selected.node) {
+					showDetail(selected.node, selected.crumbs || ['Cluster']);
+				}
+			} finally {
+				setSnapshotLoading(false);
+				syncSnapshotButtons();
 			}
 		}
 

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -927,6 +927,9 @@ const indexHTML = `<!doctype html>
 		.toast { pointer-events:auto; max-width:420px; border:1px solid #334155; border-radius:8px; padding:10px 12px; background:rgba(15,23,42,.92); box-shadow:0 8px 28px rgba(2,6,23,.45); font-size:13px; }
 		.toast.error { border-color:rgba(239,68,68,.55); color:#fecaca; }
 		.toast.info { border-color:rgba(59,130,246,.55); color:#bfdbfe; }
+		.ns-pager { margin:6px 10px 10px; display:flex; align-items:center; gap:8px; }
+		.ns-pager button { padding:3px 8px; border-radius:6px; border:1px solid #334155; background:#0f172a; color:#cbd5e1; font-size:11px; cursor:pointer; }
+		.ns-pager button:hover { border-color:#64748b; }
   </style>
 </head>
 <body>
@@ -974,6 +977,8 @@ const indexHTML = `<!doctype html>
     let activeTab = 'json';
 	let visibleNodes = [];
 	let activeNodeIdx = -1;
+	const namespacePageSize = 120;
+	let namespaceVisibleLimit = {};
 
     const el = {
       tree: document.getElementById('tree'),
@@ -1016,6 +1021,16 @@ const indexHTML = `<!doctype html>
 			box.className = 'tree-state ' + type;
 			box.textContent = message;
 			el.tree.appendChild(box);
+		}
+
+		function namespaceLimit(name) {
+			if (!namespaceVisibleLimit[name]) namespaceVisibleLimit[name] = namespacePageSize;
+			return namespaceVisibleLimit[name];
+		}
+
+		function showMoreNamespace(name) {
+			namespaceVisibleLimit[name] = namespaceLimit(name) + namespacePageSize;
+			render();
 		}
 
 		function showToast(type, message, timeoutMs) {
@@ -1169,40 +1184,58 @@ const indexHTML = `<!doctype html>
 				const nsCount = (ns.workloads || []).length + (ns.pods || []).length + (ns.resources || []).length;
 				ds.innerHTML = '<summary>Namespace: <strong>' + ns.name + '</strong> <span class="muted">(' + nsCount + ')</span></summary>';
 
+				const nsNodes = [];
+
 			for (const w of (ns.workloads || [])) {
           if (!kindEnabled(w.kind) || !nodeMatches(w, q)) continue;
-					ds.appendChild(mkNode(w, ['Cluster', ns.name, w.kind, w.name], 0, ''));
-					renderedNodes++;
+					nsNodes.push(mkNode(w, ['Cluster', ns.name, w.kind, w.name], 0, ''));
           for (const p of (w.pods || [])) {
             if (!kindEnabled(p.kind) || !nodeMatches(p, q)) continue;
-						ds.appendChild(mkNode(p, ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name], 1, ''));
-						renderedNodes++;
+						nsNodes.push(mkNode(p, ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name], 1, ''));
             for (const c of (p.containers || [])) {
               const fake = {kind:'Container',name:c.name,status:'',age:'',labels:{},list_path:p.list_path};
               if (!kindEnabled('Container') || !nodeMatches(fake, q)) continue;
-							ds.appendChild(mkNode(fake, ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name, 'Container', c.name], 2, ''));
-							renderedNodes++;
+							nsNodes.push(mkNode(fake, ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name, 'Container', c.name], 2, ''));
             }
           }
         }
 
 			for (const p of (ns.pods || [])) {
           if (!kindEnabled(p.kind) || !nodeMatches(p, q)) continue;
-					ds.appendChild(mkNode(p, ['Cluster', ns.name, 'Pod', p.name], 0, ''));
-					renderedNodes++;
+					nsNodes.push(mkNode(p, ['Cluster', ns.name, 'Pod', p.name], 0, ''));
           for (const c of (p.containers || [])) {
             const fake = {kind:'Container',name:c.name,status:'',age:'',labels:{},list_path:p.list_path};
             if (!kindEnabled('Container') || !nodeMatches(fake, q)) continue;
-						ds.appendChild(mkNode(fake, ['Cluster', ns.name, 'Pod', p.name, 'Container', c.name], 1, ''));
-						renderedNodes++;
+						nsNodes.push(mkNode(fake, ['Cluster', ns.name, 'Pod', p.name, 'Container', c.name], 1, ''));
           }
         }
 
 			for (const r of (ns.resources || [])) {
           if (!kindEnabled(r.kind) || !nodeMatches(r, q)) continue;
-					ds.appendChild(mkNode(r, ['Cluster', ns.name, r.kind, r.name], 0, ''));
-					renderedNodes++;
+					nsNodes.push(mkNode(r, ['Cluster', ns.name, r.kind, r.name], 0, ''));
         }
+
+				const limit = q ? nsNodes.length : namespaceLimit(ns.name);
+				const shown = nsNodes.slice(0, limit);
+				for (const nodeEl of shown) {
+					ds.appendChild(nodeEl);
+					renderedNodes++;
+				}
+				if (!q && nsNodes.length > shown.length) {
+					const pager = document.createElement('div');
+					pager.className = 'ns-pager';
+					const hidden = nsNodes.length - shown.length;
+					const meta = document.createElement('span');
+					meta.className = 'muted';
+					meta.textContent = hidden + ' more hidden';
+					const btn = document.createElement('button');
+					btn.type = 'button';
+					btn.textContent = 'Show more';
+					btn.onclick = () => showMoreNamespace(ns.name);
+					pager.appendChild(meta);
+					pager.appendChild(btn);
+					ds.appendChild(pager);
+				}
         el.tree.appendChild(ds);
       }
 

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -891,8 +891,16 @@ const indexHTML = `<!doctype html>
     .crumbs { color:var(--muted); font-size:13px; margin-bottom:8px; }
     details { border:1px solid #1f2937; border-radius:8px; margin-bottom:8px; background:rgba(2,6,23,.45); }
     summary { cursor:pointer; padding:8px 10px; }
-    .node { padding:6px 10px; cursor:pointer; border-radius:6px; margin:3px 8px; border:1px solid transparent; }
+	.node { display:flex; align-items:center; gap:8px; padding:7px 10px; cursor:pointer; border-radius:6px; margin:3px 8px; border:1px solid transparent; }
     .node:hover { border-color:#334155; background:#0f172a; }
+	.node-name { font-weight:600; letter-spacing:.1px; }
+	.kind-chip { display:inline-block; min-width:68px; text-align:center; font-size:10px; font-weight:700; letter-spacing:.4px; text-transform:uppercase; padding:2px 6px; border-radius:999px; border:1px solid transparent; }
+	.tone-core { background:rgba(59,130,246,.18); color:#bfdbfe; border-color:rgba(59,130,246,.45); }
+	.tone-workload { background:rgba(234,179,8,.18); color:#fde68a; border-color:rgba(234,179,8,.45); }
+	.tone-pod { background:rgba(16,185,129,.18); color:#a7f3d0; border-color:rgba(16,185,129,.45); }
+	.tone-storage { background:rgba(249,115,22,.18); color:#fdba74; border-color:rgba(249,115,22,.45); }
+	.tone-security { background:rgba(244,63,94,.18); color:#fecdd3; border-color:rgba(244,63,94,.45); }
+	.tone-meta { background:rgba(148,163,184,.18); color:#e2e8f0; border-color:rgba(148,163,184,.45); }
     .muted { color:var(--muted); font-size:12px; }
     .badge { display:inline-block; font-size:11px; padding:2px 6px; border-radius:999px; margin-left:6px; background:#1f2937; }
     .ok { background:rgba(22,163,74,.2); color:#86efac; }
@@ -976,12 +984,25 @@ const indexHTML = `<!doctype html>
       return activeKinds.size === 0 || activeKinds.has(kind);
     }
 
-    function mkNode(label, node, crumbs) {
+		function kindTone(kind) {
+			const k = (kind || '').toLowerCase();
+			if (k === 'pod' || k === 'container') return 'tone-pod';
+			if (k.includes('deploy') || k.includes('stateful') || k.includes('daemon') || k.includes('job') || k.includes('replicaset')) return 'tone-workload';
+			if (k.includes('secret') || k.includes('serviceaccount') || k.includes('role')) return 'tone-security';
+			if (k.includes('persistent') || k.includes('storage') || k.includes('volume')) return 'tone-storage';
+			if (k === 'node' || k === 'namespace' || k === 'service') return 'tone-core';
+			return 'tone-meta';
+		}
+
+		function mkNode(node, crumbs, depth, namePrefix) {
       const d = document.createElement('div');
       d.className = 'node';
+			d.style.paddingLeft = (10 + (depth * 16)) + 'px';
       d.title = [node.kind, node.status, node.age, Object.entries(node.labels || {}).slice(0,5).map(([k,v]) => k + '=' + v).join(', ')].filter(Boolean).join(' | ');
       const badge = node.status ? '<span class="badge ' + statusClass(node.status) + '">' + node.status + '</span>' : '';
-      d.innerHTML = '<strong>' + label + '</strong>' + badge + (node.age ? ' <span class="muted">' + node.age + '</span>' : '');
+			const kindChip = '<span class="kind-chip ' + kindTone(node.kind) + '">' + (node.kind || 'Resource') + '</span>';
+			const nodeName = '<span class="node-name">' + (namePrefix ? namePrefix + node.name : node.name) + '</span>';
+			d.innerHTML = kindChip + nodeName + badge + (node.age ? ' <span class="muted">' + node.age + '</span>' : '');
       d.onclick = () => showDetail(node, crumbs);
       return d;
     }
@@ -1004,45 +1025,46 @@ const indexHTML = `<!doctype html>
 
       const cs = document.createElement('details');
       cs.open = true;
-      cs.innerHTML = '<summary>Cluster-scoped resources</summary>';
+			cs.innerHTML = '<summary>Cluster-scoped resources <span class="muted">(' + treeData.cluster_scoped.length + ')</span></summary>';
       for (const node of treeData.cluster_scoped) {
         if (!kindEnabled(node.kind) || !nodeMatches(node, q)) continue;
-        cs.appendChild(mkNode(node.kind + ' ' + node.name, node, ['Cluster', node.kind, node.name]));
+				cs.appendChild(mkNode(node, ['Cluster', node.kind, node.name], 0, ''));
       }
       el.tree.appendChild(cs);
 
       for (const ns of treeData.namespaces) {
         const ds = document.createElement('details');
         ds.open = true;
-        ds.innerHTML = '<summary>Namespace: <strong>' + ns.name + '</strong></summary>';
+				const nsCount = (ns.workloads || []).length + (ns.pods || []).length + (ns.resources || []).length;
+				ds.innerHTML = '<summary>Namespace: <strong>' + ns.name + '</strong> <span class="muted">(' + nsCount + ')</span></summary>';
 
 			for (const w of (ns.workloads || [])) {
           if (!kindEnabled(w.kind) || !nodeMatches(w, q)) continue;
-          ds.appendChild(mkNode(w.kind + ' ' + w.name, w, ['Cluster', ns.name, w.kind, w.name]));
+					ds.appendChild(mkNode(w, ['Cluster', ns.name, w.kind, w.name], 0, ''));
           for (const p of (w.pods || [])) {
             if (!kindEnabled(p.kind) || !nodeMatches(p, q)) continue;
-            ds.appendChild(mkNode('  Pod ' + p.name, p, ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name]));
+						ds.appendChild(mkNode(p, ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name], 1, ''));
             for (const c of (p.containers || [])) {
               const fake = {kind:'Container',name:c.name,status:'',age:'',labels:{},list_path:p.list_path};
               if (!kindEnabled('Container') || !nodeMatches(fake, q)) continue;
-              ds.appendChild(mkNode('    Container ' + c.name, fake, ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name, 'Container', c.name]));
+							ds.appendChild(mkNode(fake, ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name, 'Container', c.name], 2, ''));
             }
           }
         }
 
 			for (const p of (ns.pods || [])) {
           if (!kindEnabled(p.kind) || !nodeMatches(p, q)) continue;
-          ds.appendChild(mkNode('Pod ' + p.name, p, ['Cluster', ns.name, 'Pod', p.name]));
+					ds.appendChild(mkNode(p, ['Cluster', ns.name, 'Pod', p.name], 0, ''));
           for (const c of (p.containers || [])) {
             const fake = {kind:'Container',name:c.name,status:'',age:'',labels:{},list_path:p.list_path};
             if (!kindEnabled('Container') || !nodeMatches(fake, q)) continue;
-            ds.appendChild(mkNode('  Container ' + c.name, fake, ['Cluster', ns.name, 'Pod', p.name, 'Container', c.name]));
+						ds.appendChild(mkNode(fake, ['Cluster', ns.name, 'Pod', p.name, 'Container', c.name], 1, ''));
           }
         }
 
 			for (const r of (ns.resources || [])) {
           if (!kindEnabled(r.kind) || !nodeMatches(r, q)) continue;
-          ds.appendChild(mkNode(r.kind + ' ' + r.name, r, ['Cluster', ns.name, r.kind, r.name]));
+					ds.appendChild(mkNode(r, ['Cluster', ns.name, r.kind, r.name], 0, ''));
         }
         el.tree.appendChild(ds);
       }

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -53,6 +53,8 @@ type timestampsResponse struct {
 	CapturedAt    time.Time `json:"captured_at"`
 	CapturedUntil time.Time `json:"captured_until"`
 	DefaultAt     string    `json:"default_at,omitempty"`
+	TotalCount    int       `json:"total_count"`
+	Sampled       bool      `json:"sampled"`
 	Timestamps    []string  `json:"timestamps"`
 }
 
@@ -273,10 +275,12 @@ func (h *explorerHandler) serveDetail(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *explorerHandler) serveTimestamps(w http.ResponseWriter, r *http.Request) {
-	times := collectTimestamps(h.store.Index)
+	times, totalCount, sampled := collectTimestamps(h.store.Index, 180)
 	resp := timestampsResponse{
 		CapturedAt:    h.store.Metadata.CapturedAt,
 		CapturedUntil: h.store.Metadata.CapturedUntil,
+		TotalCount:    totalCount,
+		Sampled:       sampled,
 		Timestamps:    times,
 	}
 	if !h.at.IsZero() {
@@ -861,9 +865,9 @@ func (h *explorerHandler) responseBodiesAt(path string, at time.Time) ([][]byte,
 	return bodies, true
 }
 
-func collectTimestamps(index capture.Index) []string {
+func collectTimestamps(index capture.Index, limit int) ([]string, int, bool) {
 	if len(index) == 0 {
-		return nil
+		return nil, 0, false
 	}
 	uniq := make(map[time.Time]struct{})
 	for _, entry := range index {
@@ -879,11 +883,49 @@ func collectTimestamps(index capture.Index) []string {
 		out = append(out, t)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Before(out[j]) })
+	totalCount := len(out)
+	if limit > 0 && len(out) > limit {
+		out = sampleTimes(out, limit)
+	}
 	rfc := make([]string, 0, len(out))
 	for _, t := range out {
 		rfc = append(rfc, t.Format(time.RFC3339))
 	}
-	return rfc
+	return rfc, totalCount, totalCount > len(rfc)
+}
+
+func sampleTimes(times []time.Time, limit int) []time.Time {
+	if limit <= 0 || len(times) <= limit {
+		return append([]time.Time(nil), times...)
+	}
+	if limit == 1 {
+		return []time.Time{times[len(times)-1]}
+	}
+
+	selected := make([]time.Time, 0, limit)
+	seen := make(map[time.Time]struct{}, limit)
+	lastIdx := len(times) - 1
+	for i := 0; i < limit; i++ {
+		idx := (i * lastIdx) / (limit - 1)
+		t := times[idx]
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		selected = append(selected, t)
+	}
+	if len(selected) == 0 || !selected[0].Equal(times[0]) {
+		selected = append([]time.Time{times[0]}, selected...)
+	}
+	if !selected[len(selected)-1].Equal(times[len(times)-1]) {
+		selected = append(selected, times[len(times)-1])
+	}
+	sort.Slice(selected, func(i, j int) bool { return selected[i].Before(selected[j]) })
+	if len(selected) > limit {
+		selected = selected[len(selected)-limit:]
+		sort.Slice(selected, func(i, j int) bool { return selected[i].Before(selected[j]) })
+	}
+	return selected
 }
 
 func (h *explorerHandler) readRecordBody(id string) ([]byte, bool) {
@@ -1014,6 +1056,7 @@ const indexHTML = `<!doctype html>
 	.snapshot-nav { display:flex; align-items:center; gap:6px; }
 	.snapshot-select { min-width:220px; max-width:340px; box-sizing:border-box; padding:6px 8px; border:1px solid #334155; border-radius:8px; background:#0f172a; color:var(--text); }
 	.snapshot-label { color:var(--muted); font-size:12px; }
+	.snapshot-hint { color:var(--muted); font-size:11px; white-space:nowrap; }
 	.snapshot-btn { padding:6px 10px; border-radius:8px; border:1px solid #334155; background:#0f172a; color:#cbd5e1; cursor:pointer; font-size:12px; }
 	.snapshot-btn:hover { border-color:#64748b; }
 	.snapshot-btn:disabled { opacity:.45; cursor:not-allowed; border-color:#1f2937; }
@@ -1084,6 +1127,7 @@ const indexHTML = `<!doctype html>
 				<select id="snapshotAt" class="snapshot-select" title="Select capture timestamp"></select>
 				<button id="snapshotNext" class="snapshot-btn" type="button" title="Jump to newer snapshot">Next</button>
 			</div>
+			<div id="snapshotHint" class="snapshot-hint"></div>
 			<div id="meta" class="muted"></div>
 		</div>
   </header>
@@ -1161,6 +1205,7 @@ const indexHTML = `<!doctype html>
 			snapshotPrev: document.getElementById('snapshotPrev'),
 			snapshotAt: document.getElementById('snapshotAt'),
 			snapshotNext: document.getElementById('snapshotNext'),
+			snapshotHint: document.getElementById('snapshotHint'),
 			toasts: document.getElementById('toasts')
     };
 
@@ -1258,7 +1303,7 @@ const indexHTML = `<!doctype html>
 		el.meta.textContent = 'capture ' + start + ' to ' + end + ' | view: ' + atLabel;
 	}
 
-	function renderSnapshotSelector(times, defaultAt) {
+	function renderSnapshotSelector(times, defaultAt, totalCount, sampled) {
 		const opts = Array.isArray(times) ? times.slice().reverse() : [];
 		const unique = [];
 		const seen = new Set();
@@ -1294,6 +1339,13 @@ const indexHTML = `<!doctype html>
 			el.snapshotAt.appendChild(opt);
 		}
 		el.snapshotAt.value = currentAt;
+		if (sampled && totalCount > opts.length) {
+			el.snapshotHint.textContent = 'showing ' + opts.length + ' sampled of ' + totalCount;
+		} else if (totalCount > 0) {
+			el.snapshotHint.textContent = totalCount + ' snapshot' + (totalCount === 1 ? '' : 's');
+		} else {
+			el.snapshotHint.textContent = '';
+		}
 		syncSnapshotButtons();
 	}
 
@@ -1752,7 +1804,7 @@ const indexHTML = `<!doctype html>
 				const msg = (data && data.error) ? data.error : ('request failed with status ' + res.status);
 				throw new Error(msg);
 			}
-			renderSnapshotSelector(data.timestamps || [], data.default_at || '');
+			renderSnapshotSelector(data.timestamps || [], data.default_at || '', data.total_count || 0, !!data.sampled);
 			syncAtInURL();
 		}
 

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -979,6 +979,9 @@ const indexHTML = `<!doctype html>
 	let activeNodeIdx = -1;
 	const namespacePageSize = 120;
 	let namespaceVisibleLimit = {};
+	const storageKindsKey = 'kshrk.ui.activeKinds.v1';
+	const storageExpandedKey = 'kshrk.ui.expandedSections.v1';
+	let expandedSections = {};
 
     const el = {
       tree: document.getElementById('tree'),
@@ -1040,6 +1043,50 @@ const indexHTML = `<!doctype html>
 			el.toasts.appendChild(toast);
 			const ttl = timeoutMs || (type === 'error' ? 7000 : 3000);
 			window.setTimeout(() => toast.remove(), ttl);
+		}
+
+		function loadPreferences() {
+			try {
+				const kindsRaw = window.localStorage.getItem(storageKindsKey);
+				if (kindsRaw) {
+					const parsed = JSON.parse(kindsRaw);
+					if (Array.isArray(parsed)) activeKinds = new Set(parsed);
+				}
+			} catch (_) {}
+			try {
+				const expandedRaw = window.localStorage.getItem(storageExpandedKey);
+				if (expandedRaw) {
+					const parsed = JSON.parse(expandedRaw);
+					if (parsed && typeof parsed === 'object') expandedSections = parsed;
+				}
+			} catch (_) {}
+		}
+
+		function persistKinds() {
+			try {
+				window.localStorage.setItem(storageKindsKey, JSON.stringify(Array.from(activeKinds)));
+			} catch (_) {}
+		}
+
+		function persistExpandedSections() {
+			try {
+				window.localStorage.setItem(storageExpandedKey, JSON.stringify(expandedSections));
+			} catch (_) {}
+		}
+
+		function sectionOpen(sectionKey, fallbackOpen) {
+			if (Object.prototype.hasOwnProperty.call(expandedSections, sectionKey)) {
+				return !!expandedSections[sectionKey];
+			}
+			return fallbackOpen;
+		}
+
+		function bindSectionState(details, sectionKey) {
+			details.onToggle = null;
+			details.addEventListener('toggle', () => {
+				expandedSections[sectionKey] = details.open;
+				persistExpandedSections();
+			});
 		}
 
     function statusClass(status) {
@@ -1169,8 +1216,9 @@ const indexHTML = `<!doctype html>
 			let renderedNodes = 0;
 
       const cs = document.createElement('details');
-      cs.open = true;
+			cs.open = sectionOpen('cluster-scoped', true);
 			cs.innerHTML = '<summary>Cluster-scoped resources <span class="muted">(' + treeData.cluster_scoped.length + ')</span></summary>';
+			bindSectionState(cs, 'cluster-scoped');
       for (const node of treeData.cluster_scoped) {
         if (!kindEnabled(node.kind) || !nodeMatches(node, q)) continue;
 				cs.appendChild(mkNode(node, ['Cluster', node.kind, node.name], 0, ''));
@@ -1180,9 +1228,10 @@ const indexHTML = `<!doctype html>
 
       for (const ns of treeData.namespaces) {
         const ds = document.createElement('details');
-        ds.open = true;
+				ds.open = sectionOpen('ns:' + ns.name, true);
 				const nsCount = (ns.workloads || []).length + (ns.pods || []).length + (ns.resources || []).length;
 				ds.innerHTML = '<summary>Namespace: <strong>' + ns.name + '</strong> <span class="muted">(' + nsCount + ')</span></summary>';
+				bindSectionState(ds, 'ns:' + ns.name);
 
 				const nsNodes = [];
 
@@ -1261,7 +1310,12 @@ const indexHTML = `<!doctype html>
     }
 
     function renderToggles(kinds) {
-      activeKinds = new Set(kinds);
+			if (activeKinds.size === 0) {
+				activeKinds = new Set(kinds);
+			} else {
+				const allowed = new Set(kinds);
+				activeKinds = new Set(Array.from(activeKinds).filter((k) => allowed.has(k)));
+			}
       el.toggles.innerHTML = '';
       for (const kind of kinds) {
         const row = document.createElement('label');
@@ -1269,9 +1323,10 @@ const indexHTML = `<!doctype html>
         const cb = document.createElement('input');
         cb.type = 'checkbox';
 				cb.dataset.kind = kind;
-        cb.checked = true;
+				cb.checked = activeKinds.has(kind);
         cb.onchange = () => {
           if (cb.checked) activeKinds.add(kind); else activeKinds.delete(kind);
+				persistKinds();
           render();
         };
         row.appendChild(cb);
@@ -1289,18 +1344,28 @@ const indexHTML = `<!doctype html>
 			} else {
 				activeKinds = new Set();
 			}
+			persistKinds();
 			render();
 		}
 
 		function setAllTreeDetails(open) {
 			for (const details of el.tree.querySelectorAll('details')) {
 				details.open = open;
+				const summary = details.querySelector('summary');
+				if (summary && summary.textContent.startsWith('Namespace:')) {
+					const strong = summary.querySelector('strong');
+					if (strong) expandedSections['ns:' + strong.textContent] = open;
+				} else {
+					expandedSections['cluster-scoped'] = open;
+				}
 			}
+			persistExpandedSections();
 		}
 
     async function init() {
 			setTreeState('loading', 'Loading captured resources...');
 			try {
+				loadPreferences();
 				const res = await fetch('/api/ui/tree');
 				const data = await res.json();
 				if (!res.ok) {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -9,12 +9,14 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
 	"github.com/phenixblue/k8shark/internal/server"
 	"gopkg.in/yaml.v3"
 )
@@ -87,6 +89,11 @@ type resourceNode struct {
 	Age      string            `json:"age,omitempty"`
 	ListPath string            `json:"list_path"`
 	Labels   map[string]string `json:"labels,omitempty"`
+}
+
+type listItem struct {
+	path string
+	item map[string]any
 }
 
 func Open(opts OpenOptions) (*Server, error) {
@@ -189,24 +196,32 @@ func (h *explorerHandler) serveDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, code, err := h.store.Latest(path, h.at)
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
-	}
-	if code == http.StatusNotFound {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "path not found in capture"})
-		return
-	}
-
 	name := r.URL.Query().Get("name")
+	var (
+		body []byte
+		code = http.StatusOK
+		err  error
+	)
 	if name != "" {
-		item, ok := findListItemByName(body, name)
-		if !ok {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": "item not found in list response"})
+		body, code, err = h.findResourceBody(path, name)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 			return
 		}
-		body = item
+		if code == http.StatusNotFound {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "item not found in response"})
+			return
+		}
+	} else {
+		body, code, err = h.store.Latest(path, h.at)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		if code == http.StatusNotFound {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "path not found in capture"})
+			return
+		}
 	}
 
 	prettyJSON := body
@@ -233,7 +248,6 @@ func (h *explorerHandler) buildTree() (*treeResponse, error) {
 	nsMap := map[string]*namespaceNode{}
 	clusterScoped := make([]resourceNode, 0)
 	kindSet := map[string]bool{}
-
 	workloadKinds := map[string]bool{
 		"deployments":  true,
 		"statefulsets": true,
@@ -241,79 +255,77 @@ func (h *explorerHandler) buildTree() (*treeResponse, error) {
 		"jobs":         true,
 		"replicasets":  true,
 	}
-
+	// Map of (namespace, resource) -> all candidate index paths
+	byNSRes := map[string]map[string][]string{}
 	for path := range h.store.Index {
-		if strings.Contains(path, "?") {
-			continue
-		}
-		group, version, resource, ns := parseAPIPath(path)
+		group, version, resource, ns, _ := parseAPIPath(baseAPIPath(path))
 		if resource == "" {
 			continue
 		}
-
-		listBody, code, err := h.store.Latest(path, h.at)
-		if err != nil || code != http.StatusOK {
-			continue
+		if byNSRes[ns] == nil {
+			byNSRes[ns] = map[string][]string{}
 		}
-		items, err := parseListItems(listBody)
-		if err != nil {
-			continue
-		}
-
-		if ns == "" {
-			for _, item := range items {
-				node := toResourceNode(resource, path, item)
-				clusterScoped = append(clusterScoped, node)
-				kindSet[node.Kind] = true
-			}
-			continue
-		}
-
-		node, ok := nsMap[ns]
-		if !ok {
-			node = &namespaceNode{Name: ns}
-			nsMap[ns] = node
-		}
-
-		if workloadKinds[resource] {
-			for _, item := range items {
-				w := workloadNode{
-					Kind:     firstNonEmpty(asString(item["kind"]), kindFromResource(resource)),
-					Name:     getMetaName(item),
-					Status:   summarizeStatus(item),
-					Age:      summarizeAge(item),
-					ListPath: path,
-					Labels:   getMetaLabels(item),
-				}
-				node.Workloads = append(node.Workloads, w)
-				kindSet[w.Kind] = true
-			}
-			continue
-		}
-
-		if resource == "pods" {
-			for _, item := range items {
-				p := toPodNode(path, item)
-				node.Pods = append(node.Pods, p)
-				kindSet[p.Kind] = true
-			}
-			continue
-		}
-
-		for _, item := range items {
-			rn := toResourceNode(resource, path, item)
-			node.Resources = append(node.Resources, rn)
-			kindSet[rn.Kind] = true
-		}
-
+		byNSRes[ns][resource] = append(byNSRes[ns][resource], path)
 		_ = group
 		_ = version
 	}
-
+	for ns, resMap := range byNSRes {
+		for resource, candidates := range resMap {
+			items, ok := h.loadResourceItems(candidates)
+			if !ok {
+				continue
+			}
+			if ns == "" {
+				for _, entry := range items {
+					node := toResourceNode(resource, entry.path, entry.item)
+					clusterScoped = append(clusterScoped, node)
+					kindSet[node.Kind] = true
+				}
+				continue
+			}
+			node, ok := nsMap[ns]
+			if !ok {
+				node = &namespaceNode{
+					Name:      ns,
+					Workloads: []workloadNode{},
+					Pods:      []podNode{},
+					Resources: []resourceNode{},
+				}
+				nsMap[ns] = node
+			}
+			if workloadKinds[resource] {
+				for _, entry := range items {
+					w := workloadNode{
+						Kind:     firstNonEmpty(asString(entry.item["kind"]), kindFromResource(resource)),
+						Name:     getMetaName(entry.item),
+						Status:   summarizeStatus(entry.item),
+						Age:      summarizeAge(entry.item),
+						ListPath: entry.path,
+						Labels:   getMetaLabels(entry.item),
+					}
+					node.Workloads = append(node.Workloads, w)
+					kindSet[w.Kind] = true
+				}
+				continue
+			}
+			if resource == "pods" {
+				for _, entry := range items {
+					p := toPodNode(entry.path, entry.item)
+					node.Pods = append(node.Pods, p)
+					kindSet[p.Kind] = true
+				}
+				continue
+			}
+			for _, entry := range items {
+				rn := toResourceNode(resource, entry.path, entry.item)
+				node.Resources = append(node.Resources, rn)
+				kindSet[rn.Kind] = true
+			}
+		}
+	}
 	for ns := range nsMap {
 		attachPodsToWorkloads(nsMap[ns])
 	}
-
 	namespaces := make([]namespaceNode, 0, len(nsMap))
 	for _, ns := range nsMap {
 		sort.Slice(ns.Workloads, func(i, j int) bool {
@@ -338,13 +350,11 @@ func (h *explorerHandler) buildTree() (*treeResponse, error) {
 		}
 		return clusterScoped[i].Kind < clusterScoped[j].Kind
 	})
-
 	kinds := make([]string, 0, len(kindSet))
 	for k := range kindSet {
 		kinds = append(kinds, k)
 	}
 	sort.Strings(kinds)
-
 	return &treeResponse{
 		CapturedAt:    h.store.Metadata.CapturedAt,
 		CapturedUntil: h.store.Metadata.CapturedUntil,
@@ -442,6 +452,14 @@ func findListItemByName(body []byte, name string) ([]byte, bool) {
 	return nil, false
 }
 
+func matchesObjectName(body []byte, name string) bool {
+	var item map[string]any
+	if err := json.Unmarshal(body, &item); err != nil {
+		return false
+	}
+	return getMetaName(item) == name
+}
+
 func getMetaName(item map[string]any) string {
 	meta, _ := item["metadata"].(map[string]any)
 	return asString(meta["name"])
@@ -529,25 +547,282 @@ func kindFromResource(resource string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
 }
 
-func parseAPIPath(path string) (group, version, resource, namespace string) {
+func buildPathCandidates(index map[string]*capture.IndexEntry) map[string][]string {
+	pathsByBase := make(map[string][]string)
+	for path := range index {
+		base := baseAPIPath(path)
+		if _, _, resource, _, _ := parseAPIPath(base); resource == "" {
+			continue
+		}
+		pathsByBase[base] = append(pathsByBase[base], path)
+	}
+	for base := range pathsByBase {
+		sort.Slice(pathsByBase[base], func(i, j int) bool {
+			pi := pathPriority(pathsByBase[base][i])
+			pj := pathPriority(pathsByBase[base][j])
+			if pi == pj {
+				return pathsByBase[base][i] < pathsByBase[base][j]
+			}
+			return pi < pj
+		})
+	}
+	return pathsByBase
+}
+
+func sortedKeys(m map[string][]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (h *explorerHandler) loadResourceItems(candidates []string) ([]listItem, bool) {
+	sorted := append([]string(nil), candidates...)
+	sort.Slice(sorted, func(i, j int) bool {
+		pi := pathPriority(sorted[i])
+		pj := pathPriority(sorted[j])
+		if pi == pj {
+			return sorted[i] < sorted[j]
+		}
+		return pi < pj
+	})
+
+	var fallbackItems []listItem
+	var foundFallback bool
+	itemsByKey := make(map[string]listItem)
+	var itemOrder []string
+	for _, candidate := range sorted {
+		bodies, ok := h.responseBodies(candidate)
+		if !ok {
+			continue
+		}
+		for _, body := range bodies {
+			entries, hadItems, ok := parseResponseItems(candidate, body)
+			if !ok {
+				continue
+			}
+			if hadItems {
+				for _, entry := range entries {
+					key := itemIdentityKey(entry.item)
+					if _, exists := itemsByKey[key]; exists {
+						continue
+					}
+					itemsByKey[key] = entry
+					itemOrder = append(itemOrder, key)
+				}
+				continue
+			}
+			if !foundFallback {
+				fallbackItems = entries
+				foundFallback = true
+			}
+		}
+	}
+	if len(itemOrder) > 0 {
+		merged := make([]listItem, 0, len(itemOrder))
+		for _, key := range itemOrder {
+			merged = append(merged, itemsByKey[key])
+		}
+		return merged, true
+	}
+	if foundFallback {
+		return fallbackItems, true
+	}
+	return nil, false
+}
+
+func parseResponseItems(path string, body []byte) ([]listItem, bool, bool) {
+	if items, err := parseListItems(body); err == nil {
+		entries := make([]listItem, 0, len(items))
+		for _, item := range items {
+			entries = append(entries, listItem{path: path, item: item})
+		}
+		return entries, len(entries) > 0, true
+	}
+
+	if items, ok := parseTableItems(body); ok {
+		entries := make([]listItem, 0, len(items))
+		for _, item := range items {
+			entries = append(entries, listItem{path: path, item: item})
+		}
+		return entries, len(entries) > 0, true
+	}
+
+	var item map[string]any
+	if err := json.Unmarshal(body, &item); err != nil {
+		return nil, false, false
+	}
+	meta, _ := item["metadata"].(map[string]any)
+	if meta == nil || asString(meta["name"]) == "" {
+		return nil, false, false
+	}
+	return []listItem{{path: path, item: item}}, true, true
+}
+
+func parseTableItems(body []byte) ([]map[string]any, bool) {
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, false
+	}
+	kind := asString(raw["kind"])
+	rowsAny, ok := raw["rows"].([]any)
+	if !ok {
+		return nil, false
+	}
+	if kind != "Table" && !strings.HasSuffix(kind, "Table") {
+		return nil, false
+	}
+
+	items := make([]map[string]any, 0, len(rowsAny))
+	for _, row := range rowsAny {
+		rowMap, ok := row.(map[string]any)
+		if !ok {
+			continue
+		}
+		obj, ok := rowMap["object"].(map[string]any)
+		if !ok {
+			continue
+		}
+		meta, _ := obj["metadata"].(map[string]any)
+		if asString(meta["name"]) == "" {
+			continue
+		}
+		items = append(items, obj)
+	}
+	return items, true
+}
+
+func itemIdentityKey(item map[string]any) string {
+	meta, _ := item["metadata"].(map[string]any)
+	uid := asString(meta["uid"])
+	if uid != "" {
+		return uid
+	}
+	return firstNonEmpty(asString(item["kind"]), "?") + "/" + asString(meta["namespace"]) + "/" + asString(meta["name"])
+}
+
+func (h *explorerHandler) findResourceBody(path, name string) ([]byte, int, error) {
+	bodies, ok := h.responseBodies(path)
+	if !ok {
+		return nil, http.StatusNotFound, nil
+	}
+	for i := len(bodies) - 1; i >= 0; i-- {
+		body := bodies[i]
+		if item, ok := findListItemByName(body, name); ok {
+			return item, http.StatusOK, nil
+		}
+		if matchesObjectName(body, name) {
+			return body, http.StatusOK, nil
+		}
+	}
+	return nil, http.StatusNotFound, nil
+}
+
+func (h *explorerHandler) responseBodies(path string) ([][]byte, bool) {
+	entry, ok := h.store.Index[path]
+	if !ok || len(entry.RecordIDs) == 0 {
+		return nil, false
+	}
+
+	if !h.at.IsZero() {
+		index := -1
+		for i, t := range entry.Times {
+			if !t.After(h.at) {
+				index = i
+			}
+		}
+		if index < 0 {
+			return nil, false
+		}
+		body, ok := h.readRecordBody(entry.RecordIDs[index])
+		if !ok {
+			return nil, false
+		}
+		return [][]byte{body}, true
+	}
+
+	bodies := make([][]byte, 0, len(entry.RecordIDs))
+	for _, id := range entry.RecordIDs {
+		body, ok := h.readRecordBody(id)
+		if !ok {
+			continue
+		}
+		bodies = append(bodies, body)
+	}
+	if len(bodies) == 0 {
+		return nil, false
+	}
+	return bodies, true
+}
+
+func (h *explorerHandler) readRecordBody(id string) ([]byte, bool) {
+	data, err := os.ReadFile(filepath.Join(h.store.Dir, "k8shark-capture", "records", id+".json"))
+	if err != nil {
+		return nil, false
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return nil, false
+	}
+	if rec.ResponseCode != http.StatusOK {
+		return nil, false
+	}
+	return rec.ResponseBody, true
+}
+
+func baseAPIPath(path string) string {
+	if i := strings.Index(path, "?"); i >= 0 {
+		return path[:i]
+	}
+	return path
+}
+
+func pathPriority(path string) int {
+	if strings.Contains(path, "?as=Table") {
+		return 2
+	}
+	if strings.Contains(path, "?") {
+		return 1
+	}
+	return 0
+}
+
+func parseAPIPath(path string) (group, version, resource, namespace, name string) {
+	path = baseAPIPath(path)
 	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
 	switch {
 	case len(parts) >= 3 && parts[0] == "api":
 		version = parts[1]
 		if len(parts) == 3 {
 			resource = parts[2]
+		} else if len(parts) == 4 {
+			resource = parts[2]
+			name = parts[3]
 		} else if len(parts) == 5 && parts[2] == "namespaces" {
 			namespace = parts[3]
 			resource = parts[4]
+		} else if len(parts) == 6 && parts[2] == "namespaces" {
+			namespace = parts[3]
+			resource = parts[4]
+			name = parts[5]
 		}
 	case len(parts) >= 4 && parts[0] == "apis":
 		group = parts[1]
 		version = parts[2]
 		if len(parts) == 4 {
 			resource = parts[3]
+		} else if len(parts) == 5 {
+			resource = parts[3]
+			name = parts[4]
 		} else if len(parts) == 6 && parts[3] == "namespaces" {
 			namespace = parts[4]
 			resource = parts[5]
+		} else if len(parts) == 7 && parts[3] == "namespaces" {
+			namespace = parts[4]
+			resource = parts[5]
+			name = parts[6]
 		}
 	}
 	return
@@ -741,7 +1016,7 @@ const indexHTML = `<!doctype html>
         ds.open = true;
         ds.innerHTML = '<summary>Namespace: <strong>' + ns.name + '</strong></summary>';
 
-        for (const w of ns.workloads) {
+			for (const w of (ns.workloads || [])) {
           if (!kindEnabled(w.kind) || !nodeMatches(w, q)) continue;
           ds.appendChild(mkNode(w.kind + ' ' + w.name, w, ['Cluster', ns.name, w.kind, w.name]));
           for (const p of (w.pods || [])) {
@@ -755,7 +1030,7 @@ const indexHTML = `<!doctype html>
           }
         }
 
-        for (const p of ns.pods) {
+			for (const p of (ns.pods || [])) {
           if (!kindEnabled(p.kind) || !nodeMatches(p, q)) continue;
           ds.appendChild(mkNode('Pod ' + p.name, p, ['Cluster', ns.name, 'Pod', p.name]));
           for (const c of (p.containers || [])) {
@@ -765,7 +1040,7 @@ const indexHTML = `<!doctype html>
           }
         }
 
-        for (const r of ns.resources) {
+			for (const r of (ns.resources || [])) {
           if (!kindEnabled(r.kind) || !nodeMatches(r, q)) continue;
           ds.appendChild(mkNode(r.kind + ' ' + r.name, r, ['Cluster', ns.name, r.kind, r.name]));
         }

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -886,6 +886,10 @@ const indexHTML = `<!doctype html>
     .panel:last-child { border-right:none; border-left:1px solid var(--line); }
     .side { padding:12px; background:rgba(17,24,39,.85); }
     .search { width:100%; box-sizing:border-box; padding:8px 10px; border:1px solid #334155; border-radius:8px; background:#0f172a; color:var(--text); }
+	.toggle-head { margin-top:10px; display:flex; justify-content:space-between; align-items:center; }
+	.toggle-head-title { font-size:11px; color:var(--muted); text-transform:uppercase; letter-spacing:.6px; }
+	.toggle-actions button { margin-left:6px; padding:3px 8px; border-radius:6px; border:1px solid #334155; background:#0f172a; color:#cbd5e1; font-size:11px; cursor:pointer; }
+	.toggle-actions button:hover { border-color:#64748b; }
     .toggle-list { margin-top:10px; display:grid; gap:6px; }
     .tree { padding:12px; }
     .crumbs { color:var(--muted); font-size:13px; margin-bottom:8px; }
@@ -916,6 +920,10 @@ const indexHTML = `<!doctype html>
     pre { white-space:pre-wrap; background:#020617; border:1px solid #1f2937; padding:10px; border-radius:8px; }
     .tabs button { margin-right:6px; padding:6px 10px; border-radius:7px; border:1px solid #334155; background:#0f172a; color:var(--text); cursor:pointer; }
     .tabs button.active { border-color:var(--accent); color:#86efac; }
+		.toast-stack { position:fixed; right:14px; bottom:14px; display:grid; gap:8px; z-index:40; pointer-events:none; }
+		.toast { pointer-events:auto; max-width:420px; border:1px solid #334155; border-radius:8px; padding:10px 12px; background:rgba(15,23,42,.92); box-shadow:0 8px 28px rgba(2,6,23,.45); font-size:13px; }
+		.toast.error { border-color:rgba(239,68,68,.55); color:#fecaca; }
+		.toast.info { border-color:rgba(59,130,246,.55); color:#bfdbfe; }
   </style>
 </head>
 <body>
@@ -926,6 +934,13 @@ const indexHTML = `<!doctype html>
   <div class="layout">
     <aside class="panel side">
       <input class="search" id="search" placeholder="Search name or label..."/>
+			<div class="toggle-head">
+				<span class="toggle-head-title">Kinds</span>
+				<span class="toggle-actions">
+					<button id="toggleAll" type="button">All</button>
+					<button id="toggleNone" type="button">None</button>
+				</span>
+			</div>
       <div class="toggle-list" id="toggles"></div>
     </aside>
     <main class="panel tree">
@@ -941,6 +956,7 @@ const indexHTML = `<!doctype html>
       <pre id="detailBody">Click a node in the tree to inspect details.</pre>
     </section>
   </div>
+	<div id="toasts" class="toast-stack" aria-live="polite"></div>
   <script>
     let treeData = null;
     let activeKinds = new Set();
@@ -958,12 +974,17 @@ const indexHTML = `<!doctype html>
       detailTitle: document.getElementById('detailTitle'),
       detailBody: document.getElementById('detailBody'),
       tabJson: document.getElementById('tabJson'),
-      tabYaml: document.getElementById('tabYaml')
+			tabYaml: document.getElementById('tabYaml'),
+			toggleAll: document.getElementById('toggleAll'),
+			toggleNone: document.getElementById('toggleNone'),
+			toasts: document.getElementById('toasts')
     };
 
     el.tabJson.onclick = () => setTab('json');
     el.tabYaml.onclick = () => setTab('yaml');
     el.search.oninput = render;
+		el.toggleAll.onclick = () => setAllKinds(true);
+		el.toggleNone.onclick = () => setAllKinds(false);
 	document.addEventListener('keydown', onTreeKeyDown);
 
     function setTab(tab) {
@@ -981,6 +1002,15 @@ const indexHTML = `<!doctype html>
 			box.className = 'tree-state ' + type;
 			box.textContent = message;
 			el.tree.appendChild(box);
+		}
+
+		function showToast(type, message, timeoutMs) {
+			const toast = document.createElement('div');
+			toast.className = 'toast ' + type;
+			toast.textContent = message;
+			el.toasts.appendChild(toast);
+			const ttl = timeoutMs || (type === 'error' ? 7000 : 3000);
+			window.setTimeout(() => toast.remove(), ttl);
 		}
 
     function statusClass(status) {
@@ -1094,7 +1124,9 @@ const indexHTML = `<!doctype html>
 				el.detailBody.textContent = data[activeTab] || JSON.stringify(data, null, 2);
 			} catch (err) {
 				selected.detail = null;
-				el.detailBody.textContent = 'Failed to load detail: ' + (err && err.message ? err.message : String(err));
+				const msg = (err && err.message ? err.message : String(err));
+				el.detailBody.textContent = 'Failed to load detail: ' + msg;
+				showToast('error', 'Detail request failed: ' + msg);
 			}
     }
 
@@ -1189,6 +1221,7 @@ const indexHTML = `<!doctype html>
         row.className = 'muted';
         const cb = document.createElement('input');
         cb.type = 'checkbox';
+				cb.dataset.kind = kind;
         cb.checked = true;
         cb.onchange = () => {
           if (cb.checked) activeKinds.add(kind); else activeKinds.delete(kind);
@@ -1199,6 +1232,18 @@ const indexHTML = `<!doctype html>
         el.toggles.appendChild(row);
       }
     }
+
+		function setAllKinds(enabled) {
+			const inputs = el.toggles.querySelectorAll('input[type="checkbox"]');
+			for (const input of inputs) input.checked = enabled;
+			if (enabled) {
+				const kinds = Array.from(inputs).map((input) => input.dataset.kind || '').filter(Boolean);
+				activeKinds = new Set(kinds);
+			} else {
+				activeKinds = new Set();
+			}
+			render();
+		}
 
     async function init() {
 			setTreeState('loading', 'Loading captured resources...');
@@ -1214,7 +1259,9 @@ const indexHTML = `<!doctype html>
 				renderToggles((treeData.resource_kinds || []).concat(['Container']));
 				render();
 			} catch (err) {
-				setTreeState('error', 'Failed to load capture tree: ' + (err && err.message ? err.message : String(err)));
+				const msg = (err && err.message ? err.message : String(err));
+				setTreeState('error', 'Failed to load capture tree: ' + msg);
+				showToast('error', 'Capture tree failed to load: ' + msg);
 				el.meta.textContent = 'capture unavailable';
 			}
     }

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -224,6 +224,13 @@ func (h *explorerHandler) serveDetail(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	normalizedBody, err := normalizeDetailBody(body, path)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "invalid object body"})
+		return
+	}
+	body = normalizedBody
+
 	prettyJSON := body
 	var out bytes.Buffer
 	if err := json.Indent(&out, body, "", "  "); err == nil {
@@ -242,6 +249,39 @@ func (h *explorerHandler) serveDetail(w http.ResponseWriter, r *http.Request) {
 		"json":        string(prettyJSON),
 		"yaml":        string(yml),
 	})
+}
+
+func normalizeDetailBody(body []byte, path string) ([]byte, error) {
+	var obj map[string]any
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return nil, err
+	}
+
+	// Keep list/table/detail envelopes as-is.
+	if _, hasItems := obj["items"]; hasItems {
+		return body, nil
+	}
+	if strings.HasSuffix(asString(obj["kind"]), "Table") {
+		return body, nil
+	}
+
+	group, version, resource, _, _ := parseAPIPath(path)
+	if asString(obj["apiVersion"]) == "" {
+		if group == "" {
+			obj["apiVersion"] = version
+		} else {
+			obj["apiVersion"] = group + "/" + version
+		}
+	}
+	if asString(obj["kind"]) == "" {
+		obj["kind"] = kindFromResource(resource)
+	}
+
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 func (h *explorerHandler) buildTree() (*treeResponse, error) {
@@ -923,7 +963,10 @@ const indexHTML = `<!doctype html>
 	.tree-state.empty { border-color:rgba(148,163,184,.45); color:#cbd5e1; }
 	.tree-state.loading { border-color:rgba(59,130,246,.45); color:#bfdbfe; }
     pre { white-space:pre-wrap; background:#020617; border:1px solid #1f2937; padding:10px; border-radius:8px; }
-    .tabs button { margin-right:6px; padding:6px 10px; border-radius:7px; border:1px solid #334155; background:#0f172a; color:var(--text); cursor:pointer; }
+	.tabs { display:flex; align-items:center; justify-content:space-between; margin-bottom:6px; }
+	.tabs-left button { margin-right:6px; padding:6px 10px; border-radius:7px; border:1px solid #334155; background:#0f172a; color:var(--text); cursor:pointer; }
+	.copy-btn { padding:6px 10px; border-radius:7px; border:1px solid #334155; background:#0f172a; color:#cbd5e1; cursor:pointer; font-size:12px; }
+	.copy-btn:hover { border-color:#64748b; }
     .tabs button.active { border-color:var(--accent); color:#86efac; }
 		.toast-stack { position:fixed; right:14px; bottom:14px; display:grid; gap:8px; z-index:40; pointer-events:none; }
 		.toast { pointer-events:auto; max-width:420px; border:1px solid #334155; border-radius:8px; padding:10px 12px; background:rgba(15,23,42,.92); box-shadow:0 8px 28px rgba(2,6,23,.45); font-size:13px; }
@@ -966,8 +1009,11 @@ const indexHTML = `<!doctype html>
       <h3 id="detailTitle">Select a resource</h3>
 			<div id="detailSummary" class="detail-summary"></div>
       <div class="tabs">
-        <button id="tabJson" class="active">JSON</button>
-        <button id="tabYaml">YAML</button>
+				<span class="tabs-left">
+					<button id="tabJson" class="active">JSON</button>
+					<button id="tabYaml">YAML</button>
+				</span>
+				<button id="copyDetail" class="copy-btn" type="button">Copy JSON</button>
       </div>
       <pre id="detailBody">Click a node in the tree to inspect details.</pre>
     </section>
@@ -997,6 +1043,7 @@ const indexHTML = `<!doctype html>
       detailBody: document.getElementById('detailBody'),
       tabJson: document.getElementById('tabJson'),
 			tabYaml: document.getElementById('tabYaml'),
+			copyDetail: document.getElementById('copyDetail'),
 			toggleAll: document.getElementById('toggleAll'),
 			toggleNone: document.getElementById('toggleNone'),
 			expandAll: document.getElementById('expandAll'),
@@ -1006,6 +1053,7 @@ const indexHTML = `<!doctype html>
 
     el.tabJson.onclick = () => setTab('json');
     el.tabYaml.onclick = () => setTab('yaml');
+	el.copyDetail.onclick = () => copyActiveDetail();
     el.search.oninput = render;
 		el.toggleAll.onclick = () => setAllKinds(true);
 		el.toggleNone.onclick = () => setAllKinds(false);
@@ -1017,10 +1065,38 @@ const indexHTML = `<!doctype html>
       activeTab = tab;
       el.tabJson.classList.toggle('active', tab === 'json');
       el.tabYaml.classList.toggle('active', tab === 'yaml');
+			el.copyDetail.textContent = tab === 'yaml' ? 'Copy YAML' : 'Copy JSON';
       if (selected && selected.detail) {
         el.detailBody.textContent = selected.detail[activeTab] || '';
       }
     }
+
+		async function copyActiveDetail() {
+			if (!selected || !selected.detail) {
+				showToast('info', 'Select a resource first.');
+				return;
+			}
+			const text = selected.detail[activeTab] || '';
+			if (!text) {
+				showToast('info', 'No content available to copy.');
+				return;
+			}
+			try {
+				if (navigator.clipboard && navigator.clipboard.writeText) {
+					await navigator.clipboard.writeText(text);
+				} else {
+					const tmp = document.createElement('textarea');
+					tmp.value = text;
+					document.body.appendChild(tmp);
+					tmp.select();
+					document.execCommand('copy');
+					tmp.remove();
+				}
+				showToast('info', (activeTab === 'yaml' ? 'YAML' : 'JSON') + ' copied to clipboard.');
+			} catch (err) {
+				showToast('error', 'Copy failed: ' + (err && err.message ? err.message : String(err)));
+			}
+		}
 
 		function setTreeState(type, message) {
 			el.tree.innerHTML = '';

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1060,8 +1060,12 @@ const indexHTML = `<!doctype html>
 	.snapshot-btn { padding:6px 10px; border-radius:8px; border:1px solid #334155; background:#0f172a; color:#cbd5e1; cursor:pointer; font-size:12px; }
 	.snapshot-btn:hover { border-color:#64748b; }
 	.snapshot-btn:disabled { opacity:.45; cursor:not-allowed; border-color:#1f2937; }
+	.scrub-wrap { display:flex; align-items:center; gap:8px; min-width:240px; }
+	.scrub { width:100%; accent-color:#22c55e; }
+	.scrub-pos { color:var(--muted); font-size:11px; min-width:72px; text-align:right; }
 	body.loading-snapshot .snapshot-select,
-	body.loading-snapshot .snapshot-btn { opacity:.7; }
+	body.loading-snapshot .snapshot-btn,
+	body.loading-snapshot .scrub { opacity:.7; }
     .layout { display:grid; grid-template-columns:260px 1fr 40%; min-height:calc(100vh - 56px); }
     .panel { border-right:1px solid var(--line); overflow:auto; }
     .panel:last-child { border-right:none; border-left:1px solid var(--line); }
@@ -1129,6 +1133,10 @@ const indexHTML = `<!doctype html>
 				<select id="snapshotAt" class="snapshot-select" title="Select capture timestamp"></select>
 				<button id="snapshotNext" class="snapshot-btn" type="button" title="Jump to newer snapshot">Next</button>
 			</div>
+			<div class="scrub-wrap">
+				<input id="timelineScrub" class="scrub" type="range" min="0" max="0" step="1" value="0"/>
+				<span id="timelinePosition" class="scrub-pos"></span>
+			</div>
 			<div id="snapshotHint" class="snapshot-hint"></div>
 			<div id="meta" class="muted"></div>
 		</div>
@@ -1186,6 +1194,8 @@ const indexHTML = `<!doctype html>
 	const storageExpandedKey = 'kshrk.ui.expandedSections.v1';
 	let expandedSections = {};
 	let currentAt = '';
+	let timelinePoints = [];
+	let scrubDebounce = null;
 
     const el = {
       tree: document.getElementById('tree'),
@@ -1207,6 +1217,8 @@ const indexHTML = `<!doctype html>
 			snapshotPrev: document.getElementById('snapshotPrev'),
 			snapshotAt: document.getElementById('snapshotAt'),
 			snapshotNext: document.getElementById('snapshotNext'),
+			timelineScrub: document.getElementById('timelineScrub'),
+			timelinePosition: document.getElementById('timelinePosition'),
 			snapshotHint: document.getElementById('snapshotHint'),
 			toasts: document.getElementById('toasts')
     };
@@ -1224,10 +1236,18 @@ const indexHTML = `<!doctype html>
 	el.snapshotAt.onchange = () => {
 		currentAt = el.snapshotAt.value || '';
 		syncSnapshotButtons();
+		syncScrubber();
 		syncAtInURL();
 		refreshTree();
 	};
 	el.snapshotNext.onclick = () => stepSnapshot(-1);
+	el.timelineScrub.oninput = () => {
+		syncScrubberLabel();
+		if (scrubDebounce) window.clearTimeout(scrubDebounce);
+		scrubDebounce = window.setTimeout(() => {
+			applyScrubberSelection();
+		}, 120);
+	};
 	document.addEventListener('keydown', onTreeKeyDown);
 
 	function syncAtInURL() {
@@ -1273,6 +1293,51 @@ const indexHTML = `<!doctype html>
 		el.snapshotNext.disabled = idx <= 0;
 	}
 
+	function syncScrubberLabel() {
+		if (!timelinePoints.length) {
+			el.timelinePosition.textContent = '';
+			return;
+		}
+		const idx = Number(el.timelineScrub.value || 0);
+		const pos = Math.max(0, Math.min(idx, timelinePoints.length - 1));
+		el.timelinePosition.textContent = (pos + 1) + '/' + timelinePoints.length;
+	}
+
+	function syncScrubber() {
+		if (!timelinePoints.length) {
+			el.timelineScrub.min = '0';
+			el.timelineScrub.max = '0';
+			el.timelineScrub.value = '0';
+			el.timelineScrub.disabled = true;
+			syncScrubberLabel();
+			return;
+		}
+		el.timelineScrub.disabled = false;
+		el.timelineScrub.min = '0';
+		el.timelineScrub.max = String(timelinePoints.length - 1);
+		let target = timelinePoints.length - 1;
+		if (currentAt && currentAt !== 'latest') {
+			const idx = timelinePoints.indexOf(currentAt);
+			if (idx >= 0) target = idx;
+		}
+		el.timelineScrub.value = String(target);
+		syncScrubberLabel();
+	}
+
+	function applyScrubberSelection() {
+		if (!timelinePoints.length) return;
+		const idx = Number(el.timelineScrub.value || 0);
+		const pos = Math.max(0, Math.min(idx, timelinePoints.length - 1));
+		const ts = timelinePoints[pos];
+		const newest = timelinePoints[timelinePoints.length - 1];
+		currentAt = ts === newest ? 'latest' : ts;
+		el.snapshotAt.value = currentAt;
+		syncSnapshotButtons();
+		syncScrubber();
+		syncAtInURL();
+		refreshTree();
+	}
+
 	function stepSnapshot(delta) {
 		const sequence = snapshotSequence();
 		if (sequence.length === 0) {
@@ -1290,6 +1355,7 @@ const indexHTML = `<!doctype html>
 		currentAt = sequence[nextIdx];
 		el.snapshotAt.value = currentAt;
 		syncSnapshotButtons();
+		syncScrubber();
 		syncAtInURL();
 		refreshTree();
 	}
@@ -1306,7 +1372,9 @@ const indexHTML = `<!doctype html>
 	}
 
 	function renderSnapshotSelector(times, defaultAt, totalCount, sampled) {
-		const opts = Array.isArray(times) ? times.slice().reverse() : [];
+		const asc = Array.isArray(times) ? times.slice() : [];
+		timelinePoints = asc.slice();
+		const opts = asc.slice().reverse();
 		const unique = [];
 		const seen = new Set();
 		for (const ts of opts) {
@@ -1341,6 +1409,7 @@ const indexHTML = `<!doctype html>
 			el.snapshotAt.appendChild(opt);
 		}
 		el.snapshotAt.value = currentAt;
+		syncScrubber();
 		if (sampled && totalCount > opts.length) {
 			el.snapshotHint.textContent = 'showing ' + opts.length + ' sampled of ' + totalCount;
 		} else if (totalCount > 0) {
@@ -1448,8 +1517,13 @@ const indexHTML = `<!doctype html>
 		function setSnapshotLoading(loading) {
 			document.body.classList.toggle('loading-snapshot', !!loading);
 			el.snapshotAt.disabled = !!loading;
-			el.snapshotPrev.disabled = !!loading || el.snapshotPrev.disabled;
-			el.snapshotNext.disabled = !!loading || el.snapshotNext.disabled;
+			el.timelineScrub.disabled = !!loading || timelinePoints.length === 0;
+			if (loading) {
+				el.snapshotPrev.disabled = true;
+				el.snapshotNext.disabled = true;
+			} else {
+				syncSnapshotButtons();
+			}
 			if (loading) {
 				el.snapshotHint.textContent = 'loading snapshot...';
 			}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1196,6 +1196,8 @@ const indexHTML = `<!doctype html>
 	let currentAt = '';
 	let timelinePoints = [];
 	let scrubDebounce = null;
+	let lastLoadedAt = '';
+	let refreshToken = 0;
 
     const el = {
       tree: document.getElementById('tree'),
@@ -1245,8 +1247,15 @@ const indexHTML = `<!doctype html>
 		syncScrubberLabel();
 		if (scrubDebounce) window.clearTimeout(scrubDebounce);
 		scrubDebounce = window.setTimeout(() => {
-			applyScrubberSelection();
-		}, 120);
+			applyScrubberSelection(false);
+		}, 180);
+	};
+	el.timelineScrub.onchange = () => {
+		if (scrubDebounce) {
+			window.clearTimeout(scrubDebounce);
+			scrubDebounce = null;
+		}
+		applyScrubberSelection(true);
 	};
 	document.addEventListener('keydown', onTreeKeyDown);
 
@@ -1300,7 +1309,8 @@ const indexHTML = `<!doctype html>
 		}
 		const idx = Number(el.timelineScrub.value || 0);
 		const pos = Math.max(0, Math.min(idx, timelinePoints.length - 1));
-		el.timelinePosition.textContent = (pos + 1) + '/' + timelinePoints.length;
+		const ts = timelinePoints[pos] || '';
+		el.timelinePosition.textContent = (pos + 1) + '/' + timelinePoints.length + (ts ? (' · ' + formatAtLabel(ts)) : '');
 	}
 
 	function syncScrubber() {
@@ -1324,18 +1334,23 @@ const indexHTML = `<!doctype html>
 		syncScrubberLabel();
 	}
 
-	function applyScrubberSelection() {
+	function applyScrubberSelection(forceRefresh) {
 		if (!timelinePoints.length) return;
 		const idx = Number(el.timelineScrub.value || 0);
 		const pos = Math.max(0, Math.min(idx, timelinePoints.length - 1));
 		const ts = timelinePoints[pos];
 		const newest = timelinePoints[timelinePoints.length - 1];
-		currentAt = ts === newest ? 'latest' : ts;
+		const nextAt = ts === newest ? 'latest' : ts;
+		if (nextAt === currentAt && !forceRefresh) {
+			syncScrubberLabel();
+			return;
+		}
+		currentAt = nextAt;
 		el.snapshotAt.value = currentAt;
 		syncSnapshotButtons();
 		syncScrubber();
 		syncAtInURL();
-		refreshTree();
+		refreshTree(!!forceRefresh);
 	}
 
 	function stepSnapshot(delta) {
@@ -1357,7 +1372,11 @@ const indexHTML = `<!doctype html>
 		syncSnapshotButtons();
 		syncScrubber();
 		syncAtInURL();
-		refreshTree();
+		refreshTree(true);
+	}
+
+	function normalizedAt() {
+		return currentAt && currentAt !== 'latest' ? currentAt : 'latest';
 	}
 
 	function updateMetaLine() {
@@ -1695,9 +1714,19 @@ const indexHTML = `<!doctype html>
 		}
 
 		function onTreeKeyDown(ev) {
-			if (visibleNodes.length === 0) return;
 			const tag = (document.activeElement && document.activeElement.tagName) || '';
 			if (tag === 'INPUT' || tag === 'TEXTAREA' || (document.activeElement && document.activeElement.isContentEditable)) return;
+			if (ev.altKey && ev.key === 'ArrowLeft') {
+				ev.preventDefault();
+				stepSnapshot(1);
+				return;
+			}
+			if (ev.altKey && ev.key === 'ArrowRight') {
+				ev.preventDefault();
+				stepSnapshot(-1);
+				return;
+			}
+			if (visibleNodes.length === 0) return;
 			if (ev.key === 'ArrowDown') {
 				ev.preventDefault();
 				selectNodeAt(activeNodeIdx < 0 ? 0 : activeNodeIdx + 1, true);
@@ -1912,8 +1941,12 @@ const indexHTML = `<!doctype html>
 			syncAtInURL();
 		}
 
-		async function refreshTree() {
+		async function refreshTree(forceRefresh) {
 			const previousSelectionKey = selected && selected.node ? nodeIdentity(selected.node) : '';
+			if (!forceRefresh && normalizedAt() === lastLoadedAt) {
+				return;
+			}
+			const token = ++refreshToken;
 			setTreeState('loading', 'Loading captured resources...');
 			setSnapshotLoading(true);
 			const q = withAtQuery(new URLSearchParams());
@@ -1921,11 +1954,15 @@ const indexHTML = `<!doctype html>
 			try {
 				const res = await fetch(url);
 				const data = await res.json();
+				if (token !== refreshToken) {
+					return;
+				}
 				if (!res.ok) {
 					const msg = (data && data.error) ? data.error : ('request failed with status ' + res.status);
 					throw new Error(msg);
 				}
 				treeData = data;
+				lastLoadedAt = normalizedAt();
 				updateMetaLine();
 				renderToggles((treeData.resource_kinds || []).concat(['Container']));
 				render();
@@ -1940,8 +1977,10 @@ const indexHTML = `<!doctype html>
 					showDetail(selected.node, selected.crumbs || ['Cluster']);
 				}
 			} finally {
-				setSnapshotLoading(false);
-				syncSnapshotButtons();
+				if (token === refreshToken) {
+					setSnapshotLoading(false);
+					syncSnapshotButtons();
+				}
 			}
 		}
 
@@ -1951,7 +1990,7 @@ const indexHTML = `<!doctype html>
 				loadPreferences();
 				initAtFromURL();
 				await loadTimestamps();
-				await refreshTree();
+				await refreshTree(true);
 			} catch (err) {
 				const msg = (err && err.message ? err.message : String(err));
 				setTreeState('error', 'Failed to load capture tree: ' + msg);

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -49,6 +49,13 @@ type treeResponse struct {
 	ResourceKinds []string        `json:"resource_kinds"`
 }
 
+type timestampsResponse struct {
+	CapturedAt    time.Time `json:"captured_at"`
+	CapturedUntil time.Time `json:"captured_until"`
+	DefaultAt     string    `json:"default_at,omitempty"`
+	Timestamps    []string  `json:"timestamps"`
+}
+
 type namespaceNode struct {
 	Name      string         `json:"name"`
 	Workloads []workloadNode `json:"workloads"`
@@ -134,6 +141,7 @@ func Open(opts OpenOptions) (*Server, error) {
 	mux.HandleFunc("/", h.serveIndex)
 	mux.HandleFunc("/api/ui/tree", h.serveTree)
 	mux.HandleFunc("/api/ui/detail", h.serveDetail)
+	mux.HandleFunc("/api/ui/timestamps", h.serveTimestamps)
 
 	httpSrv := &http.Server{Handler: mux}
 	done := make(chan struct{})
@@ -181,7 +189,13 @@ func (h *explorerHandler) serveIndex(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *explorerHandler) serveTree(w http.ResponseWriter, r *http.Request) {
-	resp, err := h.buildTree()
+	at, err := h.resolveRequestAt(r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	resp, err := h.buildTreeAt(at)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
@@ -190,6 +204,12 @@ func (h *explorerHandler) serveTree(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *explorerHandler) serveDetail(w http.ResponseWriter, r *http.Request) {
+	at, atErr := h.resolveRequestAt(r)
+	if atErr != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": atErr.Error()})
+		return
+	}
+
 	path := r.URL.Query().Get("path")
 	if path == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing path query parameter"})
@@ -203,7 +223,7 @@ func (h *explorerHandler) serveDetail(w http.ResponseWriter, r *http.Request) {
 		err  error
 	)
 	if name != "" {
-		body, code, err = h.findResourceBody(path, name)
+		body, code, err = h.findResourceBodyAt(path, name, at)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 			return
@@ -213,7 +233,7 @@ func (h *explorerHandler) serveDetail(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		body, code, err = h.store.Latest(path, h.at)
+		body, code, err = h.store.Latest(path, at)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 			return
@@ -250,6 +270,30 @@ func (h *explorerHandler) serveDetail(w http.ResponseWriter, r *http.Request) {
 		"yaml":        string(yml),
 		"inferred":    inferred,
 	})
+}
+
+func (h *explorerHandler) serveTimestamps(w http.ResponseWriter, r *http.Request) {
+	times := collectTimestamps(h.store.Index)
+	resp := timestampsResponse{
+		CapturedAt:    h.store.Metadata.CapturedAt,
+		CapturedUntil: h.store.Metadata.CapturedUntil,
+		Timestamps:    times,
+	}
+	if !h.at.IsZero() {
+		resp.DefaultAt = h.at.UTC().Format(time.RFC3339)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *explorerHandler) resolveRequestAt(r *http.Request) (time.Time, error) {
+	raw := strings.TrimSpace(r.URL.Query().Get("at"))
+	if raw == "" {
+		return h.at, nil
+	}
+	if strings.EqualFold(raw, "latest") {
+		return time.Time{}, nil
+	}
+	return parseReplayAt(h.store.Metadata.CapturedAt, h.store.Metadata.CapturedUntil, raw)
 }
 
 func normalizeDetailBody(body []byte, path string) ([]byte, map[string]bool, error) {
@@ -289,6 +333,10 @@ func normalizeDetailBody(body []byte, path string) ([]byte, map[string]bool, err
 }
 
 func (h *explorerHandler) buildTree() (*treeResponse, error) {
+	return h.buildTreeAt(h.at)
+}
+
+func (h *explorerHandler) buildTreeAt(at time.Time) (*treeResponse, error) {
 	nsMap := map[string]*namespaceNode{}
 	clusterScoped := make([]resourceNode, 0)
 	kindSet := map[string]bool{}
@@ -315,7 +363,7 @@ func (h *explorerHandler) buildTree() (*treeResponse, error) {
 	}
 	for ns, resMap := range byNSRes {
 		for resource, candidates := range resMap {
-			items, ok := h.loadResourceItems(candidates)
+			items, ok := h.loadResourceItemsAt(candidates, at)
 			if !ok {
 				continue
 			}
@@ -623,6 +671,10 @@ func sortedKeys(m map[string][]string) []string {
 }
 
 func (h *explorerHandler) loadResourceItems(candidates []string) ([]listItem, bool) {
+	return h.loadResourceItemsAt(candidates, h.at)
+}
+
+func (h *explorerHandler) loadResourceItemsAt(candidates []string, at time.Time) ([]listItem, bool) {
 	sorted := append([]string(nil), candidates...)
 	sort.Slice(sorted, func(i, j int) bool {
 		pi := pathPriority(sorted[i])
@@ -638,7 +690,7 @@ func (h *explorerHandler) loadResourceItems(candidates []string) ([]listItem, bo
 	itemsByKey := make(map[string]listItem)
 	var itemOrder []string
 	for _, candidate := range sorted {
-		bodies, ok := h.responseBodies(candidate)
+		bodies, ok := h.responseBodiesAt(candidate, at)
 		if !ok {
 			continue
 		}
@@ -748,7 +800,11 @@ func itemIdentityKey(item map[string]any) string {
 }
 
 func (h *explorerHandler) findResourceBody(path, name string) ([]byte, int, error) {
-	bodies, ok := h.responseBodies(path)
+	return h.findResourceBodyAt(path, name, h.at)
+}
+
+func (h *explorerHandler) findResourceBodyAt(path, name string, at time.Time) ([]byte, int, error) {
+	bodies, ok := h.responseBodiesAt(path, at)
 	if !ok {
 		return nil, http.StatusNotFound, nil
 	}
@@ -765,15 +821,19 @@ func (h *explorerHandler) findResourceBody(path, name string) ([]byte, int, erro
 }
 
 func (h *explorerHandler) responseBodies(path string) ([][]byte, bool) {
+	return h.responseBodiesAt(path, h.at)
+}
+
+func (h *explorerHandler) responseBodiesAt(path string, at time.Time) ([][]byte, bool) {
 	entry, ok := h.store.Index[path]
 	if !ok || len(entry.RecordIDs) == 0 {
 		return nil, false
 	}
 
-	if !h.at.IsZero() {
+	if !at.IsZero() {
 		index := -1
 		for i, t := range entry.Times {
-			if !t.After(h.at) {
+			if !t.After(at) {
 				index = i
 			}
 		}
@@ -799,6 +859,31 @@ func (h *explorerHandler) responseBodies(path string) ([][]byte, bool) {
 		return nil, false
 	}
 	return bodies, true
+}
+
+func collectTimestamps(index capture.Index) []string {
+	if len(index) == 0 {
+		return nil
+	}
+	uniq := make(map[time.Time]struct{})
+	for _, entry := range index {
+		for _, t := range entry.Times {
+			if t.IsZero() {
+				continue
+			}
+			uniq[t.UTC()] = struct{}{}
+		}
+	}
+	out := make([]time.Time, 0, len(uniq))
+	for t := range uniq {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Before(out[j]) })
+	rfc := make([]string, 0, len(out))
+	for _, t := range out {
+		rfc = append(rfc, t.Format(time.RFC3339))
+	}
+	return rfc
 }
 
 func (h *explorerHandler) readRecordBody(id string) ([]byte, bool) {
@@ -924,7 +1009,10 @@ const indexHTML = `<!doctype html>
   <style>
     :root { --bg:#0b0f14; --panel:#111827; --text:#e5e7eb; --muted:#94a3b8; --line:#1f2937; --ok:#16a34a; --warn:#f59e0b; --bad:#dc2626; --accent:#22c55e; }
     body { margin:0; font-family: ui-sans-serif, -apple-system, Segoe UI, sans-serif; background:linear-gradient(145deg,#0b0f14,#0f172a); color:var(--text); }
-    header { padding:14px 18px; border-bottom:1px solid var(--line); display:flex; justify-content:space-between; align-items:center; }
+	header { padding:14px 18px; border-bottom:1px solid var(--line); display:flex; justify-content:space-between; align-items:center; gap:12px; }
+	.head-right { display:flex; align-items:center; gap:10px; }
+	.snapshot-select { min-width:220px; max-width:340px; box-sizing:border-box; padding:6px 8px; border:1px solid #334155; border-radius:8px; background:#0f172a; color:var(--text); }
+	.snapshot-label { color:var(--muted); font-size:12px; }
     .layout { display:grid; grid-template-columns:260px 1fr 40%; min-height:calc(100vh - 56px); }
     .panel { border-right:1px solid var(--line); overflow:auto; }
     .panel:last-child { border-right:none; border-left:1px solid var(--line); }
@@ -985,7 +1073,11 @@ const indexHTML = `<!doctype html>
 <body>
   <header>
     <div><strong>kshrk capture explorer</strong></div>
-    <div id="meta" class="muted"></div>
+		<div class="head-right">
+			<span class="snapshot-label">Snapshot</span>
+			<select id="snapshotAt" class="snapshot-select" title="Select capture timestamp"></select>
+			<div id="meta" class="muted"></div>
+		</div>
   </header>
   <div class="layout">
     <aside class="panel side">
@@ -1039,6 +1131,7 @@ const indexHTML = `<!doctype html>
 	const storageKindsKey = 'kshrk.ui.activeKinds.v1';
 	const storageExpandedKey = 'kshrk.ui.expandedSections.v1';
 	let expandedSections = {};
+	let currentAt = '';
 
     const el = {
       tree: document.getElementById('tree'),
@@ -1057,6 +1150,7 @@ const indexHTML = `<!doctype html>
 			toggleNone: document.getElementById('toggleNone'),
 			expandAll: document.getElementById('expandAll'),
 			collapseAll: document.getElementById('collapseAll'),
+			snapshotAt: document.getElementById('snapshotAt'),
 			toasts: document.getElementById('toasts')
     };
 
@@ -1069,7 +1163,93 @@ const indexHTML = `<!doctype html>
 		el.toggleNone.onclick = () => setAllKinds(false);
 	el.expandAll.onclick = () => setAllTreeDetails(true);
 	el.collapseAll.onclick = () => setAllTreeDetails(false);
+	el.snapshotAt.onchange = () => {
+		currentAt = el.snapshotAt.value || '';
+		syncAtInURL();
+		refreshTree();
+	};
 	document.addEventListener('keydown', onTreeKeyDown);
+
+	function syncAtInURL() {
+		const u = new URL(window.location.href);
+		if (currentAt) {
+			u.searchParams.set('at', currentAt);
+		} else {
+			u.searchParams.delete('at');
+		}
+		window.history.replaceState({}, '', u.toString());
+	}
+
+	function initAtFromURL() {
+		const u = new URL(window.location.href);
+		const at = (u.searchParams.get('at') || '').trim();
+		if (at) {
+			currentAt = at;
+		}
+	}
+
+	function withAtQuery(params) {
+		if (currentAt) {
+			params.set('at', currentAt);
+		}
+		return params;
+	}
+
+	function formatAtLabel(v) {
+		if (!v || v === 'latest') return 'Latest available';
+		const d = new Date(v);
+		if (Number.isNaN(d.getTime())) return v;
+		return d.toISOString();
+	}
+
+	function updateMetaLine() {
+		if (!treeData) {
+			el.meta.textContent = 'capture unavailable';
+			return;
+		}
+		const start = new Date(treeData.captured_at).toISOString();
+		const end = new Date(treeData.captured_until).toISOString();
+		const atLabel = formatAtLabel(currentAt);
+		el.meta.textContent = 'capture ' + start + ' to ' + end + ' | view: ' + atLabel;
+	}
+
+	function renderSnapshotSelector(times, defaultAt) {
+		const opts = Array.isArray(times) ? times.slice() : [];
+		const unique = [];
+		const seen = new Set();
+		for (const ts of opts) {
+			if (!ts || seen.has(ts)) continue;
+			seen.add(ts);
+			unique.push(ts);
+		}
+
+		el.snapshotAt.innerHTML = '';
+		const latest = document.createElement('option');
+		latest.value = 'latest';
+		latest.textContent = 'Latest available';
+		el.snapshotAt.appendChild(latest);
+
+		for (const ts of unique) {
+			const opt = document.createElement('option');
+			opt.value = ts;
+			opt.textContent = formatAtLabel(ts);
+			el.snapshotAt.appendChild(opt);
+		}
+
+		if (!currentAt && defaultAt) {
+			currentAt = defaultAt;
+		}
+		if (!currentAt) {
+			currentAt = 'latest';
+		}
+		if (currentAt !== 'latest' && !seen.has(currentAt)) {
+			const opt = document.createElement('option');
+			opt.value = currentAt;
+			opt.textContent = formatAtLabel(currentAt);
+			el.snapshotAt.appendChild(opt);
+		}
+		el.snapshotAt.value = currentAt;
+	}
 
     function setTab(tab) {
       activeTab = tab;
@@ -1342,7 +1522,7 @@ const indexHTML = `<!doctype html>
       el.detailTitle.textContent = node.kind + ' ' + node.name;
 			el.detailBody.textContent = 'Loading detail...';
 			try {
-				const q = new URLSearchParams({ path: node.list_path, name: node.name });
+				const q = withAtQuery(new URLSearchParams({ path: node.list_path, name: node.name }));
 				const res = await fetch('/api/ui/detail?' + q.toString());
 				const data = await res.json();
 				if (!res.ok) {
@@ -1517,20 +1697,45 @@ const indexHTML = `<!doctype html>
 			persistExpandedSections();
 		}
 
-    async function init() {
+		async function loadTimestamps() {
+			const q = withAtQuery(new URLSearchParams());
+			const url = q.toString() ? ('/api/ui/timestamps?' + q.toString()) : '/api/ui/timestamps';
+			const res = await fetch(url);
+			const data = await res.json();
+			if (!res.ok) {
+				const msg = (data && data.error) ? data.error : ('request failed with status ' + res.status);
+				throw new Error(msg);
+			}
+			renderSnapshotSelector(data.timestamps || [], data.default_at || '');
+			syncAtInURL();
+		}
+
+		async function refreshTree() {
+			setTreeState('loading', 'Loading captured resources...');
+			const q = withAtQuery(new URLSearchParams());
+			const url = q.toString() ? ('/api/ui/tree?' + q.toString()) : '/api/ui/tree';
+			const res = await fetch(url);
+			const data = await res.json();
+			if (!res.ok) {
+				const msg = (data && data.error) ? data.error : ('request failed with status ' + res.status);
+				throw new Error(msg);
+			}
+			treeData = data;
+			updateMetaLine();
+			renderToggles((treeData.resource_kinds || []).concat(['Container']));
+			render();
+			if (selected && selected.node) {
+				showDetail(selected.node, selected.crumbs || ['Cluster']);
+			}
+		}
+
+		async function init() {
 			setTreeState('loading', 'Loading captured resources...');
 			try {
 				loadPreferences();
-				const res = await fetch('/api/ui/tree');
-				const data = await res.json();
-				if (!res.ok) {
-					const msg = (data && data.error) ? data.error : ('request failed with status ' + res.status);
-					throw new Error(msg);
-				}
-				treeData = data;
-				el.meta.textContent = 'capture ' + new Date(treeData.captured_at).toISOString() + ' to ' + new Date(treeData.captured_until).toISOString();
-				renderToggles((treeData.resource_kinds || []).concat(['Container']));
-				render();
+				initAtFromURL();
+				await loadTimestamps();
+				await refreshTree();
 			} catch (err) {
 				const msg = (err && err.message ? err.message : String(err));
 				setTreeState('error', 'Failed to load capture tree: ' + msg);

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -1,0 +1,95 @@
+package ui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/server"
+)
+
+func TestBuildTree_Hierarchy(t *testing.T) {
+	store := buildTestStore(t)
+	h := &explorerHandler{store: store}
+	tree, err := h.buildTree()
+	if err != nil {
+		t.Fatalf("buildTree: %v", err)
+	}
+	if len(tree.Namespaces) != 1 || tree.Namespaces[0].Name != "default" {
+		t.Fatalf("expected one default namespace, got %+v", tree.Namespaces)
+	}
+	ns := tree.Namespaces[0]
+	if len(ns.Workloads) == 0 {
+		t.Fatal("expected workloads in namespace")
+	}
+	if len(ns.Workloads[0].Pods) == 0 {
+		t.Fatal("expected pod attached to workload")
+	}
+	if len(ns.Workloads[0].Pods[0].Containers) == 0 {
+		t.Fatal("expected containers in pod")
+	}
+}
+
+func TestServeDetail_ItemFromList(t *testing.T) {
+	store := buildTestStore(t)
+	h := &explorerHandler{store: store}
+	req := httptest.NewRequest(http.MethodGet, "/api/ui/detail?path=/api/v1/namespaces/default/pods&name=demo-pod", nil)
+	rr := httptest.NewRecorder()
+	h.serveDetail(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if body["json"] == nil || body["yaml"] == nil {
+		t.Fatalf("expected json and yaml in response, got %v", body)
+	}
+}
+
+func buildTestStore(t *testing.T) *server.CaptureStore {
+	t.Helper()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "capture.tar.gz")
+	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+
+	deployList := `{"apiVersion":"apps/v1","kind":"DeploymentList","items":[{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"demo-deploy","namespace":"default","labels":{"app":"demo"}}}]}`
+	podList := `{"apiVersion":"v1","kind":"PodList","items":[{"apiVersion":"v1","kind":"Pod","metadata":{"name":"demo-pod","namespace":"default","labels":{"app":"demo"},"ownerReferences":[{"kind":"Deployment","name":"demo-deploy"}]},"spec":{"containers":[{"name":"main"},{"name":"sidecar"}]},"status":{"phase":"Running"}}]}`
+	nodeList := `{"apiVersion":"v1","kind":"NodeList","items":[{"apiVersion":"v1","kind":"Node","metadata":{"name":"node-1"},"status":{"phase":"Ready"}}]}`
+
+	recs := []*capture.Record{
+		{ID: "r1", CapturedAt: now, APIPath: "/apis/apps/v1/namespaces/default/deployments", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(deployList)},
+		{ID: "r2", CapturedAt: now, APIPath: "/api/v1/namespaces/default/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(podList)},
+		{ID: "r3", CapturedAt: now, APIPath: "/api/v1/nodes", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(nodeList)},
+	}
+	idx := capture.Index{
+		"/apis/apps/v1/namespaces/default/deployments": {APIPath: "/apis/apps/v1/namespaces/default/deployments", RecordIDs: []string{"r1"}, Times: []time.Time{now}},
+		"/api/v1/namespaces/default/pods":              {APIPath: "/api/v1/namespaces/default/pods", RecordIDs: []string{"r2"}, Times: []time.Time{now}},
+		"/api/v1/nodes":                                {APIPath: "/api/v1/nodes", RecordIDs: []string{"r3"}, Times: []time.Time{now}},
+	}
+	meta := &capture.CaptureMetadata{CaptureID: "ui-test", CapturedAt: now.Add(-5 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
+	if err := archive.Write(out, meta, recs, idx); err != nil {
+		t.Fatalf("archive.Write: %v", err)
+	}
+
+	extractDir := filepath.Join(dir, "extract")
+	if err := os.MkdirAll(extractDir, 0o750); err != nil {
+		t.Fatalf("mkdir extract: %v", err)
+	}
+	if err := archive.Open(out, extractDir); err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	store, err := server.LoadStore(extractDir)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	return store
+}

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -174,10 +174,52 @@ func TestServeTimestamps(t *testing.T) {
 	if len(raw) != 2 {
 		t.Fatalf("expected 2 timestamps, got %d", len(raw))
 	}
+	if total, ok := body["total_count"].(float64); !ok || int(total) != 2 {
+		t.Fatalf("expected total_count=2, got %#v", body["total_count"])
+	}
+	if sampled, ok := body["sampled"].(bool); !ok || sampled {
+		t.Fatalf("expected sampled=false, got %#v", body["sampled"])
+	}
 	first, _ := raw[0].(string)
 	second, _ := raw[1].(string)
 	if !(strings.HasSuffix(first, "Z") && strings.HasSuffix(second, "Z")) {
 		t.Fatalf("expected RFC3339 timestamps, got %q and %q", first, second)
+	}
+}
+
+func TestCollectTimestamps_Sampled(t *testing.T) {
+	base := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	index := capture.Index{}
+	for i := 0; i < 20; i++ {
+		path := "/api/v1/namespaces/default/pods?snapshot=" + time.Duration(i).String()
+		ts := base.Add(time.Duration(i) * time.Minute)
+		index[path] = &capture.IndexEntry{
+			APIPath:   path,
+			RecordIDs: []string{"r"},
+			Times:     []time.Time{ts},
+		}
+	}
+
+	timestamps, totalCount, sampled := collectTimestamps(index, 5)
+	if totalCount != 20 {
+		t.Fatalf("expected total_count=20, got %d", totalCount)
+	}
+	if !sampled {
+		t.Fatal("expected sampled=true")
+	}
+	if len(timestamps) != 5 {
+		t.Fatalf("expected 5 sampled timestamps, got %d", len(timestamps))
+	}
+	if timestamps[0] != base.Format(time.RFC3339) {
+		t.Fatalf("expected first timestamp preserved, got %q", timestamps[0])
+	}
+	if timestamps[len(timestamps)-1] != base.Add(19*time.Minute).Format(time.RFC3339) {
+		t.Fatalf("expected last timestamp preserved, got %q", timestamps[len(timestamps)-1])
+	}
+	for i := 1; i < len(timestamps); i++ {
+		if timestamps[i] <= timestamps[i-1] {
+			t.Fatalf("expected strictly increasing timestamps, got %v", timestamps)
+		}
 	}
 }
 

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -55,6 +55,103 @@ func TestServeDetail_ItemFromList(t *testing.T) {
 	}
 }
 
+func TestBuildTree_IncludesQueryOnlyListPath(t *testing.T) {
+	store := buildQueryOnlyStore(t)
+	h := &explorerHandler{store: store}
+	tree, err := h.buildTree()
+	if err != nil {
+		t.Fatalf("buildTree: %v", err)
+	}
+	if len(tree.Namespaces) != 1 || tree.Namespaces[0].Name != "default" {
+		t.Fatalf("expected one default namespace, got %+v", tree.Namespaces)
+	}
+	ns := tree.Namespaces[0]
+	found := false
+	for _, r := range ns.Resources {
+		if r.Kind == "ConfigMap" && r.Name == "demo-config" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected ConfigMap from query-only path, got resources: %+v", ns.Resources)
+	}
+}
+
+func TestBuildTree_PrefersNonEmptyQueryListOverEmptyBaseList(t *testing.T) {
+	store := buildPreferredQueryStore(t)
+	h := &explorerHandler{store: store}
+	tree, err := h.buildTree()
+	if err != nil {
+		t.Fatalf("buildTree: %v", err)
+	}
+	if len(tree.Namespaces) != 1 || tree.Namespaces[0].Name != "default" {
+		t.Fatalf("expected one default namespace, got %+v", tree.Namespaces)
+	}
+	ns := tree.Namespaces[0]
+	if len(ns.Pods) != 1 || ns.Pods[0].Name != "demo-pod" {
+		t.Fatalf("expected pod from non-empty query list, got %+v", ns.Pods)
+	}
+	if ns.Pods[0].ListPath != "/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo" {
+		t.Fatalf("expected query path to back detail lookup, got %q", ns.Pods[0].ListPath)
+	}
+}
+
+func TestBuildTree_MergesItemsAcrossCapturedQueryLists(t *testing.T) {
+	store := buildMergedQueryStore(t)
+	h := &explorerHandler{store: store}
+	tree, err := h.buildTree()
+	if err != nil {
+		t.Fatalf("buildTree: %v", err)
+	}
+	if len(tree.Namespaces) != 1 || tree.Namespaces[0].Name != "default" {
+		t.Fatalf("expected one default namespace, got %+v", tree.Namespaces)
+	}
+	ns := tree.Namespaces[0]
+	if len(ns.Pods) != 2 {
+		t.Fatalf("expected two merged pods, got %+v", ns.Pods)
+	}
+	names := []string{ns.Pods[0].Name, ns.Pods[1].Name}
+	if !(contains(names, "demo-a") && contains(names, "demo-b")) {
+		t.Fatalf("expected merged pod names demo-a and demo-b, got %v", names)
+	}
+}
+
+func TestBuildTree_IncludesItemOnlyPaths(t *testing.T) {
+	store := buildItemOnlyStore(t)
+	h := &explorerHandler{store: store}
+	tree, err := h.buildTree()
+	if err != nil {
+		t.Fatalf("buildTree: %v", err)
+	}
+	if len(tree.Namespaces) != 1 || tree.Namespaces[0].Name != "default" {
+		t.Fatalf("expected one default namespace, got %+v", tree.Namespaces)
+	}
+	ns := tree.Namespaces[0]
+	if len(ns.Resources) != 1 || ns.Resources[0].Name != "demo-config" {
+		t.Fatalf("expected item-only ConfigMap to appear, got %+v", ns.Resources)
+	}
+	if ns.Resources[0].ListPath != "/api/v1/namespaces/default/configmaps/demo-config" {
+		t.Fatalf("expected item path to be used for detail lookup, got %q", ns.Resources[0].ListPath)
+	}
+}
+
+func TestBuildTree_IncludesTableRows(t *testing.T) {
+	store := buildTableOnlyStore(t)
+	h := &explorerHandler{store: store}
+	tree, err := h.buildTree()
+	if err != nil {
+		t.Fatalf("buildTree: %v", err)
+	}
+	if len(tree.Namespaces) != 1 || tree.Namespaces[0].Name != "default" {
+		t.Fatalf("expected one default namespace, got %+v", tree.Namespaces)
+	}
+	ns := tree.Namespaces[0]
+	if len(ns.Resources) != 1 || ns.Resources[0].Name != "table-config" {
+		t.Fatalf("expected table row object to appear, got %+v", ns.Resources)
+	}
+}
+
 func buildTestStore(t *testing.T) *server.CaptureStore {
 	t.Helper()
 	dir := t.TempDir()
@@ -92,4 +189,212 @@ func buildTestStore(t *testing.T) *server.CaptureStore {
 		t.Fatalf("LoadStore: %v", err)
 	}
 	return store
+}
+
+func buildQueryOnlyStore(t *testing.T) *server.CaptureStore {
+	t.Helper()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "capture-query-only.tar.gz")
+	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+
+	configMapList := `{"apiVersion":"v1","kind":"ConfigMapList","items":[{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"demo-config","namespace":"default","labels":{"app":"demo"}}}]}`
+
+	recs := []*capture.Record{
+		{ID: "q1", CapturedAt: now, APIPath: "/api/v1/namespaces/default/configmaps?labelSelector=app%3Ddemo", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(configMapList)},
+	}
+	idx := capture.Index{
+		"/api/v1/namespaces/default/configmaps?labelSelector=app%3Ddemo": {
+			APIPath:   "/api/v1/namespaces/default/configmaps?labelSelector=app%3Ddemo",
+			RecordIDs: []string{"q1"},
+			Times:     []time.Time{now},
+		},
+	}
+	meta := &capture.CaptureMetadata{CaptureID: "ui-query-test", CapturedAt: now.Add(-2 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
+	if err := archive.Write(out, meta, recs, idx); err != nil {
+		t.Fatalf("archive.Write: %v", err)
+	}
+
+	extractDir := filepath.Join(dir, "extract")
+	if err := os.MkdirAll(extractDir, 0o750); err != nil {
+		t.Fatalf("mkdir extract: %v", err)
+	}
+	if err := archive.Open(out, extractDir); err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	store, err := server.LoadStore(extractDir)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	return store
+}
+
+func buildPreferredQueryStore(t *testing.T) *server.CaptureStore {
+	t.Helper()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "capture-preferred-query.tar.gz")
+	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+
+	emptyPodList := `{"apiVersion":"v1","kind":"PodList","items":[]}`
+	queryPodList := `{"apiVersion":"v1","kind":"PodList","items":[{"apiVersion":"v1","kind":"Pod","metadata":{"name":"demo-pod","namespace":"default","labels":{"app":"demo"}},"spec":{"containers":[{"name":"main"}]},"status":{"phase":"Running"}}]}`
+
+	recs := []*capture.Record{
+		{ID: "p1", CapturedAt: now, APIPath: "/api/v1/namespaces/default/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(emptyPodList)},
+		{ID: "p2", CapturedAt: now, APIPath: "/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(queryPodList)},
+	}
+	idx := capture.Index{
+		"/api/v1/namespaces/default/pods": {
+			APIPath:   "/api/v1/namespaces/default/pods",
+			RecordIDs: []string{"p1"},
+			Times:     []time.Time{now},
+		},
+		"/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo": {
+			APIPath:   "/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo",
+			RecordIDs: []string{"p2"},
+			Times:     []time.Time{now},
+		},
+	}
+	meta := &capture.CaptureMetadata{CaptureID: "ui-preferred-query-test", CapturedAt: now.Add(-2 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
+	if err := archive.Write(out, meta, recs, idx); err != nil {
+		t.Fatalf("archive.Write: %v", err)
+	}
+
+	extractDir := filepath.Join(dir, "extract")
+	if err := os.MkdirAll(extractDir, 0o750); err != nil {
+		t.Fatalf("mkdir extract: %v", err)
+	}
+	if err := archive.Open(out, extractDir); err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	store, err := server.LoadStore(extractDir)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	return store
+}
+
+func buildMergedQueryStore(t *testing.T) *server.CaptureStore {
+	t.Helper()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "capture-merged-query.tar.gz")
+	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+
+	queryA := `{"apiVersion":"v1","kind":"PodList","items":[{"apiVersion":"v1","kind":"Pod","metadata":{"name":"demo-a","namespace":"default","uid":"uid-a","labels":{"app":"demo-a"}},"spec":{"containers":[{"name":"main"}]},"status":{"phase":"Running"}}]}`
+	queryB := `{"apiVersion":"v1","kind":"PodList","items":[{"apiVersion":"v1","kind":"Pod","metadata":{"name":"demo-b","namespace":"default","uid":"uid-b","labels":{"app":"demo-b"}},"spec":{"containers":[{"name":"main"}]},"status":{"phase":"Running"}}]}`
+
+	recs := []*capture.Record{
+		{ID: "m1", CapturedAt: now, APIPath: "/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo-a", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(queryA)},
+		{ID: "m2", CapturedAt: now, APIPath: "/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo-b", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(queryB)},
+	}
+	idx := capture.Index{
+		"/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo-a": {
+			APIPath:   "/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo-a",
+			RecordIDs: []string{"m1"},
+			Times:     []time.Time{now},
+		},
+		"/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo-b": {
+			APIPath:   "/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo-b",
+			RecordIDs: []string{"m2"},
+			Times:     []time.Time{now},
+		},
+	}
+	meta := &capture.CaptureMetadata{CaptureID: "ui-merged-query-test", CapturedAt: now.Add(-2 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
+	if err := archive.Write(out, meta, recs, idx); err != nil {
+		t.Fatalf("archive.Write: %v", err)
+	}
+
+	extractDir := filepath.Join(dir, "extract")
+	if err := os.MkdirAll(extractDir, 0o750); err != nil {
+		t.Fatalf("mkdir extract: %v", err)
+	}
+	if err := archive.Open(out, extractDir); err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	store, err := server.LoadStore(extractDir)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	return store
+}
+
+func buildItemOnlyStore(t *testing.T) *server.CaptureStore {
+	t.Helper()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "capture-item-only.tar.gz")
+	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+
+	configMap := `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"demo-config","namespace":"default","uid":"cfg-1","labels":{"app":"demo"}},"data":{"k":"v"}}`
+
+	recs := []*capture.Record{
+		{ID: "i1", CapturedAt: now, APIPath: "/api/v1/namespaces/default/configmaps/demo-config", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(configMap)},
+	}
+	idx := capture.Index{
+		"/api/v1/namespaces/default/configmaps/demo-config": {
+			APIPath:   "/api/v1/namespaces/default/configmaps/demo-config",
+			RecordIDs: []string{"i1"},
+			Times:     []time.Time{now},
+		},
+	}
+	meta := &capture.CaptureMetadata{CaptureID: "ui-item-only-test", CapturedAt: now.Add(-2 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
+	if err := archive.Write(out, meta, recs, idx); err != nil {
+		t.Fatalf("archive.Write: %v", err)
+	}
+
+	extractDir := filepath.Join(dir, "extract")
+	if err := os.MkdirAll(extractDir, 0o750); err != nil {
+		t.Fatalf("mkdir extract: %v", err)
+	}
+	if err := archive.Open(out, extractDir); err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	store, err := server.LoadStore(extractDir)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	return store
+}
+
+func buildTableOnlyStore(t *testing.T) *server.CaptureStore {
+	t.Helper()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "capture-table-only.tar.gz")
+	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+
+	table := `{"apiVersion":"meta.k8s.io/v1","kind":"Table","columnDefinitions":[],"rows":[{"object":{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"table-config","namespace":"default","uid":"tbl-1"}}}]}`
+
+	recs := []*capture.Record{
+		{ID: "t1", CapturedAt: now, APIPath: "/api/v1/namespaces/default/configmaps?as=Table", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(table)},
+	}
+	idx := capture.Index{
+		"/api/v1/namespaces/default/configmaps?as=Table": {
+			APIPath:   "/api/v1/namespaces/default/configmaps?as=Table",
+			RecordIDs: []string{"t1"},
+			Times:     []time.Time{now},
+		},
+	}
+	meta := &capture.CaptureMetadata{CaptureID: "ui-table-only-test", CapturedAt: now.Add(-2 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
+	if err := archive.Write(out, meta, recs, idx); err != nil {
+		t.Fatalf("archive.Write: %v", err)
+	}
+
+	extractDir := filepath.Join(dir, "extract")
+	if err := os.MkdirAll(extractDir, 0o750); err != nil {
+		t.Fatalf("mkdir extract: %v", err)
+	}
+	if err := archive.Open(out, extractDir); err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	store, err := server.LoadStore(extractDir)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	return store
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -149,6 +150,68 @@ func TestBuildTree_IncludesTableRows(t *testing.T) {
 	ns := tree.Namespaces[0]
 	if len(ns.Resources) != 1 || ns.Resources[0].Name != "table-config" {
 		t.Fatalf("expected table row object to appear, got %+v", ns.Resources)
+	}
+}
+
+func TestServeTimestamps(t *testing.T) {
+	store := buildMultiSnapshotStore(t)
+	h := &explorerHandler{store: store}
+	req := httptest.NewRequest(http.MethodGet, "/api/ui/timestamps", nil)
+	rr := httptest.NewRecorder()
+	h.serveTimestamps(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	raw, ok := body["timestamps"].([]any)
+	if !ok {
+		t.Fatalf("expected timestamps array, got %T", body["timestamps"])
+	}
+	if len(raw) != 2 {
+		t.Fatalf("expected 2 timestamps, got %d", len(raw))
+	}
+	first, _ := raw[0].(string)
+	second, _ := raw[1].(string)
+	if !(strings.HasSuffix(first, "Z") && strings.HasSuffix(second, "Z")) {
+		t.Fatalf("expected RFC3339 timestamps, got %q and %q", first, second)
+	}
+}
+
+func TestServeTree_AtOverride(t *testing.T) {
+	store := buildMultiSnapshotStore(t)
+	h := &explorerHandler{store: store}
+	target := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	req := httptest.NewRequest(http.MethodGet, "/api/ui/tree?at="+target, nil)
+	rr := httptest.NewRecorder()
+	h.serveTree(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var tree treeResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &tree); err != nil {
+		t.Fatalf("unmarshal tree: %v", err)
+	}
+	if len(tree.Namespaces) != 1 || len(tree.Namespaces[0].Pods) != 1 {
+		t.Fatalf("expected one namespace with one pod, got %+v", tree.Namespaces)
+	}
+	if tree.Namespaces[0].Pods[0].Name != "demo-old" {
+		t.Fatalf("expected older pod at selected timestamp, got %q", tree.Namespaces[0].Pods[0].Name)
+	}
+}
+
+func TestServeTree_AtInvalid(t *testing.T) {
+	store := buildTestStore(t)
+	h := &explorerHandler{store: store}
+	req := httptest.NewRequest(http.MethodGet, "/api/ui/tree?at=not-a-time", nil)
+	rr := httptest.NewRecorder()
+	h.serveTree(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
 	}
 }
 
@@ -372,6 +435,46 @@ func buildTableOnlyStore(t *testing.T) *server.CaptureStore {
 		},
 	}
 	meta := &capture.CaptureMetadata{CaptureID: "ui-table-only-test", CapturedAt: now.Add(-2 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
+	if err := archive.Write(out, meta, recs, idx); err != nil {
+		t.Fatalf("archive.Write: %v", err)
+	}
+
+	extractDir := filepath.Join(dir, "extract")
+	if err := os.MkdirAll(extractDir, 0o750); err != nil {
+		t.Fatalf("mkdir extract: %v", err)
+	}
+	if err := archive.Open(out, extractDir); err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	store, err := server.LoadStore(extractDir)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	return store
+}
+
+func buildMultiSnapshotStore(t *testing.T) *server.CaptureStore {
+	t.Helper()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "capture-multi-snapshot.tar.gz")
+	t1 := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	t2 := t1.Add(5 * time.Minute)
+
+	podListOld := `{"apiVersion":"v1","kind":"PodList","items":[{"apiVersion":"v1","kind":"Pod","metadata":{"name":"demo-old","namespace":"default","uid":"pod-old"},"spec":{"containers":[{"name":"main"}]},"status":{"phase":"Running"}}]}`
+	podListNew := `{"apiVersion":"v1","kind":"PodList","items":[{"apiVersion":"v1","kind":"Pod","metadata":{"name":"demo-new","namespace":"default","uid":"pod-new"},"spec":{"containers":[{"name":"main"}]},"status":{"phase":"Running"}}]}`
+
+	recs := []*capture.Record{
+		{ID: "s1", CapturedAt: t1, APIPath: "/api/v1/namespaces/default/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(podListOld)},
+		{ID: "s2", CapturedAt: t2, APIPath: "/api/v1/namespaces/default/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(podListNew)},
+	}
+	idx := capture.Index{
+		"/api/v1/namespaces/default/pods": {
+			APIPath:   "/api/v1/namespaces/default/pods",
+			RecordIDs: []string{"s1", "s2"},
+			Times:     []time.Time{t1, t2},
+		},
+	}
+	meta := &capture.CaptureMetadata{CaptureID: "ui-multi-snapshot-test", CapturedAt: t1, CapturedUntil: t2, RecordCount: len(recs)}
 	if err := archive.Write(out, meta, recs, idx); err != nil {
 		t.Fatalf("archive.Write: %v", err)
 	}


### PR DESCRIPTION
Implements the first v1 slice for Issue #7.

## What changed

- add new kshrk ui <capture.tar.gz> command
- add a local UI server that reads existing capture archives
- add web explorer APIs:
  - GET /api/ui/tree for hierarchy/tree data
  - GET /api/ui/detail for JSON/YAML detail payloads
- add embedded interactive browser UI with:
  - cluster/namespace/workload/pod/container drill-down
  - resource type toggles
  - search by name/label text
  - click-to-open detail panel with JSON and YAML tabs
- add unit tests for tree construction and detail endpoint behavior
- add usage docs for kshrk ui

## Validation

- make fmt
- go test ./internal/ui ./cmd
- go test ./...

## Follow-up checklist (v1.1 / v2)

### v1.1 hardening

- [ ] Add pagination and server-side filtering to reduce large payload sizes
- [ ] Add keyboard navigation and focus states for accessibility
- [ ] Add loading and empty states for tree and detail panels
- [ ] Add explicit API error envelopes and user-facing error toasts
- [ ] Expand tests for cluster-scoped resources and malformed query cases

### v2 expansion

- [ ] Add timeline view with point-in-time scrubber integration
- [ ] Add cross-resource relation graph (owner refs, services to workloads, ingress paths)
- [ ] Add diff mode between two snapshots or times
- [ ] Add persistent saved views (filters, expanded nodes, selected detail)
- [ ] Add optional plugin panel for custom renderers and domain-specific inspectors

Refs #7