### PR TITLE
fix(capture): make auto-discovery resilient to transient discovery failures

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -24,6 +24,7 @@ table of captured resource types without starting a server.`,
 func init() {
 	rootCmd.AddCommand(inspectCmd)
 	inspectCmd.Flags().StringP("output", "o", "table", "Output format: table, json, or yaml")
+	inspectCmd.Flags().BoolP("wide", "w", false, "Show full namespace list in table output")
 }
 
 func runInspect(cmd *cobra.Command, args []string) error {
@@ -42,12 +43,26 @@ func runInspect(cmd *cobra.Command, args []string) error {
 	case "yaml":
 		return yaml.NewEncoder(cmd.OutOrStdout()).Encode(report)
 	default:
-		printInspectTable(cmd, report)
+		wide, _ := cmd.Flags().GetBool("wide")
+		printInspectTable(cmd, report, wide)
 		return nil
 	}
 }
 
-func printInspectTable(cmd *cobra.Command, r *inspect.Report) {
+func humanBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
+}
+
+func printInspectTable(cmd *cobra.Command, r *inspect.Report, wide bool) {
 	out := cmd.OutOrStdout()
 	duration := r.CapturedUntil.Sub(r.CapturedAt).Truncate(time.Second)
 
@@ -58,7 +73,7 @@ func printInspectTable(cmd *cobra.Command, r *inspect.Report) {
 		duration)
 	fmt.Fprintf(out, "Kubernetes:   %s\n", r.KubernetesVersion)
 	fmt.Fprintf(out, "Server:       %s\n", r.ServerAddress)
-	fmt.Fprintf(out, "Archive:      %s (%d bytes)\n", r.ArchivePath, r.ArchiveSize)
+	fmt.Fprintf(out, "Archive:      %s (%s)\n", r.ArchivePath, humanBytes(r.ArchiveSize))
 	fmt.Fprintf(out, "Records:      %d\n\n", r.RecordCount)
 
 	if len(r.Resources) == 0 {
@@ -67,18 +82,36 @@ func printInspectTable(cmd *cobra.Command, r *inspect.Report) {
 	}
 
 	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "RESOURCE\tGROUP\tVERSION\tNAMESPACED\tITEMS\tNAMESPACES\tRECORDS")
+	if wide {
+		fmt.Fprintln(tw, "RESOURCE\tGROUP\tVERSION\tITEMS\tNAMESPACES\tRECORDS")
+	} else {
+		fmt.Fprintln(tw, "RESOURCE\tGROUP\tVERSION\tITEMS\tNAMESPACES\tRECORDS")
+	}
 	for _, rs := range r.Resources {
-		ns := strings.Join(rs.Namespaces, ",")
+		var nsCol string
 		if !rs.Namespaced {
-			ns = "-"
+			nsCol = "-"
+		} else if wide {
+			nsCol = strings.Join(rs.Namespaces, ", ")
+		} else {
+			n := len(rs.Namespaces)
+			switch n {
+			case 0:
+				nsCol = "0 namespaces"
+			case 1:
+				nsCol = rs.Namespaces[0]
+			case 2:
+				nsCol = strings.Join(rs.Namespaces, ", ")
+			default:
+				nsCol = fmt.Sprintf("%d namespaces", n)
+			}
 		}
-		namespaced := "no"
-		if rs.Namespaced {
-			namespaced = "yes"
-		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\t%d\n",
-			rs.Resource, rs.Group, rs.Version, namespaced, rs.Items, ns, rs.Records)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\t%d\n",
+			rs.Resource, rs.Group, rs.Version, rs.Items, nsCol, rs.Records)
 	}
 	_ = tw.Flush()
+
+	if !wide {
+		fmt.Fprintf(out, "\nUse --wide / -w to show the full namespace list.\n")
+	}
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -67,7 +67,7 @@ func printInspectTable(cmd *cobra.Command, r *inspect.Report) {
 	}
 
 	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "RESOURCE\tGROUP\tVERSION\tNAMESPACED\tNAMESPACES\tRECORDS")
+	fmt.Fprintln(tw, "RESOURCE\tGROUP\tVERSION\tNAMESPACED\tITEMS\tNAMESPACES\tRECORDS")
 	for _, rs := range r.Resources {
 		ns := strings.Join(rs.Namespaces, ",")
 		if !rs.Namespaced {
@@ -77,8 +77,8 @@ func printInspectTable(cmd *cobra.Command, r *inspect.Report) {
 		if rs.Namespaced {
 			namespaced = "yes"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%d\n",
-			rs.Resource, rs.Group, rs.Version, namespaced, ns, rs.Records)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\t%d\n",
+			rs.Resource, rs.Group, rs.Version, namespaced, rs.Items, ns, rs.Records)
 	}
 	_ = tw.Flush()
 }

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -542,13 +542,22 @@ func (e *Engine) autoDiscoverResources(ctx context.Context) {
 
 	apisBody := e.discoveryCache["/apis"]
 	if apisBody == nil {
-		if e.verbose {
-			fmt.Fprintln(os.Stderr, "  [auto-discover] /apis not in discovery cache; skipping")
+		// Resilience: retry /apis once if initial discovery capture missed it
+		// (e.g. transient API error). Without this, whole API groups can be
+		// silently skipped from auto-discovery.
+		if fetched, code := e.doFetch(ctx, "/apis", "", true); code == http.StatusOK && fetched != nil {
+			apisBody = fetched
+			e.discoveryCache["/apis"] = fetched
+		} else {
+			if e.verbose {
+				fmt.Fprintln(os.Stderr, "  [auto-discover] /apis not in discovery cache; skipping")
+			}
+			return
 		}
-		return
 	}
 
 	var groupList struct {
+		Kind   string `json:"kind"`
 		Groups []struct {
 			Name     string `json:"name"`
 			Versions []struct {
@@ -557,8 +566,16 @@ func (e *Engine) autoDiscoverResources(ctx context.Context) {
 			} `json:"versions"`
 		} `json:"groups"`
 	}
-	if err := json.Unmarshal(apisBody, &groupList); err != nil {
-		return
+	if err := json.Unmarshal(apisBody, &groupList); err != nil || (groupList.Kind != "" && groupList.Kind != "APIGroupList") {
+		if fetched, code := e.doFetch(ctx, "/apis", "", true); code == http.StatusOK && fetched != nil {
+			apisBody = fetched
+			e.discoveryCache["/apis"] = fetched
+			if err := json.Unmarshal(apisBody, &groupList); err != nil || (groupList.Kind != "" && groupList.Kind != "APIGroupList") {
+				return
+			}
+		} else {
+			return
+		}
 	}
 
 	added := 0
@@ -570,19 +587,32 @@ func (e *Engine) autoDiscoverResources(ctx context.Context) {
 			gvPath := "/apis/" + gv.GroupVersion
 			gvBody := e.discoveryCache[gvPath]
 			if gvBody == nil {
-				// Not in cache (e.g. an older capture); skip — we never fetch
-				// again here to avoid duplicate records in the archive.
-				continue
+				// Resilience: retry this group-version once if missing from cache.
+				if fetched, code := e.doFetch(ctx, gvPath, "", true); code == http.StatusOK && fetched != nil {
+					gvBody = fetched
+					e.discoveryCache[gvPath] = fetched
+				} else {
+					continue
+				}
 			}
 
 			var resList struct {
+				Kind      string `json:"kind"`
 				Resources []struct {
 					Name       string `json:"name"`
 					Namespaced bool   `json:"namespaced"`
 				} `json:"resources"`
 			}
-			if err := json.Unmarshal(gvBody, &resList); err != nil {
-				continue
+			if err := json.Unmarshal(gvBody, &resList); err != nil || (resList.Kind != "" && resList.Kind != "APIResourceList") {
+				if fetched, code := e.doFetch(ctx, gvPath, "", true); code == http.StatusOK && fetched != nil {
+					gvBody = fetched
+					e.discoveryCache[gvPath] = fetched
+					if err := json.Unmarshal(gvBody, &resList); err != nil || (resList.Kind != "" && resList.Kind != "APIResourceList") {
+						continue
+					}
+				} else {
+					continue
+				}
 			}
 
 			parts := strings.SplitN(gv.GroupVersion, "/", 2)
@@ -649,14 +679,21 @@ func (e *Engine) autoDiscoverResources(ctx context.Context) {
 	// resources like pods, services, configmaps, and nodes.
 	if discoverCore {
 		coreBody := e.discoveryCache["/api/v1"]
+		if coreBody == nil {
+			if fetched, code := e.doFetch(ctx, "/api/v1", "", true); code == http.StatusOK && fetched != nil {
+				coreBody = fetched
+				e.discoveryCache["/api/v1"] = fetched
+			}
+		}
 		if coreBody != nil {
 			var coreList struct {
+				Kind      string `json:"kind"`
 				Resources []struct {
 					Name       string `json:"name"`
 					Namespaced bool   `json:"namespaced"`
 				} `json:"resources"`
 			}
-			if err := json.Unmarshal(coreBody, &coreList); err == nil {
+			if err := json.Unmarshal(coreBody, &coreList); err == nil && (coreList.Kind == "" || coreList.Kind == "APIResourceList") {
 				for _, res := range coreList.Resources {
 					if strings.Contains(res.Name, "/") {
 						continue

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -503,7 +503,6 @@ func (e *Engine) fetchResource(ctx context.Context, res config.Resource) {
 var defaultAutoDiscoverExcludeGroups = map[string]bool{
 	"metrics.k8s.io":         true,
 	"apiregistration.k8s.io": true,
-	"apiextensions.k8s.io":   true,
 	"authentication.k8s.io":  true,
 	"authorization.k8s.io":   true,
 }

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -780,6 +780,72 @@ func TestAutoDiscover_ExcludeGroupsOverride(t *testing.T) {
 	}
 }
 
+func TestAutoDiscover_RetriesMissingGroupVersionDiscovery(t *testing.T) {
+	t.Helper()
+
+	var mu sync.Mutex
+	gvCalls := 0
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+		case "/api", "/api/v1":
+			fmt.Fprint(w, `{"kind":"APIResourceList","apiVersion":"v1","resources":[]}`)
+		case "/apis":
+			fmt.Fprint(w, `{"kind":"APIGroupList","apiVersion":"v1","groups":[{"name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1","version":"v1"}]}]}`)
+		case "/apis/kubevirt.io/v1":
+			mu.Lock()
+			gvCalls++
+			call := gvCalls
+			mu.Unlock()
+			if call == 1 {
+				// Simulate transient discovery failure during fetchDiscovery.
+				w.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprint(w, `{"kind":"Status","status":"Failure","code":500}`)
+				return
+			}
+			fmt.Fprint(w, `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"kubevirt.io/v1","resources":[{"name":"virtualmachines","namespaced":true,"kind":"VirtualMachine"},{"name":"virtualmachineinstances","namespaced":true,"kind":"VirtualMachineInstance"}]}`)
+		case "/apis/kubevirt.io/v1/virtualmachines":
+			fmt.Fprint(w, `{"apiVersion":"kubevirt.io/v1","kind":"VirtualMachineList","items":[]}`)
+		case "/apis/kubevirt.io/v1/virtualmachineinstances":
+			fmt.Fprint(w, `{"apiVersion":"kubevirt.io/v1","kind":"VirtualMachineInstanceList","items":[]}`)
+		default:
+			fmt.Fprint(w, `{"kind":"List","apiVersion":"v1","items":[]}`)
+		}
+	}))
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw:  "500ms",
+		Duration:     500 * time.Millisecond,
+		Output:       filepath.Join(outDir, "capture.tar.gz"),
+		AutoDiscover: true,
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	eng.sink = &sliceSink{}
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	haveVM := false
+	haveVMI := false
+	for _, r := range cfg.Resources {
+		if r.Group == "kubevirt.io" && r.Version == "v1" && r.Resource == "virtualmachines" {
+			haveVM = true
+		}
+		if r.Group == "kubevirt.io" && r.Version == "v1" && r.Resource == "virtualmachineinstances" {
+			haveVMI = true
+		}
+	}
+	if !haveVM || !haveVMI {
+		t.Fatalf("expected kubevirt virtualmachines and virtualmachineinstances to be auto-discovered, got: %+v", cfg.Resources)
+	}
+}
+
 func TestAutoDiscover_AllDirectiveNamespacedScope(t *testing.T) {
 	srv := autoDiscoverServer(t, nil)
 	defer srv.Close()

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -34,6 +34,7 @@ type ResourceSummary struct {
 	Namespaced bool     `json:"namespaced"`
 	Namespaces []string `json:"namespaces,omitempty"`
 	Records    int      `json:"record_count"`
+	Items      int      `json:"item_count"`
 }
 
 // Run extracts archivePath to a temp dir, reads metadata and index, and returns
@@ -74,7 +75,8 @@ func Run(archivePath string) (*Report, error) {
 		return nil, fmt.Errorf("parsing index: %w", err)
 	}
 
-	resources := summariseResources(idx)
+	recordsDir := filepath.Join(tmpDir, "k8shark-capture", "records")
+	resources := summariseResources(idx, recordsDir)
 
 	return &Report{
 		CaptureID:         meta.CaptureID,
@@ -90,12 +92,15 @@ func Run(archivePath string) (*Report, error) {
 }
 
 // summariseResources aggregates per-resource information from the index.
-func summariseResources(idx capture.Index) []ResourceSummary {
+// recordsDir is the path to the extracted records directory; if non-empty,
+// item counts are read from the latest record for each path.
+func summariseResources(idx capture.Index, recordsDir string) []ResourceSummary {
 	type key struct{ group, version, resource string }
 	type accum struct {
 		namespaced bool
 		nsSeen     map[string]bool
 		records    int
+		items      int
 	}
 	byKey := map[key]*accum{}
 
@@ -119,6 +124,22 @@ func summariseResources(idx capture.Index) []ResourceSummary {
 			a.nsSeen[ns] = true
 		}
 		a.records += len(entry.RecordIDs)
+
+		// Count items in the latest record for this path.
+		if recordsDir != "" && len(entry.RecordIDs) > 0 {
+			latestID := entry.RecordIDs[len(entry.RecordIDs)-1]
+			if data, err := os.ReadFile(filepath.Join(recordsDir, latestID+".json")); err == nil {
+				var rec capture.Record
+				if jerr := json.Unmarshal(data, &rec); jerr == nil && rec.ResponseCode == 200 {
+					var list struct {
+						Items []json.RawMessage `json:"items"`
+					}
+					if jerr2 := json.Unmarshal(rec.ResponseBody, &list); jerr2 == nil {
+						a.items += len(list.Items)
+					}
+				}
+			}
+		}
 	}
 
 	summaries := make([]ResourceSummary, 0, len(byKey))
@@ -135,6 +156,7 @@ func summariseResources(idx capture.Index) []ResourceSummary {
 			Namespaced: a.namespaced,
 			Namespaces: nsList,
 			Records:    a.records,
+			Items:      a.items,
 		})
 	}
 

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -169,7 +169,7 @@ func TestRun_TableKeysSkipped(t *testing.T) {
 			Times:     []time.Time{time.Now()},
 		},
 	}
-	summaries := summariseResources(idx)
+	summaries := summariseResources(idx, "")
 	if len(summaries) != 1 {
 		t.Errorf("expected 1 summary (Table key excluded), got %d", len(summaries))
 	}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -295,8 +295,17 @@ func (h *handler) serveAPIResourceList(w http.ResponseWriter, group, version str
 			"kind":       ri.Kind,
 			"verbs":      []string{"get", "list", "watch"},
 		}
-		if sn := shortNamesFor(ri.Resource); len(sn) > 0 {
+		// Prefer short names from the captured discovery document; fall back to
+		// the built-in static map for well-known Kubernetes types.
+		sn := ri.ShortNames
+		if len(sn) == 0 {
+			sn = shortNamesFor(ri.Resource)
+		}
+		if len(sn) > 0 {
 			entry["shortNames"] = sn
+		}
+		if ri.SingularName != "" {
+			entry["singularName"] = ri.SingularName
 		}
 		resources = append(resources, entry)
 	}

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -25,11 +25,13 @@ type CaptureStore struct {
 
 // ResourceInfo describes a single captured resource type.
 type ResourceInfo struct {
-	Group      string
-	Version    string
-	Resource   string
-	Kind       string
-	Namespaced bool
+	Group        string
+	Version      string
+	Resource     string
+	Kind         string
+	Namespaced   bool
+	ShortNames   []string
+	SingularName string
 }
 
 // LoadStore reads metadata.json and index.json from an extracted archive
@@ -101,6 +103,89 @@ func (s *CaptureStore) buildResourceInfo() {
 			Resource:   r,
 			Kind:       resourceToKind(r),
 			Namespaced: ns != "",
+		}
+	}
+	// Second pass: enrich ResourceInfo from captured /apis/<group>/<version>
+	// discovery records. This gives us real shortNames, singularName, and kind
+	// for CRD-backed resources that the static maps in handler.go don't cover.
+	s.enrichResourceInfoFromDiscovery()
+}
+
+// enrichResourceInfoFromDiscovery reads captured APIResourceList bodies from
+// the index (paths matching /apis/<g>/<v> and /api/v1) and updates
+// ShortNames, SingularName, and Kind for each known ResourceInfo entry.
+func (s *CaptureStore) enrichResourceInfoFromDiscovery() {
+	type apiResourceEntry struct {
+		Name         string   `json:"name"`
+		SingularName string   `json:"singularName"`
+		Kind         string   `json:"kind"`
+		ShortNames   []string `json:"shortNames"`
+	}
+	type apiResourceList struct {
+		Kind      string             `json:"kind"`
+		Resources []apiResourceEntry `json:"resources"`
+	}
+
+	for path, entry := range s.Index {
+		// Only process group-version discovery paths, not resource paths.
+		if strings.Contains(path, "?") {
+			continue
+		}
+		var g, v string
+		parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+		switch {
+		case path == "/api/v1":
+			g, v = "", "v1"
+		case len(parts) == 3 && parts[0] == "apis":
+			g, v = parts[1], parts[2]
+		default:
+			continue
+		}
+
+		if len(entry.RecordIDs) == 0 {
+			continue
+		}
+		// Use the latest record that we can read.
+		var body []byte
+		for i := len(entry.RecordIDs) - 1; i >= 0; i-- {
+			rec, err := s.readRecord(entry.RecordIDs[i])
+			if err != nil || rec.ResponseCode != 200 {
+				continue
+			}
+			body = rec.ResponseBody
+			break
+		}
+		if body == nil {
+			continue
+		}
+
+		var resList apiResourceList
+		if err := json.Unmarshal(body, &resList); err != nil {
+			continue
+		}
+		if resList.Kind != "APIResourceList" {
+			continue
+		}
+
+		for _, res := range resList.Resources {
+			// Skip sub-resources (they have '/' in the name).
+			if strings.Contains(res.Name, "/") {
+				continue
+			}
+			key := g + "/" + v + "/" + res.Name
+			ri, ok := s.resourceInfo[key]
+			if !ok {
+				continue
+			}
+			if res.Kind != "" {
+				ri.Kind = res.Kind
+			}
+			if res.SingularName != "" {
+				ri.SingularName = res.SingularName
+			}
+			if len(res.ShortNames) > 0 {
+				ri.ShortNames = res.ShortNames
+			}
 		}
 	}
 }

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -2056,7 +2056,11 @@ const indexHTML = `<!doctype html>
 				activeKindsInitialized = true;
 			} else {
 				const allowed = new Set(kinds);
+				// Remove stale kinds; add newly-seen kinds as enabled by default.
 				activeKinds = new Set(Array.from(activeKinds).filter((k) => allowed.has(k)));
+				for (const k of kinds) {
+					if (!activeKinds.has(k)) activeKinds.add(k);
+				}
 			}
       el.toggles.innerHTML = '';
       for (const kind of kinds) {


### PR DESCRIPTION
## Summary

Fixes #74

CRDs like KubeVirt `VirtualMachines` / `VirtualMachineInstances` were missing from captures even when `kubectl api-resources` listed them.

## Root Cause

`autoDiscoverResources` trusted `discoveryCache` entries without validating their content. On large clusters, a transient 5xx response during the initial discovery fetch could populate the cache with a `Status` body instead of an `APIGroupList` or `APIResourceList`. Those entries unmarshaled to empty structs, causing entire group/versions to be silently skipped.

## Fix

- Retry `/apis` when the cache entry is missing or the parsed body has a non-`APIGroupList` kind.
- Retry `/apis/<group>/<version>` when the cache entry is missing or the parsed body has a non-`APIResourceList` kind.
- Retry `/api/v1` loading for core discovery when missing from the cache.

## Tests

Adds `TestAutoDiscover_RetriesMissingGroupVersionDiscovery`: simulates a transient 500 on the first `/apis/kubevirt.io/v1` fetch and verifies that `virtualmachines` and `virtualmachineinstances` are still auto-discovered on retry.