### PR TITLE
feat(#50): separate watch-event timeline from snapshots for replay reconstruction

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -15,7 +15,9 @@ import (
 // It decouples the engine from the specific output format (tar.gz vs NDJSON).
 type RecordSink interface {
 	WriteRecord(rec any) error
-	Finish(meta, index any) error
+	// Finish writes metadata.json, index.json, and (when watchIndex is non-nil)
+	// watch-index.json, then closes the archive.
+	Finish(meta, index, watchIndex any) error
 	RecordCount() int
 }
 
@@ -63,8 +65,9 @@ func (w *StreamWriter) WriteRecord(rec any) error {
 	return nil
 }
 
-// Finish writes metadata.json and index.json then closes the archive.
-func (w *StreamWriter) Finish(meta, index any) error {
+// Finish writes metadata.json, index.json, and (when watchIndex is non-nil)
+// watch-index.json, then closes the archive.
+func (w *StreamWriter) Finish(meta, index, watchIndex any) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if err := writeJSON(w.tw, "k8shark-capture/metadata.json", meta); err != nil {
@@ -72,6 +75,11 @@ func (w *StreamWriter) Finish(meta, index any) error {
 	}
 	if err := writeJSON(w.tw, "k8shark-capture/index.json", index); err != nil {
 		return err
+	}
+	if watchIndex != nil {
+		if err := writeJSON(w.tw, "k8shark-capture/watch-index.json", watchIndex); err != nil {
+			return err
+		}
 	}
 	if err := w.tw.Close(); err != nil {
 		return fmt.Errorf("closing tar: %w", err)
@@ -115,7 +123,7 @@ func (w *NDJSONWriter) WriteRecord(rec any) error {
 }
 
 // Finish is a no-op for NDJSONWriter.
-func (w *NDJSONWriter) Finish(_, _ any) error { return nil }
+func (w *NDJSONWriter) Finish(_, _, _ any) error { return nil }
 
 // RecordCount returns the number of records written so far.
 func (w *NDJSONWriter) RecordCount() int {

--- a/internal/archive/bench_test.go
+++ b/internal/archive/bench_test.go
@@ -38,7 +38,7 @@ func BenchmarkStreamWriter_WriteRecord(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	_ = w.Finish(nil, nil)
+	_ = w.Finish(nil, nil, nil)
 }
 
 // BenchmarkStreamWriter_RoundTrip measures the full write→finish→open cycle
@@ -59,7 +59,7 @@ func BenchmarkStreamWriter_RoundTrip(b *testing.B) {
 						b.Fatal(err)
 					}
 				}
-				if err := w.Finish(map[string]any{"capture_id": "bench"}, map[string]any{}); err != nil {
+				if err := w.Finish(map[string]any{"capture_id": "bench"}, map[string]any{}, nil); err != nil {
 					b.Fatal(err)
 				}
 				if err := Open(path, b.TempDir()); err != nil {

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -39,11 +39,14 @@ type Engine struct {
 	baseURL        string
 	mu             sync.Mutex
 	index          Index
+	watchIndex     WatchIndex
 	sink           archive.RecordSink // set by Run(); exposed for tests
 	discoveryCache map[string][]byte  // bodies saved by fetchDiscovery for autoDiscoverResources
 	lastHash       map[string][32]byte
 	dedupSkipped   int
 }
+
+const maxConcurrentWatchStreams = 256
 
 // NewEngine creates a capture Engine from validated config.
 func NewEngine(cfg *config.Config, verbose bool) (*Engine, error) {
@@ -73,6 +76,7 @@ func NewEngine(cfg *config.Config, verbose bool) (*Engine, error) {
 		httpClient:     httpClient,
 		baseURL:        restCfg.Host,
 		index:          make(Index),
+		watchIndex:     make(WatchIndex),
 		discoveryCache: make(map[string][]byte),
 		lastHash:       make(map[string][32]byte),
 	}, nil
@@ -87,6 +91,7 @@ func newEngineWith(cfg *config.Config, client *http.Client, baseURL string, verb
 		httpClient:     client,
 		baseURL:        baseURL,
 		index:          make(Index),
+		watchIndex:     make(WatchIndex),
 		discoveryCache: make(map[string][]byte),
 		lastHash:       make(map[string][32]byte),
 	}
@@ -144,6 +149,10 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 		return nil, err
 	}
 
+	if err := e.validateWatchConcurrency(); err != nil {
+		return nil, err
+	}
+
 	var wg sync.WaitGroup
 	for _, res := range e.cfg.Resources {
 		if res.All {
@@ -192,7 +201,7 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 		fmt.Fprintf(os.Stdout, "  captured %d records\n", e.sink.RecordCount())
 	}
 
-	if err := e.sink.Finish(meta, e.index); err != nil {
+	if err := e.sink.Finish(meta, e.index, e.watchIndex); err != nil {
 		return nil, err
 	}
 
@@ -352,11 +361,12 @@ func (e *Engine) streamWatch(ctx context.Context, apiPath, resourceVersion strin
 		}
 
 		e.mu.Lock()
-		if _, ok := e.index[apiPath]; !ok {
-			e.index[apiPath] = &IndexEntry{APIPath: apiPath}
+		if _, ok := e.watchIndex[apiPath]; !ok {
+			e.watchIndex[apiPath] = &WatchIndexEntry{APIPath: apiPath}
 		}
-		e.index[apiPath].RecordIDs = append(e.index[apiPath].RecordIDs, rec.ID)
-		e.index[apiPath].Times = append(e.index[apiPath].Times, rec.CapturedAt)
+		e.watchIndex[apiPath].RecordIDs = append(e.watchIndex[apiPath].RecordIDs, rec.ID)
+		e.watchIndex[apiPath].Times = append(e.watchIndex[apiPath].Times, rec.CapturedAt)
+		e.watchIndex[apiPath].EventTypes = append(e.watchIndex[apiPath].EventTypes, rec.EventType)
 		e.mu.Unlock()
 	}
 }
@@ -644,6 +654,29 @@ func hasAllDirective(resources []config.Resource) bool {
 		}
 	}
 	return false
+}
+
+func (e *Engine) validateWatchConcurrency() error {
+	watchStreams := 0
+	for _, r := range e.cfg.Resources {
+		if !r.Watch || r.All {
+			continue
+		}
+		if len(r.Namespaces) == 0 {
+			watchStreams++
+			continue
+		}
+		watchStreams += len(r.Namespaces)
+	}
+
+	if watchStreams > maxConcurrentWatchStreams {
+		return fmt.Errorf(
+			"capture config expands to %d concurrent watch streams (max %d); reduce watch usage, narrow namespaces, or avoid all=true with watch=true",
+			watchStreams,
+			maxConcurrentWatchStreams,
+		)
+	}
+	return nil
 }
 
 // fetchDiscovery captures the Kubernetes API discovery endpoints so the mock
@@ -963,7 +996,16 @@ func (e *Engine) expandWildcardNamespaces(ctx context.Context) error {
 	// Fetch the namespace list from the cluster.
 	nsBody, code := e.doFetch(ctx, "/api/v1/namespaces", "", true)
 	if code != http.StatusOK || nsBody == nil {
-		return fmt.Errorf("namespace discovery failed (HTTP %d): check cluster permissions", code)
+		if code == 0 {
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("namespace discovery failed: request cancelled before completion (try a longer --duration): %w", err)
+			}
+			return fmt.Errorf("namespace discovery failed (HTTP 0): request could not be completed; check kubeconfig/context and cluster connectivity")
+		}
+		if code == http.StatusForbidden {
+			return fmt.Errorf("namespace discovery failed (HTTP %d): check cluster permissions", code)
+		}
+		return fmt.Errorf("namespace discovery failed (HTTP %d): unable to list namespaces", code)
 	}
 	var nsList struct {
 		Items []struct {

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -36,7 +36,7 @@ func (s *sliceSink) WriteRecord(rec any) error {
 	s.mu.Unlock()
 	return nil
 }
-func (s *sliceSink) Finish(_, _ any) error { return nil }
+func (s *sliceSink) Finish(_, _, _ any) error { return nil }
 func (s *sliceSink) RecordCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -466,6 +466,91 @@ func TestExpandWildcard_DiscoveryFailure(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "namespace discovery failed") {
 		t.Errorf("expected 'namespace discovery failed' in error, got: %v", err)
+	}
+}
+
+func TestExpandWildcard_DiscoveryCancelledByDuration(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/namespaces":
+			// Ensure the run context times out before this response is returned.
+			time.Sleep(100 * time.Millisecond)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"kind":"NamespaceList","items":[]}`)
+		case "/version":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"kind":"List","items":[]}`)
+		}
+	}))
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw: "50ms",
+		Duration:    50 * time.Millisecond,
+		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Resources: []config.Resource{
+			{Version: "v1", Resource: "pods", Namespaces: []string{"*"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	_, err := eng.Run()
+	if err == nil {
+		t.Fatal("expected timeout/cancellation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "request cancelled before completion") {
+		t.Errorf("expected cancellation hint in error, got: %v", err)
+	}
+}
+
+func TestRun_FailsWhenWatchConcurrencyTooHigh(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+		case "/api":
+			fmt.Fprint(w, `{"versions":["v1"]}`)
+		case "/api/v1":
+			fmt.Fprint(w, `{"kind":"APIResourceList","resources":[]}`)
+		case "/apis":
+			fmt.Fprint(w, `{"kind":"APIGroupList","groups":[]}`)
+		case "/openapi/v2":
+			fmt.Fprint(w, `{}`)
+		case "/openapi/v3":
+			fmt.Fprint(w, `{"paths":{}}`)
+		default:
+			fmt.Fprint(w, `{"kind":"List","items":[]}`)
+		}
+	}))
+	defer srv.Close()
+
+	ns := make([]string, 0, maxConcurrentWatchStreams+1)
+	for i := 0; i < maxConcurrentWatchStreams+1; i++ {
+		ns = append(ns, fmt.Sprintf("ns-%d", i))
+	}
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw: "30s",
+		Duration:    30 * time.Second,
+		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Resources: []config.Resource{
+			{Version: "v1", Resource: "pods", Namespaces: ns, Watch: true, IntervalRaw: "30s", Interval: 30 * time.Second},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	_, err := eng.Run()
+	if err == nil {
+		t.Fatal("expected watch concurrency guard error, got nil")
+	}
+	if !strings.Contains(err.Error(), "concurrent watch streams") {
+		t.Fatalf("expected watch concurrency guard error, got: %v", err)
 	}
 }
 

--- a/internal/capture/record.go
+++ b/internal/capture/record.go
@@ -38,3 +38,18 @@ type IndexEntry struct {
 // Index is the top-level index.json written inside the archive.
 // Key is the canonical API path.
 type Index map[string]*IndexEntry
+
+// WatchIndexEntry maps an API path to the ordered watch events captured for it.
+// Each watch event is a separate record with event_type ADDED, MODIFIED, or DELETED.
+// EventTypes is kept in sync with RecordIDs and Times for fast filtering without
+// reading every record file.
+type WatchIndexEntry struct {
+	APIPath    string      `json:"api_path"`
+	RecordIDs  []string    `json:"record_ids"`
+	Times      []time.Time `json:"times"`
+	EventTypes []string    `json:"event_types"`
+}
+
+// WatchIndex is the top-level watch-index.json written inside the archive.
+// Key is the canonical API path. Only present in archives captured with watch: true.
+type WatchIndex map[string]*WatchIndexEntry

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+const minDiscoveryStartupDuration = 5 * time.Second
+
 // Resource describes a single Kubernetes resource type to capture.
 type Resource struct {
 	// All enables auto-discovery expansion for this resource entry. When true,
@@ -157,6 +159,14 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("no resources defined in config; add at least one entry under 'resources:' or set 'auto_discover: true'")
 	}
 
+	if c.requiresDiscoveryStartup() && c.Duration < minDiscoveryStartupDuration {
+		return fmt.Errorf(
+			"duration %q is too short when using discovery/wildcard capture; set duration >= %s or disable auto_discover, all=true, and namespaces ['*']",
+			c.DurationRaw,
+			minDiscoveryStartupDuration,
+		)
+	}
+
 	for i := range c.Resources {
 		r := &c.Resources[i]
 		if r.All {
@@ -197,6 +207,23 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+func (c *Config) requiresDiscoveryStartup() bool {
+	if c.AutoDiscover {
+		return true
+	}
+	for _, r := range c.Resources {
+		if r.All {
+			return true
+		}
+		for _, ns := range r.Namespaces {
+			if ns == "*" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // knownClusterScoped is the set of well-known cluster-scoped resource kinds.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -202,6 +202,56 @@ func TestValidate_AllDirective_InvalidScope(t *testing.T) {
 	}
 }
 
+func TestValidate_DiscoveryStartup_TooShortDuration_WithAllDirective(t *testing.T) {
+	cfg := &Config{
+		DurationRaw: "2s",
+		Output:      "/tmp/k8shark-test-out.tar.gz",
+		Resources: []Resource{{
+			All: true,
+		}},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected duration guard error, got nil")
+	}
+	if !contains(err.Error(), "duration") || !contains(err.Error(), "too short") {
+		t.Fatalf("expected short-duration guard error, got: %v", err)
+	}
+}
+
+func TestValidate_DiscoveryStartup_TooShortDuration_WithWildcardNamespaces(t *testing.T) {
+	cfg := &Config{
+		DurationRaw: "2s",
+		Output:      "/tmp/k8shark-test-out.tar.gz",
+		Resources: []Resource{{
+			Version:    "v1",
+			Resource:   "pods",
+			Namespaces: []string{"*"},
+		}},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected duration guard error, got nil")
+	}
+	if !contains(err.Error(), "duration") || !contains(err.Error(), "too short") {
+		t.Fatalf("expected short-duration guard error, got: %v", err)
+	}
+}
+
+func TestValidate_DiscoveryStartup_NormalResource_AllowsShortDuration(t *testing.T) {
+	cfg := &Config{
+		DurationRaw: "2s",
+		Output:      "/tmp/k8shark-test-out.tar.gz",
+		Resources: []Resource{{
+			Version:  "v1",
+			Resource: "pods",
+		}},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected short duration without discovery startup to validate, got: %v", err)
+	}
+}
+
 func TestRedactionConfig_ParsesCorrectly(t *testing.T) {
 	cfg := &Config{
 		DurationRaw: "5m",

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -282,7 +282,7 @@ func (h *handler) serveGroupResourceList(w http.ResponseWriter, path string) {
 }
 
 func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path string, at time.Time) {
-	body, code, err := h.store.Latest(path, at)
+	body, code, err := h.store.ReconstructAt(path, at)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, statusObj(500, err.Error()))
 		return
@@ -563,7 +563,7 @@ func (h *handler) trySingleItemGet(path string, at time.Time) ([]byte, int) {
 }
 
 func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path string, at time.Time) {
-	rawBody, code, err := h.store.Latest(strings.TrimSuffix(path, "/"), at)
+	rawBody, code, err := h.store.ReconstructAt(strings.TrimSuffix(path, "/"), at)
 	if err != nil || code != 200 {
 		h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q not found in capture", path))
 		return

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -239,10 +239,6 @@ func (s *CaptureStore) ReconstructAt(apiPath string, at time.Time) ([]byte, int,
 	}
 
 	// Build ordered key list and object map from snapshot items.
-	type itemEntry struct {
-		key string
-		raw json.RawMessage
-	}
 	itemOrder := make([]string, 0, len(snapList.Items))
 	items := make(map[string]json.RawMessage, len(snapList.Items))
 	for _, item := range snapList.Items {

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -17,6 +17,7 @@ type CaptureStore struct {
 	Dir          string
 	Metadata     capture.CaptureMetadata
 	Index        capture.Index
+	WatchIndex   capture.WatchIndex
 	resourceInfo map[string]*ResourceInfo
 }
 
@@ -54,8 +55,19 @@ func LoadStore(dir string) (*CaptureStore, error) {
 		Dir:          dir,
 		Metadata:     meta,
 		Index:        idx,
+		WatchIndex:   make(capture.WatchIndex),
 		resourceInfo: make(map[string]*ResourceInfo),
 	}
+
+	// Load watch-index.json if present. Older archives without it are treated
+	// as snapshot-only — this is the primary backward-compatibility mechanism.
+	if wiData, rerr := os.ReadFile(filepath.Join(dir, "k8shark-capture", "watch-index.json")); rerr == nil {
+		var wi capture.WatchIndex
+		if jerr := json.Unmarshal(wiData, &wi); jerr == nil && wi != nil {
+			s.WatchIndex = wi
+		}
+	}
+
 	s.buildResourceInfo()
 	return s, nil
 }
@@ -130,6 +142,180 @@ func (s *CaptureStore) Latest(apiPath string, at time.Time) ([]byte, int, error)
 		return nil, 500, fmt.Errorf("parsing record %s: %w", id, err)
 	}
 	return rec.ResponseBody, rec.ResponseCode, nil
+}
+
+// readRecord reads and parses a single capture.Record by ID from the archive.
+func (s *CaptureStore) readRecord(id string) (capture.Record, error) {
+	data, err := os.ReadFile(filepath.Join(s.Dir, "k8shark-capture", "records", id+".json"))
+	if err != nil {
+		return capture.Record{}, fmt.Errorf("reading record %s: %w", id, err)
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return capture.Record{}, fmt.Errorf("parsing record %s: %w", id, err)
+	}
+	return rec, nil
+}
+
+// SnapshotAt returns the body, HTTP code, and capture time of the most recent
+// snapshot record (i.e. non-watch-event record) for apiPath at or before at.
+// Returns (nil, 404, time.Time{}, nil) when no snapshot exists.
+func (s *CaptureStore) SnapshotAt(apiPath string, at time.Time) ([]byte, int, time.Time, error) {
+	entry, ok := s.Index[apiPath]
+	if !ok || len(entry.RecordIDs) == 0 {
+		return nil, 404, time.Time{}, nil
+	}
+
+	id := entry.RecordIDs[len(entry.RecordIDs)-1]
+	snapTime := entry.Times[len(entry.Times)-1]
+	if !at.IsZero() && len(entry.Times) == len(entry.RecordIDs) && len(entry.Times) > 0 {
+		idx := sort.Search(len(entry.Times), func(i int) bool {
+			return entry.Times[i].After(at)
+		})
+		if idx == 0 {
+			return nil, 404, time.Time{}, nil
+		}
+		id = entry.RecordIDs[idx-1]
+		snapTime = entry.Times[idx-1]
+	}
+
+	rec, err := s.readRecord(id)
+	if err != nil {
+		return nil, 500, time.Time{}, err
+	}
+	return rec.ResponseBody, rec.ResponseCode, snapTime, nil
+}
+
+// objectKey returns the stable identity key for a Kubernetes object JSON blob.
+// Namespaced objects use "namespace/name"; cluster-scoped use "name".
+func objectKey(raw json.RawMessage) string {
+	var meta struct {
+		Metadata struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return ""
+	}
+	if meta.Metadata.Namespace != "" {
+		return meta.Metadata.Namespace + "/" + meta.Metadata.Name
+	}
+	return meta.Metadata.Name
+}
+
+// ReconstructAt returns the reconstructed list body for apiPath at time T.
+// If a WatchIndex entry exists for the path, it applies ADDED/MODIFIED/DELETED
+// watch events from (snapshot_time, T] on top of the latest snapshot.
+// Falls back to Latest for paths without watch events.
+func (s *CaptureStore) ReconstructAt(apiPath string, at time.Time) ([]byte, int, error) {
+	wi, hasWatch := s.WatchIndex[apiPath]
+	if !hasWatch || len(wi.RecordIDs) == 0 {
+		// No watch events for this path — fall back to snapshot lookup.
+		body, code, err := s.Latest(apiPath, at)
+		return body, code, err
+	}
+
+	// Get the latest snapshot at or before T.
+	snapBody, snapCode, snapTime, err := s.SnapshotAt(apiPath, at)
+	if err != nil {
+		return nil, 500, err
+	}
+	if snapCode != 200 {
+		// No snapshot at all — can't reconstruct.
+		return nil, 404, nil
+	}
+
+	// Parse snapshot into an ordered item map (preserves insertion order).
+	var snapList struct {
+		APIVersion string            `json:"apiVersion"`
+		Kind       string            `json:"kind"`
+		Metadata   json.RawMessage   `json:"metadata"`
+		Items      []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(snapBody, &snapList); err != nil {
+		// Snapshot not a list body (e.g. single object) — fall through unchanged.
+		return snapBody, snapCode, nil
+	}
+
+	// Build ordered key list and object map from snapshot items.
+	type itemEntry struct {
+		key string
+		raw json.RawMessage
+	}
+	itemOrder := make([]string, 0, len(snapList.Items))
+	items := make(map[string]json.RawMessage, len(snapList.Items))
+	for _, item := range snapList.Items {
+		k := objectKey(item)
+		if k == "" {
+			continue
+		}
+		items[k] = item
+		itemOrder = append(itemOrder, k)
+	}
+
+	// Collect watch events from (snapTime, at] in index order.
+	for i, id := range wi.RecordIDs {
+		if i >= len(wi.Times) || i >= len(wi.EventTypes) {
+			break
+		}
+		evTime := wi.Times[i]
+		if evTime.IsZero() || !evTime.After(snapTime) {
+			continue
+		}
+		if !at.IsZero() && evTime.After(at) {
+			break
+		}
+
+		eventType := wi.EventTypes[i]
+		rec, rerr := s.readRecord(id)
+		if rerr != nil {
+			continue
+		}
+		k := objectKey(rec.ResponseBody)
+		if k == "" {
+			continue
+		}
+
+		switch eventType {
+		case "ADDED":
+			if _, exists := items[k]; !exists {
+				itemOrder = append(itemOrder, k)
+			}
+			items[k] = rec.ResponseBody
+		case "MODIFIED":
+			if _, exists := items[k]; !exists {
+				itemOrder = append(itemOrder, k)
+			}
+			items[k] = rec.ResponseBody
+		case "DELETED":
+			delete(items, k)
+		}
+	}
+
+	// Reconstruct ordered items list (skip deleted).
+	reconstructed := make([]json.RawMessage, 0, len(itemOrder))
+	seen := make(map[string]bool, len(itemOrder))
+	for _, k := range itemOrder {
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		if raw, ok := items[k]; ok {
+			reconstructed = append(reconstructed, raw)
+		}
+	}
+
+	out, err := json.Marshal(map[string]any{
+		"apiVersion": snapList.APIVersion,
+		"kind":       snapList.Kind,
+		"metadata":   snapList.Metadata,
+		"items":      reconstructed,
+	})
+	if err != nil {
+		return nil, 500, err
+	}
+	return out, 200, nil
 }
 
 // AggregateAcrossNamespaces aggregates list items from all namespaced paths

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -226,3 +226,258 @@ func TestStore_Latest_AtTimestamp(t *testing.T) {
 }
 
 func containsString(s, sub string) bool { return strings.Contains(s, sub) }
+
+// buildTestStoreWithWatch creates a CaptureStore with snapshot records in
+// index.json and watch event records in watch-index.json.
+func buildTestStoreWithWatch(t *testing.T, snapshots map[string]watchTestRecord, events []watchTestEvent) *CaptureStore {
+	t.Helper()
+	dir := t.TempDir()
+	recDir := filepath.Join(dir, "k8shark-capture", "records")
+	if err := os.MkdirAll(recDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	index := make(capture.Index)
+	watchIndex := make(capture.WatchIndex)
+
+	for apiPath, s := range snapshots {
+		rec := capture.Record{
+			ID:           s.id,
+			CapturedAt:   s.at,
+			APIPath:      apiPath,
+			HTTPMethod:   "GET",
+			ResponseCode: 200,
+			ResponseBody: json.RawMessage(s.body),
+		}
+		data, _ := json.Marshal(rec)
+		if err := os.WriteFile(filepath.Join(recDir, s.id+".json"), data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		index[apiPath] = &capture.IndexEntry{
+			APIPath:   apiPath,
+			RecordIDs: []string{s.id},
+			Times:     []time.Time{s.at},
+		}
+	}
+
+	for _, ev := range events {
+		rec := capture.Record{
+			ID:           ev.id,
+			CapturedAt:   ev.at,
+			APIPath:      ev.apiPath,
+			EventType:    ev.eventType,
+			HTTPMethod:   "GET",
+			ResponseCode: 200,
+			ResponseBody: json.RawMessage(ev.objectBody),
+		}
+		data, _ := json.Marshal(rec)
+		if err := os.WriteFile(filepath.Join(recDir, ev.id+".json"), data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		wi := watchIndex[ev.apiPath]
+		if wi == nil {
+			wi = &capture.WatchIndexEntry{APIPath: ev.apiPath}
+			watchIndex[ev.apiPath] = wi
+		}
+		wi.RecordIDs = append(wi.RecordIDs, ev.id)
+		wi.Times = append(wi.Times, ev.at)
+		wi.EventTypes = append(wi.EventTypes, ev.eventType)
+	}
+
+	metaJSON, _ := json.Marshal(capture.CaptureMetadata{
+		CaptureID: "test-watch-id", KubernetesVersion: "v1.29.0",
+		CapturedAt: time.Now().UTC().Add(-time.Minute), CapturedUntil: time.Now().UTC(),
+	})
+	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "metadata.json"), metaJSON, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idxJSON, _ := json.Marshal(index)
+	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "index.json"), idxJSON, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wiJSON, _ := json.Marshal(watchIndex)
+	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "watch-index.json"), wiJSON, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := LoadStore(dir)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	return store
+}
+
+type watchTestRecord struct {
+	id   string
+	at   time.Time
+	body string
+}
+type watchTestEvent struct {
+	id         string
+	apiPath    string
+	at         time.Time
+	eventType  string
+	objectBody string
+}
+
+func TestStore_ReconstructAt_NoWatchEvents_FallsBackToLatest(t *testing.T) {
+	snapBody := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/pods": []byte(snapBody),
+	})
+	body, code, err := store.ReconstructAt("/api/v1/namespaces/default/pods", time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if !containsString(string(body), "nginx") {
+		t.Errorf("expected nginx in result, got %s", string(body))
+	}
+}
+
+func TestStore_ReconstructAt_Added(t *testing.T) {
+	path := "/api/v1/namespaces/default/pods"
+	t0 := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(30 * time.Second)
+
+	snap := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
+	newPod := `{"metadata":{"name":"redis","namespace":"default"},"spec":{}}`
+
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{
+			path: {id: "snap-1", at: t0, body: snap},
+		},
+		[]watchTestEvent{
+			{id: "ev-1", apiPath: path, at: t1, eventType: "ADDED", objectBody: newPod},
+		},
+	)
+
+	body, code, err := store.ReconstructAt(path, t1.Add(time.Second))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if !containsString(string(body), "nginx") {
+		t.Errorf("expected nginx still present, got %s", string(body))
+	}
+	if !containsString(string(body), "redis") {
+		t.Errorf("expected redis added, got %s", string(body))
+	}
+}
+
+func TestStore_ReconstructAt_Modified(t *testing.T) {
+	path := "/api/v1/namespaces/default/pods"
+	t0 := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(30 * time.Second)
+
+	snap := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":{"name":"nginx","namespace":"default"},"status":{"phase":"Pending"}}]}`
+	modifiedPod := `{"metadata":{"name":"nginx","namespace":"default"},"status":{"phase":"Running"}}`
+
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{
+			path: {id: "snap-1", at: t0, body: snap},
+		},
+		[]watchTestEvent{
+			{id: "ev-1", apiPath: path, at: t1, eventType: "MODIFIED", objectBody: modifiedPod},
+		},
+	)
+
+	body, code, err := store.ReconstructAt(path, t1.Add(time.Second))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if containsString(string(body), "Pending") {
+		t.Errorf("Pending phase should have been replaced, got %s", string(body))
+	}
+	if !containsString(string(body), "Running") {
+		t.Errorf("expected Running phase after MODIFIED, got %s", string(body))
+	}
+}
+
+func TestStore_ReconstructAt_Deleted(t *testing.T) {
+	path := "/api/v1/namespaces/default/pods"
+	t0 := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(30 * time.Second)
+
+	snap := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":{"name":"nginx","namespace":"default"}},{"metadata":{"name":"redis","namespace":"default"}}]}`
+	deletedPod := `{"metadata":{"name":"nginx","namespace":"default"}}`
+
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{
+			path: {id: "snap-1", at: t0, body: snap},
+		},
+		[]watchTestEvent{
+			{id: "ev-1", apiPath: path, at: t1, eventType: "DELETED", objectBody: deletedPod},
+		},
+	)
+
+	body, code, err := store.ReconstructAt(path, t1.Add(time.Second))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if containsString(string(body), "nginx") {
+		t.Errorf("nginx should have been deleted, got %s", string(body))
+	}
+	if !containsString(string(body), "redis") {
+		t.Errorf("redis should still be present, got %s", string(body))
+	}
+}
+
+func TestStore_ReconstructAt_EventBeforeSnapshot_Ignored(t *testing.T) {
+	path := "/api/v1/namespaces/default/pods"
+	t0 := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
+	// Event is before the snapshot — should not be applied.
+	tBefore := t0.Add(-10 * time.Second)
+
+	snap := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
+	stalePod := `{"metadata":{"name":"ghost","namespace":"default"}}`
+
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{
+			path: {id: "snap-1", at: t0, body: snap},
+		},
+		[]watchTestEvent{
+			{id: "ev-1", apiPath: path, at: tBefore, eventType: "ADDED", objectBody: stalePod},
+		},
+	)
+
+	body, code, err := store.ReconstructAt(path, t0.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if containsString(string(body), "ghost") {
+		t.Errorf("event before snapshot should be ignored, got %s", string(body))
+	}
+}
+
+func TestStore_ReconstructAt_OldArchiveNoWatchIndex(t *testing.T) {
+	// Old archives without watch-index.json must load and serve correctly.
+	snapBody := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/pods": []byte(snapBody),
+	})
+	// WatchIndex should be empty (not nil).
+	if store.WatchIndex == nil {
+		t.Fatal("WatchIndex should be initialized to empty map, not nil")
+	}
+	body, code, err := store.ReconstructAt("/api/v1/namespaces/default/pods", time.Time{})
+	if err != nil || code != 200 {
+		t.Fatalf("old archive must serve via Latest fallback: code=%d err=%v", code, err)
+	}
+	if !containsString(string(body), "nginx") {
+		t.Errorf("expected nginx, got %s", string(body))
+	}
+}


### PR DESCRIPTION
## Summary
- separate watch events from snapshot timeline by introducing a dedicated `watch-index.json`
- keep snapshot index semantics intact for poll snapshots
- add replay reconstruction at time `T`: latest snapshot <= `T` + watch events in `(snapshot_time, T]`
- update handlers to serve reconstructed list state for GET and synthetic watch initial stream
- keep backward compatibility for old archives with no watch index

## Key Changes
- `internal/capture/record.go`
  - add `WatchIndexEntry` and `WatchIndex`
- `internal/capture/engine.go`
  - add `watchIndex` on engine
  - route watch records to `watchIndex` (not snapshot index)
  - write `watchIndex` via sink finish
- `internal/archive/archive.go`
  - extend `RecordSink.Finish(meta, index, watchIndex)`
  - write `k8shark-capture/watch-index.json` when provided
- `internal/server/store.go`
  - load optional `watch-index.json`
  - add `SnapshotAt` + `ReconstructAt`
  - reconstruct list state by object identity (`namespace/name` or `name`)
- `internal/server/handler.go`
  - use reconstruction path for resource serving and synthetic watch baseline

## Backward Compatibility
- archives without `watch-index.json` continue to work via fallback behavior

## Validation
- `go test ./...`
- `make fmt`
- `golangci-lint run` (v1.64.8, CI-pinned)

## Notes
- This is the core replay-model step for #50 and preserves old capture usability while enabling correct snapshot+event semantics going forward.