### PR TITLE
fix: single-item GET returns 'not found' when capture is cluster-scoped

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -588,7 +588,28 @@ func (h *handler) trySingleItemGet(path string, at time.Time) ([]byte, int) {
 
 	body, code, err := h.store.ReconstructAt(parentPath, at)
 	if err != nil || code != 200 {
-		return nil, 404
+		// Namespace-scoped single-item GET whose per-namespace list was not
+		// captured: fall back to the cluster-scoped list and filter by namespace.
+		g, v, resource, ns := parseAPIPath(parentPath)
+		if ns != "" && resource != "" {
+			var clusterParent string
+			if g == "" {
+				clusterParent = "/api/" + v + "/" + resource
+			} else {
+				clusterParent = "/apis/" + g + "/" + v + "/" + resource
+			}
+			clusterBody, clusterCode, cerr := h.store.ReconstructAt(clusterParent, at)
+			if cerr == nil && clusterCode == 200 {
+				// Filter to the requested namespace before doing the name lookup.
+				filtered, ferr := applySelectors(clusterBody, "", "metadata.namespace="+ns)
+				if ferr == nil {
+					body, code = filtered, 200
+				}
+			}
+		}
+		if code != 200 {
+			return nil, 404
+		}
 	}
 
 	var list struct {

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -791,3 +791,42 @@ func TestHandler_NamespaceQueryFallsBackToClusterPath(t *testing.T) {
 		t.Errorf("expected [nginx], got %v", names)
 	}
 }
+
+// TestHandler_SingleItemGetFallsBackToClusterPath verifies that a single-item
+// GET (e.g. kubectl get pod nginx -n default) works when the capture only
+// stored the cluster-scoped /api/v1/pods path.
+func TestHandler_SingleItemGetFallsBackToClusterPath(t *testing.T) {
+	podList := listWithPods([]podSpec{
+		{name: "nginx", namespace: "default"},
+		{name: "redis", namespace: "kube-system"},
+	})
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/pods": podList,
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	// Single-item GET for the nginx pod in default — must resolve from cluster path.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/nginx", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d\nbody: %s", rw.Code, rw.Body.String())
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(rw.Body.Bytes(), &obj); err != nil {
+		t.Fatalf("expected JSON body: %v", err)
+	}
+	meta, _ := obj["metadata"].(map[string]any)
+	if meta == nil || meta["name"] != "nginx" {
+		t.Errorf("expected metadata.name=nginx, got: %v", obj)
+	}
+
+	// redis is in kube-system — looking it up in default must return 404.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/redis", nil)
+	rw2 := httptest.NewRecorder()
+	h.ServeHTTP(rw2, req2)
+	if rw2.Code == http.StatusOK {
+		t.Errorf("expected non-200 for redis in default, got 200: %s", rw2.Body.String())
+	}
+}


### PR DESCRIPTION
## Problem

When a resource is stored at the cluster-scoped path only (e.g. `/api/v1/pods`), `trySingleItemGet` looked up the namespaced parent list (`/api/v1/namespaces/<ns>/pods`) which also 404s, and immediately gave up — returning "not found in capture" even though the pod was visible in both `kubectl get pods -A` and `kubectl get pods -n <ns>`.

This is the same root cause as the list-query fix in PR #68: auto-discovery captures on large clusters (e.g. OpenShift) store resources at the cluster-scoped path when they fire the `allNotFound` fallback, or when a config entry omits `namespaces:`.

## Fix

When `ReconstructAt(parentPath)` returns 404 for a namespace-scoped list path, fall back to the cluster-scoped list, filter by `metadata.namespace`, then perform the name lookup against the filtered result.

A cross-namespace guard is enforced: a resource in namespace A cannot be retrieved when querying namespace B.

## Tests

- `TestHandler_SingleItemGetFallsBackToClusterPath` — success case (`nginx` in `default`) and cross-namespace guard (`redis` in `kube-system` not found when queried in `default`)
- All 77 server tests pass