### PR TITLE
fix: namespace-scoped watch returns empty list when capture is cluster-scoped

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -670,6 +670,29 @@ func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path strin
 	}
 
 	if code == 404 {
+		// Cluster-scoped fallback: resource was captured at the cluster path
+		// (e.g. /api/v1/pods) but the watch targets a specific namespace.
+		// Filter by metadata.namespace so k9s pod/container watchers that use
+		// a namespaced watch path see the right items.
+		g, v, resource, ns := parseAPIPath(watchPath)
+		if ns != "" && resource != "" {
+			var clusterPath string
+			if g == "" {
+				clusterPath = "/api/" + v + "/" + resource
+			} else {
+				clusterPath = "/apis/" + g + "/" + v + "/" + resource
+			}
+			clusterBody, clusterCode, cerr := h.store.ReconstructAt(clusterPath, at)
+			if cerr == nil && clusterCode == 200 {
+				filtered, ferr := applySelectors(clusterBody, "", "metadata.namespace="+ns)
+				if ferr == nil {
+					rawBody, code = filtered, 200
+				}
+			}
+		}
+	}
+
+	if code == 404 {
 		g, v, resource, _ := parseAPIPath(watchPath)
 		if resource != "" {
 			av := v

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -830,3 +830,31 @@ func TestHandler_SingleItemGetFallsBackToClusterPath(t *testing.T) {
 		t.Errorf("expected non-200 for redis in default, got 200: %s", rw2.Body.String())
 	}
 }
+
+// TestHandler_WatchFallsBackToClusterPath verifies that a namespace-scoped
+// watch (e.g. from k9s pod/container watchers) returns the correct items when
+// the capture only stored the cluster-scoped list path.
+func TestHandler_WatchFallsBackToClusterPath(t *testing.T) {
+	podList := listWithPods([]podSpec{
+		{name: "nginx", namespace: "default"},
+		{name: "redis", namespace: "kube-system"},
+	})
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/pods": podList,
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	// Watch for pods in default — must receive an ADDED event for nginx only.
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/namespaces/default/pods?watch=1&timeoutSeconds=1", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	body := rw.Body.String()
+	if !strings.Contains(body, `"nginx"`) {
+		t.Errorf("expected nginx in watch stream, got: %s", body)
+	}
+	if strings.Contains(body, `"redis"`) {
+		t.Errorf("redis (kube-system) must not appear in default namespace watch")
+	}
+}


### PR DESCRIPTION
## Problem

k9s (and other tools) set up namespace-scoped watches (e.g. `/api/v1/namespaces/<ns>/pods?watch=1`) to track pod and container status. When a capture stores resources at the cluster-scoped path only (e.g. `/api/v1/pods` — common with auto-discovery / OpenShift captures), `handleWatch` fell through to the empty-list stub because it was missing the cluster-scoped fallback that `serveResource` and `trySingleItemGet` already have.

Result: k9s reported:
```
Watcher failed for containers -- failed to locate pod "openshift-cnv/aaq-operator-c7d4d447b-mjz99": pods "aaq-operator-c7d4d447b-mjz99" not found
```
…even though the pod was visible via `kubectl get pod -n <ns> <name>`.

## Fix

Add the cluster-scoped namespace filter fallback to `handleWatch`, between the `AggregateAcrossNamespaces` attempt and the empty-list stub — matching the pattern already used in `serveResource` (PR #68) and `trySingleItemGet` (PR #69).

## Tests

- `TestHandler_WatchFallsBackToClusterPath` — asserts nginx (default) appears in watch stream; asserts redis (kube-system) does not bleed into default namespace watch
- All 78 server tests pass