### PR TITLE
fix: kubectl get pods -n <ns> returns empty when capture is cluster-scoped

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -345,6 +345,34 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 	}
 
 	if code == 404 {
+		// Cluster-scoped fallback: if the resource was captured at the cluster
+		// path (e.g. pods with no namespaces: in config, or allNotFound fallback)
+		// but the request targets a specific namespace, try the cluster path and
+		// filter items by metadata.namespace. This makes kubectl get pods -n <ns>
+		// work even when only /api/v1/pods (not per-namespace paths) was captured.
+		g, v, resource, ns := parseAPIPath(path)
+		if ns != "" && resource != "" {
+			var clusterPath string
+			if g == "" {
+				clusterPath = "/api/" + v + "/" + resource
+			} else {
+				clusterPath = "/apis/" + g + "/" + v + "/" + resource
+			}
+			clusterBody, clusterCode, cerr := h.store.ReconstructAt(clusterPath, at)
+			if cerr != nil {
+				writeJSON(w, http.StatusInternalServerError, statusObj(500, cerr.Error()))
+				return
+			}
+			if clusterCode == 200 {
+				filtered, ferr := applySelectors(clusterBody, "", "metadata.namespace="+ns)
+				if ferr == nil {
+					body, code = filtered, 200
+				}
+			}
+		}
+	}
+
+	if code == 404 {
 		// If the path parses as a list-level resource (not an item GET), return
 		// an empty list with a Warning header so kubectl shows
 		// "No resources found" rather than "Error from server: not found".

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -758,3 +758,36 @@ func TestHandler_ProxySubResource405(t *testing.T) {
 		}
 	}
 }
+
+// TestHandler_NamespaceQueryFallsBackToClusterPath verifies that a request for
+// namespace-scoped pods (e.g. kubectl get pods -n default) returns the correct
+// items even when the capture only stored the cluster-scoped /api/v1/pods path
+// (no per-namespace paths in the index). This matches the behaviour when a
+// config entry for pods omits namespaces: or when the allNotFound fallback fires
+// during auto-discovery.
+func TestHandler_NamespaceQueryFallsBackToClusterPath(t *testing.T) {
+	// Cluster-scoped pod list with pods in two different namespaces.
+	podList := listWithPods([]podSpec{
+		{name: "nginx", namespace: "default"},
+		{name: "redis", namespace: "kube-system"},
+	})
+	// Only the cluster-scoped path is stored — no per-namespace paths.
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/pods": podList,
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	// Querying by namespace should still return only pods from that namespace.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d\nbody: %s", rw.Code, rw.Body.String())
+	}
+
+	names := itemNames(t, rw.Body.Bytes())
+	if len(names) != 1 || names[0] != "nginx" {
+		t.Errorf("expected [nginx], got %v", names)
+	}
+}


### PR DESCRIPTION
## Summary

When a resource is captured at the cluster-scoped path only (e.g. `/api/v1/pods` — because `namespaces:` is omitted from the config, or the `allNotFound` fallback fires during auto-discovery on a large cluster), namespace-specific queries were silently returning an empty list.

### Symptoms

- `kubectl get pods -A` → works (hits `/api/v1/pods` directly)
- `kubectl get pods -n <ns>` → empty list (hits `/api/v1/namespaces/<ns>/pods` which is not in the index)

This was the main symptom reported for large auto-discovery captures on OpenShift.

### Root Cause

`serveResource` tried `ReconstructAt` then `AggregateAcrossNamespaces` for the namespaced path. Both return 404 when no per-namespace index entries exist, so the handler fell through to the empty-list stub.

### Fix (`internal/server/handler.go`)

Add a third fallback after `AggregateAcrossNamespaces`: when the namespaced path is still 404, try the cluster-scoped path (`/api/v1/pods`) and filter the result by `metadata.namespace`. This makes namespace-specific queries work correctly regardless of how the capture was structured.

### Testing

- Added `TestHandler_NamespaceQueryFallsBackToClusterPath`: stores only `/api/v1/pods` with pods in two namespaces, asserts that querying `/api/v1/namespaces/default/pods` returns only the `default` pods
- All 76 server package tests pass
- `golangci-lint run` clean