### PR TITLE
feat(#50): UI extensions — timeline markers, object history, diff mode

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -516,7 +516,7 @@ func (h *handler) trySingleItemGet(path string, at time.Time) ([]byte, int) {
 	name := path[i+1:]
 	parentPath := path[:i]
 
-	body, code, err := h.store.Latest(parentPath, at)
+	body, code, err := h.store.ReconstructAt(parentPath, at)
 	if err != nil || code != 200 {
 		return nil, 404
 	}

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -221,21 +221,30 @@ func (s *CaptureStore) ReconstructAt(apiPath string, at time.Time) ([]byte, int,
 	if err != nil {
 		return nil, 500, err
 	}
-	if snapCode != 200 {
-		// No snapshot at all — can't reconstruct.
-		return nil, 404, nil
-	}
-
-	// Parse snapshot into an ordered item map (preserves insertion order).
 	var snapList struct {
 		APIVersion string            `json:"apiVersion"`
 		Kind       string            `json:"kind"`
 		Metadata   json.RawMessage   `json:"metadata"`
 		Items      []json.RawMessage `json:"items"`
 	}
-	if err := json.Unmarshal(snapBody, &snapList); err != nil {
-		// Snapshot not a list body (e.g. single object) — fall through unchanged.
-		return snapBody, snapCode, nil
+	if snapCode == 200 {
+		// Parse snapshot into an ordered item map (preserves insertion order).
+		if err := json.Unmarshal(snapBody, &snapList); err != nil {
+			// Snapshot not a list body (e.g. single object) — fall through unchanged.
+			return snapBody, snapCode, nil
+		}
+	} else {
+		group, version, resource, _ := parseAPIPath(apiPath)
+		if resource == "" {
+			return nil, 404, nil
+		}
+		if group == "" {
+			snapList.APIVersion = version
+		} else {
+			snapList.APIVersion = group + "/" + version
+		}
+		snapList.Kind = resourceToKind(resource) + "List"
+		snapList.Metadata = json.RawMessage(`{"resourceVersion":"0"}`)
 	}
 
 	// Build ordered key list and object map from snapshot items.
@@ -342,7 +351,7 @@ func (s *CaptureStore) AggregateAcrossNamespaces(clusterPath string, at time.Tim
 		if !strings.HasPrefix(indexPath, pathPrefix) || !strings.HasSuffix(indexPath, suffix) {
 			continue
 		}
-		body, code, err := s.Latest(indexPath, at)
+		body, code, err := s.ReconstructAt(indexPath, at)
 		if err != nil || code != 200 {
 			continue
 		}

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -369,6 +369,40 @@ func TestStore_ReconstructAt_Added(t *testing.T) {
 	}
 }
 
+func TestStore_ReconstructAt_WatchOnlyPath(t *testing.T) {
+	path := "/api/v1/namespaces/default/pods"
+	t0 := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(30 * time.Second)
+
+	newPod := `{"metadata":{"name":"redis","namespace":"default"},"spec":{}}`
+
+	store := buildTestStoreWithWatch(t, nil, []watchTestEvent{
+		{id: "ev-1", apiPath: path, at: t1, eventType: "ADDED", objectBody: newPod},
+	})
+
+	body, code, err := store.ReconstructAt(path, t0.Add(5*time.Second))
+	if err != nil {
+		t.Fatalf("unexpected error before event: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected 200 before event, got %d", code)
+	}
+	if containsString(string(body), "redis") {
+		t.Fatalf("did not expect redis before event, got %s", string(body))
+	}
+
+	body, code, err = store.ReconstructAt(path, t1.Add(time.Second))
+	if err != nil {
+		t.Fatalf("unexpected error after event: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected 200 after event, got %d", code)
+	}
+	if !containsString(string(body), "redis") {
+		t.Fatalf("expected redis after watch-only add, got %s", string(body))
+	}
+}
+
 func TestStore_ReconstructAt_Modified(t *testing.T) {
 	path := "/api/v1/namespaces/default/pods"
 	t0 := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -864,26 +864,14 @@ func (h *explorerHandler) findResourceBodyAt(path, name string, at time.Time) ([
 }
 
 func (h *explorerHandler) responseBodiesAt(path string, at time.Time) ([][]byte, bool) {
+	body, code, err := h.store.ReconstructAt(path, at)
+	if err == nil && code == http.StatusOK && len(body) > 0 {
+		return [][]byte{body}, true
+	}
+
 	entry, ok := h.store.Index[path]
 	if !ok || len(entry.RecordIDs) == 0 {
 		return nil, false
-	}
-
-	if !at.IsZero() {
-		index := -1
-		for i, t := range entry.Times {
-			if !t.After(at) {
-				index = i
-			}
-		}
-		if index < 0 {
-			return nil, false
-		}
-		body, ok := h.readRecordBody(entry.RecordIDs[index])
-		if !ok {
-			return nil, false
-		}
-		return [][]byte{body}, true
 	}
 
 	bodies := make([][]byte, 0, len(entry.RecordIDs))

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1237,6 +1237,7 @@ const indexHTML = `<!doctype html>
   <script>
     let treeData = null;
     let activeKinds = new Set();
+	let activeKindsInitialized = false;
     let selected = null;
     let activeTab = 'json';
 	let visibleNodes = [];
@@ -1663,7 +1664,10 @@ const indexHTML = `<!doctype html>
 				const kindsRaw = window.localStorage.getItem(storageKindsKey);
 				if (kindsRaw) {
 					const parsed = JSON.parse(kindsRaw);
-					if (Array.isArray(parsed)) activeKinds = new Set(parsed);
+					if (Array.isArray(parsed)) {
+						activeKinds = new Set(parsed);
+						activeKindsInitialized = true;
+					}
 				}
 			} catch (_) {}
 			try {
@@ -1717,7 +1721,7 @@ const indexHTML = `<!doctype html>
     }
 
     function kindEnabled(kind) {
-      return activeKinds.size === 0 || activeKinds.has(kind);
+		return !activeKindsInitialized || activeKinds.has(kind);
     }
 
 		function kindTone(kind) {
@@ -1777,9 +1781,22 @@ const indexHTML = `<!doctype html>
 			showDetail(nodeEl._node, nodeEl._crumbs);
 		}
 
+		function normalizeListPath(path) {
+			const raw = String(path || '');
+			return raw.split('?')[0];
+		}
+
+		function namespaceFromPath(path) {
+			const match = normalizeListPath(path).match(/\/namespaces\/([^/]+)\//);
+			return match ? match[1] : '';
+		}
+
 		function nodeIdentity(node) {
 			if (!node) return '';
-			return [node.list_path || '', node.kind || '', node.name || ''].join('|');
+			if ((node.kind || '') === 'Container') {
+				return ['container', normalizeListPath(node.list_path), node.name || ''].join('|');
+			}
+			return [namespaceFromPath(node.list_path), node.kind || '', node.name || ''].join('|');
 		}
 
 		function restoreSelectionByKey(nodeKey) {
@@ -1821,8 +1838,12 @@ const indexHTML = `<!doctype html>
 		}
 
     async function showDetail(node, crumbs) {
+			const previousKey = selected && selected.node ? nodeIdentity(selected.node) : '';
+			const nextKey = nodeIdentity(node);
       selected = { node, crumbs };
-      selectedHistoryEntry = null;
+			if (previousKey !== nextKey) {
+				selectedHistoryEntry = null;
+			}
       el.crumbs.textContent = crumbs.join(' / ');
       el.detailTitle.textContent = node.kind + ' ' + node.name;
 			el.detailBody.textContent = 'Loading detail...';
@@ -1881,18 +1902,29 @@ const indexHTML = `<!doctype html>
 				const nsNodes = [];
 
 			for (const w of (ns.workloads || [])) {
-          if (!kindEnabled(w.kind) || !nodeMatches(w, q)) continue;
+				const workloadVisible = kindEnabled(w.kind) && nodeMatches(w, q);
+				if (workloadVisible) {
 					nsNodes.push(mkNode(w, ['Cluster', ns.name, w.kind, w.name], 0, ''));
-          for (const p of (w.pods || [])) {
-            if (!kindEnabled(p.kind) || !nodeMatches(p, q)) continue;
-						nsNodes.push(mkNode(p, ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name], 1, ''));
-            for (const c of (p.containers || [])) {
-              const fake = {kind:'Container',name:c.name,status:'',age:'',labels:{},list_path:p.list_path};
-              if (!kindEnabled('Container') || !nodeMatches(fake, q)) continue;
-							nsNodes.push(mkNode(fake, ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name, 'Container', c.name], 2, ''));
-            }
-          }
-        }
+				}
+				for (const p of (w.pods || [])) {
+					const podVisible = kindEnabled(p.kind) && nodeMatches(p, q);
+					if (podVisible) {
+						const podCrumbs = workloadVisible
+							? ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name]
+							: ['Cluster', ns.name, 'Pod', p.name];
+						nsNodes.push(mkNode(p, podCrumbs, workloadVisible ? 1 : 0, ''));
+					}
+					for (const c of (p.containers || [])) {
+						const fake = {kind:'Container',name:c.name,status:'',age:'',labels:{},list_path:p.list_path};
+						if (!kindEnabled('Container') || !nodeMatches(fake, q)) continue;
+						const containerDepth = workloadVisible ? 2 : (podVisible ? 1 : 0);
+						const containerCrumbs = workloadVisible
+							? ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name, 'Container', c.name]
+							: ['Cluster', ns.name, 'Pod', p.name, 'Container', c.name];
+						nsNodes.push(mkNode(fake, containerCrumbs, containerDepth, ''));
+					}
+				}
+			}
 
 			for (const p of (ns.pods || [])) {
           if (!kindEnabled(p.kind) || !nodeMatches(p, q)) continue;
@@ -1958,8 +1990,9 @@ const indexHTML = `<!doctype html>
     }
 
     function renderToggles(kinds) {
-			if (activeKinds.size === 0) {
+			if (!activeKindsInitialized) {
 				activeKinds = new Set(kinds);
+				activeKindsInitialized = true;
 			} else {
 				const allowed = new Set(kinds);
 				activeKinds = new Set(Array.from(activeKinds).filter((k) => allowed.has(k)));
@@ -1986,6 +2019,7 @@ const indexHTML = `<!doctype html>
 		function setAllKinds(enabled) {
 			const inputs = el.toggles.querySelectorAll('input[type="checkbox"]');
 			for (const input of inputs) input.checked = enabled;
+			activeKindsInitialized = true;
 			if (enabled) {
 				const kinds = Array.from(inputs).map((input) => input.dataset.kind || '').filter(Boolean);
 				activeKinds = new Set(kinds);
@@ -2071,6 +2105,8 @@ const indexHTML = `<!doctype html>
 			el.historyPane.innerHTML = '<div class="history-empty">Loading history...</div>';
 			try {
 				const q = new URLSearchParams({name: node.name});
+				const ns = namespaceFromPath(node.list_path);
+				if (ns) q.set('namespace', ns);
 				if (node.kind) {
 					const res2kind = {Pod:'pods',Deployment:'deployments',StatefulSet:'statefulsets',DaemonSet:'daemonsets',Job:'jobs',ReplicaSet:'replicasets',Service:'services',Node:'nodes',ConfigMap:'configmaps',Secret:'secrets'};
 					const r = Object.entries(res2kind).find(([k]) => k === node.kind);
@@ -2231,9 +2267,22 @@ const indexHTML = `<!doctype html>
 						return;
 					}
 				}
-				if (selected && selected.node) {
-					showDetail(selected.node, selected.crumbs || ['Cluster']);
+				if ((activeTab === 'history' || activeTab === 'diff') && selectedHistoryEntry) {
+					// Keep the selected transition context even when the object is
+					// absent at this exact timeline position (e.g. deleted events).
+					if (activeTab === 'diff') {
+						renderDiffPane();
+					}
+					return;
 				}
+				selected = null;
+				selectedHistoryEntry = null;
+				el.crumbs.textContent = '';
+				el.detailTitle.textContent = 'Select a resource';
+				el.detailSummary.innerHTML = '';
+				el.detailBody.textContent = 'No resource is available at the selected time.';
+				el.historyPane.innerHTML = '<div class="history-empty">No resource is selected.</div>';
+				el.diffPane.innerHTML = '<div class="history-empty">Select an event in the History tab to view its diff.</div>';
 			} finally {
 				if (token === refreshToken) {
 					setSnapshotLoading(false);

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
 	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/transitions"
 	"gopkg.in/yaml.v3"
 )
 
@@ -36,9 +37,11 @@ type Server struct {
 }
 
 type explorerHandler struct {
-	store   *server.CaptureStore
-	at      time.Time
-	verbose bool
+	store          *server.CaptureStore
+	at             time.Time
+	verbose        bool
+	archivePath    string
+	allTransitions []transitions.Transition
 }
 
 type treeResponse struct {
@@ -138,12 +141,17 @@ func Open(opts OpenOptions) (*Server, error) {
 		return nil, fmt.Errorf("listening: %w", err)
 	}
 
-	h := &explorerHandler{store: store, at: at, verbose: opts.Verbose}
+	// Pre-compute transitions for the archive (best-effort; empty on error).
+	allTrans, _ := transitions.LoadTransitions(opts.ArchivePath, transitions.FilterOpts{})
+
+	h := &explorerHandler{store: store, at: at, verbose: opts.Verbose, archivePath: opts.ArchivePath, allTransitions: allTrans}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", h.serveIndex)
 	mux.HandleFunc("/api/ui/tree", h.serveTree)
 	mux.HandleFunc("/api/ui/detail", h.serveDetail)
 	mux.HandleFunc("/api/ui/timestamps", h.serveTimestamps)
+	mux.HandleFunc("/api/ui/transitions", h.serveTransitions)
+	mux.HandleFunc("/api/ui/object-history", h.serveObjectHistory)
 
 	httpSrv := &http.Server{Handler: mux}
 	done := make(chan struct{})
@@ -287,6 +295,76 @@ func (h *explorerHandler) serveTimestamps(w http.ResponseWriter, r *http.Request
 		resp.DefaultAt = h.at.UTC().Format(time.RFC3339)
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// transitionMarker is a lightweight summary of a transition for the timeline.
+type transitionMarker struct {
+	Time      string `json:"time"`
+	EventType string `json:"event_type"`
+	Resource  string `json:"resource"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+}
+
+func (h *explorerHandler) serveTransitions(w http.ResponseWriter, r *http.Request) {
+	resource := r.URL.Query().Get("resource")
+	namespace := r.URL.Query().Get("namespace")
+
+	markers := make([]transitionMarker, 0, len(h.allTransitions))
+	for _, t := range h.allTransitions {
+		if resource != "" && !strings.Contains(t.Resource, resource) {
+			continue
+		}
+		if namespace != "" && t.Namespace != namespace {
+			continue
+		}
+		markers = append(markers, transitionMarker{
+			Time:      t.Time.UTC().Format(time.RFC3339),
+			EventType: t.EventType,
+			Resource:  t.Resource,
+			Namespace: t.Namespace,
+			Name:      t.Name,
+		})
+	}
+	writeJSON(w, http.StatusOK, markers)
+}
+
+// objectHistoryEntry represents one transition for a specific object.
+type objectHistoryEntry struct {
+	Time      string          `json:"time"`
+	EventType string          `json:"event_type"`
+	Before    json.RawMessage `json:"before,omitempty"`
+	After     json.RawMessage `json:"after,omitempty"`
+}
+
+func (h *explorerHandler) serveObjectHistory(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	if name == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing name query parameter"})
+		return
+	}
+	resource := r.URL.Query().Get("resource")
+	namespace := r.URL.Query().Get("namespace")
+
+	entries := make([]objectHistoryEntry, 0)
+	for _, t := range h.allTransitions {
+		if t.Name != name {
+			continue
+		}
+		if resource != "" && !strings.Contains(t.Resource, resource) {
+			continue
+		}
+		if namespace != "" && t.Namespace != namespace {
+			continue
+		}
+		entries = append(entries, objectHistoryEntry{
+			Time:      t.Time.UTC().Format(time.RFC3339),
+			EventType: t.EventType,
+			Before:    t.Before,
+			After:     t.After,
+		})
+	}
+	writeJSON(w, http.StatusOK, entries)
 }
 
 func (h *explorerHandler) resolveRequestAt(r *http.Request) (time.Time, error) {
@@ -1078,6 +1156,29 @@ const indexHTML = `<!doctype html>
 		.ns-pager { margin:6px 10px 10px; display:flex; align-items:center; gap:8px; }
 		.ns-pager button { padding:3px 8px; border-radius:6px; border:1px solid #334155; background:#0f172a; color:#cbd5e1; font-size:11px; cursor:pointer; }
 		.ns-pager button:hover { border-color:#64748b; }
+		.scrub-track { position:relative; flex:1; height:24px; display:flex; align-items:center; }
+		.scrub-track .scrub { position:relative; z-index:2; }
+		.marker-layer { position:absolute; left:8px; right:8px; top:0; bottom:0; pointer-events:none; z-index:1; }
+		.marker-dot { position:absolute; width:6px; height:6px; border-radius:50%; transform:translate(-50%,-50%); top:50%; pointer-events:auto; cursor:pointer; opacity:.85; }
+		.marker-dot:hover { opacity:1; transform:translate(-50%,-50%) scale(1.6); }
+		.marker-dot.ev-added { background:#22c55e; }
+		.marker-dot.ev-modified { background:#f59e0b; }
+		.marker-dot.ev-deleted { background:#ef4444; }
+		.marker-tooltip { position:absolute; bottom:calc(100% + 6px); left:50%; transform:translateX(-50%); background:#1e293b; border:1px solid #334155; border-radius:6px; padding:4px 8px; font-size:11px; color:#e2e8f0; white-space:nowrap; pointer-events:none; z-index:10; }
+		.history-list { margin:0; padding:0; list-style:none; }
+		.history-item { padding:8px 10px; border-bottom:1px solid #1f2937; cursor:pointer; display:flex; align-items:center; gap:8px; }
+		.history-item:hover { background:#0f172a; }
+		.history-item.active { background:rgba(34,197,94,.12); border-left:3px solid #22c55e; }
+		.history-event { font-size:11px; font-weight:700; letter-spacing:.4px; text-transform:uppercase; padding:2px 6px; border-radius:999px; }
+		.history-event.ev-added { background:rgba(34,197,94,.2); color:#86efac; }
+		.history-event.ev-modified { background:rgba(245,158,11,.2); color:#fcd34d; }
+		.history-event.ev-deleted { background:rgba(239,68,68,.2); color:#fca5a5; }
+		.history-time { color:var(--muted); font-size:12px; }
+		.diff-block { white-space:pre-wrap; font-family:ui-monospace,SFMono-Regular,monospace; font-size:12px; line-height:1.6; }
+		.diff-line-add { color:#86efac; }
+		.diff-line-del { color:#fca5a5; }
+		.diff-line-hdr { color:#94a3b8; }
+		.history-empty { padding:16px; color:var(--muted); font-size:13px; }
   </style>
 </head>
 <body>
@@ -1091,7 +1192,10 @@ const indexHTML = `<!doctype html>
 				<button id="snapshotNext" class="snapshot-btn" type="button" title="Jump to newer snapshot">Next</button>
 			</div>
 			<div class="scrub-wrap">
-				<input id="timelineScrub" class="scrub" type="range" min="0" max="0" step="1" value="0"/>
+				<div class="scrub-track">
+					<div id="markerLayer" class="marker-layer"></div>
+					<input id="timelineScrub" class="scrub" type="range" min="0" max="0" step="1" value="0"/>
+				</div>
 				<span id="timelinePosition" class="scrub-pos"></span>
 			</div>
 			<div id="snapshotHint" class="snapshot-hint"></div>
@@ -1128,6 +1232,8 @@ const indexHTML = `<!doctype html>
 				<span class="tabs-left">
 					<button id="tabJson" class="active">JSON</button>
 					<button id="tabYaml">YAML</button>
+					<button id="tabHistory">History</button>
+					<button id="tabDiff">Diff</button>
 				</span>
 				<span class="detail-actions">
 					<button id="copyDetail" class="copy-btn" type="button">Copy JSON</button>
@@ -1135,6 +1241,8 @@ const indexHTML = `<!doctype html>
 				</span>
       </div>
       <pre id="detailBody">Click a node in the tree to inspect details.</pre>
+      <div id="historyPane" style="display:none"></div>
+      <div id="diffPane" style="display:none"></div>
     </section>
   </div>
 	<div id="toasts" class="toast-stack" aria-live="polite"></div>
@@ -1155,6 +1263,8 @@ const indexHTML = `<!doctype html>
 	let scrubDebounce = null;
 	let lastLoadedAt = '';
 	let refreshToken = 0;
+	let allTransitions = [];
+	let objectHistory = [];
 
     const el = {
       tree: document.getElementById('tree'),
@@ -1179,11 +1289,18 @@ const indexHTML = `<!doctype html>
 			timelineScrub: document.getElementById('timelineScrub'),
 			timelinePosition: document.getElementById('timelinePosition'),
 			snapshotHint: document.getElementById('snapshotHint'),
-			toasts: document.getElementById('toasts')
+			toasts: document.getElementById('toasts'),
+			tabHistory: document.getElementById('tabHistory'),
+			tabDiff: document.getElementById('tabDiff'),
+			historyPane: document.getElementById('historyPane'),
+			diffPane: document.getElementById('diffPane'),
+			markerLayer: document.getElementById('markerLayer')
     };
 
     el.tabJson.onclick = () => setTab('json');
     el.tabYaml.onclick = () => setTab('yaml');
+	el.tabHistory.onclick = () => setTab('history');
+	el.tabDiff.onclick = () => setTab('diff');
 	el.copyDetail.onclick = () => copyActiveDetail();
 	el.downloadDetail.onclick = () => downloadActiveDetail();
     el.search.oninput = render;
@@ -1400,10 +1517,25 @@ const indexHTML = `<!doctype html>
       activeTab = tab;
       el.tabJson.classList.toggle('active', tab === 'json');
       el.tabYaml.classList.toggle('active', tab === 'yaml');
-			el.copyDetail.textContent = tab === 'yaml' ? 'Copy YAML' : 'Copy JSON';
-			el.downloadDetail.textContent = tab === 'yaml' ? 'Download YAML' : 'Download JSON';
-      if (selected && selected.detail) {
-        el.detailBody.textContent = selected.detail[activeTab] || '';
+      el.tabHistory.classList.toggle('active', tab === 'history');
+      el.tabDiff.classList.toggle('active', tab === 'diff');
+      el.detailBody.style.display = (tab === 'json' || tab === 'yaml') ? '' : 'none';
+      el.historyPane.style.display = tab === 'history' ? '' : 'none';
+      el.diffPane.style.display = tab === 'diff' ? '' : 'none';
+			el.copyDetail.style.display = (tab === 'json' || tab === 'yaml') ? '' : 'none';
+			el.downloadDetail.style.display = (tab === 'json' || tab === 'yaml') ? '' : 'none';
+			if (tab === 'json' || tab === 'yaml') {
+				el.copyDetail.textContent = tab === 'yaml' ? 'Copy YAML' : 'Copy JSON';
+				el.downloadDetail.textContent = tab === 'yaml' ? 'Download YAML' : 'Download JSON';
+			}
+      if ((tab === 'json' || tab === 'yaml') && selected && selected.detail) {
+        el.detailBody.textContent = selected.detail[tab] || '';
+      }
+      if (tab === 'history' && selected && selected.node) {
+        loadObjectHistory(selected.node);
+      }
+      if (tab === 'diff') {
+        renderDiffPane();
       }
     }
 
@@ -1702,6 +1834,7 @@ const indexHTML = `<!doctype html>
 
     async function showDetail(node, crumbs) {
       selected = { node, crumbs };
+      selectedHistoryEntry = null;
       el.crumbs.textContent = crumbs.join(' / ');
       el.detailTitle.textContent = node.kind + ' ' + node.name;
 			el.detailBody.textContent = 'Loading detail...';
@@ -1715,7 +1848,9 @@ const indexHTML = `<!doctype html>
 				}
 				selected.detail = data;
 				updateDetailSummary(data, node);
-				el.detailBody.textContent = data[activeTab] || JSON.stringify(data, null, 2);
+				if (activeTab === 'json' || activeTab === 'yaml') {
+					el.detailBody.textContent = data[activeTab] || JSON.stringify(data, null, 2);
+				}
 			} catch (err) {
 				selected.detail = null;
 				el.detailSummary.innerHTML = '';
@@ -1723,6 +1858,8 @@ const indexHTML = `<!doctype html>
 				el.detailBody.textContent = 'Failed to load detail: ' + msg;
 				showToast('error', 'Detail request failed: ' + msg);
 			}
+			if (activeTab === 'history') loadObjectHistory(node);
+			if (activeTab === 'diff') renderDiffPane();
     }
 
     function render() {
@@ -1898,6 +2035,182 @@ const indexHTML = `<!doctype html>
 			syncAtInURL();
 		}
 
+		async function loadTransitions() {
+			try {
+				const res = await fetch('/api/ui/transitions');
+				if (res.ok) {
+					allTransitions = await res.json();
+				}
+			} catch (_) {
+				allTransitions = [];
+			}
+		}
+
+		function renderTimelineMarkers() {
+			el.markerLayer.innerHTML = '';
+			if (!allTransitions.length || !timelinePoints.length) return;
+			const first = new Date(timelinePoints[0]).getTime();
+			const last = new Date(timelinePoints[timelinePoints.length - 1]).getTime();
+			const span = last - first;
+			if (span <= 0) return;
+			for (const t of allTransitions) {
+				const ms = new Date(t.time).getTime();
+				if (ms < first || ms > last) continue;
+				const pct = ((ms - first) / span) * 100;
+				const dot = document.createElement('div');
+				dot.className = 'marker-dot ev-' + t.event_type.toLowerCase();
+				dot.style.left = pct + '%';
+				dot.title = t.time + ' ' + t.event_type + ' ' + t.resource + '/' + (t.namespace ? t.namespace + '/' : '') + t.name;
+				dot.onclick = (e) => {
+					e.stopPropagation();
+					seekToTime(t.time);
+				};
+				el.markerLayer.appendChild(dot);
+			}
+		}
+
+		function seekToTime(ts) {
+			if (!timelinePoints.length) return;
+			let best = 0;
+			for (let i = 0; i < timelinePoints.length; i++) {
+				if (timelinePoints[i] <= ts) best = i;
+			}
+			el.timelineScrub.value = String(best);
+			applyScrubberSelection(true);
+		}
+
+		async function loadObjectHistory(node) {
+			el.historyPane.innerHTML = '<div class="history-empty">Loading history...</div>';
+			try {
+				const q = new URLSearchParams({name: node.name});
+				if (node.kind) {
+					const res2kind = {Pod:'pods',Deployment:'deployments',StatefulSet:'statefulsets',DaemonSet:'daemonsets',Job:'jobs',ReplicaSet:'replicasets',Service:'services',Node:'nodes',ConfigMap:'configmaps',Secret:'secrets'};
+					const r = Object.entries(res2kind).find(([k]) => k === node.kind);
+					if (r) q.set('resource', r[1]);
+				}
+				const res = await fetch('/api/ui/object-history?' + q.toString());
+				if (!res.ok) throw new Error('status ' + res.status);
+				objectHistory = await res.json();
+			} catch (err) {
+				objectHistory = [];
+				el.historyPane.innerHTML = '<div class="history-empty">Failed to load history: ' + (err.message || err) + '</div>';
+				return;
+			}
+			renderHistoryList();
+		}
+
+		function renderHistoryList() {
+			el.historyPane.innerHTML = '';
+			if (!objectHistory.length) {
+				el.historyPane.innerHTML = '<div class="history-empty">No transitions detected for this object.</div>';
+				return;
+			}
+			const ul = document.createElement('ul');
+			ul.className = 'history-list';
+			for (let i = 0; i < objectHistory.length; i++) {
+				const entry = objectHistory[i];
+				const li = document.createElement('li');
+				li.className = 'history-item';
+				li.innerHTML = '<span class="history-event ev-' + entry.event_type.toLowerCase() + '">' + entry.event_type + '</span>' +
+					'<span class="history-time">' + entry.time + '</span>';
+				li.onclick = () => {
+					for (const item of ul.children) item.classList.remove('active');
+					li.classList.add('active');
+					seekToTime(entry.time);
+					showHistoryDiff(entry);
+				};
+				ul.appendChild(li);
+			}
+			el.historyPane.appendChild(ul);
+		}
+
+		function showHistoryDiff(entry) {
+			selectedHistoryEntry = entry;
+			if (activeTab === 'diff') renderDiffPane();
+		}
+
+		let selectedHistoryEntry = null;
+
+		function renderDiffPane() {
+			el.diffPane.innerHTML = '';
+			if (!selectedHistoryEntry) {
+				el.diffPane.innerHTML = '<div class="history-empty">Select an event in the History tab to view its diff.</div>';
+				return;
+			}
+			const entry = selectedHistoryEntry;
+			const header = document.createElement('div');
+			header.style.cssText = 'margin-bottom:8px;font-size:13px;color:#cbd5e1;';
+			header.innerHTML = '<span class="history-event ev-' + entry.event_type.toLowerCase() + '">' + entry.event_type + '</span> at ' + entry.time;
+			el.diffPane.appendChild(header);
+
+			if (entry.event_type === 'ADDED') {
+				const block = document.createElement('pre');
+				block.className = 'diff-block';
+				block.innerHTML = colorizeJSON(entry.after, 'diff-line-add');
+				el.diffPane.appendChild(block);
+			} else if (entry.event_type === 'DELETED') {
+				const block = document.createElement('pre');
+				block.className = 'diff-block';
+				block.innerHTML = colorizeJSON(entry.before, 'diff-line-del');
+				el.diffPane.appendChild(block);
+			} else if (entry.event_type === 'MODIFIED') {
+				const beforeLines = prettyJSONLines(entry.before);
+				const afterLines = prettyJSONLines(entry.after);
+				const diffLines = simpleDiff(beforeLines, afterLines);
+				const block = document.createElement('pre');
+				block.className = 'diff-block';
+				block.innerHTML = diffLines.map(renderDiffLine).join('\n');
+				el.diffPane.appendChild(block);
+			}
+		}
+
+		function prettyJSONLines(raw) {
+			if (!raw) return [];
+			try {
+				return JSON.stringify(JSON.parse(typeof raw === 'string' ? raw : JSON.stringify(raw)), null, 2).split('\n');
+			} catch (_) {
+				return String(raw).split('\n');
+			}
+		}
+
+		function colorizeJSON(raw, cls) {
+			const lines = prettyJSONLines(raw);
+			return lines.map((l) => '<span class="' + cls + '">' + escapeHTML(l) + '</span>').join('\n');
+		}
+
+		function escapeHTML(s) {
+			return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+		}
+
+		function simpleDiff(a, b) {
+			const out = [];
+			const max = Math.max(a.length, b.length);
+			let ai = 0, bi = 0;
+			while (ai < a.length || bi < b.length) {
+				if (ai < a.length && bi < b.length && a[ai] === b[bi]) {
+					out.push({type:'ctx', text:a[ai]});
+					ai++; bi++;
+				} else if (ai < a.length && (bi >= b.length || !b.includes(a[ai]))) {
+					out.push({type:'del', text:a[ai]});
+					ai++;
+				} else if (bi < b.length && (ai >= a.length || !a.includes(b[bi]))) {
+					out.push({type:'add', text:b[bi]});
+					bi++;
+				} else {
+					out.push({type:'del', text:a[ai]});
+					out.push({type:'add', text:b[bi]});
+					ai++; bi++;
+				}
+			}
+			return out;
+		}
+
+		function renderDiffLine(line) {
+			const prefix = line.type === 'add' ? '+' : line.type === 'del' ? '-' : ' ';
+			const cls = line.type === 'add' ? 'diff-line-add' : line.type === 'del' ? 'diff-line-del' : '';
+			return '<span class="' + cls + '">' + escapeHTML(prefix + ' ' + line.text) + '</span>';
+		}
+
 		async function refreshTree(forceRefresh) {
 			const previousSelectionKey = selected && selected.node ? nodeIdentity(selected.node) : '';
 			if (!forceRefresh && normalizedAt() === lastLoadedAt) {
@@ -1947,7 +2260,9 @@ const indexHTML = `<!doctype html>
 				loadPreferences();
 				initAtFromURL();
 				await loadTimestamps();
+				await loadTransitions();
 				await refreshTree(true);
+				renderTimelineMarkers();
 			} catch (err) {
 				const msg = (err && err.message ? err.message : String(err));
 				setTreeState('error', 'Failed to load capture tree: ' + msg);

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
 	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/transitions"
 )
 
 func TestBuildTree_Hierarchy(t *testing.T) {
@@ -542,4 +543,95 @@ func contains(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func TestServeTransitions(t *testing.T) {
+	store := buildTestStore(t)
+	h := &explorerHandler{
+		store: store,
+		allTransitions: []transitions.Transition{
+			{Time: time.Date(2026, 4, 10, 10, 0, 5, 0, time.UTC), EventType: "ADDED", Resource: "pods", Namespace: "default", Name: "nginx"},
+			{Time: time.Date(2026, 4, 10, 10, 0, 10, 0, time.UTC), EventType: "MODIFIED", Resource: "pods", Namespace: "default", Name: "nginx"},
+			{Time: time.Date(2026, 4, 10, 10, 0, 15, 0, time.UTC), EventType: "ADDED", Resource: "deployments", Namespace: "kube-system", Name: "coredns"},
+		},
+	}
+
+	// Unfiltered — returns all 3.
+	req := httptest.NewRequest(http.MethodGet, "/api/ui/transitions", nil)
+	rr := httptest.NewRecorder()
+	h.serveTransitions(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var markers []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &markers); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(markers) != 3 {
+		t.Fatalf("expected 3 markers, got %d", len(markers))
+	}
+
+	// Filter by resource.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/ui/transitions?resource=pods", nil)
+	rr2 := httptest.NewRecorder()
+	h.serveTransitions(rr2, req2)
+	var filtered []map[string]any
+	_ = json.Unmarshal(rr2.Body.Bytes(), &filtered)
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 pod markers, got %d", len(filtered))
+	}
+
+	// Filter by namespace.
+	req3 := httptest.NewRequest(http.MethodGet, "/api/ui/transitions?namespace=kube-system", nil)
+	rr3 := httptest.NewRecorder()
+	h.serveTransitions(rr3, req3)
+	var nsFiltered []map[string]any
+	_ = json.Unmarshal(rr3.Body.Bytes(), &nsFiltered)
+	if len(nsFiltered) != 1 {
+		t.Fatalf("expected 1 kube-system marker, got %d", len(nsFiltered))
+	}
+}
+
+func TestServeObjectHistory(t *testing.T) {
+	store := buildTestStore(t)
+	h := &explorerHandler{
+		store: store,
+		allTransitions: []transitions.Transition{
+			{Time: time.Date(2026, 4, 10, 10, 0, 5, 0, time.UTC), EventType: "ADDED", Resource: "pods", Namespace: "default", Name: "nginx", After: json.RawMessage(`{"metadata":{"name":"nginx"}}`)},
+			{Time: time.Date(2026, 4, 10, 10, 0, 10, 0, time.UTC), EventType: "MODIFIED", Resource: "pods", Namespace: "default", Name: "nginx", Before: json.RawMessage(`{"metadata":{"name":"nginx"}}`), After: json.RawMessage(`{"metadata":{"name":"nginx"},"status":{"phase":"Running"}}`)},
+			{Time: time.Date(2026, 4, 10, 10, 0, 15, 0, time.UTC), EventType: "ADDED", Resource: "pods", Namespace: "default", Name: "redis"},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/ui/object-history?name=nginx", nil)
+	rr := httptest.NewRecorder()
+	h.serveObjectHistory(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var entries []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &entries); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 history entries for nginx, got %d", len(entries))
+	}
+	if entries[0]["event_type"] != "ADDED" || entries[1]["event_type"] != "MODIFIED" {
+		t.Errorf("unexpected event types: %v, %v", entries[0]["event_type"], entries[1]["event_type"])
+	}
+	// MODIFIED entry should have before and after.
+	if entries[1]["before"] == nil || entries[1]["after"] == nil {
+		t.Errorf("expected before/after on MODIFIED entry")
+	}
+}
+
+func TestServeObjectHistory_MissingName(t *testing.T) {
+	store := buildTestStore(t)
+	h := &explorerHandler{store: store}
+	req := httptest.NewRequest(http.MethodGet, "/api/ui/object-history", nil)
+	rr := httptest.NewRecorder()
+	h.serveObjectHistory(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
 }

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -57,6 +57,42 @@ func TestServeDetail_ItemFromList(t *testing.T) {
 	}
 }
 
+func TestServeDetail_ItemFromWatchOnlyAddedResource(t *testing.T) {
+	store := buildWatchOnlyStore(t)
+	h := &explorerHandler{store: store}
+	req := httptest.NewRequest(http.MethodGet, "/api/ui/detail?path=/api/v1/namespaces/default/pods&name=redis&at=2026-04-10T10:00:31Z", nil)
+	rr := httptest.NewRecorder()
+	h.serveDetail(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	jsonBody, _ := body["json"].(string)
+	if !strings.Contains(jsonBody, "redis") {
+		t.Fatalf("expected redis in detail response, got %s", jsonBody)
+	}
+}
+
+func TestBuildTree_IncludesWatchOnlyAddedResource(t *testing.T) {
+	store := buildWatchOnlyStore(t)
+	h := &explorerHandler{store: store}
+	tree, err := h.buildTreeAt(time.Date(2026, 4, 10, 10, 0, 31, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("buildTreeAt: %v", err)
+	}
+	if len(tree.Namespaces) != 1 || tree.Namespaces[0].Name != "default" {
+		t.Fatalf("expected one default namespace, got %+v", tree.Namespaces)
+	}
+	ns := tree.Namespaces[0]
+	if len(ns.Pods) != 1 || ns.Pods[0].Name != "redis" {
+		t.Fatalf("expected watch-only pod to appear, got %+v", ns.Pods)
+	}
+}
+
 func TestBuildTree_IncludesQueryOnlyListPath(t *testing.T) {
 	store := buildQueryOnlyStore(t)
 	h := &explorerHandler{store: store}
@@ -530,6 +566,67 @@ func buildMultiSnapshotStore(t *testing.T) *server.CaptureStore {
 		t.Fatalf("archive.Open: %v", err)
 	}
 	store, err := server.LoadStore(extractDir)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	return store
+}
+
+func buildWatchOnlyStore(t *testing.T) *server.CaptureStore {
+	t.Helper()
+	dir := t.TempDir()
+	base := filepath.Join(dir, "k8shark-capture")
+	recDir := filepath.Join(base, "records")
+	if err := os.MkdirAll(recDir, 0o750); err != nil {
+		t.Fatalf("mkdir records: %v", err)
+	}
+
+	t0 := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(30 * time.Second)
+	rec := capture.Record{
+		ID:           "watch-1",
+		CapturedAt:   t1,
+		APIPath:      "/api/v1/namespaces/default/pods",
+		EventType:    "ADDED",
+		HTTPMethod:   http.MethodGet,
+		ResponseCode: http.StatusOK,
+		ResponseBody: json.RawMessage(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"redis","namespace":"default","uid":"pod-redis"},"spec":{"containers":[{"name":"main"}]},"status":{"phase":"Running"}}`),
+	}
+	recData, _ := json.Marshal(rec)
+	if err := os.WriteFile(filepath.Join(recDir, rec.ID+".json"), recData, 0o644); err != nil {
+		t.Fatalf("write record: %v", err)
+	}
+
+	meta := capture.CaptureMetadata{CaptureID: "ui-watch-only-test", CapturedAt: t0, CapturedUntil: t1.Add(time.Second), RecordCount: 1}
+	metaData, _ := json.Marshal(meta)
+	if err := os.WriteFile(filepath.Join(base, "metadata.json"), metaData, 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	indexData, _ := json.Marshal(capture.Index{
+		"/api/v1/namespaces/default/pods": {
+			APIPath:   "/api/v1/namespaces/default/pods",
+			RecordIDs: []string{},
+			Times:     []time.Time{},
+		},
+	})
+	if err := os.WriteFile(filepath.Join(base, "index.json"), indexData, 0o644); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+
+	watchIndexData, _ := json.Marshal(capture.WatchIndex{
+		"/api/v1/namespaces/default/pods": {
+			APIPath:    "/api/v1/namespaces/default/pods",
+			RecordIDs:  []string{"watch-1"},
+			Times:      []time.Time{t1},
+			EventTypes: []string{"ADDED"},
+		},
+	})
+	if err := os.WriteFile(filepath.Join(base, "watch-index.json"), watchIndexData, 0o644); err != nil {
+		t.Fatalf("write watch-index: %v", err)
+	}
+
+	store, err := server.LoadStore(dir)
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}


### PR DESCRIPTION
## Summary

Adds three UI extensions to the `kshrk ui` explorer, completing the final piece of issue #50:

### Timeline Markers
- Colored dots on the timeline scrubber showing where transitions occurred
- Green = ADDED, amber = MODIFIED, red = DELETED
- Click a marker to seek the timeline to that point

### Per-Object History Pane
- New **History** tab in the detail panel
- Shows chronological list of transitions for the selected object
- Click an entry to seek the timeline and view its diff

### Diff Mode
- New **Diff** tab in the detail panel
- Shows before/after comparison for MODIFIED transitions
- ADDED events show the full object in green, DELETED in red

### Backend
- `/api/ui/transitions` — returns all transition markers (filterable by resource/namespace)
- `/api/ui/object-history` — returns transitions for a specific object
- Transitions are pre-computed once on `Open()` for efficient serving

### Tests
- `TestServeTransitions` — tests unfiltered + resource/namespace filtering
- `TestServeObjectHistory` — tests name filtering with event type and before/after verification
- `TestServeObjectHistory_MissingName` — tests 400 on missing required param

Closes #50