### PR TITLE
feat(#50): add kshrk transitions subcommand for detecting state changes

### DIFF
--- a/cmd/transitions.go
+++ b/cmd/transitions.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/transitions"
+	"github.com/spf13/cobra"
+)
+
+var transitionsCmd = &cobra.Command{
+	Use:   "transitions <capture.tar.gz>",
+	Short: "List resource state changes from a capture archive",
+	Long: `Reads a k8shark capture archive and reports ADDED, MODIFIED, and DELETED
+events for captured resources, without starting a replay server.
+
+For watch-enabled captures, events are read directly from the watch-event index.
+For poll-only captures, consecutive snapshots are diff'd to infer changes.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runTransitions,
+}
+
+func init() {
+	rootCmd.AddCommand(transitionsCmd)
+	transitionsCmd.Flags().String("resource", "", "filter by resource name fragment (e.g. pods, deployments)")
+	transitionsCmd.Flags().String("namespace", "", "filter by exact namespace")
+	transitionsCmd.Flags().String("name", "", "filter by exact object name")
+	transitionsCmd.Flags().String("since", "", "start of time window (RFC3339)")
+	transitionsCmd.Flags().String("until", "", "end of time window (RFC3339)")
+	transitionsCmd.Flags().Bool("diff", false, "show field diffs for MODIFIED events")
+	transitionsCmd.Flags().StringP("output", "o", "table", "output format: table or json")
+}
+
+func runTransitions(cmd *cobra.Command, args []string) error {
+	resource, _ := cmd.Flags().GetString("resource")
+	namespace, _ := cmd.Flags().GetString("namespace")
+	name, _ := cmd.Flags().GetString("name")
+	sinceStr, _ := cmd.Flags().GetString("since")
+	untilStr, _ := cmd.Flags().GetString("until")
+	showDiff, _ := cmd.Flags().GetBool("diff")
+	output, _ := cmd.Flags().GetString("output")
+
+	opts := transitions.FilterOpts{
+		Resource:  resource,
+		Namespace: namespace,
+		Name:      name,
+	}
+	if sinceStr != "" {
+		t, err := time.Parse(time.RFC3339, sinceStr)
+		if err != nil {
+			return fmt.Errorf("invalid --since %q: must be RFC3339", sinceStr)
+		}
+		opts.Since = t
+	}
+	if untilStr != "" {
+		t, err := time.Parse(time.RFC3339, untilStr)
+		if err != nil {
+			return fmt.Errorf("invalid --until %q: must be RFC3339", untilStr)
+		}
+		opts.Until = t
+	}
+
+	ts, err := transitions.LoadTransitions(args[0], opts)
+	if err != nil {
+		return err
+	}
+
+	switch strings.ToLower(output) {
+	case "json":
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(ts)
+	default:
+		return printTransitionTable(cmd, ts, showDiff)
+	}
+}
+
+func printTransitionTable(cmd *cobra.Command, ts []transitions.Transition, showDiff bool) error {
+	out := cmd.OutOrStdout()
+
+	if len(ts) == 0 {
+		fmt.Fprintln(out, "No transitions found.")
+		return nil
+	}
+
+	if !showDiff {
+		tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "TIME\tEVENT\tRESOURCE\tNAMESPACE\tNAME")
+		for _, t := range ts {
+			ns := t.Namespace
+			if ns == "" {
+				ns = "-"
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+				t.Time.UTC().Format(time.RFC3339),
+				t.EventType,
+				t.Resource,
+				ns,
+				t.Name,
+			)
+		}
+		return tw.Flush()
+	}
+
+	// Diff mode: one block per transition, with field diff for MODIFIED.
+	for _, t := range ts {
+		ns := t.Namespace
+		if ns == "" {
+			ns = "-"
+		}
+		header := fmt.Sprintf("%s  %-8s  %s/%s/%s",
+			t.Time.UTC().Format(time.RFC3339),
+			t.EventType,
+			t.Resource, ns, t.Name,
+		)
+		fmt.Fprintln(out, header)
+
+		if t.EventType == "MODIFIED" {
+			d, err := transitions.DiffJSON(t.Before, t.After)
+			if err == nil && d != "" {
+				fmt.Fprint(out, transitions.ColorizeDiff(d))
+			}
+		}
+	}
+	return nil
+}

--- a/internal/transitions/diff.go
+++ b/internal/transitions/diff.go
@@ -1,0 +1,61 @@
+package transitions
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+// DiffJSON returns a unified diff string comparing two JSON blobs.
+// Returns an empty string when the blobs are semantically equal or when
+// either is nil/empty.
+func DiffJSON(before, after json.RawMessage) (string, error) {
+	a := prettyJSON(before)
+	b := prettyJSON(after)
+	if a == b {
+		return "", nil
+	}
+	return difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:       difflib.SplitLines(a),
+		B:       difflib.SplitLines(b),
+		Context: 3,
+	})
+}
+
+// ColorizeDiff adds ANSI color codes to a unified diff string.
+// Lines starting with "-" are red; lines starting with "+" are green.
+func ColorizeDiff(in string) string {
+	const (
+		red   = "\x1b[31m"
+		green = "\x1b[32m"
+		reset = "\x1b[0m"
+	)
+	var out strings.Builder
+	for _, line := range difflib.SplitLines(in) {
+		switch {
+		case strings.HasPrefix(line, "---") || strings.HasPrefix(line, "+++"):
+			out.WriteString(line)
+		case strings.HasPrefix(line, "-"):
+			out.WriteString(red + line + reset)
+		case strings.HasPrefix(line, "+"):
+			out.WriteString(green + line + reset)
+		default:
+			out.WriteString(line)
+		}
+	}
+	return out.String()
+}
+
+func prettyJSON(body []byte) string {
+	if len(body) == 0 {
+		return "null\n"
+	}
+	var out bytes.Buffer
+	if err := json.Indent(&out, body, "", "  "); err == nil {
+		out.WriteByte('\n')
+		return out.String()
+	}
+	return string(body) + "\n"
+}

--- a/internal/transitions/transitions.go
+++ b/internal/transitions/transitions.go
@@ -1,0 +1,406 @@
+package transitions
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// Transition is a single state-change event for a Kubernetes object detected
+// from a capture archive.
+type Transition struct {
+	Time      time.Time       `json:"time"`
+	EventType string          `json:"event_type"` // ADDED, MODIFIED, or DELETED
+	APIPath   string          `json:"api_path"`
+	Group     string          `json:"group,omitempty"`
+	Version   string          `json:"version,omitempty"`
+	Resource  string          `json:"resource,omitempty"`
+	Namespace string          `json:"namespace,omitempty"`
+	Name      string          `json:"name"`
+	Before    json.RawMessage `json:"before,omitempty"` // prior body (MODIFIED, DELETED)
+	After     json.RawMessage `json:"after,omitempty"`  // new body  (ADDED,   MODIFIED)
+}
+
+// FilterOpts narrows which transitions are returned by LoadTransitions.
+type FilterOpts struct {
+	Resource  string    // substring match against the resource name (e.g. "pods")
+	Namespace string    // exact namespace match
+	Name      string    // exact object name match
+	Since     time.Time // inclusive lower bound on event time (zero = unbounded)
+	Until     time.Time // inclusive upper bound on event time (zero = unbounded)
+}
+
+// LoadTransitions opens archivePath, discovers all state-change events that
+// match opts, and returns them sorted by time.
+//
+// Detection modes:
+//   - Watch-enabled paths: events are read directly from watch-index.json
+//     (ADDED/MODIFIED/DELETED labels captured at watch-stream time).
+//   - Poll-only paths: consecutive snapshot pairs are diff'd by object identity
+//     to detect additions, modifications, and deletions.
+func LoadTransitions(archivePath string, opts FilterOpts) ([]Transition, error) {
+	tmpDir, err := os.MkdirTemp("", "k8shark-transitions-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err := archive.Open(archivePath, tmpDir); err != nil {
+		return nil, fmt.Errorf("opening archive: %w", err)
+	}
+
+	base := filepath.Join(tmpDir, "k8shark-capture")
+
+	idxData, err := os.ReadFile(filepath.Join(base, "index.json"))
+	if err != nil {
+		return nil, fmt.Errorf("reading index: %w", err)
+	}
+	var idx capture.Index
+	if err := json.Unmarshal(idxData, &idx); err != nil {
+		return nil, fmt.Errorf("parsing index: %w", err)
+	}
+
+	// Watch-index may be absent for older archives.
+	var wi capture.WatchIndex
+	if wiData, rerr := os.ReadFile(filepath.Join(base, "watch-index.json")); rerr == nil {
+		_ = json.Unmarshal(wiData, &wi)
+	}
+
+	var all []Transition
+
+	for apiPath, entry := range idx {
+		// Skip Table-format query parameters.
+		if strings.Contains(apiPath, "?") {
+			continue
+		}
+		g, v, r, ns := parseAPIPath(apiPath)
+		if r == "" {
+			continue
+		}
+		if !matchesResourceFilter(r, ns, opts) {
+			continue
+		}
+
+		if wiEntry, hasWatch := wi[apiPath]; hasWatch && len(wiEntry.RecordIDs) > 0 {
+			ts, err := watchTransitions(base, apiPath, wiEntry, g, v, r, ns, opts)
+			if err != nil {
+				return nil, err
+			}
+			all = append(all, ts...)
+		} else {
+			ts, err := pollTransitions(base, apiPath, entry, g, v, r, ns, opts)
+			if err != nil {
+				return nil, err
+			}
+			all = append(all, ts...)
+		}
+	}
+
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Time.Before(all[j].Time)
+	})
+
+	return all, nil
+}
+
+// watchTransitions emits transitions for a watch-captured API path by walking
+// the watch-index entries in chronological order. Per-object state is tracked
+// so that Before is populated accurately for MODIFIED and DELETED events.
+func watchTransitions(base, apiPath string, wi *capture.WatchIndexEntry, g, v, r, ns string, opts FilterOpts) ([]Transition, error) {
+	// lastState tracks the most recently seen body per object key so we can
+	// populate Before for MODIFIED and DELETED events.
+	lastState := make(map[string]json.RawMessage)
+
+	var out []Transition
+	for i, id := range wi.RecordIDs {
+		if i >= len(wi.Times) || i >= len(wi.EventTypes) {
+			break
+		}
+		evTime := wi.Times[i]
+		evType := wi.EventTypes[i]
+
+		// Events are stored in chronological order; once we exceed Until we stop.
+		if !opts.Until.IsZero() && evTime.After(opts.Until) {
+			break
+		}
+
+		rec, err := readRecord(base, id)
+		if err != nil {
+			// Tolerate individual record read failures.
+			continue
+		}
+
+		k := objectKey(rec.ResponseBody)
+		name := objectName(rec.ResponseBody)
+
+		shouldEmit := inWindow(evTime, opts.Since, opts.Until) &&
+			(opts.Name == "" || name == opts.Name)
+
+		if shouldEmit {
+			t := Transition{
+				Time:      evTime,
+				EventType: evType,
+				APIPath:   apiPath,
+				Group:     g,
+				Version:   v,
+				Resource:  r,
+				Namespace: ns,
+				Name:      name,
+			}
+			switch evType {
+			case "ADDED":
+				t.After = rec.ResponseBody
+			case "MODIFIED":
+				t.Before = lastState[k]
+				t.After = rec.ResponseBody
+			case "DELETED":
+				t.Before = lastState[k]
+			}
+			out = append(out, t)
+		}
+
+		// Update per-object state for future Before lookups.
+		if k != "" {
+			if evType == "DELETED" {
+				delete(lastState, k)
+			} else {
+				lastState[k] = rec.ResponseBody
+			}
+		}
+	}
+	return out, nil
+}
+
+// pollTransitions emits transitions for a poll-only API path by diffing
+// consecutive snapshot pairs. The transition timestamp is that of the newer
+// snapshot in each pair.
+func pollTransitions(base, apiPath string, entry *capture.IndexEntry, g, v, r, ns string, opts FilterOpts) ([]Transition, error) {
+	var out []Transition
+
+	var prevItems map[string]json.RawMessage
+	var prevOrder []string
+
+	for i, id := range entry.RecordIDs {
+		rec, err := readRecord(base, id)
+		if err != nil {
+			return nil, fmt.Errorf("reading record %s: %w", id, err)
+		}
+
+		var list struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		if jerr := json.Unmarshal(rec.ResponseBody, &list); jerr != nil || list.Items == nil {
+			// Not a list body; reset and skip.
+			prevItems = nil
+			prevOrder = nil
+			continue
+		}
+
+		currItems := make(map[string]json.RawMessage, len(list.Items))
+		currOrder := make([]string, 0, len(list.Items))
+		for _, item := range list.Items {
+			k := objectKey(item)
+			if k == "" {
+				continue
+			}
+			currItems[k] = item
+			currOrder = append(currOrder, k)
+		}
+
+		if prevItems != nil {
+			var snapTime time.Time
+			if i < len(entry.Times) {
+				snapTime = entry.Times[i]
+			}
+			if inWindow(snapTime, opts.Since, opts.Until) {
+				ts := diffItems(prevItems, prevOrder, currItems, currOrder,
+					snapTime, apiPath, g, v, r, ns, opts.Name)
+				out = append(out, ts...)
+			}
+		}
+
+		prevItems = currItems
+		prevOrder = currOrder
+	}
+	return out, nil
+}
+
+// diffItems compares two consecutive item sets and emits ADDED/MODIFIED/DELETED
+// transitions at the given timestamp.
+func diffItems(
+	prev map[string]json.RawMessage, prevOrder []string,
+	curr map[string]json.RawMessage, currOrder []string,
+	at time.Time, apiPath, g, v, r, ns, nameFilter string,
+) []Transition {
+	var out []Transition
+
+	// ADDED and MODIFIED: objects present in curr.
+	for _, k := range currOrder {
+		currBody := curr[k]
+		name := objectName(currBody)
+		if nameFilter != "" && name != nameFilter {
+			continue
+		}
+		if prevBody, existed := prev[k]; !existed {
+			out = append(out, Transition{
+				Time:      at,
+				EventType: "ADDED",
+				APIPath:   apiPath,
+				Group:     g,
+				Version:   v,
+				Resource:  r,
+				Namespace: ns,
+				Name:      name,
+				After:     currBody,
+			})
+		} else if !jsonEqual(prevBody, currBody) {
+			out = append(out, Transition{
+				Time:      at,
+				EventType: "MODIFIED",
+				APIPath:   apiPath,
+				Group:     g,
+				Version:   v,
+				Resource:  r,
+				Namespace: ns,
+				Name:      name,
+				Before:    prevBody,
+				After:     currBody,
+			})
+		}
+	}
+
+	// DELETED: objects present in prev but absent from curr.
+	for _, k := range prevOrder {
+		if _, exists := curr[k]; !exists {
+			name := objectName(prev[k])
+			if nameFilter != "" && name != nameFilter {
+				continue
+			}
+			out = append(out, Transition{
+				Time:      at,
+				EventType: "DELETED",
+				APIPath:   apiPath,
+				Group:     g,
+				Version:   v,
+				Resource:  r,
+				Namespace: ns,
+				Name:      name,
+				Before:    prev[k],
+			})
+		}
+	}
+	return out
+}
+
+// readRecord reads and parses a single capture.Record by ID from the archive.
+func readRecord(base, id string) (capture.Record, error) {
+	data, err := os.ReadFile(filepath.Join(base, "records", id+".json"))
+	if err != nil {
+		return capture.Record{}, fmt.Errorf("reading record %s: %w", id, err)
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return capture.Record{}, fmt.Errorf("parsing record %s: %w", id, err)
+	}
+	return rec, nil
+}
+
+// objectKey returns "namespace/name" for namespaced objects and "name" for
+// cluster-scoped objects. Returns "" if the body cannot be parsed.
+func objectKey(raw json.RawMessage) string {
+	var meta struct {
+		Metadata struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return ""
+	}
+	if meta.Metadata.Namespace != "" {
+		return meta.Metadata.Namespace + "/" + meta.Metadata.Name
+	}
+	return meta.Metadata.Name
+}
+
+// objectName returns only the name field from a Kubernetes object body.
+func objectName(raw json.RawMessage) string {
+	var meta struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+	_ = json.Unmarshal(raw, &meta)
+	return meta.Metadata.Name
+}
+
+// matchesResourceFilter returns true when the resource and namespace satisfy
+// the resource and namespace filters in opts.
+func matchesResourceFilter(resource, namespace string, opts FilterOpts) bool {
+	if opts.Resource != "" && !strings.Contains(resource, opts.Resource) {
+		return false
+	}
+	if opts.Namespace != "" && namespace != opts.Namespace {
+		return false
+	}
+	return true
+}
+
+// inWindow returns true when t is within the [since, until] range.
+// A zero value means "no bound".
+func inWindow(t, since, until time.Time) bool {
+	if !since.IsZero() && t.Before(since) {
+		return false
+	}
+	if !until.IsZero() && t.After(until) {
+		return false
+	}
+	return true
+}
+
+// parseAPIPath extracts group, version, resource, and namespace from a
+// canonical Kubernetes API path (/api/... or /apis/...).
+func parseAPIPath(path string) (group, version, resource, namespace string) {
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	switch {
+	case len(parts) >= 3 && parts[0] == "api":
+		version = parts[1]
+		if len(parts) == 3 {
+			resource = parts[2]
+		} else if len(parts) == 5 && parts[2] == "namespaces" {
+			namespace = parts[3]
+			resource = parts[4]
+		}
+	case len(parts) >= 4 && parts[0] == "apis":
+		group = parts[1]
+		version = parts[2]
+		if len(parts) == 4 {
+			resource = parts[3]
+		} else if len(parts) == 6 && parts[3] == "namespaces" {
+			namespace = parts[4]
+			resource = parts[5]
+		}
+	}
+	return
+}
+
+// jsonEqual reports whether two JSON blobs are semantically equivalent.
+func jsonEqual(a, b json.RawMessage) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	var av, bv any
+	if json.Unmarshal(a, &av) != nil || json.Unmarshal(b, &bv) != nil {
+		return string(a) == string(b)
+	}
+	aj, _ := json.Marshal(av)
+	bj, _ := json.Marshal(bv)
+	return string(aj) == string(bj)
+}

--- a/internal/transitions/transitions_test.go
+++ b/internal/transitions/transitions_test.go
@@ -1,0 +1,350 @@
+package transitions
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// ---- archive builder helpers ------------------------------------------------
+
+// buildPollArchive creates a tar.gz with consecutive snapshot records for a
+// single API path. Each body in bodies is a separate snapshot record, ordered
+// by their position in the slice (times start at t0 with 1-minute intervals).
+func buildPollArchive(t *testing.T, apiPath string, bodies []string) string {
+	t.Helper()
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "test.tar.gz")
+
+	t0 := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	idx := make(capture.Index)
+	var recs []*capture.Record
+
+	for i, body := range bodies {
+		id := fmt.Sprintf("snap-%d", i)
+		at := t0.Add(time.Duration(i) * time.Minute)
+		rec := &capture.Record{
+			ID:           id,
+			CapturedAt:   at,
+			APIPath:      apiPath,
+			HTTPMethod:   "GET",
+			ResponseCode: 200,
+			ResponseBody: json.RawMessage(body),
+		}
+		recs = append(recs, rec)
+
+		e := idx[apiPath]
+		if e == nil {
+			e = &capture.IndexEntry{APIPath: apiPath}
+			idx[apiPath] = e
+		}
+		e.RecordIDs = append(e.RecordIDs, id)
+		e.Times = append(e.Times, at)
+	}
+
+	meta := &capture.CaptureMetadata{
+		CaptureID:     "poll-test",
+		CapturedAt:    t0,
+		CapturedUntil: t0.Add(time.Duration(len(bodies)) * time.Minute),
+		RecordCount:   len(recs),
+	}
+	if err := archive.Write(outPath, meta, recs, idx); err != nil {
+		t.Fatalf("buildPollArchive: %v", err)
+	}
+	return outPath
+}
+
+// buildWatchArchive creates a tar.gz with a single snapshot record and watch
+// event records for the same API path.
+func buildWatchArchive(t *testing.T, apiPath, snapBody string, events []watchEvent) string {
+	t.Helper()
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "test.tar.gz")
+
+	t0 := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+
+	snapRec := &capture.Record{
+		ID:           "snap-0",
+		CapturedAt:   t0,
+		APIPath:      apiPath,
+		HTTPMethod:   "GET",
+		ResponseCode: 200,
+		ResponseBody: json.RawMessage(snapBody),
+	}
+
+	idx := capture.Index{
+		apiPath: {
+			APIPath:   apiPath,
+			RecordIDs: []string{snapRec.ID},
+			Times:     []time.Time{t0},
+		},
+	}
+
+	wi := make(capture.WatchIndex)
+	wiEntry := &capture.WatchIndexEntry{APIPath: apiPath}
+	wi[apiPath] = wiEntry
+
+	w, err := archive.NewStreamWriter(outPath)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	if err := w.WriteRecord(snapRec); err != nil {
+		t.Fatalf("WriteRecord(snap): %v", err)
+	}
+
+	for i, ev := range events {
+		id := fmt.Sprintf("watch-%d", i)
+		at := t0.Add(time.Duration(i+1) * time.Second * 5)
+		rec := &capture.Record{
+			ID:           id,
+			CapturedAt:   at,
+			APIPath:      apiPath,
+			EventType:    ev.eventType,
+			HTTPMethod:   "GET",
+			ResponseCode: 200,
+			ResponseBody: json.RawMessage(ev.body),
+		}
+		if err := w.WriteRecord(rec); err != nil {
+			t.Fatalf("WriteRecord(watch %d): %v", i, err)
+		}
+		wiEntry.RecordIDs = append(wiEntry.RecordIDs, id)
+		wiEntry.Times = append(wiEntry.Times, at)
+		wiEntry.EventTypes = append(wiEntry.EventTypes, ev.eventType)
+	}
+
+	meta := &capture.CaptureMetadata{
+		CaptureID:     "watch-test",
+		CapturedAt:    t0,
+		CapturedUntil: t0.Add(time.Minute),
+		RecordCount:   1 + len(events),
+	}
+	if err := w.Finish(meta, idx, wi); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	return outPath
+}
+
+type watchEvent struct {
+	eventType string
+	body      string
+}
+
+// ---- tests ------------------------------------------------------------------
+
+func TestPollTransitions_Added(t *testing.T) {
+	snap1 := `{"items":[]}`
+	snap2 := `{"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
+	archivePath := buildPollArchive(t, "/api/v1/namespaces/default/pods", []string{snap1, snap2})
+
+	ts, err := LoadTransitions(archivePath, FilterOpts{})
+	if err != nil {
+		t.Fatalf("LoadTransitions: %v", err)
+	}
+	if len(ts) != 1 {
+		t.Fatalf("expected 1 transition, got %d: %+v", len(ts), ts)
+	}
+	if ts[0].EventType != "ADDED" {
+		t.Errorf("expected ADDED, got %s", ts[0].EventType)
+	}
+	if ts[0].Name != "nginx" {
+		t.Errorf("expected name nginx, got %s", ts[0].Name)
+	}
+}
+
+func TestPollTransitions_Modified(t *testing.T) {
+	snap1 := `{"items":[{"metadata":{"name":"nginx","namespace":"default"},"status":{"phase":"Pending"}}]}`
+	snap2 := `{"items":[{"metadata":{"name":"nginx","namespace":"default"},"status":{"phase":"Running"}}]}`
+	archivePath := buildPollArchive(t, "/api/v1/namespaces/default/pods", []string{snap1, snap2})
+
+	ts, err := LoadTransitions(archivePath, FilterOpts{})
+	if err != nil {
+		t.Fatalf("LoadTransitions: %v", err)
+	}
+	if len(ts) != 1 {
+		t.Fatalf("expected 1 transition, got %d", len(ts))
+	}
+	if ts[0].EventType != "MODIFIED" {
+		t.Errorf("expected MODIFIED, got %s", ts[0].EventType)
+	}
+	if !strings.Contains(string(ts[0].Before), "Pending") {
+		t.Errorf("expected Before to contain Pending, got %s", ts[0].Before)
+	}
+	if !strings.Contains(string(ts[0].After), "Running") {
+		t.Errorf("expected After to contain Running, got %s", ts[0].After)
+	}
+}
+
+func TestPollTransitions_Deleted(t *testing.T) {
+	snap1 := `{"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
+	snap2 := `{"items":[]}`
+	archivePath := buildPollArchive(t, "/api/v1/namespaces/default/pods", []string{snap1, snap2})
+
+	ts, err := LoadTransitions(archivePath, FilterOpts{})
+	if err != nil {
+		t.Fatalf("LoadTransitions: %v", err)
+	}
+	if len(ts) != 1 {
+		t.Fatalf("expected 1 transition, got %d", len(ts))
+	}
+	if ts[0].EventType != "DELETED" {
+		t.Errorf("expected DELETED, got %s", ts[0].EventType)
+	}
+	if ts[0].Name != "nginx" {
+		t.Errorf("expected name nginx, got %s", ts[0].Name)
+	}
+}
+
+func TestPollTransitions_NoChange(t *testing.T) {
+	body := `{"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
+	archivePath := buildPollArchive(t, "/api/v1/namespaces/default/pods", []string{body, body})
+
+	ts, err := LoadTransitions(archivePath, FilterOpts{})
+	if err != nil {
+		t.Fatalf("LoadTransitions: %v", err)
+	}
+	if len(ts) != 0 {
+		t.Errorf("expected 0 transitions for identical snapshots, got %d", len(ts))
+	}
+}
+
+func TestWatchTransitions_Direct(t *testing.T) {
+	snap := `{"items":[]}`
+	events := []watchEvent{
+		{"ADDED", `{"metadata":{"name":"pod-a","namespace":"default"}}`},
+		{"MODIFIED", `{"metadata":{"name":"pod-a","namespace":"default"},"status":{"phase":"Running"}}`},
+		{"DELETED", `{"metadata":{"name":"pod-a","namespace":"default"}}`},
+	}
+	archivePath := buildWatchArchive(t, "/api/v1/namespaces/default/pods", snap, events)
+
+	ts, err := LoadTransitions(archivePath, FilterOpts{})
+	if err != nil {
+		t.Fatalf("LoadTransitions: %v", err)
+	}
+	if len(ts) != 3 {
+		t.Fatalf("expected 3 transitions, got %d: %+v", len(ts), ts)
+	}
+	if ts[0].EventType != "ADDED" {
+		t.Errorf("[0] expected ADDED, got %s", ts[0].EventType)
+	}
+	if ts[1].EventType != "MODIFIED" {
+		t.Errorf("[1] expected MODIFIED, got %s", ts[1].EventType)
+	}
+	// Before should be set to the ADDED state body.
+	if !strings.Contains(string(ts[1].Before), "pod-a") {
+		t.Errorf("[1].Before expected pod-a, got %s", ts[1].Before)
+	}
+	if ts[2].EventType != "DELETED" {
+		t.Errorf("[2] expected DELETED, got %s", ts[2].EventType)
+	}
+}
+
+func TestFilterByName(t *testing.T) {
+	snap1 := `{"items":[]}`
+	snap2 := `{"items":[{"metadata":{"name":"nginx","namespace":"default"}},{"metadata":{"name":"redis","namespace":"default"}}]}`
+	archivePath := buildPollArchive(t, "/api/v1/namespaces/default/pods", []string{snap1, snap2})
+
+	ts, err := LoadTransitions(archivePath, FilterOpts{Name: "nginx"})
+	if err != nil {
+		t.Fatalf("LoadTransitions: %v", err)
+	}
+	if len(ts) != 1 {
+		t.Fatalf("expected 1 transition, got %d", len(ts))
+	}
+	if ts[0].Name != "nginx" {
+		t.Errorf("expected nginx, got %s", ts[0].Name)
+	}
+}
+
+func TestFilterByResource(t *testing.T) {
+	snap1 := `{"items":[]}`
+	snap2 := `{"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
+	archive1 := buildPollArchive(t, "/api/v1/namespaces/default/pods", []string{snap1, snap2})
+
+	// Only match pods, not services.
+	ts, err := LoadTransitions(archive1, FilterOpts{Resource: "pods"})
+	if err != nil {
+		t.Fatalf("LoadTransitions: %v", err)
+	}
+	if len(ts) != 1 || ts[0].Resource != "pods" {
+		t.Errorf("expected 1 pod transition, got %d: %+v", len(ts), ts)
+	}
+
+	ts2, err := LoadTransitions(archive1, FilterOpts{Resource: "services"})
+	if err != nil {
+		t.Fatalf("LoadTransitions (services): %v", err)
+	}
+	if len(ts2) != 0 {
+		t.Errorf("expected 0 service transitions, got %d", len(ts2))
+	}
+}
+
+func TestFilterByTimeWindow(t *testing.T) {
+	snap1 := `{"items":[]}`
+	snap2 := `{"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
+	snap3 := `{"items":[{"metadata":{"name":"redis","namespace":"default"}},{"metadata":{"name":"nginx","namespace":"default"}}]}`
+	archivePath := buildPollArchive(t, "/api/v1/namespaces/default/pods", []string{snap1, snap2, snap3})
+
+	t0 := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	// snap2 at t0+1m, snap3 at t0+2m
+	// Use --since after snap2 timestamp → only snap3 change (redis ADDED) visible.
+	since := t0.Add(90 * time.Second)
+
+	ts, err := LoadTransitions(archivePath, FilterOpts{Since: since})
+	if err != nil {
+		t.Fatalf("LoadTransitions: %v", err)
+	}
+	if len(ts) != 1 {
+		t.Fatalf("expected 1 transition after window, got %d: %+v", len(ts), ts)
+	}
+	if ts[0].Name != "redis" {
+		t.Errorf("expected redis, got %s", ts[0].Name)
+	}
+}
+
+func TestDiffJSON_Changed(t *testing.T) {
+	before := json.RawMessage(`{"status":{"phase":"Pending"}}`)
+	after := json.RawMessage(`{"status":{"phase":"Running"}}`)
+
+	d, err := DiffJSON(before, after)
+	if err != nil {
+		t.Fatalf("DiffJSON: %v", err)
+	}
+	if d == "" {
+		t.Fatal("expected non-empty diff")
+	}
+	if !strings.Contains(d, "Pending") || !strings.Contains(d, "Running") {
+		t.Errorf("diff missing expected lines:\n%s", d)
+	}
+}
+
+func TestDiffJSON_Identical(t *testing.T) {
+	body := json.RawMessage(`{"status":{"phase":"Running"}}`)
+	d, err := DiffJSON(body, body)
+	if err != nil {
+		t.Fatalf("DiffJSON: %v", err)
+	}
+	if d != "" {
+		t.Errorf("expected empty diff for identical blobs, got:\n%s", d)
+	}
+}
+
+// Ensure archives without watch-index.json still work (backward compat).
+func TestLoadTransitions_OldArchiveNoWatchIndex(t *testing.T) {
+	body := `{"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
+	archivePath := buildPollArchive(t, "/api/v1/namespaces/default/pods", []string{body})
+
+	ts, err := LoadTransitions(archivePath, FilterOpts{})
+	if err != nil {
+		t.Fatalf("LoadTransitions: %v", err)
+	}
+	// Single snapshot → no pairs to diff → no transitions.
+	if len(ts) != 0 {
+		t.Errorf("expected 0 transitions from single snapshot, got %d", len(ts))
+	}
+}


### PR DESCRIPTION
- internal/transitions/transitions.go: LoadTransitions walks archive and
  emits ADDED/MODIFIED/DELETED transitions sorted by time
  - watch-enabled paths: events read directly from watch-index.json
  - poll-only paths: consecutive snapshot pairs diff'd by object identity
- internal/transitions/diff.go: DiffJSON and ColorizeDiff helpers
  using go-difflib for --diff flag rendering
- cmd/transitions.go: cobra subcommand with --resource, --namespace,
  --name, --since, --until, --diff, --output flags
  - table output (default): aligned tabwriter table
  - json output: JSON array of Transition objects
  - diff mode: one block per transition with unified diff for MODIFIED
- internal/transitions/transitions_test.go: 11 tests covering
  poll ADDED/MODIFIED/DELETED/no-change, watch pass-through, name/
  resource/time-window filters, DiffJSON, and backward compat
