### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,9 @@ on:
       - '.github/*.yml'
       - '.github/*.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/phenixblue/k8shark/security/code-scanning/1](https://github.com/phenixblue/k8shark/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/e2e.yml` at the workflow root (top-level), so it applies to all jobs unless overridden. For this workflow, the minimal safe baseline is:

- `contents: read`

This is sufficient for `actions/checkout` and typical read-only CI operations. Place it after the `on:` section (or near the top-level keys before `jobs:`) to keep structure clear and preserve behavior.

No imports, methods, or extra definitions are needed—just YAML key insertion in `.github/workflows/e2e.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
