### PR TITLE
fix: suppress allNotFound fallback warnings unless --verbose; deduplicate

### DIFF
--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -44,6 +44,7 @@ type Engine struct {
 	discoveryCache map[string][]byte  // bodies saved by fetchDiscovery for autoDiscoverResources
 	lastHash       map[string][32]byte
 	dedupSkipped   int
+	warnedFallback map[string]bool // dedup set for allNotFound cluster-scoped fallback warnings
 }
 
 const maxConcurrentWatchStreams = 256
@@ -79,6 +80,7 @@ func NewEngine(cfg *config.Config, verbose bool) (*Engine, error) {
 		watchIndex:     make(WatchIndex),
 		discoveryCache: make(map[string][]byte),
 		lastHash:       make(map[string][32]byte),
+		warnedFallback: make(map[string]bool),
 	}, nil
 }
 
@@ -94,6 +96,7 @@ func newEngineWith(cfg *config.Config, client *http.Client, baseURL string, verb
 		watchIndex:     make(WatchIndex),
 		discoveryCache: make(map[string][]byte),
 		lastHash:       make(map[string][32]byte),
+		warnedFallback: make(map[string]bool),
 	}
 }
 
@@ -461,16 +464,33 @@ func (e *Engine) fetchResource(ctx context.Context, res config.Resource) {
 		// (especially OpenShift CRDs) report "namespaced" in discovery but only
 		// serve data at the cluster-scoped path. Silently fall back rather than
 		// printing a misleading "remove 'namespaces:'" hint the user can't act on.
-		if !res.AutoDiscovered {
-			fmt.Fprintf(os.Stderr,
-				"  [warn] %s: all namespace-scoped fetches returned 404 — "+
-					"this is likely a cluster-scoped resource; remove 'namespaces:' "+
-					"from its config entry. Fetching cluster-scoped path %s as fallback.\n",
-				res.Resource, clusterPath)
-		} else if e.verbose {
-			fmt.Fprintf(os.Stderr,
-				"  [debug] %s: all namespace-scoped fetches returned 404; falling back to cluster-scoped path %s\n",
-				res.Resource, clusterPath)
+		if !res.AutoDiscovered && e.verbose {
+			// Deduplicate: only warn once per unique cluster-scoped path per run.
+			e.mu.Lock()
+			alreadyWarned := e.warnedFallback[clusterPath]
+			if !alreadyWarned {
+				e.warnedFallback[clusterPath] = true
+			}
+			e.mu.Unlock()
+			if !alreadyWarned {
+				fmt.Fprintf(os.Stderr,
+					"  [warn] %s: all namespace-scoped fetches returned 404 — "+
+						"this is likely a cluster-scoped resource; remove 'namespaces:' "+
+						"from its config entry. Fetching cluster-scoped path %s as fallback.\n",
+					res.Resource, clusterPath)
+			}
+		} else if res.AutoDiscovered && e.verbose {
+			e.mu.Lock()
+			alreadyWarned := e.warnedFallback[clusterPath]
+			if !alreadyWarned {
+				e.warnedFallback[clusterPath] = true
+			}
+			e.mu.Unlock()
+			if !alreadyWarned {
+				fmt.Fprintf(os.Stderr,
+					"  [debug] %s: all namespace-scoped fetches returned 404; falling back to cluster-scoped path %s\n",
+					res.Resource, clusterPath)
+			}
 		}
 		e.doFetch(ctx, clusterPath, "", dedupEnabled)
 		e.doFetch(ctx, clusterPath, tableIndexKeySuffix, dedupEnabled)

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -1378,8 +1378,52 @@ func TestFetchResource_AutoDiscoveredSilentFallback(t *testing.T) {
 
 // TestFetchResource_ExplicitNamespaceWarnOnAllNotFound verifies that when a
 // manually-configured resource (AutoDiscovered=false) has all namespace-scoped
-// fetches return 404, the warning IS printed to stderr.
+// fetches return 404, the warning IS printed to stderr when --verbose is set,
+// and is suppressed when --verbose is not set.
 func TestFetchResource_ExplicitNamespaceWarnOnAllNotFound(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/version" {
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"kind":"Status","status":"Failure","code":404}`)
+	}))
+	defer srv.Close()
+
+	oldStderr := os.Stderr
+	r, wPipe, _ := os.Pipe()
+	os.Stderr = wPipe
+
+	// verbose=true: warnings for explicit (non-auto-discovered) resources must
+	// appear when --verbose is set.
+	eng := newEngineWith(&config.Config{}, srv.Client(), srv.URL, true)
+	eng.sink = &sliceSink{}
+
+	res := config.Resource{
+		Version:        "v1",
+		Resource:       "widgets",
+		Namespaces:     []string{"default"},
+		IntervalRaw:    "500ms",
+		Interval:       500 * time.Millisecond,
+		AutoDiscovered: false,
+	}
+	eng.fetchResource(context.Background(), res)
+
+	wPipe.Close()
+	os.Stderr = oldStderr
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	if !strings.Contains(buf.String(), "[warn]") {
+		t.Errorf("expected [warn] on stderr for explicit resource with all-404 namespaces, got: %s", buf.String())
+	}
+}
+
+// TestFetchResource_ExplicitNamespaceNoWarnWithoutVerbose verifies that the
+// allNotFound fallback warning is suppressed when verbose=false.
+func TestFetchResource_ExplicitNamespaceNoWarnWithoutVerbose(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path == "/version" {
@@ -1413,7 +1457,52 @@ func TestFetchResource_ExplicitNamespaceWarnOnAllNotFound(t *testing.T) {
 	var buf bytes.Buffer
 	_, _ = io.Copy(&buf, r)
 
-	if !strings.Contains(buf.String(), "[warn]") {
-		t.Errorf("expected [warn] on stderr for explicit resource with all-404 namespaces, got: %s", buf.String())
+	if strings.Contains(buf.String(), "[warn]") {
+		t.Errorf("expected NO [warn] on stderr when verbose=false, got: %s", buf.String())
+	}
+}
+
+// TestFetchResource_ExplicitNamespaceWarnDedup verifies that the same
+// allNotFound warning is emitted at most once per unique cluster-scoped path
+// within a single engine run.
+func TestFetchResource_ExplicitNamespaceWarnDedup(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/version" {
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"kind":"Status","status":"Failure","code":404}`)
+	}))
+	defer srv.Close()
+
+	oldStderr := os.Stderr
+	r, wPipe, _ := os.Pipe()
+	os.Stderr = wPipe
+
+	eng := newEngineWith(&config.Config{}, srv.Client(), srv.URL, true)
+	eng.sink = &sliceSink{}
+
+	res := config.Resource{
+		Version:        "v1",
+		Resource:       "widgets",
+		Namespaces:     []string{"default"},
+		IntervalRaw:    "500ms",
+		Interval:       500 * time.Millisecond,
+		AutoDiscovered: false,
+	}
+	// Call fetchResource twice for the same resource — warning must appear only once.
+	eng.fetchResource(context.Background(), res)
+	eng.fetchResource(context.Background(), res)
+
+	wPipe.Close()
+	os.Stderr = oldStderr
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	count := strings.Count(buf.String(), "[warn]")
+	if count != 1 {
+		t.Errorf("expected exactly 1 [warn] for duplicate resource, got %d:\n%s", count, buf.String())
 	}
 }

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -670,6 +670,29 @@ func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path strin
 	}
 
 	if code == 404 {
+		// Cluster-scoped fallback: resource was captured at the cluster path
+		// (e.g. /api/v1/pods) but the watch targets a specific namespace.
+		// Filter by metadata.namespace so k9s pod/container watchers that use
+		// a namespaced watch path see the right items.
+		g, v, resource, ns := parseAPIPath(watchPath)
+		if ns != "" && resource != "" {
+			var clusterPath string
+			if g == "" {
+				clusterPath = "/api/" + v + "/" + resource
+			} else {
+				clusterPath = "/apis/" + g + "/" + v + "/" + resource
+			}
+			clusterBody, clusterCode, cerr := h.store.ReconstructAt(clusterPath, at)
+			if cerr == nil && clusterCode == 200 {
+				filtered, ferr := applySelectors(clusterBody, "", "metadata.namespace="+ns)
+				if ferr == nil {
+					rawBody, code = filtered, 200
+				}
+			}
+		}
+	}
+
+	if code == 404 {
 		g, v, resource, _ := parseAPIPath(watchPath)
 		if resource != "" {
 			av := v

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -830,3 +830,31 @@ func TestHandler_SingleItemGetFallsBackToClusterPath(t *testing.T) {
 		t.Errorf("expected non-200 for redis in default, got 200: %s", rw2.Body.String())
 	}
 }
+
+// TestHandler_WatchFallsBackToClusterPath verifies that a namespace-scoped
+// watch (e.g. from k9s pod/container watchers) returns the correct items when
+// the capture only stored the cluster-scoped list path.
+func TestHandler_WatchFallsBackToClusterPath(t *testing.T) {
+	podList := listWithPods([]podSpec{
+		{name: "nginx", namespace: "default"},
+		{name: "redis", namespace: "kube-system"},
+	})
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/pods": podList,
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	// Watch for pods in default — must receive an ADDED event for nginx only.
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/namespaces/default/pods?watch=1&timeoutSeconds=1", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	body := rw.Body.String()
+	if !strings.Contains(body, `"nginx"`) {
+		t.Errorf("expected nginx in watch stream, got: %s", body)
+	}
+	if strings.Contains(body, `"redis"`) {
+		t.Errorf("redis (kube-system) must not appear in default namespace watch")
+	}
+}


### PR DESCRIPTION
## Problem

On large OpenShift clusters with auto-discovery, every resource that discovery reports as namespaced but that only serves data at the cluster-scoped path emits a `[warn]` line — producing 100+ lines of noise on every `kshrk capture` run even though the fallback works correctly.

## Changes

- **Gate on `--verbose`**: the `[warn]` message for explicit (non-auto-discovered) config entries is now only printed when `--verbose` is set, matching the existing `[debug]` path for auto-discovered resources.
- **Deduplicate**: added `warnedFallback map[string]bool` to `Engine`; each unique cluster-scoped fallback path is reported at most once per run (relevant when the same resource appears in multiple poll ticks).

## Result

Normal `kshrk capture` output is clean. Running with `--verbose` still shows all warnings/debug lines, deduplicated.

## Tests

- `TestFetchResource_ExplicitNamespaceNoWarnWithoutVerbose` — no output when verbose=false
- `TestFetchResource_ExplicitNamespaceWarnDedup` — duplicate fetchResource calls emit exactly one warning
- Updated `TestFetchResource_ExplicitNamespaceWarnOnAllNotFound` to run with verbose=true
- All 31 capture tests + 109 total tests pass