### PR TITLE
fix: improve web UI performance for large captures

### DIFF
--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/phenixblue/k8shark/internal/capture"
@@ -19,6 +20,7 @@ type CaptureStore struct {
 	Index        capture.Index
 	WatchIndex   capture.WatchIndex
 	resourceInfo map[string]*ResourceInfo
+	recordCache  sync.Map // key: record ID string → capture.Record
 }
 
 // ResourceInfo describes a single captured resource type.
@@ -133,19 +135,19 @@ func (s *CaptureStore) Latest(apiPath string, at time.Time) ([]byte, int, error)
 		id = entry.RecordIDs[idx-1]
 	}
 
-	data, err := os.ReadFile(filepath.Join(s.Dir, "k8shark-capture", "records", id+".json"))
+	rec, err := s.readRecord(id)
 	if err != nil {
-		return nil, 500, fmt.Errorf("reading record %s: %w", id, err)
-	}
-	var rec capture.Record
-	if err := json.Unmarshal(data, &rec); err != nil {
-		return nil, 500, fmt.Errorf("parsing record %s: %w", id, err)
+		return nil, 500, err
 	}
 	return rec.ResponseBody, rec.ResponseCode, nil
 }
 
 // readRecord reads and parses a single capture.Record by ID from the archive.
+// Results are cached in memory so repeated reads of the same record are free.
 func (s *CaptureStore) readRecord(id string) (capture.Record, error) {
+	if v, ok := s.recordCache.Load(id); ok {
+		return v.(capture.Record), nil
+	}
 	data, err := os.ReadFile(filepath.Join(s.Dir, "k8shark-capture", "records", id+".json"))
 	if err != nil {
 		return capture.Record{}, fmt.Errorf("reading record %s: %w", id, err)
@@ -154,6 +156,7 @@ func (s *CaptureStore) readRecord(id string) (capture.Record, error) {
 	if err := json.Unmarshal(data, &rec); err != nil {
 		return capture.Record{}, fmt.Errorf("parsing record %s: %w", id, err)
 	}
+	s.recordCache.Store(id, rec)
 	return rec, nil
 }
 

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -762,6 +762,12 @@ func (h *explorerHandler) loadResourceItemsAt(candidates []string, at time.Time)
 				foundFallback = true
 			}
 		}
+		// Once we have concrete items from the regular (non-table) path,
+		// skip remaining candidates — the ?as=Table path would only duplicate
+		// the same items at the cost of additional disk reads.
+		if len(itemOrder) > 0 && pathPriority(candidate) == 0 {
+			break
+		}
 	}
 	if len(itemOrder) > 0 {
 		merged := make([]listItem, 0, len(itemOrder))
@@ -1244,6 +1250,8 @@ const indexHTML = `<!doctype html>
 	let activeNodeIdx = -1;
 	const namespacePageSize = 120;
 	let namespaceVisibleLimit = {};
+	const namespacesPageSize = 50;
+	let namespacesVisibleLimit = namespacesPageSize;
 	const storageKindsKey = 'kshrk.ui.activeKinds.v1';
 	const storageExpandedKey = 'kshrk.ui.expandedSections.v1';
 	let expandedSections = {};
@@ -1892,9 +1900,10 @@ const indexHTML = `<!doctype html>
       }
       el.tree.appendChild(cs);
 
-      for (const ns of treeData.namespaces) {
+      const visibleNamespaces = q ? treeData.namespaces : treeData.namespaces.slice(0, namespacesVisibleLimit);
+      for (const ns of visibleNamespaces) {
         const ds = document.createElement('details');
-				ds.open = sectionOpen('ns:' + ns.name, true);
+				ds.open = sectionOpen('ns:' + ns.name, treeData.namespaces.length <= 20);
 				const nsCount = (ns.workloads || []).length + (ns.pods || []).length + (ns.resources || []).length;
 				ds.innerHTML = '<summary>Namespace: <strong>' + ns.name + '</strong> <span class="muted">(' + nsCount + ')</span></summary>';
 				bindSectionState(ds, 'ns:' + ns.name);
@@ -1964,6 +1973,21 @@ const indexHTML = `<!doctype html>
 				}
         el.tree.appendChild(ds);
       }
+
+			if (!q && treeData.namespaces.length > namespacesVisibleLimit) {
+				const nsPager = document.createElement('div');
+				nsPager.className = 'ns-pager';
+				const nsMeta = document.createElement('span');
+				nsMeta.className = 'muted';
+				nsMeta.textContent = (treeData.namespaces.length - namespacesVisibleLimit) + ' more namespaces hidden';
+				const nsBtn = document.createElement('button');
+				nsBtn.type = 'button';
+				nsBtn.textContent = 'Show more namespaces';
+				nsBtn.onclick = () => { namespacesVisibleLimit += namespacesPageSize; render(); };
+				nsPager.appendChild(nsMeta);
+				nsPager.appendChild(nsBtn);
+				el.tree.appendChild(nsPager);
+			}
 
 			if (renderedNodes === 0) {
 				const msg = q
@@ -2256,6 +2280,7 @@ const indexHTML = `<!doctype html>
 					throw new Error(msg);
 				}
 				treeData = data;
+				namespacesVisibleLimit = namespacesPageSize;
 				lastLoadedAt = normalizedAt();
 				updateMetaLine();
 				renderToggles((treeData.resource_kinds || []).concat(['Container']));


### PR DESCRIPTION
## Summary

Three targeted fixes for clusters with many namespaces (e.g. 420-namespace OpenShift captures).

### Root Causes

1. **~20K uncached disk reads per tree request** — every `buildTreeAt` call issued one `os.ReadFile` + `json.Unmarshal` per index path with no caching
2. **Duplicate reads for `?as=Table` paths** — `loadResourceItemsAt` continued iterating Table candidates even after finding items from the regular path (~2× disk I/O)
3. **420 open `<details>` elements** — all namespace sections defaulted to `open=true`, creating thousands of DOM nodes synchronously and freezing the browser, making namespaces appear "missing"

### Changes

#### `internal/server/store.go`
- Add `recordCache sync.Map` to `CaptureStore`
- `readRecord` checks cache before disk read, stores result on miss
- `Latest` now delegates to `readRecord` (eliminates duplicate `os.ReadFile` path)
- Subsequent tree builds and timeline scrubs hit the in-memory cache

#### `internal/ui/server.go`
- **Early break**: once items are found from the regular (priority-0) path in `loadResourceItemsAt`, skip remaining `?as=Table` candidates — halves disk reads per tree request
- **Namespace auto-collapse**: sections default to closed when capture has > 20 namespaces (was always `open=true`)
- **Namespace paging**: render first 50 namespaces with a "Show more namespaces" button revealing 50 at a time; `namespacesVisibleLimit` resets on each tree load

## Testing

- All 91 existing tests pass
- `golangci-lint run` clean