### PR TITLE
fix: k9s compatibility for read-only replay

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -56,6 +56,48 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Client compatibility: tools like k9s POST authorization review resources
+	// to determine what actions are available. These requests are read-only
+	// capability checks, not mutating operations, so we synthesize permissive
+	// read-only responses to avoid breaking navigation workflows.
+	if r.Method == http.MethodPost {
+		switch path {
+		case "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews":
+			writeJSON(w, http.StatusCreated, map[string]any{
+				"apiVersion": "authorization.k8s.io/v1",
+				"kind":       "SelfSubjectAccessReview",
+				"status": map[string]any{
+					"allowed": true,
+					"denied":  false,
+					"reason":  "k8shark replay server: read-only access checks allowed for client compatibility",
+				},
+			})
+			return
+		case "/apis/authorization.k8s.io/v1/selfsubjectrulesreviews":
+			writeJSON(w, http.StatusCreated, map[string]any{
+				"apiVersion": "authorization.k8s.io/v1",
+				"kind":       "SelfSubjectRulesReview",
+				"status": map[string]any{
+					"incomplete": false,
+					"resourceRules": []map[string]any{
+						{
+							"verbs":     []string{"get", "list", "watch"},
+							"apiGroups": []string{"*"},
+							"resources": []string{"*"},
+						},
+					},
+					"nonResourceRules": []map[string]any{
+						{
+							"verbs":           []string{"get"},
+							"nonResourceURLs": []string{"*"},
+						},
+					},
+				},
+			})
+			return
+		}
+	}
+
 	// Reject all write operations — k8shark replay is read-only.
 	// RFC 7231 §6.5.5 requires an Allow header with a 405 response.
 	switch r.Method {

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -450,6 +450,58 @@ func TestHandler_WriteMethodsReturn405(t *testing.T) {
 	})
 }
 
+func TestHandler_SelfSubjectAccessReview_Compatibility(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/pods": []byte(`{"kind":"PodList","items":[]}`),
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodPost, "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews", strings.NewReader(`{"kind":"SelfSubjectAccessReview"}`))
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rw.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rw.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected JSON body: %v", err)
+	}
+	if body["kind"] != "SelfSubjectAccessReview" {
+		t.Fatalf("expected kind SelfSubjectAccessReview, got %v", body["kind"])
+	}
+	status, _ := body["status"].(map[string]any)
+	if allowed, _ := status["allowed"].(bool); !allowed {
+		t.Fatalf("expected status.allowed=true, got %v", status["allowed"])
+	}
+}
+
+func TestHandler_SelfSubjectRulesReview_Compatibility(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/pods": []byte(`{"kind":"PodList","items":[]}`),
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodPost, "/apis/authorization.k8s.io/v1/selfsubjectrulesreviews", strings.NewReader(`{"kind":"SelfSubjectRulesReview"}`))
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rw.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rw.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected JSON body: %v", err)
+	}
+	if body["kind"] != "SelfSubjectRulesReview" {
+		t.Fatalf("expected kind SelfSubjectRulesReview, got %v", body["kind"])
+	}
+	status, _ := body["status"].(map[string]any)
+	if incomplete, _ := status["incomplete"].(bool); incomplete {
+		t.Fatalf("expected status.incomplete=false, got true")
+	}
+}
+
 func TestHandler_InteractiveSubResourcesReturn405(t *testing.T) {
 	store := buildTestStore(t, map[string][]byte{
 		"/api/v1/namespaces/default/pods": []byte(`{"kind":"PodList","items":[]}`),


### PR DESCRIPTION
## Summary
Add compatibility handlers for authorization review endpoints that clients like k9s POST during capability checks.

### What changed
- Handle POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews
- Handle POST /apis/authorization.k8s.io/v1/selfsubjectrulesreviews
- Return synthetic read-only-compatible responses (201 Created)
- Keep existing write-operation blocking behavior for true mutating calls

### Why
k9s performs auth review probes during normal navigation. Without these compatibility responses, the replay server returns a read-only write error and k9s workflows fail.

### Validation
- go test ./internal/server
- golangci-lint run
- go test ./...

This PR improves client interoperability while preserving replay server read-only guarantees.