### PR TITLE
fix: fail fast when capture kubeconfig/context is unusable

### DIFF
--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -117,6 +117,10 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 		}
 	}()
 
+	if err := e.preflight(ctx); err != nil {
+		return nil, err
+	}
+
 	// Create the record sink (only if not pre-set by tests).
 	var err error
 	if e.sink == nil {
@@ -219,6 +223,46 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 		ResourceCount: len(e.index),
 		Duration:      time.Since(start).Truncate(time.Second),
 	}, nil
+}
+
+// preflight validates that the configured kubeconfig/context can reach the
+// target API server before any archive writer is initialized.
+func (e *Engine) preflight(ctx context.Context) error {
+	timeout := 5 * time.Second
+	if e.cfg != nil && e.cfg.Duration > 0 && e.cfg.Duration < timeout {
+		timeout = e.cfg.Duration
+	}
+	checkCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(checkCtx, http.MethodGet, e.baseURL+"/version", nil)
+	if err != nil {
+		return fmt.Errorf("capture preflight failed (kubeconfig=%s, server=%s): building version request: %w", kubeconfigLabel(e.cfg), e.baseURL, err)
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("capture preflight failed (kubeconfig=%s, server=%s): %w", kubeconfigLabel(e.cfg), e.baseURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		detail := strings.TrimSpace(string(body))
+		if detail == "" {
+			detail = http.StatusText(resp.StatusCode)
+		}
+		return fmt.Errorf("capture preflight failed (kubeconfig=%s, server=%s): GET /version returned %d: %s", kubeconfigLabel(e.cfg), e.baseURL, resp.StatusCode, detail)
+	}
+
+	return nil
+}
+
+func kubeconfigLabel(cfg *config.Config) string {
+	if cfg != nil && strings.TrimSpace(cfg.Kubeconfig) != "" {
+		return cfg.Kubeconfig
+	}
+	return "default"
 }
 
 // pollResource polls a single resource kind at its configured interval until ctx is done.

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/phenixblue/k8shark/internal/config"
 )
 
-// sliceSink is a test RecordSink that accumulates records in memory.
 type sliceSink struct {
 	mu      sync.Mutex
 	records []*Record
@@ -551,6 +550,76 @@ func TestRun_FailsWhenWatchConcurrencyTooHigh(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "concurrent watch streams") {
 		t.Fatalf("expected watch concurrency guard error, got: %v", err)
+	}
+}
+
+func TestRun_FailsPreflightOnUnauthorized(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/version" {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, `{"kind":"Status","message":"unauthorized"}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"kind":"List","items":[]}`)
+	}))
+	defer srv.Close()
+
+	out := filepath.Join(t.TempDir(), "capture.tar.gz")
+	cfg := &config.Config{
+		DurationRaw: "2s",
+		Duration:    2 * time.Second,
+		Output:      out,
+		Resources: []config.Resource{
+			{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "500ms", Interval: 500 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	_, err := eng.Run()
+	if err == nil {
+		t.Fatal("expected preflight error, got nil")
+	}
+	if !strings.Contains(err.Error(), "capture preflight failed") {
+		t.Fatalf("expected preflight prefix in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "GET /version returned 401") {
+		t.Fatalf("expected 401 detail in error, got: %v", err)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no output archive on preflight failure, stat err: %v", statErr)
+	}
+}
+
+func TestRun_FailsPreflightOnUnreachableServer(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+	}))
+	serverURL := srv.URL
+	client := srv.Client()
+	srv.Close()
+
+	out := filepath.Join(t.TempDir(), "capture.tar.gz")
+	cfg := &config.Config{
+		DurationRaw: "2s",
+		Duration:    2 * time.Second,
+		Output:      out,
+		Resources: []config.Resource{
+			{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "500ms", Interval: 500 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, client, serverURL, false)
+	_, err := eng.Run()
+	if err == nil {
+		t.Fatal("expected preflight connectivity error, got nil")
+	}
+	if !strings.Contains(err.Error(), "capture preflight failed") {
+		t.Fatalf("expected preflight prefix in error, got: %v", err)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no output archive on preflight failure, stat err: %v", statErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
Implement fail-fast preflight validation for kshrk capture so invalid or unreachable cluster configuration exits before capture starts.

## What changed
- Added preflight check in internal/capture/engine.go before sink or archive initialization.
- Preflight performs lightweight API reachability and auth check via GET /version.
- Added actionable error context including kubeconfig label and server address.
- Preflight failure now returns immediately and prevents writing misleading empty archives.

## Tests
Added coverage in internal/capture/engine_test.go:
- TestRun_FailsPreflightOnUnauthorized
- TestRun_FailsPreflightOnUnreachableServer

Both tests also assert no output archive is created on preflight failure.

## Validation
- make fmt
- go test ./internal/capture -run 'Preflight|DiscoveryFailure|DiscoveryCancelled|WatchConcurrency'
- go test ./...
- golangci-lint run

Closes #49