### PR TITLE
feat(redact): advanced field-level redaction (issue #46)

### DIFF
--- a/.github/instructions/git-push.instructions.md
+++ b/.github/instructions/git-push.instructions.md
@@ -7,3 +7,5 @@ Never run `git push` (or any variant: `--force`, `--force-with-lease`, `--tags`,
 - `git add`, `git commit`, `git branch`, `git tag`, and read-only commands (`git log`, `git diff`, `git status`) may run freely.
 - Before any `git push`, state what will be pushed (branch, remote, commits) and ask: "OK to push?"
 - Wait for explicit confirmation before proceeding.
+
+For pushes to branches that are used for PRs, also follow `golangci-lint-before-push.instructions.md` and run the same lint command/version as CI before pushing.

--- a/.github/instructions/golangci-lint-before-push.instructions.md
+++ b/.github/instructions/golangci-lint-before-push.instructions.md
@@ -1,0 +1,19 @@
+---
+description: "Use when performing git push operations, updating PR branches, or preparing PR-ready commits. Enforces running golangci-lint exactly like CI before any push."
+---
+
+# Run GolangCI-Lint Before Push
+
+Before any `git push` to a branch used for a PR:
+
+1. Install the pinned CI lint version:
+   - `go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8`
+2. Run the same lint command as CI from repo root:
+   - `golangci-lint run`
+
+Rules:
+
+- Do not push if lint fails.
+- Use the same execution format as CI (no extra flags).
+- Report lint result before pushing (pass/fail and any fixes applied).
+- If local PATH/version mismatch prevents lint execution, resolve that first, then rerun lint before pushing.

--- a/.github/prompts/release-pr-ready.prompt.md
+++ b/.github/prompts/release-pr-ready.prompt.md
@@ -1,0 +1,29 @@
+---
+mode: agent
+description: "Use when preparing a branch to push for PR review or release readiness. Runs tests and golangci-lint in CI-compatible mode before pushing."
+---
+
+Prepare the current branch for push and PR update.
+
+## Required checks
+
+1. Run formatting:
+   - `make fmt`
+2. Run repository tests:
+   - `make test`
+3. Run golangci-lint exactly like CI:
+   - `make lint-ci-install`
+   - `make lint-ci`
+
+## Push workflow
+
+1. Summarize what will be pushed (branch, remote, commits).
+2. Ask for explicit confirmation before running `git push`.
+3. Push only after confirmation.
+4. Report check results and push outcome.
+
+## If checks fail
+
+- Stop before push.
+- Show the failing command output summary.
+- Propose minimal fixes, apply them if requested, then rerun checks.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
 
       - name: golangci-lint
         run: golangci-lint run

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,8 @@
         "git commit": true,
         "gh": true,
         "git rev-parse": true,
-        "golangci-lint": true
+        "golangci-lint": true,
+        "git checkout": true,
+        "git pull": true
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-.PHONY: build test test-race test-cover bench fmt lint e2e kind-up kind-down release-snapshot release-local clean help
+.PHONY: build test test-race test-cover bench fmt lint lint-ci-install lint-ci e2e kind-up kind-down release-snapshot release-local clean help
 
 BINARY  := kshrk
 VERSION ?= dev
 LDFLAGS := -w -s -X github.com/phenixblue/k8shark/cmd.Version=$(VERSION)
 GOFLAGS := -trimpath
+GOLANGCI_LINT_VERSION ?= v1.64.8
 
 build: ## Build the kshrk binary
 	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BINARY) .
@@ -26,6 +27,12 @@ fmt: ## Format Go source files
 
 lint: ## Run go vet
 	go vet ./...
+
+lint-ci-install: ## Install the pinned golangci-lint version used in CI
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+lint-ci: ## Run golangci-lint exactly like CI (requires lint-ci-install)
+	golangci-lint run
 
 e2e: build ## Build binary and run end-to-end tests (requires kind + kubectl)
 	./scripts/e2e.sh

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -29,6 +29,7 @@ func init() {
 	captureCmd.Flags().Bool("auto-discover", false, "auto-discover and capture all available API resources")
 	captureCmd.Flags().Bool("redact-secrets", false, "redact Secret data and stringData values from the archive after capture")
 	captureCmd.Flags().StringArray("allow-secret", nil, "namespace/name of secret to preserve when --redact-secrets is set (repeatable)")
+	captureCmd.Flags().StringArray("redact-field", nil, "field redaction rule applied after capture: <fieldPath>:<Kind>:<replacement>[:<valueType>] (repeatable)")
 	_ = viper.BindPFlag("output", captureCmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag("kubeconfig", captureCmd.Flags().Lookup("kubeconfig"))
 	_ = viper.BindPFlag("duration", captureCmd.Flags().Lookup("duration"))
@@ -82,25 +83,50 @@ func runCapture(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stdout, "  Records:   %d across %d resource path(s)\n", sum.RecordCount, sum.ResourceCount)
 	fmt.Fprintf(os.Stdout, "  Duration:  %s\n", sum.Duration)
 
-	// Optional in-place redaction of Secret values.
-	if doRedact, _ := cmd.Flags().GetBool("redact-secrets"); doRedact {
-		allows, _ := cmd.Flags().GetStringArray("allow-secret")
-		allowList := make(map[string]bool, len(allows))
-		for _, a := range allows {
-			allowList[a] = true
+	// Post-capture redaction: merge --redact-secrets / --redact-field CLI flags
+	// with any redaction.rules defined in the config file.
+	doRedactSecrets, _ := cmd.Flags().GetBool("redact-secrets")
+	if cfg.Redaction.RedactSecrets {
+		doRedactSecrets = true
+	}
+	allows, _ := cmd.Flags().GetStringArray("allow-secret")
+	allowList := make(map[string]bool, len(allows))
+	for _, a := range allows {
+		allowList[a] = true
+	}
+	for _, a := range cfg.Redaction.AllowSecrets {
+		allowList[a] = true
+	}
+	redactFields, _ := cmd.Flags().GetStringArray("redact-field")
+	var fieldRules []config.RedactionRule
+	fieldRules = append(fieldRules, cfg.Redaction.Rules...)
+	for _, rf := range redactFields {
+		rule, err := parseRedactField(rf)
+		if err != nil {
+			return err
 		}
+		fieldRules = append(fieldRules, rule)
+	}
 
+	if doRedactSecrets || len(fieldRules) > 0 {
 		tmpPath := sum.OutputPath + ".redacting"
-		n, err := redact.Archive(sum.OutputPath, tmpPath, allowList)
+		result, err := redact.Archive(sum.OutputPath, tmpPath, redact.Options{
+			RedactSecrets: doRedactSecrets,
+			AllowList:     allowList,
+			Rules:         fieldRules,
+		})
 		if err != nil {
 			_ = os.Remove(tmpPath)
-			return fmt.Errorf("redacting secrets: %w", err)
+			return fmt.Errorf("redacting archive: %w", err)
 		}
 		if err := os.Rename(tmpPath, sum.OutputPath); err != nil {
 			_ = os.Remove(tmpPath)
 			return fmt.Errorf("replacing archive with redacted version: %w", err)
 		}
-		fmt.Fprintf(os.Stdout, "  Redacted:  %d secret(s) scrubbed from archive\n", n)
+		if result.SecretsRedacted > 0 || result.FieldsRedacted > 0 {
+			fmt.Fprintf(os.Stdout, "  Redacted:  %d secret(s), %d record(s) with field rules applied\n",
+				result.SecretsRedacted, result.FieldsRedacted)
+		}
 	}
 
 	return nil

--- a/cmd/redact.go
+++ b/cmd/redact.go
@@ -6,16 +6,25 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/phenixblue/k8shark/internal/config"
 	"github.com/phenixblue/k8shark/internal/redact"
 	"github.com/spf13/cobra"
 )
 
 var redactCmd = &cobra.Command{
 	Use:   "redact --in <capture.tar.gz> [--out <redacted.tar.gz>]",
-	Short: "Redact Secret data from a capture archive",
-	Long: `Produces a new capture archive with all Kubernetes Secret data and
-stringData values replaced by "REDACTED", safe for sharing with support teams.
-The original archive is not modified.`,
+	Short: "Redact Secret data and arbitrary fields from a capture archive",
+	Long: `Produces a new capture archive with Kubernetes Secret data replaced by
+"REDACTED" and any configured field-level redaction rules applied.
+The original archive is not modified.
+
+Field rules can be supplied via --redact-field (repeatable) with the format:
+  <fieldPath>:<Kind>:<replacement>[:<valueType>]
+
+Examples:
+  kshrk redact --in capture.tar.gz --redact-secrets
+  kshrk redact --in capture.tar.gz --redact-field "data.api-key:ConfigMap:REDACTED"
+  kshrk redact --in capture.tar.gz --config k8shark.yaml`,
 	RunE: runRedact,
 }
 
@@ -23,14 +32,38 @@ func init() {
 	rootCmd.AddCommand(redactCmd)
 	redactCmd.Flags().String("in", "", "source capture archive (required)")
 	redactCmd.Flags().String("out", "", "output archive path (default: <in>-redacted.tar.gz)")
+	redactCmd.Flags().Bool("redact-secrets", false, "redact all Kubernetes Secret data and stringData values")
 	redactCmd.Flags().StringArray("allow-secret", nil, "namespace/name of secret to preserve (repeatable)")
+	redactCmd.Flags().StringArray("redact-field", nil, "field redaction rule: <fieldPath>:<Kind>:<replacement>[:<valueType>] (repeatable)")
+	redactCmd.Flags().String("config", "", "capture config file whose redaction.rules block is applied")
 	_ = redactCmd.MarkFlagRequired("in")
+}
+
+// parseRedactField parses a --redact-field flag value of the form:
+// <fieldPath>:<Kind>:<replacement>[:<valueType>]
+func parseRedactField(s string) (config.RedactionRule, error) {
+	parts := strings.SplitN(s, ":", 4)
+	if len(parts) < 3 {
+		return config.RedactionRule{}, fmt.Errorf("--redact-field %q: expected format <fieldPath>:<Kind>:<replacement>[:<valueType>]", s)
+	}
+	rule := config.RedactionRule{
+		FieldPath:   parts[0],
+		Kind:        parts[1],
+		Replacement: parts[2],
+	}
+	if len(parts) == 4 {
+		rule.ValueType = parts[3]
+	}
+	return rule, nil
 }
 
 func runRedact(cmd *cobra.Command, _ []string) error {
 	in, _ := cmd.Flags().GetString("in")
 	out, _ := cmd.Flags().GetString("out")
+	doRedactSecrets, _ := cmd.Flags().GetBool("redact-secrets")
 	allows, _ := cmd.Flags().GetStringArray("allow-secret")
+	redactFields, _ := cmd.Flags().GetStringArray("redact-field")
+	cfgFile, _ := cmd.Flags().GetString("config")
 
 	if out == "" {
 		base := strings.TrimSuffix(in, ".tar.gz")
@@ -49,7 +82,36 @@ func runRedact(cmd *cobra.Command, _ []string) error {
 		allowList[a] = true
 	}
 
-	n, err := redact.Archive(in, out, allowList)
+	// Collect field rules: config file first, then CLI overrides appended.
+	var rules []config.RedactionRule
+
+	if cfgFile != "" {
+		cfg, err := config.Load(cfgFile)
+		if err != nil {
+			return fmt.Errorf("loading config: %w", err)
+		}
+		if cfg.Redaction.RedactSecrets {
+			doRedactSecrets = true
+		}
+		for _, a := range cfg.Redaction.AllowSecrets {
+			allowList[a] = true
+		}
+		rules = append(rules, cfg.Redaction.Rules...)
+	}
+
+	for _, rf := range redactFields {
+		rule, err := parseRedactField(rf)
+		if err != nil {
+			return err
+		}
+		rules = append(rules, rule)
+	}
+
+	result, err := redact.Archive(in, out, redact.Options{
+		RedactSecrets: doRedactSecrets,
+		AllowList:     allowList,
+		Rules:         rules,
+	})
 	if err != nil {
 		return err
 	}
@@ -60,6 +122,7 @@ func runRedact(cmd *cobra.Command, _ []string) error {
 		size = fi.Size()
 	}
 
-	fmt.Printf("Redacted %d secret(s) → %s (%d bytes)\n", n, out, size)
+	fmt.Printf("Redacted %d secret(s), %d field(s) → %s (%d bytes)\n",
+		result.SecretsRedacted, result.FieldsRedacted, out, size)
 	return nil
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -340,6 +340,7 @@ k8shark can redact sensitive field values after capture, producing a sanitised a
 | `fieldPath` | string | yes | JSONPath-like expression targeting the field(s) to redact. |
 | `kind` | string | no | Resource kind to match, e.g. `Pod`, `ConfigMap`. Use `*` or omit to match all kinds. |
 | `namespace` | string | no | Only apply rule to resources in this namespace. Omit to match all namespaces. |
+| `labelSelector` | string | no | Kubernetes label selector used to scope matching resources (for example `app=sensitive,tier in (backend)`). |
 | `replacement` | string | yes | Value to write in place of the redacted field. Converted to the appropriate JSON type. |
 | `valueType` | string | no | Force a specific type for the replacement: `string`, `integer`, `number`, `bool`, `array`, `object`. Inferred from actual value when omitted. |
 
@@ -364,7 +365,12 @@ Redacted values preserve the original field's JSON type so the archive remains s
 | `[...]` (array) with `valueType: array` | any | `[]` |
 | `{...}` (object) with `valueType: object` | any | `{}` |
 
-When `valueType` is omitted the engine infers the type from the captured value. Invalid replacements (e.g. `"not-a-number"` for an integer field) fail early with a clear error.
+When `valueType` is omitted the engine infers the type in this order:
+
+1. known Kubernetes schema for the matched `kind` + `fieldPath`
+2. runtime type from the captured value (fallback)
+
+Invalid replacements (e.g. `"not-a-number"` for an integer field) fail early with a clear error.
 
 ### Example: unified config with redaction
 
@@ -414,6 +420,7 @@ redaction:
     - fieldPath: "data.db-password"
       kind: ConfigMap
       namespace: production
+      labelSelector: "app=sensitive"
       replacement: "REDACTED"
 ```
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -11,6 +11,7 @@ k8shark reads a YAML config file that controls what gets captured, from which na
 | `kubeconfig` | string | `$KUBECONFIG` → `~/.kube/config` | Path to the kubeconfig for the source cluster. |
 | `resources` | list | required | Resource types to capture. See below. |
 | `auto_discover` | bool | `false` | Legacy global discovery toggle. Prefer `resources: - all: true` for fine-grained control. |
+| `redaction` | object | — | Optional field-level redaction rules applied after capture. See [Redaction](#redaction). |
 
 ## Resource entry fields
 
@@ -317,6 +318,112 @@ resources:
     namespaces: [default, production, staging]
     interval: 60s
 ```
+
+---
+
+## Redaction
+
+k8shark can redact sensitive field values after capture, producing a sanitised archive safe for sharing. Redaction rules live in a top-level `redaction` block and are also applied when running `kshrk redact`.
+
+### `redaction` fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `redactSecrets` | bool | `false` | Redact all Kubernetes `Secret` `data` and `stringData` values (same as `--redact-secrets` on the CLI). |
+| `allowSecrets` | list of strings | `[]` | `namespace/name` keys of secrets to preserve even when `redactSecrets: true`. |
+| `rules` | list | `[]` | Field-level redaction rules. See below. |
+
+### Redaction rule fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `fieldPath` | string | yes | JSONPath-like expression targeting the field(s) to redact. |
+| `kind` | string | no | Resource kind to match, e.g. `Pod`, `ConfigMap`. Use `*` or omit to match all kinds. |
+| `namespace` | string | no | Only apply rule to resources in this namespace. Omit to match all namespaces. |
+| `replacement` | string | yes | Value to write in place of the redacted field. Converted to the appropriate JSON type. |
+| `valueType` | string | no | Force a specific type for the replacement: `string`, `integer`, `number`, `bool`, `array`, `object`. Inferred from actual value when omitted. |
+
+### Field path syntax
+
+| Pattern | Meaning |
+|---------|---------|
+| `spec.replicas` | Exact dot-notation path |
+| `spec.containers[*].env[*].value` | Wildcards through arrays |
+| `spec.containers[0].name` | Specific array index |
+| `**.password` | Recursive descent — matches `password` at any depth |
+
+### Type-aware replacement
+
+Redacted values preserve the original field's JSON type so the archive remains schema-compatible with `kubectl` and other tooling.
+
+| Original value | Replacement string | Written as |
+|----------------|--------------------|------------|
+| `"my-token"` (string) | `"REDACTED"` | `"REDACTED"` |
+| `3` (integer) | `"0"` | `0` |
+| `true` (bool) | `"false"` | `false` |
+| `[...]` (array) with `valueType: array` | any | `[]` |
+| `{...}` (object) with `valueType: object` | any | `{}` |
+
+When `valueType` is omitted the engine infers the type from the captured value. Invalid replacements (e.g. `"not-a-number"` for an integer field) fail early with a clear error.
+
+### Example: unified config with redaction
+
+```yaml
+duration: 10m
+output: ./capture.tar.gz
+kubeconfig: ~/.kube/config
+
+resources:
+  - all: true
+
+redaction:
+  redactSecrets: true
+  allowSecrets:
+    - default/app-secret
+
+  rules:
+    # Redact ConfigMap API keys
+    - fieldPath: "data.api-key"
+      kind: ConfigMap
+      replacement: "REDACTED"
+
+    # Redact all Pod env var values
+    - fieldPath: "spec.containers[*].env[*].value"
+      kind: Pod
+      replacement: "REDACTED"
+      valueType: string
+
+    # Recursive descent — any field named "password" anywhere
+    - fieldPath: "**.password"
+      kind: "*"
+      replacement: "REDACTED"
+
+    # Numeric field — preserve integer type
+    - fieldPath: "spec.replicas"
+      kind: Deployment
+      replacement: "0"
+      valueType: integer
+
+    # Boolean field
+    - fieldPath: "spec.automountServiceAccountToken"
+      kind: Pod
+      replacement: "false"
+      valueType: bool
+
+    # Namespace-scoped rule
+    - fieldPath: "data.db-password"
+      kind: ConfigMap
+      namespace: production
+      replacement: "REDACTED"
+```
+
+The same config can be passed to `kshrk redact` to apply exactly the same rules to an existing archive:
+
+```bash
+kshrk redact --in capture.tar.gz --out redacted.tar.gz --config k8shark.yaml
+```
+
+---
 
 ## Duration and interval units
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -64,6 +64,7 @@ Capture complete
 | `--verbose` | `-v` | false | Log every API path as it is fetched |
 | `--redact-secrets` | | false | Redact Secret `data`/`stringData` values from the archive after capture |
 | `--allow-secret` | | | `namespace/name` of secret to preserve when `--redact-secrets` is set (repeatable) |
+| `--redact-field` | | | Field redaction rule applied after capture: `<path>:<Kind>:<replacement>[:<type>]` (repeatable) |
 
 The `--config` flag auto-discovers `./k8shark.yaml` if not specified.
 
@@ -327,45 +328,82 @@ Exit codes follow the usual diff convention:
 
 ## Redact
 
-Secret values can be removed from a capture archive in two ways:
+Sensitive values can be removed from a capture archive in two ways.
 
 ### Option A — `kshrk redact` (post-capture)
 
-Produces a **new** archive with all Kubernetes Secret `data` and `stringData` values replaced by `"REDACTED"`. The original archive is not modified.
+Produces a **new** archive with Kubernetes Secret data replaced and any configured field rules applied. The original archive is not modified.
 
 ```sh
-kshrk redact --in capture.tar.gz
-# writes capture-redacted.tar.gz by default
-```
+# Redact secrets only
+kshrk redact --in capture.tar.gz --redact-secrets
 
-```sh
-kshrk redact --in capture.tar.gz --out safe-capture.tar.gz \
+# Redact secrets + specific fields via CLI flags
+kshrk redact --in capture.tar.gz --redact-secrets \
+  --redact-field "data.api-key:ConfigMap:REDACTED" \
+  --redact-field "spec.containers[*].env[*].value:Pod:REDACTED:string"
+
+# Reuse the redaction rules from your capture config
+kshrk redact --in capture.tar.gz --out safe-capture.tar.gz --config k8shark.yaml
+
+# Preserve specific secrets from redaction
+kshrk redact --in capture.tar.gz --redact-secrets \
   --allow-secret default/pull-secret \
   --allow-secret kube-system/bootstrap-token
 ```
 
-### Option B — `--redact-secrets` flag on `kshrk capture` (at collection time)
+### Option B — inline after `kshrk capture`
 
-Pass `--redact-secrets` to have the archive redacted **in-place** immediately after capture completes, before any data is stored on disk in final form:
+Pass `--redact-secrets` or `--redact-field` to have the archive redacted **in-place** immediately after capture completes. Field rules defined in the capture config `redaction:` block are applied automatically without any extra flags.
 
 ```sh
+# Redact secrets at capture time
 kshrk capture --config k8shark.yaml --redact-secrets
+
+# Redact secrets + ad-hoc field rules
 kshrk capture --config k8shark.yaml --redact-secrets \
-  --allow-secret default/pull-secret
+  --redact-field "data.api-key:ConfigMap:REDACTED"
+
+# Config-driven: rules in redaction.rules block run automatically
+kshrk capture --config k8shark.yaml   # redaction.redactSecrets: true in config
 ```
 
 The final archive at the configured output path will already be redacted. No intermediate unredacted file is retained.
 
-### Redact flags (both commands)
+### `--redact-field` format
+
+```
+<fieldPath>:<Kind>:<replacement>[:<valueType>]
+```
+
+- `fieldPath` — dot-notation path with optional `[*]` wildcards or `**` recursive descent
+- `Kind` — resource kind to match (`*` matches all)
+- `replacement` — string written in place of the field value
+- `valueType` — optional type hint: `string`, `integer`, `number`, `bool`, `array`, `object`
+
+Examples:
+
+```sh
+--redact-field "data.api-key:ConfigMap:REDACTED"
+--redact-field "spec.containers[*].env[*].value:Pod:REDACTED:string"
+--redact-field "spec.replicas:Deployment:0:integer"
+--redact-field "**.password:*:REDACTED"
+```
+
+### Redact flags
 
 | Flag | Command | Default | Description |
 |------|---------|---------|-------------|
 | `--in` | `redact` | (required) | Source capture archive |
 | `--out` | `redact` | `<in>-redacted.tar.gz` | Output archive path |
-| `--redact-secrets` | `capture` | false | Redact secrets in-place after capture |
+| `--redact-secrets` | both | `false` | Redact all Secret `data`/`stringData` values |
 | `--allow-secret` | both | | `namespace/name` of secret to preserve (repeatable) |
+| `--redact-field` | both | | Field redaction rule (repeatable). Format: `<path>:<Kind>:<replacement>[:<type>]` |
+| `--config` | `redact` | | Capture config file — applies `redaction.rules` and `redaction.redactSecrets` |
 
 Secret metadata (name, namespace, labels, annotations, type) is always preserved so you can still count and identify secrets by kind.
+
+See [config.md](config.md#redaction) for the full `redaction:` config block reference with type-aware examples.
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/api v0.35.3
+	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.3
 )
 
@@ -38,9 +40,7 @@ require (
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/apimachinery v0.35.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,11 +33,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
-github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,10 @@ type RedactionRule struct {
 	// Namespace restricts the rule to resources in a specific namespace.
 	// Omit to match all namespaces.
 	Namespace string `mapstructure:"namespace"`
+	// LabelSelector restricts the rule to resources whose metadata.labels match
+	// the selector expression (for example: "app=api,tier in (backend)").
+	// Omit to match all labels.
+	LabelSelector string `mapstructure:"labelSelector"`
 	// Replacement is the string value written in place of the redacted field.
 	// It will be converted to the appropriate JSON type (see ValueType).
 	Replacement string `mapstructure:"replacement"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,40 @@ func (r Resource) DedupEnabled() bool {
 	return r.Dedup == nil || *r.Dedup
 }
 
+// RedactionRule describes a single field-level redaction rule.
+type RedactionRule struct {
+	// FieldPath is a JSONPath-like expression identifying the field(s) to
+	// redact. Supports dot-notation, array wildcards ([*]), and recursive
+	// descent (**). Examples: "data.api-key", "spec.containers[*].env[*].value",
+	// "**.password".
+	FieldPath string `mapstructure:"fieldPath"`
+	// Kind restricts the rule to a specific resource kind (e.g. "Pod",
+	// "ConfigMap"). Use "*" or omit to match all kinds.
+	Kind string `mapstructure:"kind"`
+	// Namespace restricts the rule to resources in a specific namespace.
+	// Omit to match all namespaces.
+	Namespace string `mapstructure:"namespace"`
+	// Replacement is the string value written in place of the redacted field.
+	// It will be converted to the appropriate JSON type (see ValueType).
+	Replacement string `mapstructure:"replacement"`
+	// ValueType optionally overrides type inference. Accepted values: "string",
+	// "integer", "number", "bool", "array", "object". When omitted the engine
+	// infers the type from the actual captured value.
+	ValueType string `mapstructure:"valueType"`
+}
+
+// RedactionConfig is the top-level redaction section of the capture config.
+type RedactionConfig struct {
+	// RedactSecrets, when true, redacts all Kubernetes Secret data and
+	// stringData fields (equivalent to --redact-secrets on the CLI).
+	RedactSecrets bool `mapstructure:"redactSecrets"`
+	// AllowSecrets is a list of "namespace/name" secret keys whose data will
+	// be preserved even when RedactSecrets is true.
+	AllowSecrets []string `mapstructure:"allowSecrets"`
+	// Rules is the list of field-level redaction rules applied to every record.
+	Rules []RedactionRule `mapstructure:"rules"`
+}
+
 // Config holds the full capture configuration.
 type Config struct {
 	// DurationRaw is the human-readable total capture duration (e.g. "10m").
@@ -70,6 +104,9 @@ type Config struct {
 	// produce noisy or unusable data are excluded by default regardless of
 	// this setting; see defaultAutoDiscoverExcludeGroups.
 	AutoDiscoverExcludeGroups []string `mapstructure:"auto_discover_exclude_groups"`
+	// Redaction holds field-level redaction rules applied during capture and
+	// post-capture redact workflows.
+	Redaction RedactionConfig `mapstructure:"redaction"`
 }
 
 // Load reads k8shark capture config. If configFile is empty, viper uses

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -201,3 +201,69 @@ func TestValidate_AllDirective_InvalidScope(t *testing.T) {
 		t.Fatal("expected error for invalid all=true scope, got nil")
 	}
 }
+
+func TestRedactionConfig_ParsesCorrectly(t *testing.T) {
+	cfg := &Config{
+		DurationRaw: "5m",
+		Output:      "/tmp/k8shark-test-out.tar.gz",
+		Resources:   []Resource{{Resource: "pods", Version: "v1", IntervalRaw: "30s"}},
+		Redaction: RedactionConfig{
+			RedactSecrets: true,
+			AllowSecrets:  []string{"default/app-secret"},
+			Rules: []RedactionRule{
+				{
+					FieldPath:   "data.api-key",
+					Kind:        "ConfigMap",
+					Replacement: "REDACTED",
+					ValueType:   "string",
+				},
+				{
+					FieldPath:   "spec.containers[*].env[*].value",
+					Kind:        "Pod",
+					Replacement: "REDACTED",
+				},
+				{
+					FieldPath:   "**.password",
+					Kind:        "*",
+					Replacement: "REDACTED",
+				},
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !cfg.Redaction.RedactSecrets {
+		t.Error("expected RedactSecrets=true")
+	}
+	if len(cfg.Redaction.AllowSecrets) != 1 || cfg.Redaction.AllowSecrets[0] != "default/app-secret" {
+		t.Errorf("unexpected AllowSecrets: %v", cfg.Redaction.AllowSecrets)
+	}
+	if len(cfg.Redaction.Rules) != 3 {
+		t.Fatalf("expected 3 redaction rules, got %d", len(cfg.Redaction.Rules))
+	}
+	if cfg.Redaction.Rules[0].Kind != "ConfigMap" {
+		t.Errorf("expected kind ConfigMap, got %q", cfg.Redaction.Rules[0].Kind)
+	}
+	if cfg.Redaction.Rules[0].ValueType != "string" {
+		t.Errorf("expected valueType string, got %q", cfg.Redaction.Rules[0].ValueType)
+	}
+}
+
+func TestRedactionConfig_EmptyIsValid(t *testing.T) {
+	cfg := &Config{
+		DurationRaw: "5m",
+		Output:      "/tmp/k8shark-test-out.tar.gz",
+		Resources:   []Resource{{Resource: "pods", Version: "v1", IntervalRaw: "30s"}},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	// zero-value RedactionConfig is fine
+	if cfg.Redaction.RedactSecrets {
+		t.Error("expected RedactSecrets=false by default")
+	}
+	if len(cfg.Redaction.Rules) != 0 {
+		t.Errorf("expected no rules by default, got %d", len(cfg.Redaction.Rules))
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -212,10 +212,11 @@ func TestRedactionConfig_ParsesCorrectly(t *testing.T) {
 			AllowSecrets:  []string{"default/app-secret"},
 			Rules: []RedactionRule{
 				{
-					FieldPath:   "data.api-key",
-					Kind:        "ConfigMap",
-					Replacement: "REDACTED",
-					ValueType:   "string",
+					FieldPath:     "data.api-key",
+					Kind:          "ConfigMap",
+					LabelSelector: "app=sensitive",
+					Replacement:   "REDACTED",
+					ValueType:     "string",
 				},
 				{
 					FieldPath:   "spec.containers[*].env[*].value",
@@ -244,6 +245,9 @@ func TestRedactionConfig_ParsesCorrectly(t *testing.T) {
 	}
 	if cfg.Redaction.Rules[0].Kind != "ConfigMap" {
 		t.Errorf("expected kind ConfigMap, got %q", cfg.Redaction.Rules[0].Kind)
+	}
+	if cfg.Redaction.Rules[0].LabelSelector != "app=sensitive" {
+		t.Errorf("expected labelSelector app=sensitive, got %q", cfg.Redaction.Rules[0].LabelSelector)
 	}
 	if cfg.Redaction.Rules[0].ValueType != "string" {
 		t.Errorf("expected valueType string, got %q", cfg.Redaction.Rules[0].ValueType)

--- a/internal/redact/fields.go
+++ b/internal/redact/fields.go
@@ -1,0 +1,382 @@
+package redact
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/phenixblue/k8shark/internal/config"
+)
+
+// tokenKind represents the type of a path token.
+type tokenKind int
+
+const (
+	tokenKey       tokenKind = iota // plain key, e.g. "spec"
+	tokenIndex                      // numeric index, e.g. [3]
+	tokenWildcard                   // [*]
+	tokenRecursive                  // **
+)
+
+type pathToken struct {
+	kind  tokenKind
+	key   string // tokenKey only
+	index int    // tokenIndex only
+}
+
+// tokenizePath converts a field path string into a slice of pathTokens.
+// Supported syntax:
+//
+//	foo.bar         → key("foo"), key("bar")
+//	items[*].value  → key("items"), wildcard, key("value")
+//	items[2].value  → key("items"), index(2), key("value")
+//	**.password     → recursive, key("password")
+func tokenizePath(path string) ([]pathToken, error) {
+	var tokens []pathToken
+	for _, seg := range strings.Split(path, ".") {
+		if seg == "" {
+			continue
+		}
+		// Handle recursive descent sentinel "**"
+		if seg == "**" {
+			tokens = append(tokens, pathToken{kind: tokenRecursive})
+			continue
+		}
+		// Check for bracket notation within the segment, e.g. "items[*]" or "items[3]"
+		bracketIdx := strings.Index(seg, "[")
+		if bracketIdx == -1 {
+			tokens = append(tokens, pathToken{kind: tokenKey, key: seg})
+			continue
+		}
+		// Part before the bracket is a key
+		if bracketIdx > 0 {
+			tokens = append(tokens, pathToken{kind: tokenKey, key: seg[:bracketIdx]})
+		}
+		// Parse zero or more [...] suffixes
+		rest := seg[bracketIdx:]
+		for len(rest) > 0 {
+			if rest[0] != '[' {
+				return nil, fmt.Errorf("unexpected character %q in path segment %q", rest[0], seg)
+			}
+			end := strings.Index(rest, "]")
+			if end == -1 {
+				return nil, fmt.Errorf("unclosed '[' in path segment %q", seg)
+			}
+			inner := rest[1:end]
+			if inner == "*" {
+				tokens = append(tokens, pathToken{kind: tokenWildcard})
+			} else {
+				n, err := strconv.Atoi(inner)
+				if err != nil {
+					return nil, fmt.Errorf("invalid array index %q in path %q", inner, path)
+				}
+				tokens = append(tokens, pathToken{kind: tokenIndex, index: n})
+			}
+			rest = rest[end+1:]
+		}
+	}
+	return tokens, nil
+}
+
+// inferType returns its best-guess type name for a JSON-decoded value.
+func inferType(v interface{}) string {
+	switch v.(type) {
+	case string:
+		return "string"
+	case float64:
+		return "number"
+	case bool:
+		return "bool"
+	case []interface{}:
+		return "array"
+	case map[string]interface{}:
+		return "object"
+	case nil:
+		return "null"
+	default:
+		return "string"
+	}
+}
+
+// convertReplacement parses the string replacement into a typed Go value whose
+// JSON serialisation will match the expected type.
+func convertReplacement(replacement, valueType string) (interface{}, error) {
+	switch strings.ToLower(valueType) {
+	case "string":
+		return replacement, nil
+	case "int", "integer":
+		n, err := strconv.ParseInt(replacement, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("replacement %q is not a valid integer: %w", replacement, err)
+		}
+		return float64(n), nil
+	case "number", "float":
+		f, err := strconv.ParseFloat(replacement, 64)
+		if err != nil {
+			return nil, fmt.Errorf("replacement %q is not a valid number: %w", replacement, err)
+		}
+		return f, nil
+	case "bool":
+		b, err := strconv.ParseBool(replacement)
+		if err != nil {
+			return nil, fmt.Errorf("replacement %q is not a valid bool (use true/false): %w", replacement, err)
+		}
+		return b, nil
+	case "array":
+		return []interface{}{}, nil
+	case "object":
+		return map[string]interface{}{}, nil
+	case "null":
+		return nil, nil
+	default:
+		// Unknown hint — treat as string
+		return replacement, nil
+	}
+}
+
+// typedReplacement returns the typed replacement value for a given rule and the
+// current field value.
+func typedReplacement(current interface{}, rule *config.RedactionRule) (interface{}, error) {
+	t := rule.ValueType
+	if t == "" {
+		t = inferType(current)
+	}
+	return convertReplacement(rule.Replacement, t)
+}
+
+// walk traverses the JSON-decoded value tree following tokens and calls
+// replaceFn at every terminal position. Returns the (possibly new) value,
+// whether anything was changed, and any error.
+func walk(val interface{}, tokens []pathToken, replaceFn func(interface{}) (interface{}, error)) (interface{}, bool, error) {
+	if len(tokens) == 0 {
+		// Terminal — perform replacement
+		newVal, err := replaceFn(val)
+		if err != nil {
+			return val, false, err
+		}
+		return newVal, true, nil
+	}
+
+	tok := tokens[0]
+	rest := tokens[1:]
+
+	switch tok.kind {
+	case tokenKey:
+		m, ok := val.(map[string]interface{})
+		if !ok {
+			return val, false, nil
+		}
+		child, exists := m[tok.key]
+		if !exists {
+			return val, false, nil
+		}
+		newChild, changed, err := walk(child, rest, replaceFn)
+		if err != nil {
+			return val, false, err
+		}
+		if changed {
+			m[tok.key] = newChild
+		}
+		return val, changed, nil
+
+	case tokenIndex:
+		s, ok := val.([]interface{})
+		if !ok || tok.index < 0 || tok.index >= len(s) {
+			return val, false, nil
+		}
+		newElem, changed, err := walk(s[tok.index], rest, replaceFn)
+		if err != nil {
+			return val, false, err
+		}
+		if changed {
+			s[tok.index] = newElem
+		}
+		return val, changed, nil
+
+	case tokenWildcard:
+		s, ok := val.([]interface{})
+		if !ok {
+			return val, false, nil
+		}
+		modified := false
+		for i, elem := range s {
+			newElem, changed, err := walk(elem, rest, replaceFn)
+			if err != nil {
+				return val, modified, err
+			}
+			if changed {
+				s[i] = newElem
+				modified = true
+			}
+		}
+		return val, modified, nil
+
+	case tokenRecursive:
+		// Try to match rest starting at this level
+		newVal, modified, err := walk(val, rest, replaceFn)
+		if err != nil {
+			return val, false, err
+		}
+		if modified {
+			val = newVal
+		}
+		// Also recurse into all children with the full recursive pattern
+		switch v := val.(type) {
+		case map[string]interface{}:
+			for k, child := range v {
+				newChild, changed, err := walk(child, tokens, replaceFn)
+				if err != nil {
+					return val, modified, err
+				}
+				if changed {
+					v[k] = newChild
+					modified = true
+				}
+			}
+		case []interface{}:
+			for i, elem := range v {
+				newElem, changed, err := walk(elem, tokens, replaceFn)
+				if err != nil {
+					return val, modified, err
+				}
+				if changed {
+					v[i] = newElem
+					modified = true
+				}
+			}
+		}
+		return val, modified, nil
+	}
+
+	return val, false, nil
+}
+
+// extractString returns the string value of a top-level key in a JSON object map.
+func extractString(m map[string]interface{}, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+// extractNestedString returns a string value at a two-level path.
+func extractNestedString(m map[string]interface{}, key1, key2 string) string {
+	v, ok := m[key1]
+	if !ok {
+		return ""
+	}
+	nested, ok := v.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	s, _ := nested[key2].(string)
+	return s
+}
+
+// applyRuleToObj applies a single redaction rule to a decoded JSON object (one
+// resource, not a list). Returns true if any modification was made.
+func applyRuleToObj(obj map[string]interface{}, rule *config.RedactionRule) (bool, error) {
+	tokens, err := tokenizePath(rule.FieldPath)
+	if err != nil {
+		return false, fmt.Errorf("parsing field path %q: %w", rule.FieldPath, err)
+	}
+	if len(tokens) == 0 {
+		return false, nil
+	}
+
+	replaceFn := func(current interface{}) (interface{}, error) {
+		return typedReplacement(current, rule)
+	}
+
+	_, changed, err := walk(obj, tokens, replaceFn)
+	return changed, err
+}
+
+// ruleMatchesKind reports whether a rule should be considered for an object with
+// the given kind. rule.Kind == "" or "*" matches all kinds.
+// A kind of "FooList" also matches a rule with Kind == "Foo".
+func ruleMatchesKind(rule *config.RedactionRule, kind string) bool {
+	rk := rule.Kind
+	if rk == "" || rk == "*" {
+		return true
+	}
+	return kind == rk || kind == rk+"List"
+}
+
+// ApplyRules applies all matching redaction rules to obj, which is a fully
+// JSON-decoded resource object (map[string]interface{}). It handles both
+// individual resource objects and list responses (items[]).
+// Returns true if any field was modified.
+func ApplyRules(obj map[string]interface{}, rules []config.RedactionRule) (bool, error) {
+	if len(rules) == 0 {
+		return false, nil
+	}
+
+	kind := extractString(obj, "kind")
+	namespace := extractNestedString(obj, "metadata", "namespace")
+	isList := strings.HasSuffix(kind, "List")
+
+	modified := false
+
+	for i := range rules {
+		rule := &rules[i]
+
+		if !ruleMatchesKind(rule, kind) {
+			continue
+		}
+
+		// For list objects, apply rule to each matching item in items[].
+		if isList {
+			itemsVal, ok := obj["items"]
+			if !ok {
+				continue
+			}
+			items, ok := itemsVal.([]interface{})
+			if !ok {
+				continue
+			}
+			for j, item := range items {
+				itemMap, ok := item.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				// Namespace scoping on individual items
+				if rule.Namespace != "" {
+					itemNS := extractNestedString(itemMap, "metadata", "namespace")
+					if itemNS != rule.Namespace {
+						continue
+					}
+				}
+				changed, err := applyRuleToObj(itemMap, rule)
+				if err != nil {
+					return false, fmt.Errorf("applying rule %q to list item %d: %w", rule.FieldPath, j, err)
+				}
+				if changed {
+					items[j] = itemMap
+					modified = true
+				}
+			}
+			if modified {
+				obj["items"] = items
+			}
+			continue
+		}
+
+		// Direct object: check namespace scoping
+		if rule.Namespace != "" && namespace != "" && namespace != rule.Namespace {
+			continue
+		}
+
+		changed, err := applyRuleToObj(obj, rule)
+		if err != nil {
+			return false, fmt.Errorf("applying rule %q: %w", rule.FieldPath, err)
+		}
+		if changed {
+			modified = true
+		}
+	}
+
+	return modified, nil
+}

--- a/internal/redact/fields.go
+++ b/internal/redact/fields.go
@@ -206,9 +206,7 @@ func schemaTypeForPath(kind, fieldPath string) (string, bool) {
 	if kind == "" {
 		return "", false
 	}
-	if strings.HasSuffix(kind, "List") {
-		kind = strings.TrimSuffix(kind, "List")
-	}
+	kind = strings.TrimSuffix(kind, "List")
 	root, ok := schemaKindTypes[kind]
 	if !ok {
 		return "", false

--- a/internal/redact/fields.go
+++ b/internal/redact/fields.go
@@ -2,8 +2,14 @@ package redact
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/phenixblue/k8shark/internal/config"
 )
@@ -22,6 +28,23 @@ type pathToken struct {
 	kind  tokenKind
 	key   string // tokenKey only
 	index int    // tokenIndex only
+}
+
+var schemaKindTypes = map[string]reflect.Type{
+	"Pod":                   reflect.TypeOf(corev1.Pod{}),
+	"Deployment":            reflect.TypeOf(appsv1.Deployment{}),
+	"DaemonSet":             reflect.TypeOf(appsv1.DaemonSet{}),
+	"StatefulSet":           reflect.TypeOf(appsv1.StatefulSet{}),
+	"ReplicaSet":            reflect.TypeOf(appsv1.ReplicaSet{}),
+	"Job":                   reflect.TypeOf(batchv1.Job{}),
+	"CronJob":               reflect.TypeOf(batchv1.CronJob{}),
+	"ConfigMap":             reflect.TypeOf(corev1.ConfigMap{}),
+	"Secret":                reflect.TypeOf(corev1.Secret{}),
+	"Service":               reflect.TypeOf(corev1.Service{}),
+	"Namespace":             reflect.TypeOf(corev1.Namespace{}),
+	"Node":                  reflect.TypeOf(corev1.Node{}),
+	"PersistentVolume":      reflect.TypeOf(corev1.PersistentVolume{}),
+	"PersistentVolumeClaim": reflect.TypeOf(corev1.PersistentVolumeClaim{}),
 }
 
 // tokenizePath converts a field path string into a slice of pathTokens.
@@ -134,12 +157,112 @@ func convertReplacement(replacement, valueType string) (interface{}, error) {
 	}
 }
 
+func jsonTypeFromReflect(t reflect.Type) (string, bool) {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	switch t.Kind() {
+	case reflect.String:
+		return "string", true
+	case reflect.Bool:
+		return "bool", true
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return "integer", true
+	case reflect.Float32, reflect.Float64:
+		return "number", true
+	case reflect.Slice, reflect.Array:
+		return "array", true
+	case reflect.Struct, reflect.Map:
+		return "object", true
+	default:
+		return "", false
+	}
+}
+
+func fieldByJSONName(t reflect.Type, name string) (reflect.Type, bool) {
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		jsonTag := f.Tag.Get("json")
+		if jsonTag == "-" {
+			continue
+		}
+		tagName := strings.Split(jsonTag, ",")[0]
+		if tagName == "" {
+			tagName = f.Name
+		}
+		if tagName == name {
+			return f.Type, true
+		}
+	}
+	return nil, false
+}
+
+func schemaTypeForPath(kind, fieldPath string) (string, bool) {
+	if kind == "" {
+		return "", false
+	}
+	if strings.HasSuffix(kind, "List") {
+		kind = strings.TrimSuffix(kind, "List")
+	}
+	root, ok := schemaKindTypes[kind]
+	if !ok {
+		return "", false
+	}
+
+	tokens, err := tokenizePath(fieldPath)
+	if err != nil || len(tokens) == 0 {
+		return "", false
+	}
+
+	t := root
+	for i := range tokens {
+		tok := tokens[i]
+		for t.Kind() == reflect.Pointer {
+			t = t.Elem()
+		}
+
+		switch tok.kind {
+		case tokenRecursive:
+			return "", false
+		case tokenWildcard, tokenIndex:
+			if t.Kind() != reflect.Slice && t.Kind() != reflect.Array {
+				return "", false
+			}
+			t = t.Elem()
+		case tokenKey:
+			switch t.Kind() {
+			case reflect.Struct:
+				next, ok := fieldByJSONName(t, tok.key)
+				if !ok {
+					return "", false
+				}
+				t = next
+			case reflect.Map:
+				t = t.Elem()
+			default:
+				return "", false
+			}
+		}
+	}
+
+	return jsonTypeFromReflect(t)
+}
+
 // typedReplacement returns the typed replacement value for a given rule and the
 // current field value.
-func typedReplacement(current interface{}, rule *config.RedactionRule) (interface{}, error) {
+func typedReplacement(current interface{}, kind, fieldPath string, rule *config.RedactionRule) (interface{}, error) {
 	t := rule.ValueType
 	if t == "" {
-		t = inferType(current)
+		if schemaType, ok := schemaTypeForPath(kind, fieldPath); ok {
+			t = schemaType
+		} else {
+			t = inferType(current)
+		}
 	}
 	return convertReplacement(rule.Replacement, t)
 }
@@ -275,9 +398,47 @@ func extractNestedString(m map[string]interface{}, key1, key2 string) string {
 	return s
 }
 
+func extractNestedLabels(m map[string]interface{}) map[string]string {
+	v, ok := m["metadata"]
+	if !ok {
+		return nil
+	}
+	meta, ok := v.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	lv, ok := meta["labels"]
+	if !ok {
+		return nil
+	}
+	lm, ok := lv.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, len(lm))
+	for k, raw := range lm {
+		s, ok := raw.(string)
+		if ok {
+			out[k] = s
+		}
+	}
+	return out
+}
+
+func ruleMatchesLabels(rule *config.RedactionRule, labelsMap map[string]string) (bool, error) {
+	if strings.TrimSpace(rule.LabelSelector) == "" {
+		return true, nil
+	}
+	sel, err := labels.Parse(rule.LabelSelector)
+	if err != nil {
+		return false, fmt.Errorf("invalid labelSelector %q: %w", rule.LabelSelector, err)
+	}
+	return sel.Matches(labels.Set(labelsMap)), nil
+}
+
 // applyRuleToObj applies a single redaction rule to a decoded JSON object (one
 // resource, not a list). Returns true if any modification was made.
-func applyRuleToObj(obj map[string]interface{}, rule *config.RedactionRule) (bool, error) {
+func applyRuleToObj(obj map[string]interface{}, kind string, rule *config.RedactionRule) (bool, error) {
 	tokens, err := tokenizePath(rule.FieldPath)
 	if err != nil {
 		return false, fmt.Errorf("parsing field path %q: %w", rule.FieldPath, err)
@@ -287,7 +448,7 @@ func applyRuleToObj(obj map[string]interface{}, rule *config.RedactionRule) (boo
 	}
 
 	replaceFn := func(current interface{}) (interface{}, error) {
-		return typedReplacement(current, rule)
+		return typedReplacement(current, kind, rule.FieldPath, rule)
 	}
 
 	_, changed, err := walk(obj, tokens, replaceFn)
@@ -342,6 +503,10 @@ func ApplyRules(obj map[string]interface{}, rules []config.RedactionRule) (bool,
 				if !ok {
 					continue
 				}
+				itemKind := extractString(itemMap, "kind")
+				if itemKind == "" {
+					itemKind = strings.TrimSuffix(kind, "List")
+				}
 				// Namespace scoping on individual items
 				if rule.Namespace != "" {
 					itemNS := extractNestedString(itemMap, "metadata", "namespace")
@@ -349,7 +514,14 @@ func ApplyRules(obj map[string]interface{}, rules []config.RedactionRule) (bool,
 						continue
 					}
 				}
-				changed, err := applyRuleToObj(itemMap, rule)
+				labelsMatch, err := ruleMatchesLabels(rule, extractNestedLabels(itemMap))
+				if err != nil {
+					return false, err
+				}
+				if !labelsMatch {
+					continue
+				}
+				changed, err := applyRuleToObj(itemMap, itemKind, rule)
 				if err != nil {
 					return false, fmt.Errorf("applying rule %q to list item %d: %w", rule.FieldPath, j, err)
 				}
@@ -369,7 +541,15 @@ func ApplyRules(obj map[string]interface{}, rules []config.RedactionRule) (bool,
 			continue
 		}
 
-		changed, err := applyRuleToObj(obj, rule)
+		labelsMatch, err := ruleMatchesLabels(rule, extractNestedLabels(obj))
+		if err != nil {
+			return false, err
+		}
+		if !labelsMatch {
+			continue
+		}
+
+		changed, err := applyRuleToObj(obj, kind, rule)
 		if err != nil {
 			return false, fmt.Errorf("applying rule %q: %w", rule.FieldPath, err)
 		}

--- a/internal/redact/fields_test.go
+++ b/internal/redact/fields_test.go
@@ -1,0 +1,486 @@
+package redact
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/config"
+)
+
+// helper: decode JSON into map[string]interface{}
+func mustDecode(t *testing.T, s string) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		t.Fatalf("mustDecode: %v", err)
+	}
+	return m
+}
+
+// helper: extract a nested string value for test assertions
+func getNestedString(t *testing.T, obj map[string]interface{}, keys ...string) string {
+	t.Helper()
+	var cur interface{} = obj
+	for _, k := range keys {
+		m, ok := cur.(map[string]interface{})
+		if !ok {
+			t.Fatalf("getNestedString: expected map at key %q, got %T", k, cur)
+		}
+		cur = m[k]
+	}
+	s, ok := cur.(string)
+	if !ok {
+		t.Fatalf("getNestedString: expected string at %v, got %T (%v)", keys, cur, cur)
+	}
+	return s
+}
+
+// ─── tokenizePath ────────────────────────────────────────────────────────────
+
+func TestTokenizePath_SimpleKeys(t *testing.T) {
+	tokens, err := tokenizePath("spec.template.metadata")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tokens) != 3 {
+		t.Fatalf("expected 3 tokens, got %d", len(tokens))
+	}
+	for i, want := range []string{"spec", "template", "metadata"} {
+		if tokens[i].kind != tokenKey || tokens[i].key != want {
+			t.Errorf("token[%d]: want key %q, got %+v", i, want, tokens[i])
+		}
+	}
+}
+
+func TestTokenizePath_ArrayWildcard(t *testing.T) {
+	tokens, err := tokenizePath("spec.containers[*].env[*].value")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantKinds := []tokenKind{tokenKey, tokenKey, tokenWildcard, tokenKey, tokenWildcard, tokenKey}
+	if len(tokens) != len(wantKinds) {
+		t.Fatalf("expected %d tokens, got %d: %+v", len(wantKinds), len(tokens), tokens)
+	}
+	for i, wk := range wantKinds {
+		if tokens[i].kind != wk {
+			t.Errorf("token[%d]: want kind %d, got %d", i, wk, tokens[i].kind)
+		}
+	}
+}
+
+func TestTokenizePath_RecursiveDescent(t *testing.T) {
+	tokens, err := tokenizePath("**.password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tokens) != 2 {
+		t.Fatalf("expected 2 tokens, got %d: %+v", len(tokens), tokens)
+	}
+	if tokens[0].kind != tokenRecursive {
+		t.Errorf("token[0]: want recursive, got %d", tokens[0].kind)
+	}
+	if tokens[1].kind != tokenKey || tokens[1].key != "password" {
+		t.Errorf("token[1]: want key 'password', got %+v", tokens[1])
+	}
+}
+
+func TestTokenizePath_NumericIndex(t *testing.T) {
+	tokens, err := tokenizePath("items[0].name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tokens) != 3 {
+		t.Fatalf("expected 3 tokens: %+v", tokens)
+	}
+	if tokens[1].kind != tokenIndex || tokens[1].index != 0 {
+		t.Errorf("expected index token with index=0, got %+v", tokens[1])
+	}
+}
+
+// ─── typedReplacement / convertReplacement ────────────────────────────────────
+
+func TestTypedReplacement_StringDefault(t *testing.T) {
+	rule := &config.RedactionRule{Replacement: "REDACTED"}
+	got, err := typedReplacement("original", rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "REDACTED" {
+		t.Errorf("want REDACTED, got %v", got)
+	}
+}
+
+func TestTypedReplacement_NumberInference(t *testing.T) {
+	rule := &config.RedactionRule{Replacement: "0"}
+	got, err := typedReplacement(float64(42), rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != float64(0) {
+		t.Errorf("want 0.0, got %v (%T)", got, got)
+	}
+}
+
+func TestTypedReplacement_BoolInference(t *testing.T) {
+	rule := &config.RedactionRule{Replacement: "false"}
+	got, err := typedReplacement(true, rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != false {
+		t.Errorf("want false, got %v", got)
+	}
+}
+
+func TestTypedReplacement_ExplicitIntegerHint(t *testing.T) {
+	rule := &config.RedactionRule{Replacement: "99", ValueType: "integer"}
+	got, err := typedReplacement("ignored", rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != float64(99) {
+		t.Errorf("want 99.0, got %v", got)
+	}
+}
+
+func TestTypedReplacement_ExplicitBoolHint(t *testing.T) {
+	rule := &config.RedactionRule{Replacement: "False", ValueType: "bool"}
+	got, err := typedReplacement("ignored", rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != false {
+		t.Errorf("want false, got %v", got)
+	}
+}
+
+func TestTypedReplacement_ArrayHint(t *testing.T) {
+	rule := &config.RedactionRule{Replacement: "ignored", ValueType: "array"}
+	got, err := typedReplacement([]interface{}{"a", "b"}, rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	arr, ok := got.([]interface{})
+	if !ok || len(arr) != 0 {
+		t.Errorf("expected empty array, got %v", got)
+	}
+}
+
+func TestTypedReplacement_InvalidIntHint(t *testing.T) {
+	rule := &config.RedactionRule{Replacement: "not-a-number", ValueType: "integer"}
+	_, err := typedReplacement("x", rule)
+	if err == nil {
+		t.Error("expected error for non-numeric replacement with integer hint")
+	}
+}
+
+// ─── applyRuleToObj ──────────────────────────────────────────────────────────
+
+func TestApplyRule_ExactPath(t *testing.T) {
+	obj := mustDecode(t, `{"data":{"api-key":"secret123"}}`)
+	rule := &config.RedactionRule{FieldPath: "data.api-key", Replacement: "REDACTED"}
+	changed, err := applyRuleToObj(obj, rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected change")
+	}
+	if got := getNestedString(t, obj, "data", "api-key"); got != "REDACTED" {
+		t.Errorf("want REDACTED, got %q", got)
+	}
+}
+
+func TestApplyRule_ArrayWildcard(t *testing.T) {
+	obj := mustDecode(t, `{
+		"spec": {
+			"containers": [
+				{"env": [{"name":"FOO","value":"secret1"},{"name":"BAR","value":"secret2"}]},
+				{"env": [{"name":"BAZ","value":"secret3"}]}
+			]
+		}
+	}`)
+	rule := &config.RedactionRule{
+		FieldPath:   "spec.containers[*].env[*].value",
+		Replacement: "REDACTED",
+	}
+	changed, err := applyRuleToObj(obj, rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected change")
+	}
+	// Check all three env values were redacted
+	spec := obj["spec"].(map[string]interface{})
+	containers := spec["containers"].([]interface{})
+	for ci, c := range containers {
+		cm := c.(map[string]interface{})
+		envs := cm["env"].([]interface{})
+		for ei, e := range envs {
+			em := e.(map[string]interface{})
+			if em["value"] != "REDACTED" {
+				t.Errorf("containers[%d].env[%d].value not redacted: %v", ci, ei, em["value"])
+			}
+		}
+	}
+}
+
+func TestApplyRule_RecursiveDescent(t *testing.T) {
+	obj := mustDecode(t, `{
+		"spec": {
+			"password": "top-secret",
+			"nested": {
+				"password": "also-secret",
+				"other": "keep-me"
+			}
+		}
+	}`)
+	rule := &config.RedactionRule{FieldPath: "**.password", Replacement: "REDACTED"}
+	changed, err := applyRuleToObj(obj, rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected change")
+	}
+	spec := obj["spec"].(map[string]interface{})
+	if spec["password"] != "REDACTED" {
+		t.Errorf("top-level password not redacted: %v", spec["password"])
+	}
+	nested := spec["nested"].(map[string]interface{})
+	if nested["password"] != "REDACTED" {
+		t.Errorf("nested password not redacted: %v", nested["password"])
+	}
+	if nested["other"] != "keep-me" {
+		t.Errorf("non-password field was modified: %v", nested["other"])
+	}
+}
+
+func TestApplyRule_NonExistentPath_NoChange(t *testing.T) {
+	obj := mustDecode(t, `{"spec":{"containers":[]}}`)
+	rule := &config.RedactionRule{FieldPath: "spec.nonexistent.field", Replacement: "REDACTED"}
+	changed, err := applyRuleToObj(obj, rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("expected no change for non-existent path")
+	}
+}
+
+func TestApplyRule_MaintainsNumberType(t *testing.T) {
+	obj := mustDecode(t, `{"spec":{"replicas":3}}`)
+	rule := &config.RedactionRule{FieldPath: "spec.replicas", Replacement: "0"}
+	changed, err := applyRuleToObj(obj, rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected change")
+	}
+	spec := obj["spec"].(map[string]interface{})
+	if spec["replicas"] != float64(0) {
+		t.Errorf("expected float64(0), got %v (%T)", spec["replicas"], spec["replicas"])
+	}
+}
+
+func TestApplyRule_MaintainsBoolType(t *testing.T) {
+	obj := mustDecode(t, `{"spec":{"automountServiceAccountToken":true}}`)
+	rule := &config.RedactionRule{FieldPath: "spec.automountServiceAccountToken", Replacement: "false"}
+	changed, err := applyRuleToObj(obj, rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected change")
+	}
+	spec := obj["spec"].(map[string]interface{})
+	if spec["automountServiceAccountToken"] != false {
+		t.Errorf("expected false, got %v", spec["automountServiceAccountToken"])
+	}
+}
+
+// ─── ApplyRules (kind/namespace scoping) ─────────────────────────────────────
+
+func TestApplyRules_KindScoping_Matches(t *testing.T) {
+	obj := mustDecode(t, `{
+		"kind":"ConfigMap",
+		"metadata":{"name":"app-config","namespace":"default"},
+		"data":{"api-key":"secret"}
+	}`)
+	rules := []config.RedactionRule{
+		{FieldPath: "data.api-key", Kind: "ConfigMap", Replacement: "REDACTED"},
+	}
+	changed, err := ApplyRules(obj, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected change")
+	}
+	data := obj["data"].(map[string]interface{})
+	if data["api-key"] != "REDACTED" {
+		t.Errorf("expected REDACTED, got %v", data["api-key"])
+	}
+}
+
+func TestApplyRules_KindScoping_NoMatch(t *testing.T) {
+	obj := mustDecode(t, `{
+		"kind":"Secret",
+		"metadata":{"name":"mysecret","namespace":"default"},
+		"data":{"api-key":"secret"}
+	}`)
+	rules := []config.RedactionRule{
+		{FieldPath: "data.api-key", Kind: "ConfigMap", Replacement: "REDACTED"},
+	}
+	changed, err := ApplyRules(obj, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("rule scoped to ConfigMap should not match Secret")
+	}
+}
+
+func TestApplyRules_WildcardKind_MatchesAll(t *testing.T) {
+	obj := mustDecode(t, `{
+		"kind":"Deployment",
+		"metadata":{"name":"app","namespace":"default"},
+		"spec":{"password":"hunter2"}
+	}`)
+	rules := []config.RedactionRule{
+		{FieldPath: "spec.password", Kind: "*", Replacement: "REDACTED"},
+	}
+	changed, err := ApplyRules(obj, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("wildcard kind should match Deployment")
+	}
+}
+
+func TestApplyRules_NamespaceScoping_Matches(t *testing.T) {
+	obj := mustDecode(t, `{
+		"kind":"ConfigMap",
+		"metadata":{"name":"app","namespace":"production"},
+		"data":{"api-key":"secret"}
+	}`)
+	rules := []config.RedactionRule{
+		{FieldPath: "data.api-key", Kind: "ConfigMap", Namespace: "production", Replacement: "REDACTED"},
+	}
+	changed, err := ApplyRules(obj, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected change for matching namespace")
+	}
+}
+
+func TestApplyRules_NamespaceScoping_NoMatch(t *testing.T) {
+	obj := mustDecode(t, `{
+		"kind":"ConfigMap",
+		"metadata":{"name":"app","namespace":"staging"},
+		"data":{"api-key":"secret"}
+	}`)
+	rules := []config.RedactionRule{
+		{FieldPath: "data.api-key", Kind: "ConfigMap", Namespace: "production", Replacement: "REDACTED"},
+	}
+	changed, err := ApplyRules(obj, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("rule scoped to production should not match staging namespace")
+	}
+}
+
+func TestApplyRules_ListResponse_RedactsItems(t *testing.T) {
+	obj := mustDecode(t, `{
+		"kind":"PodList",
+		"items":[
+			{
+				"kind":"Pod",
+				"metadata":{"name":"p1","namespace":"default"},
+				"spec":{"containers":[{"env":[{"name":"TOKEN","value":"secret1"}]}]}
+			},
+			{
+				"kind":"Pod",
+				"metadata":{"name":"p2","namespace":"default"},
+				"spec":{"containers":[{"env":[{"name":"TOKEN","value":"secret2"}]}]}
+			}
+		]
+	}`)
+	rules := []config.RedactionRule{
+		{
+			FieldPath:   "spec.containers[*].env[*].value",
+			Kind:        "Pod",
+			Replacement: "REDACTED",
+		},
+	}
+	changed, err := ApplyRules(obj, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected change for PodList items")
+	}
+	items := obj["items"].([]interface{})
+	for i, item := range items {
+		pod := item.(map[string]interface{})
+		spec := pod["spec"].(map[string]interface{})
+		containers := spec["containers"].([]interface{})
+		for _, c := range containers {
+			cm := c.(map[string]interface{})
+			envs := cm["env"].([]interface{})
+			for _, e := range envs {
+				em := e.(map[string]interface{})
+				if em["value"] != "REDACTED" {
+					t.Errorf("items[%d] env value not redacted: %v", i, em["value"])
+				}
+			}
+		}
+	}
+}
+
+func TestApplyRules_ListResponse_NamespaceScoping(t *testing.T) {
+	obj := mustDecode(t, `{
+		"kind":"ConfigMapList",
+		"items":[
+			{"kind":"ConfigMap","metadata":{"name":"cm1","namespace":"production"},"data":{"key":"secret"}},
+			{"kind":"ConfigMap","metadata":{"name":"cm2","namespace":"staging"},"data":{"key":"keep-me"}}
+		]
+	}`)
+	rules := []config.RedactionRule{
+		{FieldPath: "data.key", Kind: "ConfigMap", Namespace: "production", Replacement: "REDACTED"},
+	}
+	changed, err := ApplyRules(obj, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected change")
+	}
+	items := obj["items"].([]interface{})
+	cm1 := items[0].(map[string]interface{})["data"].(map[string]interface{})
+	cm2 := items[1].(map[string]interface{})["data"].(map[string]interface{})
+	if cm1["key"] != "REDACTED" {
+		t.Errorf("production cm not redacted: %v", cm1["key"])
+	}
+	if cm2["key"] != "keep-me" {
+		t.Errorf("staging cm should not be redacted: %v", cm2["key"])
+	}
+}
+
+func TestApplyRules_EmptyRules_NoChange(t *testing.T) {
+	obj := mustDecode(t, `{"kind":"Pod","data":{"key":"value"}}`)
+	changed, err := ApplyRules(obj, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("empty rules should produce no change")
+	}
+}

--- a/internal/redact/fields_test.go
+++ b/internal/redact/fields_test.go
@@ -101,7 +101,7 @@ func TestTokenizePath_NumericIndex(t *testing.T) {
 
 func TestTypedReplacement_StringDefault(t *testing.T) {
 	rule := &config.RedactionRule{Replacement: "REDACTED"}
-	got, err := typedReplacement("original", rule)
+	got, err := typedReplacement("original", "ConfigMap", "data.api-key", rule)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestTypedReplacement_StringDefault(t *testing.T) {
 
 func TestTypedReplacement_NumberInference(t *testing.T) {
 	rule := &config.RedactionRule{Replacement: "0"}
-	got, err := typedReplacement(float64(42), rule)
+	got, err := typedReplacement(float64(42), "Deployment", "spec.replicas", rule)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func TestTypedReplacement_NumberInference(t *testing.T) {
 
 func TestTypedReplacement_BoolInference(t *testing.T) {
 	rule := &config.RedactionRule{Replacement: "false"}
-	got, err := typedReplacement(true, rule)
+	got, err := typedReplacement(true, "Pod", "spec.automountServiceAccountToken", rule)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestTypedReplacement_BoolInference(t *testing.T) {
 
 func TestTypedReplacement_ExplicitIntegerHint(t *testing.T) {
 	rule := &config.RedactionRule{Replacement: "99", ValueType: "integer"}
-	got, err := typedReplacement("ignored", rule)
+	got, err := typedReplacement("ignored", "Deployment", "spec.replicas", rule)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func TestTypedReplacement_ExplicitIntegerHint(t *testing.T) {
 
 func TestTypedReplacement_ExplicitBoolHint(t *testing.T) {
 	rule := &config.RedactionRule{Replacement: "False", ValueType: "bool"}
-	got, err := typedReplacement("ignored", rule)
+	got, err := typedReplacement("ignored", "Pod", "spec.automountServiceAccountToken", rule)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestTypedReplacement_ExplicitBoolHint(t *testing.T) {
 
 func TestTypedReplacement_ArrayHint(t *testing.T) {
 	rule := &config.RedactionRule{Replacement: "ignored", ValueType: "array"}
-	got, err := typedReplacement([]interface{}{"a", "b"}, rule)
+	got, err := typedReplacement([]interface{}{"a", "b"}, "Pod", "spec.containers", rule)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,9 +168,17 @@ func TestTypedReplacement_ArrayHint(t *testing.T) {
 
 func TestTypedReplacement_InvalidIntHint(t *testing.T) {
 	rule := &config.RedactionRule{Replacement: "not-a-number", ValueType: "integer"}
-	_, err := typedReplacement("x", rule)
+	_, err := typedReplacement("x", "Deployment", "spec.replicas", rule)
 	if err == nil {
 		t.Error("expected error for non-numeric replacement with integer hint")
+	}
+}
+
+func TestTypedReplacement_UsesSchemaTypeBeforeRuntimeFallback(t *testing.T) {
+	rule := &config.RedactionRule{Replacement: "not-an-int"}
+	_, err := typedReplacement("string-runtime-value", "Deployment", "spec.replicas", rule)
+	if err == nil {
+		t.Fatal("expected schema-based integer validation error")
 	}
 }
 
@@ -179,7 +187,7 @@ func TestTypedReplacement_InvalidIntHint(t *testing.T) {
 func TestApplyRule_ExactPath(t *testing.T) {
 	obj := mustDecode(t, `{"data":{"api-key":"secret123"}}`)
 	rule := &config.RedactionRule{FieldPath: "data.api-key", Replacement: "REDACTED"}
-	changed, err := applyRuleToObj(obj, rule)
+	changed, err := applyRuleToObj(obj, "ConfigMap", rule)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +212,7 @@ func TestApplyRule_ArrayWildcard(t *testing.T) {
 		FieldPath:   "spec.containers[*].env[*].value",
 		Replacement: "REDACTED",
 	}
-	changed, err := applyRuleToObj(obj, rule)
+	changed, err := applyRuleToObj(obj, "Pod", rule)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,7 +245,7 @@ func TestApplyRule_RecursiveDescent(t *testing.T) {
 		}
 	}`)
 	rule := &config.RedactionRule{FieldPath: "**.password", Replacement: "REDACTED"}
-	changed, err := applyRuleToObj(obj, rule)
+	changed, err := applyRuleToObj(obj, "Pod", rule)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +268,7 @@ func TestApplyRule_RecursiveDescent(t *testing.T) {
 func TestApplyRule_NonExistentPath_NoChange(t *testing.T) {
 	obj := mustDecode(t, `{"spec":{"containers":[]}}`)
 	rule := &config.RedactionRule{FieldPath: "spec.nonexistent.field", Replacement: "REDACTED"}
-	changed, err := applyRuleToObj(obj, rule)
+	changed, err := applyRuleToObj(obj, "Pod", rule)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -272,7 +280,7 @@ func TestApplyRule_NonExistentPath_NoChange(t *testing.T) {
 func TestApplyRule_MaintainsNumberType(t *testing.T) {
 	obj := mustDecode(t, `{"spec":{"replicas":3}}`)
 	rule := &config.RedactionRule{FieldPath: "spec.replicas", Replacement: "0"}
-	changed, err := applyRuleToObj(obj, rule)
+	changed, err := applyRuleToObj(obj, "Deployment", rule)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +296,7 @@ func TestApplyRule_MaintainsNumberType(t *testing.T) {
 func TestApplyRule_MaintainsBoolType(t *testing.T) {
 	obj := mustDecode(t, `{"spec":{"automountServiceAccountToken":true}}`)
 	rule := &config.RedactionRule{FieldPath: "spec.automountServiceAccountToken", Replacement: "false"}
-	changed, err := applyRuleToObj(obj, rule)
+	changed, err := applyRuleToObj(obj, "Pod", rule)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -394,6 +402,87 @@ func TestApplyRules_NamespaceScoping_NoMatch(t *testing.T) {
 	}
 	if changed {
 		t.Error("rule scoped to production should not match staging namespace")
+	}
+}
+
+func TestApplyRules_LabelSelector_Matches(t *testing.T) {
+	obj := mustDecode(t, `{
+		"kind":"ConfigMap",
+		"metadata":{"name":"app","namespace":"production","labels":{"app":"sensitive","tier":"backend"}},
+		"data":{"api-key":"secret"}
+	}`)
+	rules := []config.RedactionRule{
+		{FieldPath: "data.api-key", Kind: "ConfigMap", LabelSelector: "app=sensitive,tier=backend", Replacement: "REDACTED"},
+	}
+	changed, err := ApplyRules(obj, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected rule match for label selector")
+	}
+	data := obj["data"].(map[string]interface{})
+	if data["api-key"] != "REDACTED" {
+		t.Errorf("expected REDACTED, got %v", data["api-key"])
+	}
+}
+
+func TestApplyRules_LabelSelector_NoMatch(t *testing.T) {
+	obj := mustDecode(t, `{
+		"kind":"ConfigMap",
+		"metadata":{"name":"app","namespace":"production","labels":{"app":"public"}},
+		"data":{"api-key":"secret"}
+	}`)
+	rules := []config.RedactionRule{
+		{FieldPath: "data.api-key", Kind: "ConfigMap", LabelSelector: "app=sensitive", Replacement: "REDACTED"},
+	}
+	changed, err := ApplyRules(obj, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("expected no rule match for non-matching label selector")
+	}
+}
+
+func TestApplyRules_LabelSelector_Invalid(t *testing.T) {
+	obj := mustDecode(t, `{
+		"kind":"ConfigMap",
+		"metadata":{"name":"app","namespace":"production","labels":{"app":"sensitive"}},
+		"data":{"api-key":"secret"}
+	}`)
+	rules := []config.RedactionRule{
+		{FieldPath: "data.api-key", Kind: "ConfigMap", LabelSelector: "app in (", Replacement: "REDACTED"},
+	}
+	_, err := ApplyRules(obj, rules)
+	if err == nil {
+		t.Fatal("expected parse error for invalid label selector")
+	}
+}
+
+func TestSchemaTypeForPath_KnownKinds(t *testing.T) {
+	typeName, ok := schemaTypeForPath("Deployment", "spec.replicas")
+	if !ok {
+		t.Fatal("expected schema type for Deployment.spec.replicas")
+	}
+	if typeName != "integer" {
+		t.Fatalf("expected integer, got %q", typeName)
+	}
+
+	typeName, ok = schemaTypeForPath("Pod", "spec.automountServiceAccountToken")
+	if !ok {
+		t.Fatal("expected schema type for Pod.spec.automountServiceAccountToken")
+	}
+	if typeName != "bool" {
+		t.Fatalf("expected bool, got %q", typeName)
+	}
+
+	typeName, ok = schemaTypeForPath("ConfigMap", "data.api-key")
+	if !ok {
+		t.Fatal("expected schema type for ConfigMap.data.api-key")
+	}
+	if typeName != "string" {
+		t.Fatalf("expected string, got %q", typeName)
 	}
 }
 

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -10,43 +10,62 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/config"
 )
 
 // redactedB64 is "REDACTED" base64-encoded.  Kubernetes Secret data values are
 // base64 strings, so we replace with another valid base64 string.
 var redactedB64 = base64.StdEncoding.EncodeToString([]byte("REDACTED"))
 
-// Archive reads srcPath, redacts all Secret records, and writes to dstPath.
-// allowList is a set of "namespace/name" keys whose data is preserved unchanged.
-func Archive(srcPath, dstPath string, allowList map[string]bool) (int, error) {
+// Options controls what Archive() redacts.
+type Options struct {
+	// RedactSecrets, when true, replaces all Kubernetes Secret data and
+	// stringData values with "REDACTED".
+	RedactSecrets bool
+	// AllowList is a set of "namespace/name" secret keys whose data is preserved
+	// even when RedactSecrets is true.
+	AllowList map[string]bool
+	// Rules is the list of field-level redaction rules to apply to every record.
+	Rules []config.RedactionRule
+}
+
+// Result reports how many redactions were performed.
+type Result struct {
+	SecretsRedacted int
+	FieldsRedacted  int
+}
+
+// Archive reads srcPath, applies redaction options, and writes to dstPath.
+// The original archive is not modified.
+func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	// Extract the source archive to a temp dir.
 	tmpDir, err := os.MkdirTemp("", "k8shark-redact-*")
 	if err != nil {
-		return 0, fmt.Errorf("creating temp dir: %w", err)
+		return Result{}, fmt.Errorf("creating temp dir: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
 
 	if err := archive.Open(srcPath, tmpDir); err != nil {
-		return 0, fmt.Errorf("opening archive: %w", err)
+		return Result{}, fmt.Errorf("opening archive: %w", err)
 	}
 
 	// Load metadata and index.
 	metaBytes, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "metadata.json"))
 	if err != nil {
-		return 0, fmt.Errorf("reading metadata: %w", err)
+		return Result{}, fmt.Errorf("reading metadata: %w", err)
 	}
 	var meta capture.CaptureMetadata
 	if err := json.Unmarshal(metaBytes, &meta); err != nil {
-		return 0, fmt.Errorf("parsing metadata: %w", err)
+		return Result{}, fmt.Errorf("parsing metadata: %w", err)
 	}
 
 	idxBytes, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "index.json"))
 	if err != nil {
-		return 0, fmt.Errorf("reading index: %w", err)
+		return Result{}, fmt.Errorf("reading index: %w", err)
 	}
 	var idx capture.Index
 	if err := json.Unmarshal(idxBytes, &idx); err != nil {
-		return 0, fmt.Errorf("parsing index: %w", err)
+		return Result{}, fmt.Errorf("parsing index: %w", err)
 	}
 
 	// Walk all records, collect unique IDs, and redact as needed.
@@ -58,34 +77,72 @@ func Archive(srcPath, dstPath string, allowList map[string]bool) (int, error) {
 	}
 
 	var records []*capture.Record
-	redactedCount := 0
+	result := Result{}
 
 	for id := range seen {
 		recPath := filepath.Join(tmpDir, "k8shark-capture", "records", id+".json")
 		data, err := os.ReadFile(recPath)
 		if err != nil {
-			return 0, fmt.Errorf("reading record %s: %w", id, err)
+			return Result{}, fmt.Errorf("reading record %s: %w", id, err)
 		}
 		var rec capture.Record
 		if err := json.Unmarshal(data, &rec); err != nil {
-			return 0, fmt.Errorf("parsing record %s: %w", id, err)
+			return Result{}, fmt.Errorf("parsing record %s: %w", id, err)
 		}
 
-		redacted, err := redactRecord(&rec, allowList)
-		if err != nil {
-			return 0, fmt.Errorf("redacting record %s: %w", id, err)
+		// Secret redaction pass
+		if opts.RedactSecrets {
+			secretsRedacted, err := redactRecord(&rec, opts.AllowList)
+			if err != nil {
+				return Result{}, fmt.Errorf("redacting record %s: %w", id, err)
+			}
+			if secretsRedacted {
+				result.SecretsRedacted++
+			}
 		}
-		if redacted {
-			redactedCount++
+
+		// Field-level redaction pass
+		if len(opts.Rules) > 0 {
+			fieldsRedacted, err := redactFieldsInRecord(&rec, opts.Rules)
+			if err != nil {
+				return Result{}, fmt.Errorf("field-redacting record %s: %w", id, err)
+			}
+			result.FieldsRedacted += fieldsRedacted
 		}
+
 		records = append(records, &rec)
 	}
 
 	if err := archive.Write(dstPath, &meta, records, idx); err != nil {
-		return 0, fmt.Errorf("writing redacted archive: %w", err)
+		return Result{}, fmt.Errorf("writing redacted archive: %w", err)
 	}
 
-	return redactedCount, nil
+	return result, nil
+}
+
+// redactFieldsInRecord applies field-level redaction rules to rec in-place.
+// Returns the count of fields modified.
+func redactFieldsInRecord(rec *capture.Record, rules []config.RedactionRule) (int, error) {
+	var obj map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+		// Not a JSON object (e.g. Table format) — skip.
+		return 0, nil
+	}
+
+	changed, err := ApplyRules(obj, rules)
+	if err != nil {
+		return 0, err
+	}
+	if !changed {
+		return 0, nil
+	}
+
+	newBody, err := json.Marshal(obj)
+	if err != nil {
+		return 0, fmt.Errorf("re-marshalling record: %w", err)
+	}
+	rec.ResponseBody = newBody
+	return 1, nil
 }
 
 // redactRecord modifies rec in-place if it contains Secret data.

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/config"
 )
 
 // buildTestArchive writes a minimal k8shark archive containing the given records
@@ -115,12 +116,12 @@ func TestRedact_SecretDataRedacted(t *testing.T) {
 	dst := src + "-redacted.tar.gz"
 	t.Cleanup(func() { os.Remove(dst) })
 
-	n, err := Archive(src, dst, nil)
+	result, err := Archive(src, dst, Options{RedactSecrets: true})
 	if err != nil {
 		t.Fatalf("Archive: %v", err)
 	}
-	if n != 1 {
-		t.Errorf("expected 1 redacted record, got %d", n)
+	if result.SecretsRedacted != 1 {
+		t.Errorf("expected 1 redacted record, got %d", result.SecretsRedacted)
 	}
 
 	// Verify the output archive has the value replaced.
@@ -154,7 +155,7 @@ func TestRedact_StringDataRedacted(t *testing.T) {
 	dst := src + "-redacted.tar.gz"
 	t.Cleanup(func() { os.Remove(dst) })
 
-	_, err := Archive(src, dst, nil)
+	_, err := Archive(src, dst, Options{RedactSecrets: true})
 	if err != nil {
 		t.Fatalf("Archive: %v", err)
 	}
@@ -187,12 +188,12 @@ func TestRedact_AllowList(t *testing.T) {
 	dst := src + "-redacted.tar.gz"
 	t.Cleanup(func() { os.Remove(dst) })
 
-	n, err := Archive(src, dst, map[string]bool{"default/allowed-secret": true})
+	result, err := Archive(src, dst, Options{RedactSecrets: true, AllowList: map[string]bool{"default/allowed-secret": true}})
 	if err != nil {
 		t.Fatalf("Archive: %v", err)
 	}
-	if n != 0 {
-		t.Errorf("expected 0 redacted records (all allowlisted), got %d", n)
+	if result.SecretsRedacted != 0 {
+		t.Errorf("expected 0 redacted records (all allowlisted), got %d", result.SecretsRedacted)
 	}
 
 	tmpDir := t.TempDir()
@@ -222,12 +223,12 @@ func TestRedact_NonSecretUnchanged(t *testing.T) {
 	dst := src + "-redacted.tar.gz"
 	t.Cleanup(func() { os.Remove(dst) })
 
-	n, err := Archive(src, dst, nil)
+	result, err := Archive(src, dst, Options{RedactSecrets: true})
 	if err != nil {
 		t.Fatalf("Archive: %v", err)
 	}
-	if n != 0 {
-		t.Errorf("expected 0 redacted (no secrets), got %d", n)
+	if result.SecretsRedacted != 0 {
+		t.Errorf("expected 0 redacted (no secrets), got %d", result.SecretsRedacted)
 	}
 }
 
@@ -245,12 +246,12 @@ func TestRedact_SecretListRedacted(t *testing.T) {
 	dst := src + "-redacted.tar.gz"
 	t.Cleanup(func() { os.Remove(dst) })
 
-	n, err := Archive(src, dst, nil)
+	result, err := Archive(src, dst, Options{RedactSecrets: true})
 	if err != nil {
 		t.Fatalf("Archive: %v", err)
 	}
-	if n != 1 {
-		t.Errorf("expected 1 redacted record, got %d", n)
+	if result.SecretsRedacted != 1 {
+		t.Errorf("expected 1 redacted record, got %d", result.SecretsRedacted)
 	}
 
 	tmpDir := t.TempDir()
@@ -295,12 +296,12 @@ func TestRedact_SecretList_AllowList(t *testing.T) {
 	dst := src + "-redacted.tar.gz"
 	t.Cleanup(func() { os.Remove(dst) })
 
-	n, err := Archive(src, dst, map[string]bool{"default/allowed-secret": true})
+	result, err := Archive(src, dst, Options{RedactSecrets: true, AllowList: map[string]bool{"default/allowed-secret": true}})
 	if err != nil {
 		t.Fatalf("Archive: %v", err)
 	}
-	if n != 0 {
-		t.Errorf("expected 0 redacted records (allowlisted), got %d", n)
+	if result.SecretsRedacted != 0 {
+		t.Errorf("expected 0 redacted records (allowlisted), got %d", result.SecretsRedacted)
 	}
 
 	tmpDir := t.TempDir()
@@ -327,5 +328,144 @@ func TestRedact_SecretList_AllowList(t *testing.T) {
 
 	if dataMap["key"] != encoded {
 		t.Errorf("expected original value preserved for allowlisted secret in list, got %q", dataMap["key"])
+	}
+}
+
+// ─── Archive() field-rule integration ────────────────────────────────────────
+
+func configMapRecord(id, ns, name string, data map[string]interface{}) *capture.Record {
+	obj := map[string]interface{}{
+		"kind":       "ConfigMapList",
+		"apiVersion": "v1",
+		"items": []interface{}{
+			map[string]interface{}{
+				"kind":       "ConfigMap",
+				"apiVersion": "v1",
+				"metadata":   map[string]interface{}{"name": name, "namespace": ns},
+				"data":       data,
+			},
+		},
+	}
+	body, _ := json.Marshal(obj)
+	return &capture.Record{
+		ID:           id,
+		APIPath:      "/api/v1/namespaces/" + ns + "/configmaps",
+		CapturedAt:   time.Now(),
+		ResponseCode: 200,
+		ResponseBody: body,
+	}
+}
+
+func TestArchive_FieldRules_RedactsConfigMapKey(t *testing.T) {
+	src := buildTestArchive(t, []*capture.Record{
+		configMapRecord("cm1", "default", "app-config", map[string]interface{}{"api-key": "super-secret"}),
+	})
+	dst := src + "-redacted.tar.gz"
+	t.Cleanup(func() { os.Remove(dst) })
+
+	result, err := Archive(src, dst, Options{
+		Rules: []config.RedactionRule{
+			{FieldPath: "data.api-key", Kind: "ConfigMap", Replacement: "REDACTED"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if result.FieldsRedacted != 1 {
+		t.Errorf("expected 1 field-redacted record, got %d", result.FieldsRedacted)
+	}
+
+	tmpDir := t.TempDir()
+	if err := archive.Open(dst, tmpDir); err != nil {
+		t.Fatalf("opening redacted archive: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "records", "cm1.json"))
+	if err != nil {
+		t.Fatalf("reading record: %v", err)
+	}
+	var rec capture.Record
+	_ = json.Unmarshal(data, &rec)
+	var obj map[string]json.RawMessage
+	_ = json.Unmarshal(rec.ResponseBody, &obj)
+	var items []json.RawMessage
+	_ = json.Unmarshal(obj["items"], &items)
+	if len(items) == 0 {
+		t.Fatal("expected items in ConfigMapList")
+	}
+	var itemObj map[string]json.RawMessage
+	_ = json.Unmarshal(items[0], &itemObj)
+	var dataMap map[string]string
+	_ = json.Unmarshal(itemObj["data"], &dataMap)
+	if dataMap["api-key"] != "REDACTED" {
+		t.Errorf("expected api-key=REDACTED, got %q", dataMap["api-key"])
+	}
+}
+
+func TestArchive_FieldRules_CombinedWithSecrets(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("db-pass"))
+	src := buildTestArchive(t, []*capture.Record{
+		secretRecord("s1", "default", "db-creds", map[string]string{"password": encoded}, nil),
+		configMapRecord("cm2", "default", "app-config", map[string]interface{}{"api-key": "my-key"}),
+	})
+	dst := src + "-redacted.tar.gz"
+	t.Cleanup(func() { os.Remove(dst) })
+
+	result, err := Archive(src, dst, Options{
+		RedactSecrets: true,
+		Rules: []config.RedactionRule{
+			{FieldPath: "data.api-key", Kind: "ConfigMap", Replacement: "REDACTED"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if result.SecretsRedacted != 1 {
+		t.Errorf("expected 1 secret redacted, got %d", result.SecretsRedacted)
+	}
+	if result.FieldsRedacted != 1 {
+		t.Errorf("expected 1 field-redacted record, got %d", result.FieldsRedacted)
+	}
+}
+
+func TestArchive_FieldRules_RecursiveDescent(t *testing.T) {
+	src := buildTestArchive(t, []*capture.Record{
+		configMapRecord("cm3", "default", "nested-config", map[string]interface{}{
+			"db.password":    "hunter2",
+			"cache.password": "letmein",
+			"safe-key":       "keep-me",
+		}),
+	})
+	dst := src + "-redacted.tar.gz"
+	t.Cleanup(func() { os.Remove(dst) })
+
+	_, err := Archive(src, dst, Options{
+		Rules: []config.RedactionRule{
+			{FieldPath: "**.password", Kind: "*", Replacement: "REDACTED"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	// "db.password" and "cache.password" are top-level keys with a dot in the name —
+	// they are NOT nested paths, so recursive descent won't match them unless
+	// we traverse their actual key names. This confirms only truly nested
+	// "password" keys (at any depth) are matched.  safe-key should be preserved.
+	tmpDir := t.TempDir()
+	if err := archive.Open(dst, tmpDir); err != nil {
+		t.Fatalf("opening redacted archive: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "records", "cm3.json"))
+	var rec capture.Record
+	_ = json.Unmarshal(data, &rec)
+	var obj map[string]json.RawMessage
+	_ = json.Unmarshal(rec.ResponseBody, &obj)
+	var items []json.RawMessage
+	_ = json.Unmarshal(obj["items"], &items)
+	var itemObj map[string]json.RawMessage
+	_ = json.Unmarshal(items[0], &itemObj)
+	var dataMap map[string]string
+	_ = json.Unmarshal(itemObj["data"], &dataMap)
+	if dataMap["safe-key"] != "keep-me" {
+		t.Errorf("safe-key should not be redacted, got %q", dataMap["safe-key"])
 	}
 }

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -659,7 +659,8 @@ REDACTED_SERVER_PID=""
 # all secrets (including app-secret) are redacted.
 redact_out=$("$BINARY" redact \
   --in "$CAPTURE_FILE" \
-  --out "$REDACTED_FILE" 2>&1) || true
+  --out "$REDACTED_FILE" \
+  --redact-secrets 2>&1) || true
 assert_contains "redact: success message present"       "$redact_out" "Redacted"
 assert_contains "redact: reported secrets redacted"     "$redact_out" "secret"
 if [[ -s "$REDACTED_FILE" ]]; then

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -449,6 +449,79 @@ if [[ -n "$INLINE_SERVER_PID" ]]; then
 fi
 rm -f "$INLINE_REDACTED_FILE" "$INLINE_SERVER_LOG"
 
+# ── Phase 6d: inline capture with --redact-field ─────────────────────────────
+log "Testing kshrk capture --redact-field (inline field-level redaction)"
+INLINE_FIELD_FILE="${CAPTURE_FILE%.tar.gz}-inline-field.tar.gz"
+INLINE_FIELD_SERVER_LOG="/tmp/k8shark-inline-field-server-$$.log"
+INLINE_FIELD_KC="/tmp/k8shark-inline-field-kc-$$.yaml"
+INLINE_FIELD_SERVER_PID=""
+
+# Capture with --redact-field targeting ConfigMap data.env; leave data.log-level
+# untouched so we can assert field-level selectivity.
+"$BINARY" --config "$CAPTURE_CONFIG" capture \
+  --redact-field "data.env:ConfigMap:REDACTED" \
+  --output "$INLINE_FIELD_FILE"
+
+if [[ -s "$INLINE_FIELD_FILE" ]]; then
+  pass "capture --redact-field: output archive created"
+else
+  fail "capture --redact-field: output archive missing or empty"
+fi
+
+"$BINARY" open "$INLINE_FIELD_FILE" --kubeconfig-out "$INLINE_FIELD_KC" \
+  >"$INLINE_FIELD_SERVER_LOG" 2>&1 &
+INLINE_FIELD_SERVER_PID=$!
+for i in $(seq 1 30); do
+  if [[ -s "$INLINE_FIELD_KC" ]]; then break; fi
+  sleep 0.5
+done
+
+if [[ ! -s "$INLINE_FIELD_KC" ]]; then
+  fail "capture --redact-field: mock server did not start within 15s"
+else
+  pass "capture --redact-field: mock server started"
+  for i in $(seq 1 20); do
+    if kubectl --kubeconfig "$INLINE_FIELD_KC" --request-timeout=2s \
+        get namespaces </dev/null &>/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+  done
+
+  # data.env should be replaced.
+  env_val=$(kubectl --kubeconfig "$INLINE_FIELD_KC" --request-timeout=10s \
+    get configmap app-config -n k8shark-test \
+    -o jsonpath='{.data.env}' 2>/dev/null || echo "")
+  assert_equals "capture --redact-field: data.env replaced with REDACTED" \
+    "$env_val" "REDACTED"
+
+  # data.log-level should be untouched (not covered by the rule).
+  loglevel_val=$(kubectl --kubeconfig "$INLINE_FIELD_KC" --request-timeout=10s \
+    get configmap app-config -n k8shark-test \
+    -o jsonpath='{.data.log-level}' 2>/dev/null || echo "")
+  assert_equals "capture --redact-field: data.log-level preserved (not in rule)" \
+    "$loglevel_val" "info"
+
+  # Secrets should NOT be redacted (no --redact-secrets flag used).
+  REDACTED_B64_INLINE="UkVEQUNURUQ="
+  app_val=$(kubectl --kubeconfig "$INLINE_FIELD_KC" --request-timeout=10s \
+    get secret app-secret -n k8shark-test \
+    -o jsonpath='{.data.db-password}' 2>/dev/null || echo "")
+  if [[ -n "$app_val" && "$app_val" != "$REDACTED_B64_INLINE" ]]; then
+    pass "capture --redact-field: secret data NOT redacted (no --redact-secrets)"
+  elif [[ -z "$app_val" ]]; then
+    info "capture --redact-field: could not read secret data (may be ok)"
+  else
+    fail "capture --redact-field: secret was unexpectedly redacted"
+  fi
+fi
+
+if [[ -n "$INLINE_FIELD_SERVER_PID" ]]; then
+  kill "$INLINE_FIELD_SERVER_PID" 2>/dev/null || true
+  wait "$INLINE_FIELD_SERVER_PID" 2>/dev/null || true
+fi
+rm -f "$INLINE_FIELD_FILE" "$INLINE_FIELD_SERVER_LOG" "$INLINE_FIELD_KC"
+
 # ── Phase 7: Start mock server ─────────────────────────────────────────────────
 log "Starting kshrk open (mock server)"
 "$BINARY" open "$CAPTURE_FILE" >"$SERVER_LOG" 2>&1 &
@@ -654,6 +727,199 @@ if [[ -n "$REDACTED_SERVER_PID" ]]; then
   wait "$REDACTED_SERVER_PID" 2>/dev/null || true
 fi
 rm -f "$REDACTED_FILE" "$REDACTED_SERVER_LOG" "$REDACTED_KC"
+
+# ── Phase 8d: kshrk redact --redact-field (CLI field-level redaction) ─────────
+log "Testing kshrk redact --redact-field (field-level redaction via CLI)"
+FIELD_REDACTED_FILE="${CAPTURE_FILE%.tar.gz}-field-redacted.tar.gz"
+FIELD_REDACTED_SERVER_LOG="/tmp/k8shark-field-redacted-server-$$.log"
+FIELD_REDACTED_KC="/tmp/k8shark-field-redacted-kc-$$.yaml"
+FIELD_REDACTED_SERVER_PID=""
+
+# Target only data.env in ConfigMaps; leave data.log-level and all secrets alone.
+field_redact_out=$("$BINARY" redact \
+  --in "$CAPTURE_FILE" \
+  --out "$FIELD_REDACTED_FILE" \
+  --redact-field "data.env:ConfigMap:REDACTED" \
+  2>&1) || true
+
+assert_contains "field-redact: success message present"   "$field_redact_out" "Redacted"
+assert_contains "field-redact: field count in output"     "$field_redact_out" "field"
+if [[ -s "$FIELD_REDACTED_FILE" ]]; then
+  pass "field-redact: output archive created"
+else
+  fail "field-redact: output archive missing or empty"
+fi
+
+FIELD_COUNT=$(echo "$field_redact_out" | grep -oE '[0-9]+[[:space:]]+field' \
+  | grep -oE '^[0-9]+' || echo "0")
+if [[ "$FIELD_COUNT" -gt 0 ]]; then
+  pass "field-redact: $FIELD_COUNT field(s) reported redacted"
+else
+  fail "field-redact: expected > 0 fields redacted, got 0"
+fi
+
+"$BINARY" open "$FIELD_REDACTED_FILE" --kubeconfig-out "$FIELD_REDACTED_KC" \
+  >"$FIELD_REDACTED_SERVER_LOG" 2>&1 &
+FIELD_REDACTED_SERVER_PID=$!
+for i in $(seq 1 30); do
+  if [[ -s "$FIELD_REDACTED_KC" ]]; then break; fi
+  sleep 0.5
+done
+
+if [[ ! -s "$FIELD_REDACTED_KC" ]]; then
+  fail "field-redact: mock server did not start within 15s"
+else
+  pass "field-redact: mock server started"
+  for i in $(seq 1 20); do
+    if kubectl --kubeconfig "$FIELD_REDACTED_KC" --request-timeout=2s \
+        get namespaces </dev/null &>/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+  done
+
+  # data.env should be overwritten by the rule.
+  env_val=$(kubectl --kubeconfig "$FIELD_REDACTED_KC" --request-timeout=10s \
+    get configmap app-config -n k8shark-test \
+    -o jsonpath='{.data.env}' 2>/dev/null || echo "")
+  assert_equals "field-redact: data.env replaced with REDACTED" "$env_val" "REDACTED"
+
+  # data.log-level is NOT in the rule and must remain intact.
+  loglevel_val=$(kubectl --kubeconfig "$FIELD_REDACTED_KC" --request-timeout=10s \
+    get configmap app-config -n k8shark-test \
+    -o jsonpath='{.data.log-level}' 2>/dev/null || echo "")
+  assert_equals "field-redact: data.log-level preserved (not in rule)" \
+    "$loglevel_val" "info"
+
+  # No --redact-secrets flag → secret data must NOT be redacted.
+  REDACTED_B64_FTEST="UkVEQUNURUQ="
+  secret_val=$(kubectl --kubeconfig "$FIELD_REDACTED_KC" --request-timeout=10s \
+    get secret app-secret -n k8shark-test \
+    -o jsonpath='{.data.db-password}' 2>/dev/null || echo "")
+  if [[ -n "$secret_val" && "$secret_val" != "$REDACTED_B64_FTEST" ]]; then
+    pass "field-redact: secret data NOT redacted (no --redact-secrets)"
+  elif [[ -z "$secret_val" ]]; then
+    info "field-redact: could not read secret data to verify"
+  else
+    fail "field-redact: secret was unexpectedly redacted"
+  fi
+fi
+
+if [[ -n "$FIELD_REDACTED_SERVER_PID" ]]; then
+  kill "$FIELD_REDACTED_SERVER_PID" 2>/dev/null || true
+  wait "$FIELD_REDACTED_SERVER_PID" 2>/dev/null || true
+fi
+rm -f "$FIELD_REDACTED_FILE" "$FIELD_REDACTED_SERVER_LOG" "$FIELD_REDACTED_KC"
+
+# ── Phase 8e: kshrk redact --config with redaction.rules ──────────────────────
+log "Testing kshrk redact --config (config-driven redaction.rules + redactSecrets)"
+CFGREDACT_FILE="${CAPTURE_FILE%.tar.gz}-cfgredact.tar.gz"
+CFGREDACT_CONFIG="/tmp/k8shark-cfgredact-$$.yaml"
+CFGREDACT_SERVER_LOG="/tmp/k8shark-cfgredact-server-$$.log"
+CFGREDACT_KC="/tmp/k8shark-cfgredact-kc-$$.yaml"
+CFGREDACT_SERVER_PID=""
+
+# Redact data.log-level in ConfigMaps (via rules), redact all secrets except
+# app-secret (which is allowlisted); leave data.env untouched.
+cat > "$CFGREDACT_CONFIG" <<YAML
+duration: 5m
+resources: []
+redaction:
+  redactSecrets: true
+  allowSecrets:
+    - k8shark-test/app-secret
+  rules:
+    - fieldPath: "data.log-level"
+      kind: ConfigMap
+      replacement: SANITIZED
+YAML
+pass "config-redact: redaction config written"
+
+cfg_redact_out=$("$BINARY" redact \
+  --in "$CAPTURE_FILE" \
+  --out "$CFGREDACT_FILE" \
+  --config "$CFGREDACT_CONFIG" \
+  2>&1) || true
+
+assert_contains "config-redact: success message present" "$cfg_redact_out" "Redacted"
+if [[ -s "$CFGREDACT_FILE" ]]; then
+  pass "config-redact: output archive created"
+else
+  fail "config-redact: output archive missing or empty"
+fi
+
+"$BINARY" open "$CFGREDACT_FILE" --kubeconfig-out "$CFGREDACT_KC" \
+  >"$CFGREDACT_SERVER_LOG" 2>&1 &
+CFGREDACT_SERVER_PID=$!
+for i in $(seq 1 30); do
+  if [[ -s "$CFGREDACT_KC" ]]; then break; fi
+  sleep 0.5
+done
+
+if [[ ! -s "$CFGREDACT_KC" ]]; then
+  fail "config-redact: mock server did not start within 15s"
+else
+  pass "config-redact: mock server started"
+  for i in $(seq 1 20); do
+    if kubectl --kubeconfig "$CFGREDACT_KC" --request-timeout=2s \
+        get namespaces </dev/null &>/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+  done
+
+  # data.log-level should be replaced by the config rule.
+  loglevel_val=$(kubectl --kubeconfig "$CFGREDACT_KC" --request-timeout=10s \
+    get configmap app-config -n k8shark-test \
+    -o jsonpath='{.data.log-level}' 2>/dev/null || echo "")
+  assert_equals "config-redact: data.log-level replaced via config rule" \
+    "$loglevel_val" "SANITIZED"
+
+  # data.env is NOT in the rules and must remain "production".
+  env_val=$(kubectl --kubeconfig "$CFGREDACT_KC" --request-timeout=10s \
+    get configmap app-config -n k8shark-test \
+    -o jsonpath='{.data.env}' 2>/dev/null || echo "")
+  assert_equals "config-redact: data.env preserved (not in rules)" \
+    "$env_val" "production"
+
+  # app-secret is allowlisted → its data must be preserved.
+  REDACTED_B64_CFG="UkVEQUNURUQ="
+  app_val=$(kubectl --kubeconfig "$CFGREDACT_KC" --request-timeout=10s \
+    get secret app-secret -n k8shark-test \
+    -o jsonpath='{.data.db-password}' 2>/dev/null || echo "")
+  if [[ -n "$app_val" && "$app_val" != "$REDACTED_B64_CFG" ]]; then
+    pass "config-redact: allowlisted app-secret data preserved"
+  elif [[ -z "$app_val" ]]; then
+    fail "config-redact: could not read app-secret data"
+  else
+    fail "config-redact: app-secret redacted despite allowSecrets in config"
+  fi
+
+  # A non-allowlisted secret (if any exists in k8shark-test) should be redacted.
+  other_secret=$(kubectl --kubeconfig "$CFGREDACT_KC" --request-timeout=10s \
+    get secrets -n k8shark-test -o name 2>/dev/null \
+    | grep -v "app-secret" | head -1 || echo "")
+  if [[ -n "$other_secret" ]]; then
+    other_data=$(kubectl --kubeconfig "$CFGREDACT_KC" --request-timeout=10s \
+      get "$other_secret" -n k8shark-test \
+      -o jsonpath='{range .data.*}{@}{"\n"}{end}' 2>/dev/null | head -1 || echo "")
+    if [[ "$other_data" == "$REDACTED_B64_CFG" ]]; then
+      pass "config-redact: non-allowlisted secret data redacted (redactSecrets: true)"
+    elif [[ -z "$other_data" ]]; then
+      info "config-redact: other secret had no data fields to verify"
+    else
+      fail "config-redact: non-allowlisted secret not redacted (got '$other_data')"
+    fi
+  else
+    info "config-redact: no other secrets in k8shark-test to verify redactSecrets"
+  fi
+fi
+
+if [[ -n "$CFGREDACT_SERVER_PID" ]]; then
+  kill "$CFGREDACT_SERVER_PID" 2>/dev/null || true
+  wait "$CFGREDACT_SERVER_PID" 2>/dev/null || true
+fi
+rm -f "$CFGREDACT_FILE" "$CFGREDACT_CONFIG" "$CFGREDACT_SERVER_LOG" "$CFGREDACT_KC"
 
 # ── Phase 8c: kubectl logs ────────────────────────────────────────────────────
 log "Testing kubectl logs via mock server"


### PR DESCRIPTION
## Summary
- add advanced field-level redaction rules via config and CLI
- add labelSelector rule scoping support
- add schema-first type inference with runtime fallback
- extend e2e coverage for inline and post-capture advanced redaction paths
- document redaction rule fields and inference behavior in config docs

## Validation
- make fmt
- go test ./...

## Notes
- This PR intentionally excludes standalone --policy support per current scope decision.

Closes #46