### PR TITLE
fix(server): use resource kind in watch BOOKMARK instead of Status

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -605,8 +605,40 @@ func (h *handler) trySingleItemGet(path string, at time.Time) ([]byte, int) {
 }
 
 func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path string, at time.Time) {
-	rawBody, code, err := h.store.ReconstructAt(strings.TrimSuffix(path, "/"), at)
-	if err != nil || code != 200 {
+	watchPath := strings.TrimSuffix(path, "/")
+	rawBody, code, err := h.store.ReconstructAt(watchPath, at)
+	if err != nil {
+		h.writeStatus(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	if code == 404 {
+		rawBody, code, err = h.store.AggregateAcrossNamespaces(watchPath, at)
+		if err != nil {
+			h.writeStatus(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+
+	if code == 404 {
+		g, v, resource, _ := parseAPIPath(watchPath)
+		if resource != "" {
+			av := v
+			if g != "" {
+				av = g + "/" + v
+			}
+			emptyList, _ := json.Marshal(map[string]any{
+				"apiVersion": av,
+				"kind":       resourceToKind(resource) + "List",
+				"metadata":   map[string]string{"resourceVersion": "0"},
+				"items":      []any{},
+			})
+			rawBody = emptyList
+			code = 200
+		}
+	}
+
+	if code != 200 {
 		h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q not found in capture", path))
 		return
 	}
@@ -615,7 +647,9 @@ func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path strin
 	body, _ := applySelectors(rawBody, r.URL.Query().Get("labelSelector"), r.URL.Query().Get("fieldSelector"))
 
 	var list struct {
-		Metadata struct {
+		APIVersion string `json:"apiVersion"`
+		Kind       string `json:"kind"`
+		Metadata   struct {
 			ResourceVersion string `json:"resourceVersion"`
 		} `json:"metadata"`
 		Items []json.RawMessage `json:"items"`
@@ -654,11 +688,21 @@ func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path strin
 	}
 
 	// BOOKMARK signals end of initial list; kubectl -w then waits for new events.
+	// The BOOKMARK object must have the same kind as the watched resource
+	// (not "Status"), otherwise client-go reflectors log unexpected type errors.
+	bookmarkKind := strings.TrimSuffix(list.Kind, "List")
+	bookmarkAPIVersion := list.APIVersion
+	if bookmarkKind == "" {
+		bookmarkKind = "Status"
+	}
+	if bookmarkAPIVersion == "" {
+		bookmarkAPIVersion = "v1"
+	}
 	bookmark := map[string]any{
 		"type": "BOOKMARK",
 		"object": map[string]any{
-			"apiVersion": "v1",
-			"kind":       "Status",
+			"apiVersion": bookmarkAPIVersion,
+			"kind":       bookmarkKind,
 			"metadata":   map[string]string{"resourceVersion": rv},
 		},
 	}

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -218,13 +218,16 @@ func TestHandler_Watch(t *testing.T) {
 			hasAdded = true
 		case "BOOKMARK":
 			hasBookmark = true
-			// resourceVersion must be non-empty and not the placeholder "0".
 			if obj, ok := ev["object"].(map[string]any); ok {
 				if meta, ok := obj["metadata"].(map[string]any); ok {
 					rv, _ := meta["resourceVersion"].(string)
 					if rv == "" || rv == "0" {
 						t.Errorf("BOOKMARK resourceVersion should be non-zero, got %q", rv)
 					}
+				}
+				// BOOKMARK kind must match the resource kind, not "Status"
+				if kind, _ := obj["kind"].(string); kind == "Status" || kind == "" {
+					t.Errorf("BOOKMARK object kind should be the resource kind, got %q", kind)
 				}
 			}
 		}
@@ -396,6 +399,95 @@ func TestHandler_Watch_TimeoutSeconds(t *testing.T) {
 	}
 	if !hasBookmark {
 		t.Error("expected a BOOKMARK event")
+	}
+}
+
+func TestHandler_Watch_AggregateAcrossNamespacesPath(t *testing.T) {
+	svcList := `{"apiVersion":"v1","kind":"ServiceList","metadata":{"resourceVersion":"11"},"items":[{"apiVersion":"v1","kind":"Service","metadata":{"name":"nginx","namespace":"default"}}]}`
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/services": []byte(svcList),
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/services?watch=1", nil)
+	ctx, cancel := cancelableContext(req.Context())
+	req = req.WithContext(ctx)
+	rw := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.ServeHTTP(rw, req)
+	}()
+	cancel()
+	<-done
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200 for aggregated watch, got %d", rw.Code)
+	}
+	lines := strings.Split(strings.TrimSpace(rw.Body.String()), "\n")
+	var hasAdded, hasBookmark bool
+	for _, line := range lines {
+		var ev map[string]any
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue
+		}
+		switch ev["type"] {
+		case "ADDED":
+			hasAdded = true
+		case "BOOKMARK":
+			hasBookmark = true
+		}
+	}
+	if !hasAdded {
+		t.Error("expected ADDED event for aggregated services watch")
+	}
+	if !hasBookmark {
+		t.Error("expected BOOKMARK event for aggregated services watch")
+	}
+}
+
+func TestHandler_Watch_MissingListPathReturnsEmptyStream(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/pods": []byte(`{"kind":"PodList","items":[]}`),
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/secrets?watch=1", nil)
+	ctx, cancel := cancelableContext(req.Context())
+	req = req.WithContext(ctx)
+	rw := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.ServeHTTP(rw, req)
+	}()
+	cancel()
+	<-done
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200 for missing list path watch fallback, got %d", rw.Code)
+	}
+	lines := strings.Split(strings.TrimSpace(rw.Body.String()), "\n")
+	var hasAdded, hasBookmark bool
+	for _, line := range lines {
+		var ev map[string]any
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue
+		}
+		switch ev["type"] {
+		case "ADDED":
+			hasAdded = true
+		case "BOOKMARK":
+			hasBookmark = true
+		}
+	}
+	if hasAdded {
+		t.Error("did not expect ADDED events for missing list path watch fallback")
+	}
+	if !hasBookmark {
+		t.Error("expected BOOKMARK event for missing list path watch fallback")
 	}
 }
 


### PR DESCRIPTION
## Problem

When running `istioctl analyze` (or any client-go-based tool) against a k8shark replay server, watch streams produced errors like:

```
Unexpected watch event object type
expectedType=*v1.CustomResourceDefinition actualType=*v1.Status
expectedType=*v1.PartialObjectMetadata    actualType=*v1.Status
```

## Root cause

The BOOKMARK event in `handleWatch` was hardcoded to `kind: "Status"`. client-go reflectors compare the BOOKMARK object kind against the expected watch type, so receiving a `*v1.Status` BOOKMARK when watching CRDs or PartialObjectMetadata triggered the type mismatch error on every resync interval.

## Fix

- Expand the list struct in `handleWatch` to capture `apiVersion` and `kind` from the list body
- Derive BOOKMARK kind by stripping the `List` suffix (e.g. `CustomResourceDefinitionList` → `CustomResourceDefinition`)
- Fall back to `Status`/`v1` only when the list body carries no kind

## Also fixed

Two new watch handler tests were calling `ServeHTTP` without canceling the request context, causing them to hang indefinitely. They now use a cancelable context matching the pattern from `TestHandler_Watch`.