### PR TITLE
fix(capture): suppress noisy fallback warnings for auto-discovered resources

### DIFF
--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -456,11 +456,22 @@ func (e *Engine) fetchResource(ctx context.Context, res config.Resource) {
 
 	if allNotFound {
 		clusterPath := buildAPIPath(res.Group, res.Version, res.Resource, "")
-		fmt.Fprintf(os.Stderr,
-			"  [warn] %s: all namespace-scoped fetches returned 404 — "+
-				"this is likely a cluster-scoped resource; remove 'namespaces:' "+
-				"from its config entry. Fetching cluster-scoped path %s as fallback.\n",
-			res.Resource, clusterPath)
+		// For auto-discovered resources the namespace assignment came from the
+		// Kubernetes discovery API, not from user config. Some resources
+		// (especially OpenShift CRDs) report "namespaced" in discovery but only
+		// serve data at the cluster-scoped path. Silently fall back rather than
+		// printing a misleading "remove 'namespaces:'" hint the user can't act on.
+		if !res.AutoDiscovered {
+			fmt.Fprintf(os.Stderr,
+				"  [warn] %s: all namespace-scoped fetches returned 404 — "+
+					"this is likely a cluster-scoped resource; remove 'namespaces:' "+
+					"from its config entry. Fetching cluster-scoped path %s as fallback.\n",
+				res.Resource, clusterPath)
+		} else if e.verbose {
+			fmt.Fprintf(os.Stderr,
+				"  [debug] %s: all namespace-scoped fetches returned 404; falling back to cluster-scoped path %s\n",
+				res.Resource, clusterPath)
+		}
 		e.doFetch(ctx, clusterPath, "", dedupEnabled)
 		e.doFetch(ctx, clusterPath, tableIndexKeySuffix, dedupEnabled)
 	}
@@ -580,13 +591,14 @@ func (e *Engine) autoDiscoverResources(ctx context.Context) {
 					}
 
 					newRes := config.Resource{
-						Group:       group,
-						Version:     version,
-						Resource:    res.Name,
-						IntervalRaw: d.IntervalRaw,
-						Interval:    d.Interval,
-						Dedup:       d.Dedup,
-						Watch:       d.Watch,
+						Group:          group,
+						Version:        version,
+						Resource:       res.Name,
+						IntervalRaw:    d.IntervalRaw,
+						Interval:       d.Interval,
+						Dedup:          d.Dedup,
+						Watch:          d.Watch,
+						AutoDiscovered: true,
 					}
 					if newRes.Interval == 0 {
 						newRes.Interval = 30 * time.Second
@@ -643,13 +655,14 @@ func (e *Engine) autoDiscoverResources(ctx context.Context) {
 						}
 
 						newRes := config.Resource{
-							Group:       "",
-							Version:     "v1",
-							Resource:    res.Name,
-							IntervalRaw: d.IntervalRaw,
-							Interval:    d.Interval,
-							Dedup:       d.Dedup,
-							Watch:       d.Watch,
+							Group:          "",
+							Version:        "v1",
+							Resource:       res.Name,
+							IntervalRaw:    d.IntervalRaw,
+							Interval:       d.Interval,
+							Dedup:          d.Dedup,
+							Watch:          d.Watch,
+							AutoDiscovered: true,
 						}
 						if newRes.Interval == 0 {
 							newRes.Interval = 30 * time.Second

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -1318,3 +1318,102 @@ func TestWatchResource_Reconnects(t *testing.T) {
 		t.Fatalf("expected ADDED and MODIFIED watch events across reconnects, got %v", seen)
 	}
 }
+
+// TestFetchResource_AutoDiscoveredSilentFallback verifies that when a resource
+// was added via auto-discovery (AutoDiscovered=true) and every namespace-scoped
+// fetch returns 404, the engine falls back to the cluster-scoped path silently
+// — no warning is written to stderr.
+func TestFetchResource_AutoDiscoveredSilentFallback(t *testing.T) {
+	clusterFetched := false
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+		case strings.Contains(r.URL.Path, "/namespaces/"):
+			// All namespace-scoped fetches return 404.
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","code":404}`)
+		case r.URL.Path == "/apis/image.openshift.io/v1/imagestreamimages":
+			clusterFetched = true
+			fmt.Fprint(w, `{"kind":"ImageStreamImageList","apiVersion":"image.openshift.io/v1","items":[]}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Capture stderr to assert no warning is emitted.
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	eng := newEngineWith(&config.Config{}, srv.Client(), srv.URL, false)
+	eng.sink = &sliceSink{}
+
+	res := config.Resource{
+		Group:          "image.openshift.io",
+		Version:        "v1",
+		Resource:       "imagestreamimages",
+		Namespaces:     []string{"default", "production"},
+		IntervalRaw:    "500ms",
+		Interval:       500 * time.Millisecond,
+		AutoDiscovered: true,
+	}
+	eng.fetchResource(context.Background(), res)
+
+	w.Close()
+	os.Stderr = oldStderr
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	stderrOut := buf.String()
+
+	if strings.Contains(stderrOut, "[warn]") {
+		t.Errorf("expected no [warn] on stderr for auto-discovered resource, got: %s", stderrOut)
+	}
+	if !clusterFetched {
+		t.Error("expected engine to fall back to cluster-scoped path, but it was not fetched")
+	}
+}
+
+// TestFetchResource_ExplicitNamespaceWarnOnAllNotFound verifies that when a
+// manually-configured resource (AutoDiscovered=false) has all namespace-scoped
+// fetches return 404, the warning IS printed to stderr.
+func TestFetchResource_ExplicitNamespaceWarnOnAllNotFound(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/version" {
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"kind":"Status","status":"Failure","code":404}`)
+	}))
+	defer srv.Close()
+
+	oldStderr := os.Stderr
+	r, wPipe, _ := os.Pipe()
+	os.Stderr = wPipe
+
+	eng := newEngineWith(&config.Config{}, srv.Client(), srv.URL, false)
+	eng.sink = &sliceSink{}
+
+	res := config.Resource{
+		Version:        "v1",
+		Resource:       "widgets",
+		Namespaces:     []string{"default"},
+		IntervalRaw:    "500ms",
+		Interval:       500 * time.Millisecond,
+		AutoDiscovered: false,
+	}
+	eng.fetchResource(context.Background(), res)
+
+	wPipe.Close()
+	os.Stderr = oldStderr
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	if !strings.Contains(buf.String(), "[warn]") {
+		t.Errorf("expected [warn] on stderr for explicit resource with all-404 namespaces, got: %s", buf.String())
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,9 @@ type Resource struct {
 	// Watch enables a Kubernetes watch stream for this resource in addition to
 	// polling. Watch events are captured with low-latency timestamps.
 	Watch bool `mapstructure:"watch"`
+	// AutoDiscovered is set to true by the engine when this entry was generated
+	// via auto-discovery (all: true). It is not a user-facing config field.
+	AutoDiscovered bool `mapstructure:"-"`
 }
 
 // DedupEnabled reports whether polling responses for this resource should be


### PR DESCRIPTION
## Problem

When using `all: true` auto-discovery on a large cluster (e.g. OpenShift), the capture output was flooded with 100+ identical warnings like:

```
[warn] imagestreamimages: all namespace-scoped fetches returned 404 — this is likely a cluster-scoped resource; remove 'namespaces:' from its config entry.
[warn] alertingrules: all namespace-scoped fetches returned 404 ...
[warn] virtualmachines: all namespace-scoped fetches returned 404 ...
```

This happens because many OpenShift/operator CRDs report as `namespaced` in the Kubernetes discovery API but only serve data at the cluster-scoped path. The auto-discovery logic generates these `namespaces:` entries automatically — the user never wrote them — so the advice to "remove 'namespaces:'" is misleading and not actionable.

## Fix

- Add `AutoDiscovered bool` field to `config.Resource` (not user-facing, no YAML tag)
- `autoDiscoverResources` marks every generated entry with `AutoDiscovered: true`
- `fetchResource` suppresses the `[warn]` for auto-discovered resources and silently falls back to the cluster-scoped path
- `--verbose` mode still emits a `[debug]` line for these silent fallbacks
- The warning is preserved unchanged for manually-configured resources where the user explicitly set `namespaces:`

## Tests

- `TestFetchResource_AutoDiscoveredSilentFallback`: verifies no `[warn]` on stderr and cluster path is fetched
- `TestFetchResource_ExplicitNamespaceWarnOnAllNotFound`: verifies `[warn]` is still emitted for explicit configs