### PR TITLE
feat(capture): all=true auto-discovery directives (issue #44)

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -26,11 +26,13 @@ func init() {
 	captureCmd.Flags().StringP("output", "o", "", "output file path (default: ./k8shark-<timestamp>.tar.gz)")
 	captureCmd.Flags().String("kubeconfig", "", "path to kubeconfig (defaults to KUBECONFIG env, then ~/.kube/config)")
 	captureCmd.Flags().String("duration", "", "capture duration, overrides config file value (e.g. 10m, 1h)")
+	captureCmd.Flags().Bool("auto-discover", false, "auto-discover and capture all available API resources")
 	captureCmd.Flags().Bool("redact-secrets", false, "redact Secret data and stringData values from the archive after capture")
 	captureCmd.Flags().StringArray("allow-secret", nil, "namespace/name of secret to preserve when --redact-secrets is set (repeatable)")
 	_ = viper.BindPFlag("output", captureCmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag("kubeconfig", captureCmd.Flags().Lookup("kubeconfig"))
 	_ = viper.BindPFlag("duration", captureCmd.Flags().Lookup("duration"))
+	_ = viper.BindPFlag("auto_discover", captureCmd.Flags().Lookup("auto-discover"))
 }
 
 func runCapture(cmd *cobra.Command, args []string) error {
@@ -47,6 +49,10 @@ func runCapture(cmd *cobra.Command, args []string) error {
 	}
 	if v, _ := cmd.Flags().GetString("duration"); v != "" {
 		cfg.DurationRaw = v
+	}
+	if cmd.Flags().Changed("auto-discover") {
+		v, _ := cmd.Flags().GetBool("auto-discover")
+		cfg.AutoDiscover = v
 	}
 
 	if err := cfg.Validate(); err != nil {

--- a/docs/config.md
+++ b/docs/config.md
@@ -10,11 +10,14 @@ k8shark reads a YAML config file that controls what gets captured, from which na
 | `output` | string | `./k8shark-<timestamp>.tar.gz` | Path for the output archive. |
 | `kubeconfig` | string | `$KUBECONFIG` → `~/.kube/config` | Path to the kubeconfig for the source cluster. |
 | `resources` | list | required | Resource types to capture. See below. |
+| `auto_discover` | bool | `false` | Legacy global discovery toggle. Prefer `resources: - all: true` for fine-grained control. |
 
 ## Resource entry fields
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
+| `all` | bool | no | If `true`, this entry is a discovery directive. k8shark discovers API resources and expands them into concrete capture entries. |
+| `scope` | string | no | Used with `all: true`. Allowed values: `namespaced`, `cluster`, or omitted (both). |
 | `group` | string | yes | API group. Use `""` (empty string) for core group resources (`pods`, `nodes`, etc.). |
 | `version` | string | yes | API version, e.g. `v1`, `v1beta1`. |
 | `resource` | string | yes | Plural resource name, e.g. `pods`, `deployments`. |
@@ -22,6 +25,50 @@ k8shark reads a YAML config file that controls what gets captured, from which na
 | `interval` | duration string | `30s` | How often to re-poll this resource during the capture window. |
 | `dedup` | bool | `true` | Skip writing a record when the response body is identical to the previous poll for the same API path. Set `false` to force writing every poll. |
 | `watch` | bool | `false` | Start a Kubernetes watch stream (`?watch=1`) for this resource in addition to polling. Watch events are recorded with an `event_type` field. |
+
+When `all: true` is set, `group`/`version`/`resource` are not required for that entry.
+
+### Simplified discovery with `all: true`
+
+Use `all: true` to auto-discover resources via Kubernetes API discovery (including CRDs):
+
+```yaml
+duration: 10m
+output: ./cluster-snapshot.tar.gz
+
+resources:
+  - all: true
+```
+
+Scope filtering:
+
+```yaml
+resources:
+  - all: true
+    scope: namespaced  # or cluster
+```
+
+Discovery with namespace restriction for namespaced resources:
+
+```yaml
+resources:
+  - all: true
+    scope: namespaced
+    namespaces: [production, staging]
+    interval: 20s
+```
+
+Mix discovered entries with explicit overrides:
+
+```yaml
+resources:
+  - all: true
+  - group: mygroup.io
+    version: v1
+    resource: widgets
+    namespaces: [default]
+    interval: 10s
+```
 
 ### Namespaced vs. cluster-scoped resources
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -60,11 +60,21 @@ Capture complete
 | `--output` | `-o` | `./k8shark-<timestamp>.tar.gz` | Output archive path |
 | `--duration` | | from config | Override capture duration (e.g. `5m`) |
 | `--kubeconfig` | | `$KUBECONFIG` / `~/.kube/config` | Source cluster kubeconfig |
+| `--auto-discover` | | false | Auto-discover and capture all available API resources |
 | `--verbose` | `-v` | false | Log every API path as it is fetched |
 | `--redact-secrets` | | false | Redact Secret `data`/`stringData` values from the archive after capture |
 | `--allow-secret` | | | `namespace/name` of secret to preserve when `--redact-secrets` is set (repeatable) |
 
 The `--config` flag auto-discovers `./k8shark.yaml` if not specified.
+
+For full-cluster capture without enumerating resources manually, prefer config syntax:
+
+```yaml
+resources:
+  - all: true
+```
+
+`--auto-discover` is a convenience override that enables global discovery mode.
 
 ---
 

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -125,11 +125,6 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 		}
 	}
 
-	// Expand wildcard namespaces before polling begins.
-	if err := e.expandWildcardNamespaces(ctx); err != nil {
-		return nil, err
-	}
-
 	// Collect server version for metadata.
 	kVersion, serverAddr := e.fetchServerVersion(ctx)
 
@@ -140,6 +135,13 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 	// explicitly requested or when all=true directives are present.
 	if e.cfg.AutoDiscover || hasAllDirective(e.cfg.Resources) {
 		e.autoDiscoverResources(ctx)
+	}
+
+	// Expand wildcard namespaces before polling begins. This must happen after
+	// auto-discovery because all=true directives add namespaced resources with
+	// Namespaces=["*"] by default.
+	if err := e.expandWildcardNamespaces(ctx); err != nil {
+		return nil, err
 	}
 
 	var wg sync.WaitGroup
@@ -451,6 +453,7 @@ func (e *Engine) autoDiscoverResources(ctx context.Context) {
 	if len(directives) == 0 && e.cfg.AutoDiscover {
 		directives = append(directives, config.Resource{All: true, IntervalRaw: "30s", Interval: 30 * time.Second})
 	}
+	discoverCore := len(directives) > 0
 
 	apisBody := e.discoveryCache["/apis"]
 	if apisBody == nil {
@@ -556,6 +559,70 @@ func (e *Engine) autoDiscoverResources(ctx context.Context) {
 		}
 	}
 
+	// all=true directives represent "capture all", which includes core/v1
+	// resources like pods, services, configmaps, and nodes.
+	if discoverCore {
+		coreBody := e.discoveryCache["/api/v1"]
+		if coreBody != nil {
+			var coreList struct {
+				Resources []struct {
+					Name       string `json:"name"`
+					Namespaced bool   `json:"namespaced"`
+				} `json:"resources"`
+			}
+			if err := json.Unmarshal(coreBody, &coreList); err == nil {
+				for _, res := range coreList.Resources {
+					if strings.Contains(res.Name, "/") {
+						continue
+					}
+					key := gvr{"", "v1", res.Name}
+					if configured[key] {
+						continue
+					}
+
+					for _, d := range directives {
+						if d.Scope == "cluster" && res.Namespaced {
+							continue
+						}
+						if d.Scope == "namespaced" && !res.Namespaced {
+							continue
+						}
+
+						newRes := config.Resource{
+							Group:       "",
+							Version:     "v1",
+							Resource:    res.Name,
+							IntervalRaw: d.IntervalRaw,
+							Interval:    d.Interval,
+							Dedup:       d.Dedup,
+							Watch:       d.Watch,
+						}
+						if newRes.Interval == 0 {
+							newRes.Interval = 30 * time.Second
+							newRes.IntervalRaw = "30s"
+						}
+						if res.Namespaced {
+							if len(d.Namespaces) > 0 {
+								newRes.Namespaces = append([]string(nil), d.Namespaces...)
+							} else {
+								newRes.Namespaces = []string{"*"}
+							}
+						}
+
+						e.cfg.Resources = append(e.cfg.Resources, newRes)
+						configured[key] = true
+						added++
+						if e.verbose {
+							fmt.Fprintf(os.Stdout, "  [auto-discover] added %s/%s/%s (namespaced=%v, scope=%s)\n",
+								"core", "v1", res.Name, res.Namespaced, firstNonEmpty(d.Scope, "all"))
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+
 	if e.verbose {
 		fmt.Fprintf(os.Stdout, "  [auto-discover] added %d resource types\n", added)
 	}
@@ -588,7 +655,10 @@ func hasAllDirective(resources []config.Resource) bool {
 func (e *Engine) fetchDiscovery(ctx context.Context) {
 	// Core discovery paths.
 	e.doFetch(ctx, "/api", "", true)
-	e.doFetch(ctx, "/api/v1", "", true)
+	apiV1Body, _ := e.doFetch(ctx, "/api/v1", "", true)
+	if apiV1Body != nil {
+		e.discoveryCache["/api/v1"] = apiV1Body
+	}
 	apisBody, _ := e.doFetch(ctx, "/apis", "", true)
 	if apisBody != nil {
 		e.discoveryCache["/apis"] = apisBody

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -136,13 +136,17 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 	// Capture API discovery endpoints so the mock server can replay them faithfully.
 	e.fetchDiscovery(ctx)
 
-	// Auto-discover CRD-backed and non-core resources from /apis if requested.
-	if e.cfg.AutoDiscover {
+	// Auto-discover CRD-backed and non-core resources from /apis when
+	// explicitly requested or when all=true directives are present.
+	if e.cfg.AutoDiscover || hasAllDirective(e.cfg.Resources) {
 		e.autoDiscoverResources(ctx)
 	}
 
 	var wg sync.WaitGroup
 	for _, res := range e.cfg.Resources {
+		if res.All {
+			continue
+		}
 		wg.Add(1)
 		go func(r config.Resource) {
 			defer wg.Done()
@@ -162,6 +166,9 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 	// all polling so we capture the most recent log state. A short background
 	// context is used because the main capture context has already expired.
 	for _, res := range e.cfg.Resources {
+		if res.All {
+			continue
+		}
 		if res.Logs > 0 && res.Resource == "pods" {
 			logCtx, logCancel := context.WithTimeout(context.Background(), 30*time.Second)
 			e.fetchPodsLogs(logCtx, res)
@@ -433,8 +440,16 @@ func (e *Engine) autoDiscoverResources(ctx context.Context) {
 	// we don't add duplicates.
 	type gvr struct{ group, version, resource string }
 	configured := make(map[gvr]bool, len(e.cfg.Resources))
+	directives := make([]config.Resource, 0)
 	for _, r := range e.cfg.Resources {
+		if r.All {
+			directives = append(directives, r)
+			continue
+		}
 		configured[gvr{r.Group, r.Version, r.Resource}] = true
+	}
+	if len(directives) == 0 && e.cfg.AutoDiscover {
+		directives = append(directives, config.Resource{All: true, IntervalRaw: "30s", Interval: 30 * time.Second})
 	}
 
 	apisBody := e.discoveryCache["/apis"]
@@ -498,22 +513,44 @@ func (e *Engine) autoDiscoverResources(ctx context.Context) {
 				if configured[key] {
 					continue
 				}
-				newRes := config.Resource{
-					Group:       group,
-					Version:     version,
-					Resource:    res.Name,
-					IntervalRaw: "30s",
-					Interval:    30 * time.Second,
-				}
-				if res.Namespaced {
-					newRes.Namespaces = []string{"*"}
-				}
-				e.cfg.Resources = append(e.cfg.Resources, newRes)
-				configured[key] = true
-				added++
-				if e.verbose {
-					fmt.Fprintf(os.Stdout, "  [auto-discover] added %s/%s/%s (namespaced=%v)\n",
-						group, version, res.Name, res.Namespaced)
+
+				for _, d := range directives {
+					if d.Scope == "cluster" && res.Namespaced {
+						continue
+					}
+					if d.Scope == "namespaced" && !res.Namespaced {
+						continue
+					}
+
+					newRes := config.Resource{
+						Group:       group,
+						Version:     version,
+						Resource:    res.Name,
+						IntervalRaw: d.IntervalRaw,
+						Interval:    d.Interval,
+						Dedup:       d.Dedup,
+						Watch:       d.Watch,
+					}
+					if newRes.Interval == 0 {
+						newRes.Interval = 30 * time.Second
+						newRes.IntervalRaw = "30s"
+					}
+					if res.Namespaced {
+						if len(d.Namespaces) > 0 {
+							newRes.Namespaces = append([]string(nil), d.Namespaces...)
+						} else {
+							newRes.Namespaces = []string{"*"}
+						}
+					}
+
+					e.cfg.Resources = append(e.cfg.Resources, newRes)
+					configured[key] = true
+					added++
+					if e.verbose {
+						fmt.Fprintf(os.Stdout, "  [auto-discover] added %s/%s/%s (namespaced=%v, scope=%s)\n",
+							group, version, res.Name, res.Namespaced, firstNonEmpty(d.Scope, "all"))
+					}
+					break
 				}
 			}
 		}
@@ -522,6 +559,24 @@ func (e *Engine) autoDiscoverResources(ctx context.Context) {
 	if e.verbose {
 		fmt.Fprintf(os.Stdout, "  [auto-discover] added %d resource types\n", added)
 	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func hasAllDirective(resources []config.Resource) bool {
+	for _, r := range resources {
+		if r.All {
+			return true
+		}
+	}
+	return false
 }
 
 // fetchDiscovery captures the Kubernetes API discovery endpoints so the mock

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -490,6 +490,7 @@ func autoDiscoverServer(t *testing.T, reqPaths chan<- string) *httptest.Server {
 		"resources":[
 			{"name":"virtualservices","namespaced":true,"kind":"VirtualService"},
 			{"name":"gateways","namespaced":true,"kind":"Gateway"},
+			{"name":"meshconfigs","namespaced":false,"kind":"MeshConfig"},
 			{"name":"virtualservices/status","namespaced":true,"kind":"VirtualService"}
 		]
 	}`
@@ -622,6 +623,92 @@ func TestAutoDiscover_ExcludeGroupsOverride(t *testing.T) {
 		if r.Group == "networking.istio.io" {
 			t.Errorf("networking.istio.io should be excluded via AutoDiscoverExcludeGroups, but found %v", r)
 		}
+	}
+}
+
+func TestAutoDiscover_AllDirectiveNamespacedScope(t *testing.T) {
+	srv := autoDiscoverServer(t, nil)
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw: "500ms",
+		Duration:    500 * time.Millisecond,
+		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Resources: []config.Resource{
+			{All: true, Scope: "namespaced", Namespaces: []string{"team-a"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	ss := &sliceSink{}
+	eng.sink = ss
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	seenMeshConfig := false
+	seenVirtualService := false
+	for _, r := range cfg.Resources {
+		if r.All {
+			continue
+		}
+		if r.Resource == "meshconfigs" {
+			seenMeshConfig = true
+		}
+		if r.Resource == "virtualservices" {
+			seenVirtualService = true
+			if len(r.Namespaces) != 1 || r.Namespaces[0] != "team-a" {
+				t.Fatalf("expected virtualservices namespaces from all directive, got %+v", r.Namespaces)
+			}
+		}
+	}
+	if seenMeshConfig {
+		t.Fatal("cluster-scoped meshconfigs should not be discovered for scope=namespaced")
+	}
+	if !seenVirtualService {
+		t.Fatal("expected namespaced resources to be discovered for scope=namespaced")
+	}
+}
+
+func TestAutoDiscover_AllDirectiveClusterScope(t *testing.T) {
+	srv := autoDiscoverServer(t, nil)
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw: "500ms",
+		Duration:    500 * time.Millisecond,
+		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Resources: []config.Resource{
+			{All: true, Scope: "cluster", IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	ss := &sliceSink{}
+	eng.sink = ss
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	seenMeshConfig := false
+	for _, r := range cfg.Resources {
+		if r.All {
+			continue
+		}
+		if r.Resource == "meshconfigs" {
+			seenMeshConfig = true
+			if len(r.Namespaces) != 0 {
+				t.Fatalf("cluster-scoped discovered resource should not have namespaces, got %+v", r.Namespaces)
+			}
+		}
+		if r.Resource == "virtualservices" || r.Resource == "gateways" {
+			t.Fatalf("namespaced resource %q should not be discovered for scope=cluster", r.Resource)
+		}
+	}
+	if !seenMeshConfig {
+		t.Fatal("expected meshconfigs to be discovered for scope=cluster")
 	}
 }
 

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -712,6 +712,139 @@ func TestAutoDiscover_AllDirectiveClusterScope(t *testing.T) {
 	}
 }
 
+func TestAutoDiscover_AllDirectiveExpandsWildcardNamespacesBeforePolling(t *testing.T) {
+	paths := make(chan string, 256)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case paths <- r.URL.Path:
+		default:
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+		case "/api/v1/namespaces":
+			fmt.Fprint(w, `{"kind":"NamespaceList","items":[{"metadata":{"name":"default"}},{"metadata":{"name":"team-a"}}]}`)
+		case "/apis":
+			fmt.Fprint(w, `{"kind":"APIGroupList","apiVersion":"v1","groups":[{"name":"networking.istio.io","versions":[{"groupVersion":"networking.istio.io/v1beta1","version":"v1beta1"}]}]}`)
+		case "/apis/networking.istio.io/v1beta1":
+			fmt.Fprint(w, `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"networking.istio.io/v1beta1","resources":[{"name":"virtualservices","namespaced":true,"kind":"VirtualService"}]}`)
+		default:
+			fmt.Fprint(w, `{"kind":"List","items":[]}`)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		DurationRaw: "500ms",
+		Duration:    500 * time.Millisecond,
+		Output:      filepath.Join(t.TempDir(), "capture.tar.gz"),
+		Resources: []config.Resource{
+			{All: true, Scope: "namespaced", IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	ss := &sliceSink{}
+	eng.sink = ss
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	close(paths)
+	sawWildcardPath := false
+	sawExpandedPath := false
+	for p := range paths {
+		if p == "/apis/networking.istio.io/v1beta1/namespaces/*/virtualservices" {
+			sawWildcardPath = true
+		}
+		if p == "/apis/networking.istio.io/v1beta1/namespaces/default/virtualservices" ||
+			p == "/apis/networking.istio.io/v1beta1/namespaces/team-a/virtualservices" {
+			sawExpandedPath = true
+		}
+	}
+
+	if sawWildcardPath {
+		t.Fatal("found wildcard namespace API path for discovered namespaced resource; expected expansion to concrete namespaces")
+	}
+	if !sawExpandedPath {
+		t.Fatal("expected at least one concrete namespace API fetch for discovered namespaced resource")
+	}
+}
+
+func TestAutoDiscover_AllDirectiveIncludesCorePods(t *testing.T) {
+	paths := make(chan string, 256)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case paths <- r.URL.Path:
+		default:
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+		case "/api/v1/namespaces":
+			fmt.Fprint(w, `{"kind":"NamespaceList","items":[{"metadata":{"name":"default"}}]}`)
+		case "/api/v1":
+			fmt.Fprint(w, `{"kind":"APIResourceList","groupVersion":"v1","resources":[{"name":"pods","namespaced":true},{"name":"nodes","namespaced":false},{"name":"pods/status","namespaced":true}]}`)
+		case "/apis":
+			fmt.Fprint(w, `{"kind":"APIGroupList","apiVersion":"v1","groups":[]}`)
+		default:
+			fmt.Fprint(w, `{"kind":"List","items":[]}`)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		DurationRaw: "500ms",
+		Duration:    500 * time.Millisecond,
+		Output:      filepath.Join(t.TempDir(), "capture.tar.gz"),
+		Resources: []config.Resource{
+			{All: true, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	ss := &sliceSink{}
+	eng.sink = ss
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	hasPods := false
+	for _, r := range cfg.Resources {
+		if r.All {
+			continue
+		}
+		if r.Group == "" && r.Version == "v1" && r.Resource == "pods" {
+			hasPods = true
+			if len(r.Namespaces) != 1 || r.Namespaces[0] != "default" {
+				t.Fatalf("expected discovered core pods namespaces to expand to [default], got %v", r.Namespaces)
+			}
+		}
+		if r.Resource == "pods/status" {
+			t.Fatal("sub-resource pods/status should not be discovered")
+		}
+	}
+	if !hasPods {
+		t.Fatal("expected core/v1 pods to be discovered for all=true")
+	}
+
+	close(paths)
+	sawPodFetch := false
+	for p := range paths {
+		if p == "/api/v1/namespaces/default/pods" {
+			sawPodFetch = true
+			break
+		}
+	}
+	if !sawPodFetch {
+		t.Fatal("expected poll fetch for discovered core pods path")
+	}
+}
+
 func TestDoFetch_DedupAllSame_FirstAlwaysWritten(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/viper"
@@ -10,6 +11,13 @@ import (
 
 // Resource describes a single Kubernetes resource type to capture.
 type Resource struct {
+	// All enables auto-discovery expansion for this resource entry. When true,
+	// Group/Version/Resource are ignored and discovered resources are added
+	// according to Scope and Namespaces.
+	All bool `mapstructure:"all"`
+	// Scope filters discovered resources when All=true: "namespaced" or
+	// "cluster". Empty means both.
+	Scope string `mapstructure:"scope"`
 	// Group is the API group (empty string = core group).
 	Group string `mapstructure:"group"`
 	// Version is the API version (e.g. "v1", "v1beta1").
@@ -110,6 +118,24 @@ func (c *Config) Validate() error {
 
 	for i := range c.Resources {
 		r := &c.Resources[i]
+		if r.All {
+			r.Scope = strings.ToLower(strings.TrimSpace(r.Scope))
+			if r.Scope != "" && r.Scope != "namespaced" && r.Scope != "cluster" {
+				return fmt.Errorf("resources[%d]: invalid scope %q for all=true (must be namespaced, cluster, or empty)", i, r.Scope)
+			}
+			if r.IntervalRaw == "" {
+				r.IntervalRaw = "30s"
+			}
+			iv, err := time.ParseDuration(r.IntervalRaw)
+			if err != nil {
+				return fmt.Errorf("resources[%d] (all=true): invalid interval %q: %w", i, r.IntervalRaw, err)
+			}
+			r.Interval = iv
+			if r.Logs < 0 {
+				return fmt.Errorf("resources[%d] (all=true): 'logs' must be >= 0", i)
+			}
+			continue
+		}
 		if r.Resource == "" {
 			return fmt.Errorf("resources[%d]: 'resource' field is required", i)
 		}
@@ -180,7 +206,10 @@ func Warnings(cfg *Config) []string {
 		if r.Interval > 0 && r.Interval < 5*time.Second {
 			ws = append(ws, fmt.Sprintf(
 				"resources[%d] (%s): interval %s is very short and may produce a large archive",
-				i, r.Resource, r.Interval))
+				i, firstNonEmpty(r.Resource, "all"), r.Interval))
+		}
+		if r.All {
+			continue
 		}
 		if knownClusterScoped[r.Resource] && len(r.Namespaces) > 0 {
 			ws = append(ws, fmt.Sprintf(
@@ -198,4 +227,13 @@ func Warnings(cfg *Config) []string {
 		}
 	}
 	return ws
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -169,3 +169,35 @@ func TestResourceDedupEnabled_ExplicitFalse(t *testing.T) {
 		t.Fatal("expected dedup disabled when dedup is explicitly false")
 	}
 }
+
+func TestValidate_AllDirective_NoResourceFieldsRequired(t *testing.T) {
+	cfg := &Config{
+		DurationRaw: "10m",
+		Output:      "/tmp/k8shark-test-out.tar.gz",
+		Resources: []Resource{{
+			All:        true,
+			Scope:      "namespaced",
+			Namespaces: []string{"default"},
+		}},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if got := cfg.Resources[0].Interval; got != 30*time.Second {
+		t.Fatalf("expected default interval 30s, got %s", got)
+	}
+}
+
+func TestValidate_AllDirective_InvalidScope(t *testing.T) {
+	cfg := &Config{
+		DurationRaw: "10m",
+		Output:      "/tmp/k8shark-test-out.tar.gz",
+		Resources: []Resource{{
+			All:   true,
+			Scope: "invalid-scope",
+		}},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for invalid all=true scope, got nil")
+	}
+}

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -704,6 +704,84 @@ assert_equals "round-trip: node names"                        "$MOCK_NODE_NAMES"
 assert_equals "round-trip: deployment/nginx spec.replicas"    "$MOCK_NGINX_REPLICAS" "$LIVE_NGINX_REPLICAS"
 assert_equals "round-trip: deployment/nginx container image"  "$MOCK_NGINX_IMAGE"   "$LIVE_NGINX_IMAGE"
 
+# ── Phase 9b: all=true auto-discovery capture ──────────────────────────────────
+log "Testing 'resources: - all: true' auto-discovery capture"
+
+ALL_TRUE_CAPTURE_FILE="/tmp/k8shark-e2e-all-true-$$.tar.gz"
+ALL_TRUE_CONFIG="/tmp/k8shark-e2e-all-true-$$.yaml"
+ALL_TRUE_SERVER_LOG="/tmp/k8shark-all-true-server-$$.log"
+ALL_TRUE_KC="/tmp/k8shark-all-true-kc-$$.yaml"
+ALL_TRUE_SERVER_PID=""
+
+cat > "$ALL_TRUE_CONFIG" <<YAML
+duration: 15s
+output: ${ALL_TRUE_CAPTURE_FILE}
+kubeconfig: ${KIND_KUBECONFIG}
+resources:
+  - all: true
+    interval: 5s
+YAML
+pass "all=true capture config written"
+
+"$BINARY" --config "$ALL_TRUE_CONFIG" capture
+if [[ ! -s "$ALL_TRUE_CAPTURE_FILE" ]]; then
+  fail "all=true capture: archive missing or empty"
+else
+  ALL_TRUE_SIZE=$(du -h "$ALL_TRUE_CAPTURE_FILE" | cut -f1)
+  pass "all=true capture: archive written ($ALL_TRUE_SIZE)"
+fi
+
+# Open the all=true archive and assert key resources are accessible.
+"$BINARY" open "$ALL_TRUE_CAPTURE_FILE" --kubeconfig-out "$ALL_TRUE_KC" >"$ALL_TRUE_SERVER_LOG" 2>&1 &
+ALL_TRUE_SERVER_PID=$!
+
+for i in $(seq 1 30); do
+  if [[ -s "$ALL_TRUE_KC" ]]; then break; fi
+  sleep 0.5
+done
+
+if [[ ! -s "$ALL_TRUE_KC" ]]; then
+  fail "all=true capture: mock server did not start within 15s"
+else
+  pass "all=true capture: mock server started"
+
+  for i in $(seq 1 20); do
+    if kubectl --kubeconfig "$ALL_TRUE_KC" --request-timeout=2s \
+        get namespaces </dev/null &>/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+  done
+
+  AT_KC=(--kubeconfig "$ALL_TRUE_KC" --request-timeout=10s)
+
+  # Core namespaced resources.
+  out=$(kubectl "${AT_KC[@]}" get pods -n k8shark-test -o name 2>&1) || true
+  assert_not_empty "all=true: pods present in k8shark-test" "$out"
+
+  out=$(kubectl "${AT_KC[@]}" get deployments -n k8shark-test -o name 2>&1) || true
+  assert_contains "all=true: deployment/nginx present" "$out" "nginx"
+
+  out=$(kubectl "${AT_KC[@]}" get configmaps -n k8shark-test -o name 2>&1) || true
+  assert_contains "all=true: configmap/app-config present" "$out" "app-config"
+
+  out=$(kubectl "${AT_KC[@]}" get services -n k8shark-test -o name 2>&1) || true
+  assert_not_empty "all=true: services present in k8shark-test" "$out"
+
+  # Core cluster-scoped resources.
+  out=$(kubectl "${AT_KC[@]}" get nodes -o name 2>&1) || true
+  assert_not_empty "all=true: nodes present (cluster-scoped)" "$out"
+
+  out=$(kubectl "${AT_KC[@]}" get namespaces -o name 2>&1) || true
+  assert_contains "all=true: namespace/k8shark-test present" "$out" "k8shark-test"
+fi
+
+if [[ -n "$ALL_TRUE_SERVER_PID" ]]; then
+  kill "$ALL_TRUE_SERVER_PID" 2>/dev/null || true
+  wait "$ALL_TRUE_SERVER_PID" 2>/dev/null || true
+fi
+rm -f "$ALL_TRUE_CAPTURE_FILE" "$ALL_TRUE_CONFIG" "$ALL_TRUE_SERVER_LOG" "$ALL_TRUE_KC"
+
 # ── Phase 10: Summary ───────────────────────────────────────────────────────────
 log "Test summary"
 printf '  Passed: \033[1;32m%d\033[0m\n' "$PASS"


### PR DESCRIPTION
## Summary

Implements the simplified `resources: - all: true` capture config syntax from issue #44, allowing users to capture all Kubernetes resources (core and CRD-backed) via a single config directive instead of enumerating every resource type.

## Changes

### New config syntax

```yaml
resources:
  - all: true            # discover and capture everything
```

```yaml
resources:
  - all: true
    scope: namespaced    # only namespaced resources
```

```yaml
resources:
  - all: true
    scope: namespaced
    namespaces: [production, staging]
    interval: 20s
```

### Engine changes (`internal/capture/engine.go`)
- `all: true` directives trigger auto-discovery without requiring the global `auto_discover: true` flag
- Discovery now covers **core/v1 resources** (pods, nodes, services, configmaps, etc.) in addition to non-core groups from `/apis` — caches `/api/v1` body for this purpose
- `expandWildcardNamespaces` now runs **after** `autoDiscoverResources` so discovered namespaced resources get proper namespace expansion (wildcard `["*"]` → real namespaces)
- `scope: namespaced` filters to namespaced-only; `scope: cluster` to cluster-scoped only; omitting `scope` captures both
- `all: true` entries are skipped in the poll/log loops (they're only directives)

### Config changes (`internal/config/config.go`)
- Added `All` and `Scope` fields to `Resource`
- Validation: `all: true` entries skip `group`/`version`/`resource` requirements; invalid `scope` values are rejected

### CLI (`cmd/capture.go`)
- Added `--auto-discover` flag as a CLI override for `auto_discover`

### Docs (`docs/config.md`, `docs/usage.md`)
- Full documentation of `all: true`, `scope`, and examples

### Tests
- `TestAutoDiscover_AllDirectiveNamespacedScope`
- `TestAutoDiscover_AllDirectiveClusterScope`
- `TestAutoDiscover_AllDirectiveExpandsWildcardNamespacesBeforePolling`
- `TestAutoDiscover_AllDirectiveIncludesCorePods`

## Fixes

- Discovered namespaced resources were not being polled (wildcard expansion ran before discovery populated them)
- Core/v1 resources (pods, nodes, etc.) were not discovered by `all: true` directives because `/api/v1` was not cached

Closes #44