### PR TITLE
perf: ZIP+Zstd archive format with in-memory reader, LRU cache, and parallel watch reconstruction

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -14,16 +14,16 @@ import (
 
 var captureCmd = &cobra.Command{
 	Use:   "capture",
-	Short: "Capture Kubernetes cluster state to a .tar.gz archive",
+	Short: "Capture Kubernetes cluster state to a .khsrk archive",
 	Long: `Runs a series of Kubernetes API read operations at defined intervals
 for a configured duration. All responses are recorded and packaged into a
-single .tar.gz capture file for later replay.`,
+single .khsrk capture file for later replay.`,
 	RunE: runCapture,
 }
 
 func init() {
 	rootCmd.AddCommand(captureCmd)
-	captureCmd.Flags().StringP("output", "o", "", "output file path (default: ./k8shark-<timestamp>.tar.gz)")
+	captureCmd.Flags().StringP("output", "o", "", "output file path (default: ./k8shark-<timestamp>.khsrk)")
 	captureCmd.Flags().String("kubeconfig", "", "path to kubeconfig (defaults to KUBECONFIG env, then ~/.kube/config)")
 	captureCmd.Flags().String("duration", "", "capture duration, overrides config file value (e.g. 10m, 1h)")
 	captureCmd.Flags().Bool("auto-discover", false, "auto-discover and capture all available API resources")

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -87,10 +87,17 @@ func buildDiffArchive(t *testing.T, body string) string {
 	rec := &capture.Record{ID: "rec-1", CapturedAt: now, APIPath: "/api/v1/namespaces/default/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body)}
 	meta := &capture.CaptureMetadata{CaptureID: "test-capture", CapturedAt: now, CapturedUntil: now, RecordCount: 1}
 	index := capture.Index{
-		"/api/v1/namespaces/default/pods": {APIPath: "/api/v1/namespaces/default/pods", RecordIDs: []string{"rec-1"}, Times: []time.Time{now}},
+		"/api/v1/namespaces/default/pods": {APIPath: "/api/v1/namespaces/default/pods", Seqs: []int{0}, Times: []time.Time{now}},
 	}
-	if err := archivepkg.Write(out, meta, []*capture.Record{rec}, index); err != nil {
-		t.Fatalf("archive.Write: %v", err)
+	sw, err := archivepkg.NewStreamWriter(out)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	if err := sw.WriteRecord(rec); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+	if err := sw.Finish(meta, index, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
 	}
 	return out
 }

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -82,7 +82,7 @@ func newTestDiffCommand() *cobra.Command {
 
 func buildDiffArchive(t *testing.T, body string) string {
 	t.Helper()
-	out := filepath.Join(t.TempDir(), "capture.tar.gz")
+	out := filepath.Join(t.TempDir(), "capture.khsrk")
 	now := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	rec := &capture.Record{ID: "rec-1", CapturedAt: now, APIPath: "/api/v1/namespaces/default/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body)}
 	meta := &capture.CaptureMetadata{CaptureID: "test-capture", CapturedAt: now, CapturedUntil: now, RecordCount: 1}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -13,7 +13,7 @@ import (
 )
 
 var inspectCmd = &cobra.Command{
-	Use:   "inspect <capture.tar.gz>",
+	Use:   "inspect <capture.khsrk>",
 	Short: "Display a summary of a capture archive's contents",
 	Long: `Reads a k8shark capture archive and prints capture metadata and a
 table of captured resource types without starting a server.`,

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -8,7 +8,7 @@ import (
 )
 
 var openCmd = &cobra.Command{
-	Use:   "open <capture.tar.gz>",
+	Use:   "open <capture.khsrk>",
 	Short: "Open a capture file and start a mock Kubernetes API server",
 	Long: `Extracts a k8shark capture archive, starts a local mock Kubernetes
 API server, and writes a kubeconfig so kubectl can connect immediately.`,

--- a/cmd/redact.go
+++ b/cmd/redact.go
@@ -12,7 +12,7 @@ import (
 )
 
 var redactCmd = &cobra.Command{
-	Use:   "redact --in <capture.tar.gz> [--out <redacted.tar.gz>]",
+	Use:   "redact --in <capture.khsrk> [--out <redacted.khsrk>]",
 	Short: "Redact Secret data and arbitrary fields from a capture archive",
 	Long: `Produces a new capture archive with Kubernetes Secret data replaced by
 "REDACTED" and any configured field-level redaction rules applied.
@@ -22,16 +22,16 @@ Field rules can be supplied via --redact-field (repeatable) with the format:
   <fieldPath>:<Kind>:<replacement>[:<valueType>]
 
 Examples:
-  kshrk redact --in capture.tar.gz --redact-secrets
-  kshrk redact --in capture.tar.gz --redact-field "data.api-key:ConfigMap:REDACTED"
-  kshrk redact --in capture.tar.gz --config k8shark.yaml`,
+  kshrk redact --in capture.khsrk --redact-secrets
+  kshrk redact --in capture.khsrk --redact-field "data.api-key:ConfigMap:REDACTED"
+  kshrk redact --in capture.khsrk --config k8shark.yaml`,
 	RunE: runRedact,
 }
 
 func init() {
 	rootCmd.AddCommand(redactCmd)
 	redactCmd.Flags().String("in", "", "source capture archive (required)")
-	redactCmd.Flags().String("out", "", "output archive path (default: <in>-redacted.tar.gz)")
+	redactCmd.Flags().String("out", "", "output archive path (default: <in>-redacted.khsrk)")
 	redactCmd.Flags().Bool("redact-secrets", false, "redact all Kubernetes Secret data and stringData values")
 	redactCmd.Flags().StringArray("allow-secret", nil, "namespace/name of secret to preserve (repeatable)")
 	redactCmd.Flags().StringArray("redact-field", nil, "field redaction rule: <fieldPath>:<Kind>:<replacement>[:<valueType>] (repeatable)")
@@ -66,8 +66,8 @@ func runRedact(cmd *cobra.Command, _ []string) error {
 	cfgFile, _ := cmd.Flags().GetString("config")
 
 	if out == "" {
-		base := strings.TrimSuffix(in, ".tar.gz")
-		out = base + "-redacted.tar.gz"
+		base := strings.TrimSuffix(in, ".khsrk")
+		out = base + "-redacted.khsrk"
 	}
 
 	// Refuse to overwrite the source.

--- a/cmd/transitions.go
+++ b/cmd/transitions.go
@@ -12,7 +12,7 @@ import (
 )
 
 var transitionsCmd = &cobra.Command{
-	Use:   "transitions <capture.tar.gz>",
+	Use:   "transitions <capture.khsrk>",
 	Short: "List resource state changes from a capture archive",
 	Long: `Reads a k8shark capture archive and reports ADDED, MODIFIED, and DELETED
 events for captured resources, without starting a replay server.

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -12,7 +12,7 @@ import (
 )
 
 var uiCmd = &cobra.Command{
-	Use:   "ui <capture.tar.gz>",
+	Use:   "ui <capture.khsrk>",
 	Short: "Open an interactive web explorer for a capture archive",
 	Long: `Starts a local web UI for browsing a k8shark capture and also runs
 the mock Kubernetes API server with generated kubeconfig output.`,

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.1
 
 require (
 	github.com/google/uuid v1.6.0
+	github.com/klauspost/compress v1.18.5
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
@@ -21,7 +22,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
+github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -1,18 +1,22 @@
 package archive
 
 import (
-	"archive/tar"
-	"compress/gzip"
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
+	"sync/atomic"
+
+	"github.com/klauspost/compress/zstd"
 )
 
 // RecordSink accepts individual capture records as they arrive.
-// It decouples the engine from the specific output format (tar.gz vs NDJSON).
 type RecordSink interface {
 	WriteRecord(rec any) error
 	// Finish writes metadata.json, index.json, and (when watchIndex is non-nil)
@@ -21,14 +25,61 @@ type RecordSink interface {
 	RecordCount() int
 }
 
-// StreamWriter streams each record directly into a .tar.gz archive as it
-// arrives. metadata.json and index.json are written by Finish(). Thread-safe.
+// pathDir returns a short, filesystem-safe directory name for an API path.
+// We use the first 16 hex chars of SHA-256 to avoid path-length issues.
+func pathDir(apiPath string) string {
+	sum := sha256.Sum256([]byte(apiPath))
+	return fmt.Sprintf("%x", sum[:8])
+}
+
+// zstdEncoder is a package-level encoder pool for compressing record data.
+var zstdEncoderPool = sync.Pool{
+	New: func() any {
+		enc, _ := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
+		return enc
+	},
+}
+
+func zstdCompress(data []byte) ([]byte, error) {
+	enc := zstdEncoderPool.Get().(*zstd.Encoder)
+	defer zstdEncoderPool.Put(enc)
+	var buf bytes.Buffer
+	enc.Reset(&buf)
+	if _, err := enc.Write(data); err != nil {
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// zstdDecoder is a package-level decoder pool.
+var zstdDecoderPool = sync.Pool{
+	New: func() any {
+		dec, _ := zstd.NewReader(nil)
+		return dec
+	},
+}
+
+func zstdDecompress(data []byte) ([]byte, error) {
+	dec := zstdDecoderPool.Get().(*zstd.Decoder)
+	defer zstdDecoderPool.Put(dec)
+	if err := dec.Reset(bytes.NewReader(data)); err != nil {
+		return nil, err
+	}
+	return io.ReadAll(dec)
+}
+
+// StreamWriter streams each record directly into a .kshrk (ZIP+Zstd) archive.
+// metadata.json, index.json, and watch-index.json are written by Finish().
+// Thread-safe.
 type StreamWriter struct {
-	mu sync.Mutex
-	f  *os.File
-	gw *gzip.Writer
-	tw *tar.Writer
-	n  int
+	mu      sync.Mutex
+	f       *os.File
+	zw      *zip.Writer
+	n       int
+	pathSeq map[string]int // apiPath → next seq number for that path's directory
 }
 
 // NewStreamWriter creates a new StreamWriter writing to outputPath.
@@ -37,55 +88,103 @@ func NewStreamWriter(outputPath string) (*StreamWriter, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating output file %q: %w", outputPath, err)
 	}
-	gw := gzip.NewWriter(f)
-	tw := tar.NewWriter(gw)
-	return &StreamWriter{f: f, gw: gw, tw: tw}, nil
+	return &StreamWriter{
+		f:       f,
+		zw:      zip.NewWriter(f),
+		pathSeq: make(map[string]int),
+	}, nil
 }
 
-// WriteRecord marshals rec to JSON and appends it to the tar archive.
+// WriteRecord marshals rec to JSON, Zstd-compresses it, and appends it
+// to the ZIP archive under records/<pathDir(apiPath)>/<seq>.json.zst.
+// The record must have both "id" and "api_path" fields.
 func (w *StreamWriter) WriteRecord(rec any) error {
 	data, err := json.Marshal(rec)
 	if err != nil {
 		return fmt.Errorf("marshalling record: %w", err)
 	}
-	var idHolder struct {
-		ID string `json:"id"`
+	var hdr struct {
+		ID      string `json:"id"`
+		APIPath string `json:"api_path"`
 	}
-	if err := json.Unmarshal(data, &idHolder); err != nil || idHolder.ID == "" {
-		return fmt.Errorf("record missing id field")
+	if err := json.Unmarshal(data, &hdr); err != nil || hdr.ID == "" || hdr.APIPath == "" {
+		return fmt.Errorf("record missing id or api_path field")
 	}
-	path := filepath.Join("k8shark-capture", "records", idHolder.ID+".json")
+
+	compressed, err := zstdCompress(data)
+	if err != nil {
+		return fmt.Errorf("compressing record %s: %w", hdr.ID, err)
+	}
+
+	dir := pathDir(hdr.APIPath)
 
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if err := writeBytesToTar(w.tw, path, data); err != nil {
+
+	seq := w.pathSeq[hdr.APIPath]
+	w.pathSeq[hdr.APIPath] = seq + 1
+	entryName := filepath.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq))
+
+	if err := writeBytes(w.zw, entryName, compressed); err != nil {
 		return err
 	}
 	w.n++
 	return nil
 }
 
-// Finish writes metadata.json, index.json, and (when watchIndex is non-nil)
-// watch-index.json, then closes the archive.
+// WriteRecordRaw compresses data and writes it to the archive for the given
+// apiPath.  It returns the seq number assigned to this record.
+func (w *StreamWriter) WriteRecordRaw(apiPath string, data any) (int, error) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return 0, fmt.Errorf("marshalling record: %w", err)
+	}
+	compressed, err := zstdCompress(b)
+	if err != nil {
+		return 0, fmt.Errorf("compressing record: %w", err)
+	}
+	dir := pathDir(apiPath)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	seq := w.pathSeq[apiPath]
+	w.pathSeq[apiPath] = seq + 1
+	entryName := filepath.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq))
+	if err := writeBytes(w.zw, entryName, compressed); err != nil {
+		return 0, err
+	}
+	w.n++
+	return seq, nil
+}
+
+// Finish writes metadata.json, index.json, and watch-index.json, then closes.
 func (w *StreamWriter) Finish(meta, index, watchIndex any) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if err := writeJSON(w.tw, "k8shark-capture/metadata.json", meta); err != nil {
-		return err
-	}
-	if err := writeJSON(w.tw, "k8shark-capture/index.json", index); err != nil {
-		return err
-	}
-	if watchIndex != nil {
-		if err := writeJSON(w.tw, "k8shark-capture/watch-index.json", watchIndex); err != nil {
+
+	// metadata.json stored uncompressed for fast header reads.
+	if meta != nil {
+		b, err := json.MarshalIndent(meta, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshalling metadata: %w", err)
+		}
+		if err := writeBytes(w.zw, "k8shark-capture/metadata.json", b); err != nil {
 			return err
 		}
 	}
-	if err := w.tw.Close(); err != nil {
-		return fmt.Errorf("closing tar: %w", err)
+	if index != nil {
+		if err := writeJSONZstd(w.zw, "k8shark-capture/index.json.zst", index); err != nil {
+			return err
+		}
 	}
-	if err := w.gw.Close(); err != nil {
-		return fmt.Errorf("closing gzip: %w", err)
+	if watchIndex != nil {
+		if err := writeJSONZstd(w.zw, "k8shark-capture/watch-index.json.zst", watchIndex); err != nil {
+			return err
+		}
+	}
+	if err := w.zw.Close(); err != nil {
+		return fmt.Errorf("closing zip: %w", err)
 	}
 	return w.f.Close()
 }
@@ -132,188 +231,175 @@ func (w *NDJSONWriter) RecordCount() int {
 	return w.n
 }
 
-// Writable is anything that can provide records, index, and metadata for writing.
-// We use concrete types from capture to avoid circular imports by defining them as
-// any — callers pass the real values.
-
-// Write serialises all capture data into a .tar.gz archive at outputPath.
-//
-// Archive layout:
-//
-//	k8shark-capture/
-//	  metadata.json
-//	  index.json
-//	  records/<id>.json
-func Write(outputPath string, metadata any, records any, index any) error {
-	f, err := os.Create(outputPath)
-	if err != nil {
-		return fmt.Errorf("creating output file %q: %w", outputPath, err)
-	}
-	defer f.Close()
-
-	gw := gzip.NewWriter(f)
-	defer gw.Close()
-	tw := tar.NewWriter(gw)
-	defer tw.Close()
-
-	if err := writeJSON(tw, "k8shark-capture/metadata.json", metadata); err != nil {
-		return err
-	}
-	if err := writeJSON(tw, "k8shark-capture/index.json", index); err != nil {
-		return err
-	}
-
-	// Use json marshal + unmarshal round-trip to get individual records as
-	// []map[string]any so archive package stays import-cycle-free.
-	raw, err := json.Marshal(records)
-	if err != nil {
-		return fmt.Errorf("marshalling records: %w", err)
-	}
-	var recs []json.RawMessage
-	if err := json.Unmarshal(raw, &recs); err != nil {
-		return fmt.Errorf("unmarshalling records slice: %w", err)
-	}
-
-	for _, r := range recs {
-		// Extract id field only for filename.
-		var idHolder struct {
-			ID string `json:"id"`
-		}
-		if err := json.Unmarshal(r, &idHolder); err != nil || idHolder.ID == "" {
-			return fmt.Errorf("record missing id field")
-		}
-		path := filepath.Join("k8shark-capture", "records", idHolder.ID+".json")
-		if err := writeBytesToTar(tw, path, r); err != nil {
-			return err
-		}
-	}
-
-	return nil
+// Archive provides random-access reads into a k8shark ZIP+Zstd capture archive.
+// It does NOT require extraction to disk.
+type Archive struct {
+	zr     *zip.ReadCloser
+	byName map[string]*zip.File // ZIP entry name → file handle
+	size   int64
+	path   string
+	readN  atomic.Int64 // for diagnostics
 }
 
-// Open extracts a k8shark archive to destDir and returns the opened *Reader.
-func Open(archivePath, destDir string) error {
-	f, err := os.Open(archivePath)
+// Open opens a k8shark archive for reading. The caller must call Close() when done.
+func Open(archivePath string) (*Archive, error) {
+	fi, err := os.Stat(archivePath)
 	if err != nil {
-		return fmt.Errorf("opening archive %q: %w", archivePath, err)
+		return nil, fmt.Errorf("stat %q: %w", archivePath, err)
 	}
-	defer f.Close()
-
-	gr, err := gzip.NewReader(f)
+	zr, err := zip.OpenReader(archivePath)
 	if err != nil {
-		return fmt.Errorf("reading gzip stream: %w", err)
+		return nil, fmt.Errorf("opening zip archive %q: %w", archivePath, err)
 	}
-	defer gr.Close()
+	byName := make(map[string]*zip.File, len(zr.File))
+	for _, f := range zr.File {
+		byName[f.Name] = f
+	}
+	return &Archive{zr: zr, byName: byName, size: fi.Size(), path: archivePath}, nil
+}
 
-	tr := tar.NewReader(gr)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
+// Close releases the underlying file handle.
+func (a *Archive) Close() error { return a.zr.Close() }
+
+// Path returns the archive file path.
+func (a *Archive) Path() string { return a.path }
+
+// Size returns the on-disk size of the archive in bytes.
+func (a *Archive) Size() int64 { return a.size }
+
+// ReadMetadata reads and parses metadata.json from the archive.
+func (a *Archive) ReadMetadata(v any) error {
+	data, err := a.readRaw("k8shark-capture/metadata.json")
+	if err != nil {
+		return fmt.Errorf("reading metadata.json: %w", err)
+	}
+	return json.Unmarshal(data, v)
+}
+
+// ReadIndex reads and parses the Zstd-compressed index.json.zst.
+func (a *Archive) ReadIndex(v any) error {
+	data, err := a.readZstd("k8shark-capture/index.json.zst")
+	if err != nil {
+		return fmt.Errorf("reading index.json.zst: %w", err)
+	}
+	return json.Unmarshal(data, v)
+}
+
+// ReadWatchIndex reads and parses watch-index.json.zst, if present.
+// Returns (false, nil) when the archive has no watch index.
+func (a *Archive) ReadWatchIndex(v any) (bool, error) {
+	const name = "k8shark-capture/watch-index.json.zst"
+	if _, ok := a.byName[name]; !ok {
+		return false, nil
+	}
+	data, err := a.readZstd(name)
+	if err != nil {
+		return false, fmt.Errorf("reading watch-index.json.zst: %w", err)
+	}
+	return true, json.Unmarshal(data, v)
+}
+
+// ReadRecord reads the record at sequence seq under apiPath.
+// seq is 0-based and matches the order records were written for that path.
+func (a *Archive) ReadRecord(apiPath string, seq int) ([]byte, error) {
+	dir := pathDir(apiPath)
+	name := filepath.ToSlash(filepath.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq)))
+	data, err := a.readZstd(name)
+	if err != nil {
+		return nil, fmt.Errorf("reading record path=%s seq=%d: %w", apiPath, seq, err)
+	}
+	a.readN.Add(1)
+	return data, nil
+}
+
+// RecordsForPath returns all record bytes in capture order for apiPath.
+// Stops at the first missing sequence number.
+func (a *Archive) RecordsForPath(apiPath string) ([][]byte, error) {
+	dir := pathDir(apiPath)
+	var out [][]byte
+	for seq := 0; ; seq++ {
+		name := filepath.ToSlash(filepath.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq)))
+		if _, ok := a.byName[name]; !ok {
 			break
 		}
+		data, err := a.readZstd(name)
 		if err != nil {
-			return fmt.Errorf("reading tar entry: %w", err)
+			return nil, err
 		}
-		target := filepath.Join(destDir, hdr.Name) // #nosec G305 — path validated below
-		if !isPathSafe(destDir, target) {
-			return fmt.Errorf("unsafe tar path %q", hdr.Name)
-		}
-		switch hdr.Typeflag {
-		case tar.TypeDir:
-			if err := os.MkdirAll(target, 0o750); err != nil {
-				return err
-			}
+		out = append(out, data)
+	}
+	return out, nil
+}
+
+// PathDirs returns all distinct path-hash directories found under records/.
+// This allows enumeration without the index.
+func (a *Archive) PathDirs() []string {
+	seen := make(map[string]bool)
+	for name := range a.byName {
+		// prefix: k8shark-capture/records/<dir>/
+		if !strings.HasPrefix(name, "k8shark-capture/records/") {
 			continue
-		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
-				return err
-			}
-			out, err := os.Create(target)
-			if err != nil {
-				return err
-			}
-			if _, err := io.Copy(out, io.LimitReader(tr, 512<<20)); err != nil { // 512 MB per-file limit
-				out.Close()
-				return err
-			}
-			out.Close()
+		}
+		rest := strings.TrimPrefix(name, "k8shark-capture/records/")
+		parts := strings.SplitN(rest, "/", 2)
+		if len(parts) == 2 && parts[0] != "" {
+			seen[parts[0]] = true
 		}
 	}
+	dirs := make([]string, 0, len(seen))
+	for d := range seen {
+		dirs = append(dirs, d)
+	}
+	return dirs
+}
+
+// PathDir exposes the pathDir function for use by other packages (e.g. capture engine).
+func PathDir(apiPath string) string { return pathDir(apiPath) }
+
+// readRaw reads an uncompressed ZIP entry.
+func (a *Archive) readRaw(name string) ([]byte, error) {
+	zf, ok := a.byName[name]
+	if !ok {
+		return nil, fmt.Errorf("entry %q not found in archive", name)
+	}
+	rc, err := zf.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	return io.ReadAll(rc)
+}
+
+// readZstd reads a Zstd-compressed ZIP entry and returns decompressed bytes.
+func (a *Archive) readZstd(name string) ([]byte, error) {
+	compressed, err := a.readRaw(name)
+	if err != nil {
+		return nil, err
+	}
+	return zstdDecompress(compressed)
+}
+
+// ---- helpers used by StreamWriter ----
+
+func writeBytes(zw *zip.Writer, name string, data []byte) error {
+	w, err := zw.Create(name)
+	if err != nil {
+		return fmt.Errorf("creating zip entry %s: %w", name, err)
+	}
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("writing zip entry %s: %w", name, err)
+	}
 	return nil
 }
 
-// isPathSafe ensures target is inside destDir (prevents path traversal).
-func isPathSafe(destDir, target string) bool {
-	rel, err := filepath.Rel(destDir, target)
+func writeJSONZstd(zw *zip.Writer, name string, v any) error {
+	plain, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
-		return false
+		return fmt.Errorf("marshalling %s: %w", name, err)
 	}
-	if len(rel) >= 2 && rel[:2] == ".." {
-		return false
-	}
-	return true
-}
-
-func writeJSON(tw *tar.Writer, path string, v any) error {
-	data, err := json.MarshalIndent(v, "", "  ")
+	compressed, err := zstdCompress(plain)
 	if err != nil {
-		return fmt.Errorf("marshalling %s: %w", path, err)
+		return fmt.Errorf("compressing %s: %w", name, err)
 	}
-	return writeBytesToTar(tw, path, data)
-}
-
-func writeBytesToTar(tw *tar.Writer, path string, data []byte) error {
-	hdr := &tar.Header{
-		Name: path,
-		Mode: 0o644,
-		Size: int64(len(data)),
-	}
-	if err := tw.WriteHeader(hdr); err != nil {
-		return fmt.Errorf("writing tar header for %s: %w", path, err)
-	}
-	if _, err := tw.Write(data); err != nil {
-		return fmt.Errorf("writing tar body for %s: %w", path, err)
-	}
-	return nil
-}
-
-// ReadMetadata reads just metadata.json from an already-extracted archive directory.
-func ReadMetadata(dir string) (map[string]any, error) {
-	data, err := os.ReadFile(filepath.Join(dir, "k8shark-capture", "metadata.json"))
-	if err != nil {
-		return nil, err
-	}
-	var m map[string]any
-	return m, json.Unmarshal(data, &m)
-}
-
-// ReadIndex reads index.json from an already-extracted archive directory.
-func ReadIndex(dir string) (map[string]any, error) {
-	data, err := os.ReadFile(filepath.Join(dir, "k8shark-capture", "index.json"))
-	if err != nil {
-		return nil, err
-	}
-	var idx map[string]any
-	return idx, json.Unmarshal(data, &idx)
-}
-
-// ReadRecord reads a single record file by ID.
-func ReadRecord(dir, id string) ([]byte, error) {
-	path := filepath.Join(dir, "k8shark-capture", "records", id+".json")
-	return os.ReadFile(path)
-}
-
-// ListRecordIDs returns all record IDs present in the records/ directory.
-func ListRecordIDs(dir string) ([]string, error) {
-	pattern := filepath.Join(dir, "k8shark-capture", "records", "*.json")
-	matches, err := filepath.Glob(pattern)
-	if err != nil {
-		return nil, err
-	}
-	ids := make([]string, 0, len(matches))
-	for _, m := range matches {
-		base := filepath.Base(m)
-		ids = append(ids, base[:len(base)-5]) // strip .json
-	}
-	return ids, nil
+	return writeBytes(zw, name, compressed)
 }

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -71,7 +71,7 @@ func zstdDecompress(data []byte) ([]byte, error) {
 	return io.ReadAll(dec)
 }
 
-// StreamWriter streams each record directly into a .kshrk (ZIP+Zstd) archive.
+// StreamWriter streams each record directly into a .khsrk (ZIP+Zstd) archive.
 // metadata.json, index.json, and watch-index.json are written by Finish().
 // Thread-safe.
 type StreamWriter struct {

--- a/internal/archive/bench_test.go
+++ b/internal/archive/bench_test.go
@@ -62,9 +62,11 @@ func BenchmarkStreamWriter_RoundTrip(b *testing.B) {
 				if err := w.Finish(map[string]any{"capture_id": "bench"}, map[string]any{}, nil); err != nil {
 					b.Fatal(err)
 				}
-				if err := Open(path, b.TempDir()); err != nil {
+				ar, err := Open(path)
+				if err != nil {
 					b.Fatal(err)
 				}
+				_ = ar.Close()
 			}
 		})
 	}

--- a/internal/archive/bench_test.go
+++ b/internal/archive/bench_test.go
@@ -27,7 +27,7 @@ func sampleRecord(i int) any {
 // records to a streaming tar.gz archive.
 func BenchmarkStreamWriter_WriteRecord(b *testing.B) {
 	dir := b.TempDir()
-	w, err := NewStreamWriter(dir + "/capture.tar.gz")
+	w, err := NewStreamWriter(dir + "/capture.khsrk")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func BenchmarkStreamWriter_RoundTrip(b *testing.B) {
 		b.Run(fmt.Sprintf("%d_records", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				dir := b.TempDir()
-				path := dir + "/capture.tar.gz"
+				path := dir + "/capture.khsrk"
 				w, err := NewStreamWriter(path)
 				if err != nil {
 					b.Fatal(err)

--- a/internal/capture/bench_test.go
+++ b/internal/capture/bench_test.go
@@ -51,7 +51,7 @@ func BenchmarkEngine_CaptureToArchive(b *testing.B) {
 		cfg := &config.Config{
 			DurationRaw: "500ms",
 			Duration:    500 * time.Millisecond,
-			Output:      filepath.Join(b.TempDir(), "capture.tar.gz"),
+			Output:      filepath.Join(b.TempDir(), "capture.khsrk"),
 			Resources: []config.Resource{
 				{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
 				{Version: "v1", Resource: "nodes", IntervalRaw: "200ms", Interval: 200 * time.Millisecond},

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -45,6 +45,7 @@ type Engine struct {
 	lastHash       map[string][32]byte
 	dedupSkipped   int
 	warnedFallback map[string]bool // dedup set for allNotFound cluster-scoped fallback warnings
+	pathSeq        map[string]int  // per-path record sequence counter (matches archive on-disk seq)
 }
 
 const maxConcurrentWatchStreams = 256
@@ -81,6 +82,7 @@ func NewEngine(cfg *config.Config, verbose bool) (*Engine, error) {
 		discoveryCache: make(map[string][]byte),
 		lastHash:       make(map[string][32]byte),
 		warnedFallback: make(map[string]bool),
+		pathSeq:        make(map[string]int),
 	}, nil
 }
 
@@ -97,6 +99,7 @@ func newEngineWith(cfg *config.Config, client *http.Client, baseURL string, verb
 		discoveryCache: make(map[string][]byte),
 		lastHash:       make(map[string][32]byte),
 		warnedFallback: make(map[string]bool),
+		pathSeq:        make(map[string]int),
 	}
 }
 
@@ -411,7 +414,9 @@ func (e *Engine) streamWatch(ctx context.Context, apiPath, resourceVersion strin
 		if _, ok := e.watchIndex[apiPath]; !ok {
 			e.watchIndex[apiPath] = &WatchIndexEntry{APIPath: apiPath}
 		}
-		e.watchIndex[apiPath].RecordIDs = append(e.watchIndex[apiPath].RecordIDs, rec.ID)
+		seq := e.pathSeq[apiPath]
+		e.pathSeq[apiPath] = seq + 1
+		e.watchIndex[apiPath].Seqs = append(e.watchIndex[apiPath].Seqs, seq)
 		e.watchIndex[apiPath].Times = append(e.watchIndex[apiPath].Times, rec.CapturedAt)
 		e.watchIndex[apiPath].EventTypes = append(e.watchIndex[apiPath].EventTypes, rec.EventType)
 		e.mu.Unlock()
@@ -944,7 +949,9 @@ func (e *Engine) doFetch(ctx context.Context, apiPath, tableKeySuffix string, de
 	if _, ok := e.index[indexKey]; !ok {
 		e.index[indexKey] = &IndexEntry{APIPath: indexKey}
 	}
-	e.index[indexKey].RecordIDs = append(e.index[indexKey].RecordIDs, rec.ID)
+	seq := e.pathSeq[indexKey]
+	e.pathSeq[indexKey] = seq + 1
+	e.index[indexKey].Seqs = append(e.index[indexKey].Seqs, seq)
 	e.index[indexKey].Times = append(e.index[indexKey].Times, rec.CapturedAt)
 	e.mu.Unlock()
 	return body, resp.StatusCode
@@ -1076,7 +1083,9 @@ func (e *Engine) fetchOnePodLog(ctx context.Context, namespace, podName string, 
 	if _, ok := e.index[logPath]; !ok {
 		e.index[logPath] = &IndexEntry{APIPath: logPath}
 	}
-	e.index[logPath].RecordIDs = append(e.index[logPath].RecordIDs, rec.ID)
+	logSeq := e.pathSeq[logPath]
+	e.pathSeq[logPath] = logSeq + 1
+	e.index[logPath].Seqs = append(e.index[logPath].Seqs, logSeq)
 	e.index[logPath].Times = append(e.index[logPath].Times, rec.CapturedAt)
 	e.mu.Unlock()
 }

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -32,6 +32,12 @@ type CaptureSummary struct {
 }
 
 // Engine orchestrates the capture loop.
+// maxConcurrentFetches limits the number of goroutines simultaneously reading
+// HTTP response bodies during a poll pass.  Bounding this caps peak in-flight
+// memory (each body can be several MB for large list responses) regardless of
+// how many resources are configured or auto-discovered.
+const maxConcurrentFetches = 32
+
 type Engine struct {
 	cfg            *config.Config
 	verbose        bool
@@ -46,6 +52,7 @@ type Engine struct {
 	dedupSkipped   int
 	warnedFallback map[string]bool // dedup set for allNotFound cluster-scoped fallback warnings
 	pathSeq        map[string]int  // per-path record sequence counter (matches archive on-disk seq)
+	fetchSem       chan struct{}   // semaphore bounding concurrent body reads
 }
 
 const maxConcurrentWatchStreams = 256
@@ -83,6 +90,7 @@ func NewEngine(cfg *config.Config, verbose bool) (*Engine, error) {
 		lastHash:       make(map[string][32]byte),
 		warnedFallback: make(map[string]bool),
 		pathSeq:        make(map[string]int),
+		fetchSem:       make(chan struct{}, maxConcurrentFetches),
 	}, nil
 }
 
@@ -100,6 +108,7 @@ func newEngineWith(cfg *config.Config, client *http.Client, baseURL string, verb
 		lastHash:       make(map[string][32]byte),
 		warnedFallback: make(map[string]bool),
 		pathSeq:        make(map[string]int),
+		fetchSem:       make(chan struct{}, maxConcurrentFetches),
 	}
 }
 
@@ -885,7 +894,9 @@ func (e *Engine) doFetch(ctx context.Context, apiPath, tableKeySuffix string, de
 		return nil, 0
 	}
 
+	e.fetchSem <- struct{}{}
 	body, err := io.ReadAll(resp.Body)
+	<-e.fetchSem
 	resp.Body.Close()
 	if err != nil {
 		if e.verbose {

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -97,18 +97,21 @@ func TestEngine_CaptureToArchive(t *testing.T) {
 		t.Fatal("output archive is empty")
 	}
 
-	// Extract the archive and verify its contents.
-	extractDir := t.TempDir()
-	if err := archive.Open(outFile, extractDir); err != nil {
+	// Open the archive and verify its contents.
+	ar, err := archive.Open(outFile)
+	if err != nil {
 		t.Fatalf("failed to open archive: %v", err)
 	}
+	defer ar.Close()
 
-	// metadata.json must exist.
-	if _, err := os.Stat(filepath.Join(extractDir, "k8shark-capture", "metadata.json")); err != nil {
+	// metadata must be readable.
+	var capMeta CaptureMetadata
+	if err := ar.ReadMetadata(&capMeta); err != nil {
 		t.Error("metadata.json missing from archive")
 	}
-	// index.json must exist.
-	if _, err := os.Stat(filepath.Join(extractDir, "k8shark-capture", "index.json")); err != nil {
+	// index must be readable.
+	var capIdx Index
+	if err := ar.ReadIndex(&capIdx); err != nil {
 		t.Error("index.json missing from archive")
 	}
 
@@ -1089,7 +1092,7 @@ func TestDoFetch_DedupAllSame_FirstAlwaysWritten(t *testing.T) {
 		t.Fatalf("dedup skipped = %d, want 2", got)
 	}
 	entry := eng.index["/api/v1/pods"]
-	if entry == nil || len(entry.RecordIDs) != 1 || len(entry.Times) != 1 {
+	if entry == nil || len(entry.Seqs) != 1 || len(entry.Times) != 1 {
 		t.Fatalf("index entry should have exactly one written record, got %+v", entry)
 	}
 }
@@ -1179,12 +1182,13 @@ func TestEngine_MetadataIncludesDeduplicatedCount(t *testing.T) {
 		t.Fatalf("engine.Run() error: %v", err)
 	}
 
-	extractDir := t.TempDir()
-	if err := archive.Open(outFile, extractDir); err != nil {
+	ar2, err := archive.Open(outFile)
+	if err != nil {
 		t.Fatalf("failed to open archive: %v", err)
 	}
-	meta, err := archive.ReadMetadata(extractDir)
-	if err != nil {
+	defer ar2.Close()
+	var meta map[string]any
+	if err := ar2.ReadMetadata(&meta); err != nil {
 		t.Fatalf("failed to read metadata: %v", err)
 	}
 
@@ -1240,10 +1244,10 @@ func TestEngine_DedupPerResourceOptOut(t *testing.T) {
 	if podsEntry == nil || eventsEntry == nil {
 		t.Fatalf("missing index entries: pods=%v events=%v", podsEntry != nil, eventsEntry != nil)
 	}
-	if got := len(podsEntry.RecordIDs); got != 1 {
+	if got := len(podsEntry.Seqs); got != 1 {
 		t.Fatalf("pods should be deduplicated to one record, got %d", got)
 	}
-	if got := len(eventsEntry.RecordIDs); got <= 1 {
+	if got := len(eventsEntry.Seqs); got <= 1 {
 		t.Fatalf("events with dedup:false should keep multiple polls, got %d", got)
 	}
 }

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -71,7 +71,7 @@ func TestEngine_CaptureToArchive(t *testing.T) {
 	defer fake.Close()
 
 	outDir := t.TempDir()
-	outFile := filepath.Join(outDir, "capture.tar.gz")
+	outFile := filepath.Join(outDir, "capture.khsrk")
 
 	cfg := &config.Config{
 		DurationRaw: "2s",
@@ -154,7 +154,7 @@ func TestEngine_FetchPodsLogs(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw: "1s",
 		Duration:    1 * time.Second,
-		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Output:      filepath.Join(outDir, "capture.khsrk"),
 		Resources: []config.Resource{
 			{
 				Version: "v1", Resource: "pods",
@@ -229,7 +229,7 @@ func TestEngine_NoLogsWhenDisabled(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw: "1s",
 		Duration:    1 * time.Second,
-		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Output:      filepath.Join(outDir, "capture.khsrk"),
 		Resources: []config.Resource{
 			// Logs: 0 (default) — log capture disabled.
 			{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "500ms", Interval: 500 * time.Millisecond},
@@ -319,7 +319,7 @@ func TestExpandWildcard_NoWildcard(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw: "500ms",
 		Duration:    500 * time.Millisecond,
-		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Output:      filepath.Join(outDir, "capture.khsrk"),
 		Resources: []config.Resource{
 			{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
 		},
@@ -353,7 +353,7 @@ func TestExpandWildcard_AllNamespaces(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw: "500ms",
 		Duration:    500 * time.Millisecond,
-		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Output:      filepath.Join(outDir, "capture.khsrk"),
 		Resources: []config.Resource{
 			{Version: "v1", Resource: "pods", Namespaces: []string{"*"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
 		},
@@ -384,7 +384,7 @@ func TestExpandWildcard_Mixed(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw: "500ms",
 		Duration:    500 * time.Millisecond,
-		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Output:      filepath.Join(outDir, "capture.khsrk"),
 		Resources: []config.Resource{
 			// "production" explicit first, then wildcard — production must not be duplicated.
 			{Version: "v1", Resource: "pods", Namespaces: []string{"production", "*"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
@@ -422,7 +422,7 @@ func TestExpandWildcard_ClusterScoped(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw: "500ms",
 		Duration:    500 * time.Millisecond,
-		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Output:      filepath.Join(outDir, "capture.khsrk"),
 		Resources: []config.Resource{
 			{Version: "v1", Resource: "nodes", Namespaces: []string{"*"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
 		},
@@ -455,7 +455,7 @@ func TestExpandWildcard_DiscoveryFailure(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw: "500ms",
 		Duration:    500 * time.Millisecond,
-		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Output:      filepath.Join(outDir, "capture.khsrk"),
 		Resources: []config.Resource{
 			{Version: "v1", Resource: "pods", Namespaces: []string{"*"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
 		},
@@ -493,7 +493,7 @@ func TestExpandWildcard_DiscoveryCancelledByDuration(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw: "50ms",
 		Duration:    50 * time.Millisecond,
-		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Output:      filepath.Join(outDir, "capture.khsrk"),
 		Resources: []config.Resource{
 			{Version: "v1", Resource: "pods", Namespaces: []string{"*"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
 		},
@@ -540,7 +540,7 @@ func TestRun_FailsWhenWatchConcurrencyTooHigh(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw: "30s",
 		Duration:    30 * time.Second,
-		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Output:      filepath.Join(outDir, "capture.khsrk"),
 		Resources: []config.Resource{
 			{Version: "v1", Resource: "pods", Namespaces: ns, Watch: true, IntervalRaw: "30s", Interval: 30 * time.Second},
 		},
@@ -568,7 +568,7 @@ func TestRun_FailsPreflightOnUnauthorized(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	out := filepath.Join(t.TempDir(), "capture.tar.gz")
+	out := filepath.Join(t.TempDir(), "capture.khsrk")
 	cfg := &config.Config{
 		DurationRaw: "2s",
 		Duration:    2 * time.Second,
@@ -603,7 +603,7 @@ func TestRun_FailsPreflightOnUnreachableServer(t *testing.T) {
 	client := srv.Client()
 	srv.Close()
 
-	out := filepath.Join(t.TempDir(), "capture.tar.gz")
+	out := filepath.Join(t.TempDir(), "capture.khsrk")
 	cfg := &config.Config{
 		DurationRaw: "2s",
 		Duration:    2 * time.Second,
@@ -689,7 +689,7 @@ func TestAutoDiscover_AddsResources(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw:  "500ms",
 		Duration:     500 * time.Millisecond,
-		Output:       filepath.Join(outDir, "capture.tar.gz"),
+		Output:       filepath.Join(outDir, "capture.khsrk"),
 		AutoDiscover: true,
 		// No explicit resources — auto-discover should populate them.
 	}
@@ -728,7 +728,7 @@ func TestAutoDiscover_SkipsAlreadyConfigured(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw:  "500ms",
 		Duration:     500 * time.Millisecond,
-		Output:       filepath.Join(outDir, "capture.tar.gz"),
+		Output:       filepath.Join(outDir, "capture.khsrk"),
 		AutoDiscover: true,
 		Resources: []config.Resource{
 			// Pre-configured virtualservices — must not be duplicated.
@@ -764,7 +764,7 @@ func TestAutoDiscover_ExcludeGroupsOverride(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw:               "500ms",
 		Duration:                  500 * time.Millisecond,
-		Output:                    filepath.Join(outDir, "capture.tar.gz"),
+		Output:                    filepath.Join(outDir, "capture.khsrk"),
 		AutoDiscover:              true,
 		AutoDiscoverExcludeGroups: []string{"networking.istio.io"},
 	}
@@ -824,7 +824,7 @@ func TestAutoDiscover_RetriesMissingGroupVersionDiscovery(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw:  "500ms",
 		Duration:     500 * time.Millisecond,
-		Output:       filepath.Join(outDir, "capture.tar.gz"),
+		Output:       filepath.Join(outDir, "capture.khsrk"),
 		AutoDiscover: true,
 	}
 
@@ -857,7 +857,7 @@ func TestAutoDiscover_AllDirectiveNamespacedScope(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw: "500ms",
 		Duration:    500 * time.Millisecond,
-		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Output:      filepath.Join(outDir, "capture.khsrk"),
 		Resources: []config.Resource{
 			{All: true, Scope: "namespaced", Namespaces: []string{"team-a"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
 		},
@@ -902,7 +902,7 @@ func TestAutoDiscover_AllDirectiveClusterScope(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw: "500ms",
 		Duration:    500 * time.Millisecond,
-		Output:      filepath.Join(outDir, "capture.tar.gz"),
+		Output:      filepath.Join(outDir, "capture.khsrk"),
 		Resources: []config.Resource{
 			{All: true, Scope: "cluster", IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
 		},
@@ -962,7 +962,7 @@ func TestAutoDiscover_AllDirectiveExpandsWildcardNamespacesBeforePolling(t *test
 	cfg := &config.Config{
 		DurationRaw: "500ms",
 		Duration:    500 * time.Millisecond,
-		Output:      filepath.Join(t.TempDir(), "capture.tar.gz"),
+		Output:      filepath.Join(t.TempDir(), "capture.khsrk"),
 		Resources: []config.Resource{
 			{All: true, Scope: "namespaced", IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
 		},
@@ -1023,7 +1023,7 @@ func TestAutoDiscover_AllDirectiveIncludesCorePods(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw: "500ms",
 		Duration:    500 * time.Millisecond,
-		Output:      filepath.Join(t.TempDir(), "capture.tar.gz"),
+		Output:      filepath.Join(t.TempDir(), "capture.khsrk"),
 		Resources: []config.Resource{
 			{All: true, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
 		},
@@ -1167,7 +1167,7 @@ func TestEngine_MetadataIncludesDeduplicatedCount(t *testing.T) {
 	defer srv.Close()
 
 	outDir := t.TempDir()
-	outFile := filepath.Join(outDir, "capture.tar.gz")
+	outFile := filepath.Join(outDir, "capture.khsrk")
 	cfg := &config.Config{
 		DurationRaw: "1200ms",
 		Duration:    1200 * time.Millisecond,
@@ -1227,7 +1227,7 @@ func TestEngine_DedupPerResourceOptOut(t *testing.T) {
 	cfg := &config.Config{
 		DurationRaw: "1200ms",
 		Duration:    1200 * time.Millisecond,
-		Output:      filepath.Join(t.TempDir(), "capture.tar.gz"),
+		Output:      filepath.Join(t.TempDir(), "capture.khsrk"),
 		Resources: []config.Resource{
 			{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
 			{Version: "v1", Resource: "events", Namespaces: []string{"default"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond, Dedup: &falseVal},

--- a/internal/capture/record.go
+++ b/internal/capture/record.go
@@ -28,11 +28,13 @@ type CaptureMetadata struct {
 	DeduplicatedCount int       `json:"deduplicated_count"`
 }
 
-// IndexEntry maps an API path to the ordered list of record IDs captured for it.
+// IndexEntry maps an API path to the ordered list of record sequence numbers.
+// Seqs[i] is the 0-based sequence index of the i-th record for this path,
+// matching the on-disk filename records/<pathDir>/<seq>.json.zst.
 type IndexEntry struct {
-	APIPath   string      `json:"api_path"`
-	RecordIDs []string    `json:"record_ids"`
-	Times     []time.Time `json:"times"`
+	APIPath string      `json:"api_path"`
+	Seqs    []int       `json:"seqs"`
+	Times   []time.Time `json:"times"`
 }
 
 // Index is the top-level index.json written inside the archive.
@@ -41,11 +43,11 @@ type Index map[string]*IndexEntry
 
 // WatchIndexEntry maps an API path to the ordered watch events captured for it.
 // Each watch event is a separate record with event_type ADDED, MODIFIED, or DELETED.
-// EventTypes is kept in sync with RecordIDs and Times for fast filtering without
+// EventTypes is kept in sync with Seqs and Times for fast filtering without
 // reading every record file.
 type WatchIndexEntry struct {
 	APIPath    string      `json:"api_path"`
-	RecordIDs  []string    `json:"record_ids"`
+	Seqs       []int       `json:"seqs"`
 	Times      []time.Time `json:"times"`
 	EventTypes []string    `json:"event_types"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,7 +98,7 @@ type Config struct {
 	DurationRaw string `mapstructure:"duration"`
 	// Duration is parsed from DurationRaw.
 	Duration time.Duration `mapstructure:"-"`
-	// Output is the path to write the resulting .tar.gz file.
+	// Output is the path to write the resulting .khsrk file.
 	Output string `mapstructure:"output"`
 	// Kubeconfig is the path to the kubeconfig to use. Empty = default resolution.
 	Kubeconfig string `mapstructure:"kubeconfig"`
@@ -148,7 +148,7 @@ func (c *Config) Validate() error {
 	c.Duration = d
 
 	if c.Output == "" {
-		c.Output = fmt.Sprintf("k8shark-%s.tar.gz", time.Now().UTC().Format("20060102-150405"))
+		c.Output = fmt.Sprintf("k8shark-%s.khsrk", time.Now().UTC().Format("20060102-150405"))
 	}
 
 	if c.Kubeconfig == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,7 +8,7 @@ import (
 
 func validatedCfg(t *testing.T, dur string, resources []Resource) *Config {
 	t.Helper()
-	cfg := &Config{DurationRaw: dur, Output: "/tmp/k8shark-test-out.tar.gz", Resources: resources}
+	cfg := &Config{DurationRaw: dur, Output: "/tmp/k8shark-test-out.khsrk", Resources: resources}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestWarnings_ClusterScopedWithNamespaces(t *testing.T) {
 }
 
 func TestWarnings_OutputExists(t *testing.T) {
-	f, err := os.CreateTemp("", "k8shark-test-*.tar.gz")
+	f, err := os.CreateTemp("", "k8shark-test-*.khsrk")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestResourceDedupEnabled_ExplicitFalse(t *testing.T) {
 func TestValidate_AllDirective_NoResourceFieldsRequired(t *testing.T) {
 	cfg := &Config{
 		DurationRaw: "10m",
-		Output:      "/tmp/k8shark-test-out.tar.gz",
+		Output:      "/tmp/k8shark-test-out.khsrk",
 		Resources: []Resource{{
 			All:        true,
 			Scope:      "namespaced",
@@ -191,7 +191,7 @@ func TestValidate_AllDirective_NoResourceFieldsRequired(t *testing.T) {
 func TestValidate_AllDirective_InvalidScope(t *testing.T) {
 	cfg := &Config{
 		DurationRaw: "10m",
-		Output:      "/tmp/k8shark-test-out.tar.gz",
+		Output:      "/tmp/k8shark-test-out.khsrk",
 		Resources: []Resource{{
 			All:   true,
 			Scope: "invalid-scope",
@@ -205,7 +205,7 @@ func TestValidate_AllDirective_InvalidScope(t *testing.T) {
 func TestValidate_DiscoveryStartup_TooShortDuration_WithAllDirective(t *testing.T) {
 	cfg := &Config{
 		DurationRaw: "2s",
-		Output:      "/tmp/k8shark-test-out.tar.gz",
+		Output:      "/tmp/k8shark-test-out.khsrk",
 		Resources: []Resource{{
 			All: true,
 		}},
@@ -222,7 +222,7 @@ func TestValidate_DiscoveryStartup_TooShortDuration_WithAllDirective(t *testing.
 func TestValidate_DiscoveryStartup_TooShortDuration_WithWildcardNamespaces(t *testing.T) {
 	cfg := &Config{
 		DurationRaw: "2s",
-		Output:      "/tmp/k8shark-test-out.tar.gz",
+		Output:      "/tmp/k8shark-test-out.khsrk",
 		Resources: []Resource{{
 			Version:    "v1",
 			Resource:   "pods",
@@ -241,7 +241,7 @@ func TestValidate_DiscoveryStartup_TooShortDuration_WithWildcardNamespaces(t *te
 func TestValidate_DiscoveryStartup_NormalResource_AllowsShortDuration(t *testing.T) {
 	cfg := &Config{
 		DurationRaw: "2s",
-		Output:      "/tmp/k8shark-test-out.tar.gz",
+		Output:      "/tmp/k8shark-test-out.khsrk",
 		Resources: []Resource{{
 			Version:  "v1",
 			Resource: "pods",
@@ -255,7 +255,7 @@ func TestValidate_DiscoveryStartup_NormalResource_AllowsShortDuration(t *testing
 func TestRedactionConfig_ParsesCorrectly(t *testing.T) {
 	cfg := &Config{
 		DurationRaw: "5m",
-		Output:      "/tmp/k8shark-test-out.tar.gz",
+		Output:      "/tmp/k8shark-test-out.khsrk",
 		Resources:   []Resource{{Resource: "pods", Version: "v1", IntervalRaw: "30s"}},
 		Redaction: RedactionConfig{
 			RedactSecrets: true,
@@ -307,7 +307,7 @@ func TestRedactionConfig_ParsesCorrectly(t *testing.T) {
 func TestRedactionConfig_EmptyIsValid(t *testing.T) {
 	cfg := &Config{
 		DurationRaw: "5m",
-		Output:      "/tmp/k8shark-test-out.tar.gz",
+		Output:      "/tmp/k8shark-test-out.khsrk",
 		Resources:   []Resource{{Resource: "pods", Version: "v1", IntervalRaw: "30s"}},
 	}
 	if err := cfg.Validate(); err != nil {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -46,7 +44,7 @@ func Run(opts Options) (*Result, error) {
 		return nil, err
 	}
 	defer before.cleanup()
-	if after.dir != before.dir {
+	if after.ar != before.ar {
 		defer after.cleanup()
 	}
 
@@ -127,16 +125,16 @@ func RenderText(result *Result, color bool) (string, error) {
 }
 
 type archiveSnapshot struct {
-	dir      string
+	ar       *archivepkg.Archive
 	meta     capture.CaptureMetadata
 	snapshot map[string]json.RawMessage
 }
 
 func (s *archiveSnapshot) cleanup() {
-	if s == nil || s.dir == "" {
+	if s == nil || s.ar == nil {
 		return
 	}
-	_ = os.RemoveAll(s.dir)
+	_ = s.ar.Close()
 }
 
 func loadSnapshots(opts Options) (*archiveSnapshot, *archiveSnapshot, error) {
@@ -195,21 +193,17 @@ func loadSnapshots(opts Options) (*archiveSnapshot, *archiveSnapshot, error) {
 }
 
 func loadArchiveSnapshot(archivePath string, at time.Time) (*archiveSnapshot, error) {
-	dir, err := os.MkdirTemp("", "k8shark-diff-*")
+	ar, err := archivepkg.Open(archivePath)
 	if err != nil {
-		return nil, fmt.Errorf("creating temp dir: %w", err)
-	}
-	if err := archivepkg.Open(archivePath, dir); err != nil {
-		_ = os.RemoveAll(dir)
 		return nil, fmt.Errorf("opening archive %q: %w", archivePath, err)
 	}
-	store, err := server.LoadStore(dir)
+	store, err := server.LoadStore(ar)
 	if err != nil {
-		_ = os.RemoveAll(dir)
+		_ = ar.Close()
 		return nil, fmt.Errorf("loading archive %q: %w", archivePath, err)
 	}
 	shot := &archiveSnapshot{
-		dir:      dir,
+		ar:       ar,
 		meta:     store.Metadata,
 		snapshot: make(map[string]json.RawMessage, len(store.Index)),
 	}
@@ -220,7 +214,7 @@ func loadArchiveSnapshot(archivePath string, at time.Time) (*archiveSnapshot, er
 		body, code, err := store.Latest(path, at)
 		if err != nil {
 			shot.cleanup()
-			return nil, fmt.Errorf("reading %s from %q: %w", path, filepath.Base(archivePath), err)
+			return nil, fmt.Errorf("reading %s from %q: %w", path, archivePath, err)
 		}
 		if code != 200 {
 			continue

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -124,7 +124,7 @@ func TestRun_NoDiff(t *testing.T) {
 
 func buildArchive(t *testing.T, entries map[string][]capture.Record) string {
 	t.Helper()
-	out := filepath.Join(t.TempDir(), "capture.tar.gz")
+	out := filepath.Join(t.TempDir(), "capture.khsrk")
 	index := make(capture.Index)
 	var capturedAt, capturedUntil time.Time
 	totalCount := 0

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -125,35 +125,37 @@ func TestRun_NoDiff(t *testing.T) {
 func buildArchive(t *testing.T, entries map[string][]capture.Record) string {
 	t.Helper()
 	out := filepath.Join(t.TempDir(), "capture.tar.gz")
-	ids := make([]string, 0)
-	all := make([]capture.Record, 0)
 	index := make(capture.Index)
 	var capturedAt, capturedUntil time.Time
+	totalCount := 0
+
+	sw, err := archivepkg.NewStreamWriter(out)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
 	for path, records := range entries {
 		entry := &capture.IndexEntry{APIPath: path}
-		for _, rec := range records {
+		for i, rec := range records {
 			if capturedAt.IsZero() || rec.CapturedAt.Before(capturedAt) {
 				capturedAt = rec.CapturedAt
 			}
 			if capturedUntil.IsZero() || rec.CapturedAt.After(capturedUntil) {
 				capturedUntil = rec.CapturedAt
 			}
-			ids = append(ids, rec.ID)
-			all = append(all, rec)
-			entry.RecordIDs = append(entry.RecordIDs, rec.ID)
+			rcopy := rec
+			if err := sw.WriteRecord(&rcopy); err != nil {
+				t.Fatalf("WriteRecord: %v", err)
+			}
+			entry.Seqs = append(entry.Seqs, i)
 			entry.Times = append(entry.Times, rec.CapturedAt)
+			totalCount++
 		}
 		index[path] = entry
 	}
-	meta := capture.CaptureMetadata{CaptureID: "test-capture", CapturedAt: capturedAt, CapturedUntil: capturedUntil, RecordCount: len(all)}
-	recs := make([]*capture.Record, 0, len(all))
-	for i := range all {
-		recs = append(recs, &all[i])
+	meta := capture.CaptureMetadata{CaptureID: "test-capture", CapturedAt: capturedAt, CapturedUntil: capturedUntil, RecordCount: totalCount}
+	if err := sw.Finish(&meta, index, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
 	}
-	if err := archivepkg.Write(out, &meta, recs, index); err != nil {
-		t.Fatalf("archive.Write: %v", err)
-	}
-	_ = ids
 	return out
 }
 

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -3,8 +3,6 @@ package inspect
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -37,46 +35,25 @@ type ResourceSummary struct {
 	Items      int      `json:"item_count"`
 }
 
-// Run extracts archivePath to a temp dir, reads metadata and index, and returns
-// a Report. The caller need not do any clean-up; the temp dir is removed before
-// Run returns.
+// Run opens archivePath and returns a Report without extracting to disk.
 func Run(archivePath string) (*Report, error) {
-	fi, err := os.Stat(archivePath)
+	ar, err := archive.Open(archivePath)
 	if err != nil {
-		return nil, fmt.Errorf("stat %q: %w", archivePath, err)
-	}
-	archiveSize := fi.Size()
-
-	tmpDir, err := os.MkdirTemp("", "k8shark-inspect-*")
-	if err != nil {
-		return nil, fmt.Errorf("creating temp dir: %w", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	if err := archive.Open(archivePath, tmpDir); err != nil {
 		return nil, fmt.Errorf("opening archive: %w", err)
 	}
+	defer ar.Close()
 
-	metaBytes, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "metadata.json"))
-	if err != nil {
+	var meta capture.CaptureMetadata
+	if err := ar.ReadMetadata(&meta); err != nil {
 		return nil, fmt.Errorf("reading metadata: %w", err)
 	}
-	var meta capture.CaptureMetadata
-	if err := json.Unmarshal(metaBytes, &meta); err != nil {
-		return nil, fmt.Errorf("parsing metadata: %w", err)
-	}
 
-	idxBytes, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "index.json"))
-	if err != nil {
+	var idx capture.Index
+	if err := ar.ReadIndex(&idx); err != nil {
 		return nil, fmt.Errorf("reading index: %w", err)
 	}
-	var idx capture.Index
-	if err := json.Unmarshal(idxBytes, &idx); err != nil {
-		return nil, fmt.Errorf("parsing index: %w", err)
-	}
 
-	recordsDir := filepath.Join(tmpDir, "k8shark-capture", "records")
-	resources := summariseResources(idx, recordsDir)
+	resources := summariseResources(ar, idx)
 
 	return &Report{
 		CaptureID:         meta.CaptureID,
@@ -86,15 +63,14 @@ func Run(archivePath string) (*Report, error) {
 		ServerAddress:     meta.ServerAddress,
 		RecordCount:       meta.RecordCount,
 		ArchivePath:       archivePath,
-		ArchiveSize:       archiveSize,
+		ArchiveSize:       ar.Size(),
 		Resources:         resources,
 	}, nil
 }
 
 // summariseResources aggregates per-resource information from the index.
-// recordsDir is the path to the extracted records directory; if non-empty,
-// item counts are read from the latest record for each path.
-func summariseResources(idx capture.Index, recordsDir string) []ResourceSummary {
+// Item counts are read from the latest record for each path directly from the archive.
+func summariseResources(ar *archive.Archive, idx capture.Index) []ResourceSummary {
 	type key struct{ group, version, resource string }
 	type accum struct {
 		namespaced bool
@@ -123,12 +99,12 @@ func summariseResources(idx capture.Index, recordsDir string) []ResourceSummary 
 			a.namespaced = true
 			a.nsSeen[ns] = true
 		}
-		a.records += len(entry.RecordIDs)
+		a.records += len(entry.Seqs)
 
 		// Count items in the latest record for this path.
-		if recordsDir != "" && len(entry.RecordIDs) > 0 {
-			latestID := entry.RecordIDs[len(entry.RecordIDs)-1]
-			if data, err := os.ReadFile(filepath.Join(recordsDir, latestID+".json")); err == nil {
+		if len(entry.Seqs) > 0 {
+			latestSeq := entry.Seqs[len(entry.Seqs)-1]
+			if data, err := ar.ReadRecord(path, latestSeq); err == nil {
 				var rec capture.Record
 				if jerr := json.Unmarshal(data, &rec); jerr == nil && rec.ResponseCode == 200 {
 					var list struct {

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -19,13 +19,14 @@ func buildArchive(t *testing.T, records []*capture.Record) string {
 	idx := capture.Index{}
 	for _, r := range records {
 		if e, ok := idx[r.APIPath]; ok {
-			e.RecordIDs = append(e.RecordIDs, r.ID)
+			seq := len(e.Seqs)
+			e.Seqs = append(e.Seqs, seq)
 			e.Times = append(e.Times, r.CapturedAt)
 		} else {
 			idx[r.APIPath] = &capture.IndexEntry{
-				APIPath:   r.APIPath,
-				RecordIDs: []string{r.ID},
-				Times:     []time.Time{r.CapturedAt},
+				APIPath: r.APIPath,
+				Seqs:    []int{0},
+				Times:   []time.Time{r.CapturedAt},
 			}
 		}
 	}
@@ -40,8 +41,17 @@ func buildArchive(t *testing.T, records []*capture.Record) string {
 	}
 
 	outPath := filepath.Join(dir, "test.tar.gz")
-	if err := archive.Write(outPath, meta, records, idx); err != nil {
-		t.Fatalf("buildArchive: %v", err)
+	sw, err := archive.NewStreamWriter(outPath)
+	if err != nil {
+		t.Fatalf("buildArchive NewStreamWriter: %v", err)
+	}
+	for _, r := range records {
+		if err := sw.WriteRecord(r); err != nil {
+			t.Fatalf("buildArchive WriteRecord: %v", err)
+		}
+	}
+	if err := sw.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("buildArchive Finish: %v", err)
 	}
 	return outPath
 }
@@ -153,27 +163,30 @@ func TestRun_TableKeysSkipped(t *testing.T) {
 	archivePath := buildArchive(t, []*capture.Record{
 		rec("r1", "/api/v1/namespaces/default/pods"),
 	})
+	ar, err := archive.Open(archivePath)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	defer ar.Close()
 
-	// Manually inject a Table index entry into the archive would require
-	// re-building the archive; instead verify that summariseResources skips "?"
-	// paths via the unit function directly.
+	// Manually inject a Table index entry; verify that summariseResources skips
+	// paths containing "?" via the unit function directly.
 	idx := capture.Index{
 		"/api/v1/namespaces/default/pods": {
-			APIPath:   "/api/v1/namespaces/default/pods",
-			RecordIDs: []string{"r1"},
-			Times:     []time.Time{time.Now()},
+			APIPath: "/api/v1/namespaces/default/pods",
+			Seqs:    []int{0},
+			Times:   []time.Time{time.Now()},
 		},
 		"/api/v1/namespaces/default/pods?as=Table": {
-			APIPath:   "/api/v1/namespaces/default/pods?as=Table",
-			RecordIDs: []string{"r2"},
-			Times:     []time.Time{time.Now()},
+			APIPath: "/api/v1/namespaces/default/pods?as=Table",
+			Seqs:    []int{0},
+			Times:   []time.Time{time.Now()},
 		},
 	}
-	summaries := summariseResources(idx, "")
+	summaries := summariseResources(ar, idx)
 	if len(summaries) != 1 {
 		t.Errorf("expected 1 summary (Table key excluded), got %d", len(summaries))
 	}
-	_ = archivePath
 }
 
 func TestRun_SortedOutput(t *testing.T) {

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -40,7 +40,7 @@ func buildArchive(t *testing.T, records []*capture.Record) string {
 		RecordCount:       len(records),
 	}
 
-	outPath := filepath.Join(dir, "test.tar.gz")
+	outPath := filepath.Join(dir, "test.khsrk")
 	sw, err := archive.NewStreamWriter(outPath)
 	if err != nil {
 		t.Fatalf("buildArchive NewStreamWriter: %v", err)

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -4,8 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/phenixblue/k8shark/internal/archive"
@@ -38,83 +36,125 @@ type Result struct {
 // Archive reads srcPath, applies redaction options, and writes to dstPath.
 // The original archive is not modified.
 func Archive(srcPath, dstPath string, opts Options) (Result, error) {
-	// Extract the source archive to a temp dir.
-	tmpDir, err := os.MkdirTemp("", "k8shark-redact-*")
+	ar, err := archive.Open(srcPath)
 	if err != nil {
-		return Result{}, fmt.Errorf("creating temp dir: %w", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	if err := archive.Open(srcPath, tmpDir); err != nil {
 		return Result{}, fmt.Errorf("opening archive: %w", err)
 	}
+	defer ar.Close()
 
-	// Load metadata and index.
-	metaBytes, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "metadata.json"))
-	if err != nil {
+	var meta capture.CaptureMetadata
+	if err := ar.ReadMetadata(&meta); err != nil {
 		return Result{}, fmt.Errorf("reading metadata: %w", err)
 	}
-	var meta capture.CaptureMetadata
-	if err := json.Unmarshal(metaBytes, &meta); err != nil {
-		return Result{}, fmt.Errorf("parsing metadata: %w", err)
-	}
 
-	idxBytes, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "index.json"))
-	if err != nil {
+	var idx capture.Index
+	if err := ar.ReadIndex(&idx); err != nil {
 		return Result{}, fmt.Errorf("reading index: %w", err)
 	}
-	var idx capture.Index
-	if err := json.Unmarshal(idxBytes, &idx); err != nil {
-		return Result{}, fmt.Errorf("parsing index: %w", err)
-	}
 
-	// Walk all records, collect unique IDs, and redact as needed.
-	seen := map[string]bool{}
-	for _, entry := range idx {
-		for _, id := range entry.RecordIDs {
-			seen[id] = true
-		}
-	}
+	var wi capture.WatchIndex
+	_, _ = ar.ReadWatchIndex(&wi)
 
-	var records []*capture.Record
 	result := Result{}
 
-	for id := range seen {
-		recPath := filepath.Join(tmpDir, "k8shark-capture", "records", id+".json")
-		data, err := os.ReadFile(recPath)
-		if err != nil {
-			return Result{}, fmt.Errorf("reading record %s: %w", id, err)
-		}
-		var rec capture.Record
-		if err := json.Unmarshal(data, &rec); err != nil {
-			return Result{}, fmt.Errorf("parsing record %s: %w", id, err)
-		}
-
-		// Secret redaction pass
-		if opts.RedactSecrets {
-			secretsRedacted, err := redactRecord(&rec, opts.AllowList)
-			if err != nil {
-				return Result{}, fmt.Errorf("redacting record %s: %w", id, err)
-			}
-			if secretsRedacted {
-				result.SecretsRedacted++
-			}
-		}
-
-		// Field-level redaction pass
-		if len(opts.Rules) > 0 {
-			fieldsRedacted, err := redactFieldsInRecord(&rec, opts.Rules)
-			if err != nil {
-				return Result{}, fmt.Errorf("field-redacting record %s: %w", id, err)
-			}
-			result.FieldsRedacted += fieldsRedacted
-		}
-
-		records = append(records, &rec)
+	sw, err := archive.NewStreamWriter(dstPath)
+	if err != nil {
+		return Result{}, fmt.Errorf("creating output archive: %w", err)
 	}
 
-	if err := archive.Write(dstPath, &meta, records, idx); err != nil {
-		return Result{}, fmt.Errorf("writing redacted archive: %w", err)
+	// newIdx / newWI will be built with corrected seq numbers as we write.
+	newIdx := make(capture.Index, len(idx))
+	newWI := make(capture.WatchIndex, len(wi))
+
+	// Copy regular index records in order, rebuilding seqs.
+	for apiPath, entry := range idx {
+		newEntry := &capture.IndexEntry{
+			APIPath: entry.APIPath,
+			Times:   entry.Times,
+		}
+		for _, seq := range entry.Seqs {
+			data, err := ar.ReadRecord(apiPath, seq)
+			if err != nil {
+				return Result{}, fmt.Errorf("reading record seq %d: %w", seq, err)
+			}
+			var rec capture.Record
+			if err := json.Unmarshal(data, &rec); err != nil {
+				return Result{}, fmt.Errorf("parsing record seq %d: %w", seq, err)
+			}
+
+			if opts.RedactSecrets {
+				secretsRedacted, err := redactRecord(&rec, opts.AllowList)
+				if err != nil {
+					return Result{}, fmt.Errorf("redacting record seq %d: %w", seq, err)
+				}
+				if secretsRedacted {
+					result.SecretsRedacted++
+				}
+			}
+
+			if len(opts.Rules) > 0 {
+				fieldsRedacted, err := redactFieldsInRecord(&rec, opts.Rules)
+				if err != nil {
+					return Result{}, fmt.Errorf("field-redacting record seq %d: %w", seq, err)
+				}
+				result.FieldsRedacted += fieldsRedacted
+			}
+
+			newSeq, err := sw.WriteRecordRaw(apiPath, rec)
+			if err != nil {
+				return Result{}, fmt.Errorf("writing record seq %d: %w", seq, err)
+			}
+			newEntry.Seqs = append(newEntry.Seqs, newSeq)
+		}
+		newIdx[apiPath] = newEntry
+	}
+
+	// Copy watch-index records in order.
+	for apiPath, wiEntry := range wi {
+		newWIEntry := &capture.WatchIndexEntry{
+			APIPath:    wiEntry.APIPath,
+			Times:      wiEntry.Times,
+			EventTypes: wiEntry.EventTypes,
+		}
+		for _, seq := range wiEntry.Seqs {
+			data, err := ar.ReadRecord(apiPath, seq)
+			if err != nil {
+				return Result{}, fmt.Errorf("reading watch record seq %d: %w", seq, err)
+			}
+			var rec capture.Record
+			if err := json.Unmarshal(data, &rec); err != nil {
+				return Result{}, fmt.Errorf("parsing watch record seq %d: %w", seq, err)
+			}
+
+			if opts.RedactSecrets {
+				secretsRedacted, err := redactRecord(&rec, opts.AllowList)
+				if err != nil {
+					return Result{}, fmt.Errorf("redacting watch record seq %d: %w", seq, err)
+				}
+				if secretsRedacted {
+					result.SecretsRedacted++
+				}
+			}
+
+			if len(opts.Rules) > 0 {
+				fieldsRedacted, err := redactFieldsInRecord(&rec, opts.Rules)
+				if err != nil {
+					return Result{}, fmt.Errorf("field-redacting watch record seq %d: %w", seq, err)
+				}
+				result.FieldsRedacted += fieldsRedacted
+			}
+
+			newSeq, err := sw.WriteRecordRaw(apiPath, rec)
+			if err != nil {
+				return Result{}, fmt.Errorf("writing watch record seq %d: %w", seq, err)
+			}
+			newWIEntry.Seqs = append(newWIEntry.Seqs, newSeq)
+		}
+		newWI[apiPath] = newWIEntry
+	}
+
+	if err := sw.Finish(&meta, newIdx, newWI); err != nil {
+		return Result{}, fmt.Errorf("finishing output archive: %w", err)
 	}
 
 	return result, nil

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -42,7 +42,7 @@ func buildTestArchive(t *testing.T, records []*capture.Record) string {
 		RecordCount:       len(records),
 	}
 
-	outPath := filepath.Join(dir, "test.tar.gz")
+	outPath := filepath.Join(dir, "test.khsrk")
 	sw, err := archive.NewStreamWriter(outPath)
 	if err != nil {
 		t.Fatalf("buildTestArchive NewStreamWriter: %v", err)
@@ -126,7 +126,7 @@ func TestRedact_SecretDataRedacted(t *testing.T) {
 	src := buildTestArchive(t, []*capture.Record{
 		secretRecord("r1", "default", "db-creds", map[string]string{"password": encoded}, nil),
 	})
-	dst := src + "-redacted.tar.gz"
+	dst := src + "-redacted.khsrk"
 	t.Cleanup(func() { os.Remove(dst) })
 
 	result, err := Archive(src, dst, Options{RedactSecrets: true})
@@ -166,7 +166,7 @@ func TestRedact_StringDataRedacted(t *testing.T) {
 	src := buildTestArchive(t, []*capture.Record{
 		secretRecord("r2", "default", "plain-secret", nil, map[string]string{"token": "s3cr3t"}),
 	})
-	dst := src + "-redacted.tar.gz"
+	dst := src + "-redacted.khsrk"
 	t.Cleanup(func() { os.Remove(dst) })
 
 	_, err := Archive(src, dst, Options{RedactSecrets: true})
@@ -200,7 +200,7 @@ func TestRedact_AllowList(t *testing.T) {
 	src := buildTestArchive(t, []*capture.Record{
 		secretRecord("r3", "default", "allowed-secret", map[string]string{"key": encoded}, nil),
 	})
-	dst := src + "-redacted.tar.gz"
+	dst := src + "-redacted.khsrk"
 	t.Cleanup(func() { os.Remove(dst) })
 
 	result, err := Archive(src, dst, Options{RedactSecrets: true, AllowList: map[string]bool{"default/allowed-secret": true}})
@@ -236,7 +236,7 @@ func TestRedact_NonSecretUnchanged(t *testing.T) {
 	src := buildTestArchive(t, []*capture.Record{
 		podRecord("r4", "default"),
 	})
-	dst := src + "-redacted.tar.gz"
+	dst := src + "-redacted.khsrk"
 	t.Cleanup(func() { os.Remove(dst) })
 
 	result, err := Archive(src, dst, Options{RedactSecrets: true})
@@ -259,7 +259,7 @@ func TestRedact_SecretListRedacted(t *testing.T) {
 	src := buildTestArchive(t, []*capture.Record{
 		secretListRecord("r5", "k8shark-test", []map[string]any{item}),
 	})
-	dst := src + "-redacted.tar.gz"
+	dst := src + "-redacted.khsrk"
 	t.Cleanup(func() { os.Remove(dst) })
 
 	result, err := Archive(src, dst, Options{RedactSecrets: true})
@@ -310,7 +310,7 @@ func TestRedact_SecretList_AllowList(t *testing.T) {
 	src := buildTestArchive(t, []*capture.Record{
 		secretListRecord("r6", "default", []map[string]any{item}),
 	})
-	dst := src + "-redacted.tar.gz"
+	dst := src + "-redacted.khsrk"
 	t.Cleanup(func() { os.Remove(dst) })
 
 	result, err := Archive(src, dst, Options{RedactSecrets: true, AllowList: map[string]bool{"default/allowed-secret": true}})
@@ -378,7 +378,7 @@ func TestArchive_FieldRules_RedactsConfigMapKey(t *testing.T) {
 	src := buildTestArchive(t, []*capture.Record{
 		configMapRecord("cm1", "default", "app-config", map[string]interface{}{"api-key": "super-secret"}),
 	})
-	dst := src + "-redacted.tar.gz"
+	dst := src + "-redacted.khsrk"
 	t.Cleanup(func() { os.Remove(dst) })
 
 	result, err := Archive(src, dst, Options{
@@ -423,7 +423,7 @@ func TestArchive_FieldRules_CombinedWithSecrets(t *testing.T) {
 		secretRecord("s1", "default", "db-creds", map[string]string{"password": encoded}, nil),
 		configMapRecord("cm2", "default", "app-config", map[string]interface{}{"api-key": "my-key"}),
 	})
-	dst := src + "-redacted.tar.gz"
+	dst := src + "-redacted.khsrk"
 	t.Cleanup(func() { os.Remove(dst) })
 
 	result, err := Archive(src, dst, Options{
@@ -451,7 +451,7 @@ func TestArchive_FieldRules_RecursiveDescent(t *testing.T) {
 			"safe-key":       "keep-me",
 		}),
 	})
-	dst := src + "-redacted.tar.gz"
+	dst := src + "-redacted.khsrk"
 	t.Cleanup(func() { os.Remove(dst) })
 
 	_, err := Archive(src, dst, Options{

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -20,13 +20,17 @@ func buildTestArchive(t *testing.T, records []*capture.Record) string {
 	dir := t.TempDir()
 
 	idx := capture.Index{}
+	pathSeq := map[string]int{}
 	for _, r := range records {
-		e := &capture.IndexEntry{
-			APIPath:   r.APIPath,
-			RecordIDs: []string{r.ID},
-			Times:     []time.Time{r.CapturedAt},
+		seq := pathSeq[r.APIPath]
+		pathSeq[r.APIPath] = seq + 1
+		e := idx[r.APIPath]
+		if e == nil {
+			e = &capture.IndexEntry{APIPath: r.APIPath}
+			idx[r.APIPath] = e
 		}
-		idx[r.APIPath] = e
+		e.Seqs = append(e.Seqs, seq)
+		e.Times = append(e.Times, r.CapturedAt)
 	}
 
 	meta := &capture.CaptureMetadata{
@@ -39,8 +43,17 @@ func buildTestArchive(t *testing.T, records []*capture.Record) string {
 	}
 
 	outPath := filepath.Join(dir, "test.tar.gz")
-	if err := archive.Write(outPath, meta, records, idx); err != nil {
-		t.Fatalf("buildTestArchive: %v", err)
+	sw, err := archive.NewStreamWriter(outPath)
+	if err != nil {
+		t.Fatalf("buildTestArchive NewStreamWriter: %v", err)
+	}
+	for _, r := range records {
+		if err := sw.WriteRecord(r); err != nil {
+			t.Fatalf("buildTestArchive WriteRecord: %v", err)
+		}
+	}
+	if err := sw.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("buildTestArchive Finish: %v", err)
 	}
 	return outPath
 }
@@ -125,11 +138,12 @@ func TestRedact_SecretDataRedacted(t *testing.T) {
 	}
 
 	// Verify the output archive has the value replaced.
-	tmpDir := t.TempDir()
-	if err := archive.Open(dst, tmpDir); err != nil {
+	ar2, err := archive.Open(dst)
+	if err != nil {
 		t.Fatalf("opening redacted archive: %v", err)
 	}
-	data, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "records", "r1.json"))
+	defer ar2.Close()
+	data, err := ar2.ReadRecord("/api/v1/namespaces/default/secrets", 0)
 	if err != nil {
 		t.Fatalf("reading record: %v", err)
 	}
@@ -160,11 +174,12 @@ func TestRedact_StringDataRedacted(t *testing.T) {
 		t.Fatalf("Archive: %v", err)
 	}
 
-	tmpDir := t.TempDir()
-	if err := archive.Open(dst, tmpDir); err != nil {
+	ar3, err := archive.Open(dst)
+	if err != nil {
 		t.Fatalf("opening redacted archive: %v", err)
 	}
-	data, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "records", "r2.json"))
+	defer ar3.Close()
+	data, err := ar3.ReadRecord("/api/v1/namespaces/default/secrets", 0)
 	if err != nil {
 		t.Fatalf("reading record: %v", err)
 	}
@@ -196,11 +211,12 @@ func TestRedact_AllowList(t *testing.T) {
 		t.Errorf("expected 0 redacted records (all allowlisted), got %d", result.SecretsRedacted)
 	}
 
-	tmpDir := t.TempDir()
-	if err := archive.Open(dst, tmpDir); err != nil {
+	ar4, err := archive.Open(dst)
+	if err != nil {
 		t.Fatalf("opening redacted archive: %v", err)
 	}
-	data, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "records", "r3.json"))
+	defer ar4.Close()
+	data, err := ar4.ReadRecord("/api/v1/namespaces/default/secrets", 0)
 	if err != nil {
 		t.Fatalf("reading record: %v", err)
 	}
@@ -254,11 +270,12 @@ func TestRedact_SecretListRedacted(t *testing.T) {
 		t.Errorf("expected 1 redacted record, got %d", result.SecretsRedacted)
 	}
 
-	tmpDir := t.TempDir()
-	if err := archive.Open(dst, tmpDir); err != nil {
+	ar5, err := archive.Open(dst)
+	if err != nil {
 		t.Fatalf("opening redacted archive: %v", err)
 	}
-	data, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "records", "r5.json"))
+	defer ar5.Close()
+	data, err := ar5.ReadRecord("/api/v1/namespaces/k8shark-test/secrets", 0)
 	if err != nil {
 		t.Fatalf("reading record: %v", err)
 	}
@@ -304,11 +321,12 @@ func TestRedact_SecretList_AllowList(t *testing.T) {
 		t.Errorf("expected 0 redacted records (allowlisted), got %d", result.SecretsRedacted)
 	}
 
-	tmpDir := t.TempDir()
-	if err := archive.Open(dst, tmpDir); err != nil {
+	ar6, err := archive.Open(dst)
+	if err != nil {
 		t.Fatalf("opening redacted archive: %v", err)
 	}
-	data, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "records", "r6.json"))
+	defer ar6.Close()
+	data, err := ar6.ReadRecord("/api/v1/namespaces/default/secrets", 0)
 	if err != nil {
 		t.Fatalf("reading record: %v", err)
 	}
@@ -375,14 +393,12 @@ func TestArchive_FieldRules_RedactsConfigMapKey(t *testing.T) {
 		t.Errorf("expected 1 field-redacted record, got %d", result.FieldsRedacted)
 	}
 
-	tmpDir := t.TempDir()
-	if err := archive.Open(dst, tmpDir); err != nil {
+	ar7, err := archive.Open(dst)
+	if err != nil {
 		t.Fatalf("opening redacted archive: %v", err)
 	}
-	data, err := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "records", "cm1.json"))
-	if err != nil {
-		t.Fatalf("reading record: %v", err)
-	}
+	defer ar7.Close()
+	data, _ := ar7.ReadRecord("/api/v1/namespaces/default/configmaps", 0)
 	var rec capture.Record
 	_ = json.Unmarshal(data, &rec)
 	var obj map[string]json.RawMessage
@@ -450,11 +466,12 @@ func TestArchive_FieldRules_RecursiveDescent(t *testing.T) {
 	// they are NOT nested paths, so recursive descent won't match them unless
 	// we traverse their actual key names. This confirms only truly nested
 	// "password" keys (at any depth) are matched.  safe-key should be preserved.
-	tmpDir := t.TempDir()
-	if err := archive.Open(dst, tmpDir); err != nil {
+	ar8, err := archive.Open(dst)
+	if err != nil {
 		t.Fatalf("opening redacted archive: %v", err)
 	}
-	data, _ := os.ReadFile(filepath.Join(tmpDir, "k8shark-capture", "records", "cm3.json"))
+	defer ar8.Close()
+	data, _ := ar8.ReadRecord("/api/v1/namespaces/default/configmaps", 0)
 	var rec capture.Record
 	_ = json.Unmarshal(data, &rec)
 	var obj map[string]json.RawMessage

--- a/internal/server/bench_test.go
+++ b/internal/server/bench_test.go
@@ -19,7 +19,7 @@ import (
 func buildBenchStore(b *testing.B, n int) *CaptureStore {
 	b.Helper()
 	dir := b.TempDir()
-	outPath := filepath.Join(dir, "bench.kshrk")
+	outPath := filepath.Join(dir, "bench.khsrk")
 
 	sw, err := archive.NewStreamWriter(outPath)
 	if err != nil {

--- a/internal/server/bench_test.go
+++ b/internal/server/bench_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/phenixblue/k8shark/internal/archive"
 	capture "github.com/phenixblue/k8shark/internal/capture"
 )
 
@@ -19,8 +19,10 @@ import (
 func buildBenchStore(b *testing.B, n int) *CaptureStore {
 	b.Helper()
 	dir := b.TempDir()
-	recDir := filepath.Join(dir, "k8shark-capture", "records")
-	if err := os.MkdirAll(recDir, 0o750); err != nil {
+	outPath := filepath.Join(dir, "bench.kshrk")
+
+	sw, err := archive.NewStreamWriter(outPath)
+	if err != nil {
 		b.Fatal(err)
 	}
 
@@ -30,42 +32,42 @@ func buildBenchStore(b *testing.B, n int) *CaptureStore {
 		body := json.RawMessage(fmt.Sprintf(
 			`{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"pod%d","namespace":"ns%d"}}]}`,
 			i, i))
-		recID := fmt.Sprintf("bench-rec-%04d", i)
 		rec := capture.Record{
-			ID:           recID,
+			ID:           fmt.Sprintf("bench-rec-%04d", i),
 			CapturedAt:   time.Now().UTC(),
 			APIPath:      apiPath,
 			HTTPMethod:   "GET",
 			ResponseCode: 200,
 			ResponseBody: body,
 		}
-		data, _ := json.Marshal(rec)
-		if err := os.WriteFile(filepath.Join(recDir, recID+".json"), data, 0o644); err != nil {
+		if err := sw.WriteRecord(&rec); err != nil {
 			b.Fatal(err)
 		}
 		index[apiPath] = &capture.IndexEntry{
-			APIPath:   apiPath,
-			RecordIDs: []string{recID},
-			Times:     []time.Time{rec.CapturedAt},
+			APIPath: apiPath,
+			Seqs:    []int{0},
+			Times:   []time.Time{rec.CapturedAt},
 		}
 	}
 
-	metaJSON, _ := json.Marshal(capture.CaptureMetadata{
+	meta := capture.CaptureMetadata{
 		CaptureID:         "bench-capture",
 		KubernetesVersion: "v1.29.0",
 		CapturedAt:        time.Now().UTC().Add(-time.Minute),
 		CapturedUntil:     time.Now().UTC(),
 		RecordCount:       n,
-	})
-	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "metadata.json"), metaJSON, 0o644); err != nil {
-		b.Fatal(err)
 	}
-	idxJSON, _ := json.Marshal(index)
-	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "index.json"), idxJSON, 0o644); err != nil {
+	if err := sw.Finish(&meta, index, nil); err != nil {
 		b.Fatal(err)
 	}
 
-	store, err := LoadStore(dir)
+	ar, err := archive.Open(outPath)
+	if err != nil {
+		b.Fatalf("archive.Open: %v", err)
+	}
+	b.Cleanup(func() { ar.Close() })
+
+	store, err := LoadStore(ar)
 	if err != nil {
 		b.Fatalf("LoadStore: %v", err)
 	}

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -5,12 +5,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
 )
 
@@ -304,10 +304,7 @@ func TestHandler_FieldSelector(t *testing.T) {
 
 func TestHandler_ReplayAtTimestamp(t *testing.T) {
 	dir := t.TempDir()
-	recDir := filepath.Join(dir, "k8shark-capture", "records")
-	if err := os.MkdirAll(recDir, 0o750); err != nil {
-		t.Fatal(err)
-	}
+	outPath := filepath.Join(dir, "test.kshrk")
 
 	path := "/api/v1/namespaces/default/pods"
 	t1 := time.Date(2026, 4, 9, 10, 40, 0, 0, time.UTC)
@@ -316,28 +313,32 @@ func TestHandler_ReplayAtTimestamp(t *testing.T) {
 		{ID: "rec-1", CapturedAt: t1, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(`{"apiVersion":"v1","kind":"PodList","items":[{"metadata":{"name":"before"}}]}`)},
 		{ID: "rec-2", CapturedAt: t2, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(`{"apiVersion":"v1","kind":"PodList","items":[{"metadata":{"name":"after"}}]}`)},
 	}
+
+	sw, err := archive.NewStreamWriter(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, rec := range records {
-		data, err := json.Marshal(rec)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(recDir, rec.ID+".json"), data, 0o644); err != nil {
+		rcopy := rec
+		if err := sw.WriteRecord(&rcopy); err != nil {
 			t.Fatal(err)
 		}
 	}
-
-	metaJSON, _ := json.Marshal(capture.CaptureMetadata{CaptureID: "test-capture-id", CapturedAt: t1, CapturedUntil: t2, RecordCount: len(records)})
-	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "metadata.json"), metaJSON, 0o644); err != nil {
-		t.Fatal(err)
+	idx := capture.Index{
+		path: {APIPath: path, Seqs: []int{0, 1}, Times: []time.Time{t1, t2}},
 	}
-	idxJSON, _ := json.Marshal(capture.Index{
-		path: {APIPath: path, RecordIDs: []string{"rec-1", "rec-2"}, Times: []time.Time{t1, t2}},
-	})
-	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "index.json"), idxJSON, 0o644); err != nil {
+	meta := capture.CaptureMetadata{CaptureID: "test-capture-id", CapturedAt: t1, CapturedUntil: t2, RecordCount: len(records)}
+	if err := sw.Finish(&meta, idx, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	store, err := LoadStore(dir)
+	ar, err := archive.Open(outPath)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	t.Cleanup(func() { ar.Close() })
+
+	store, err := LoadStore(ar)
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -304,7 +304,7 @@ func TestHandler_FieldSelector(t *testing.T) {
 
 func TestHandler_ReplayAtTimestamp(t *testing.T) {
 	dir := t.TempDir()
-	outPath := filepath.Join(dir, "test.kshrk")
+	outPath := filepath.Join(dir, "test.khsrk")
 
 	path := "/api/v1/namespaces/default/pods"
 	t1 := time.Date(2026, 4, 9, 10, 40, 0, 0, time.UTC)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,48 +29,43 @@ type OpenOptions struct {
 type Server struct {
 	address        string
 	kubeconfigPath string
-	tmpDir         string
+	ar             *archive.Archive
 	httpServer     *http.Server
 	done           chan struct{}
 }
 
-// Open extracts a capture archive, starts the mock HTTPS server, and writes
+// Open opens a capture archive, starts the mock HTTPS server, and writes
 // a kubeconfig pointing at it.
 func Open(opts OpenOptions) (*Server, error) {
-	// Extract the archive to a temp directory.
-	tmpDir, err := os.MkdirTemp("", "k8shark-*")
+	// Open the archive for direct in-memory access (no extraction).
+	ar, err := archive.Open(opts.ArchivePath)
 	if err != nil {
-		return nil, fmt.Errorf("creating temp dir: %w", err)
-	}
-
-	if err := archive.Open(opts.ArchivePath, tmpDir); err != nil {
-		_ = os.RemoveAll(tmpDir)
-		return nil, fmt.Errorf("extracting archive: %w", err)
+		return nil, fmt.Errorf("opening archive: %w", err)
 	}
 
 	// Load the capture index into memory.
-	store, err := LoadStore(tmpDir)
+	store, err := LoadStore(ar)
 	if err != nil {
-		_ = os.RemoveAll(tmpDir)
+		_ = ar.Close()
 		return nil, fmt.Errorf("loading capture: %w", err)
 	}
 
 	// Parse optional replay timestamp.
 	at, err := parseReplayAt(store.Metadata, opts.At)
 	if err != nil {
-		_ = os.RemoveAll(tmpDir)
+		_ = ar.Close()
 		return nil, err
 	}
 
 	// Generate a self-signed TLS certificate.
 	certPEM, keyPEM, err := generateSelfSignedCert()
 	if err != nil {
-		_ = os.RemoveAll(tmpDir)
+		_ = ar.Close()
 		return nil, fmt.Errorf("generating TLS cert: %w", err)
 	}
 	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
 	if err != nil {
-		_ = os.RemoveAll(tmpDir)
+		_ = ar.Close()
 		return nil, fmt.Errorf("loading TLS cert: %w", err)
 	}
 
@@ -81,7 +76,7 @@ func Open(opts OpenOptions) (*Server, error) {
 	}
 	ln, err := net.Listen("tcp", "127.0.0.1:"+port)
 	if err != nil {
-		_ = os.RemoveAll(tmpDir)
+		_ = ar.Close()
 		return nil, fmt.Errorf("listening: %w", err)
 	}
 
@@ -94,7 +89,7 @@ func Open(opts OpenOptions) (*Server, error) {
 		kubeconfigPath = filepath.Join(home, ".kube", "k8shark-"+store.Metadata.CaptureID+".yaml")
 	}
 	if err := writeKubeconfig(addr, kubeconfigPath); err != nil {
-		_ = os.RemoveAll(tmpDir)
+		_ = ar.Close()
 		_ = ln.Close()
 		return nil, fmt.Errorf("writing kubeconfig: %w", err)
 	}
@@ -115,7 +110,7 @@ func Open(opts OpenOptions) (*Server, error) {
 	return &Server{
 		address:        addr,
 		kubeconfigPath: kubeconfigPath,
-		tmpDir:         tmpDir,
+		ar:             ar,
 		httpServer:     httpSrv,
 		done:           done,
 	}, nil
@@ -127,17 +122,19 @@ func (s *Server) Address() string { return s.address }
 // KubeconfigPath returns the path to the generated kubeconfig.
 func (s *Server) KubeconfigPath() string { return s.kubeconfigPath }
 
-// Shutdown immediately stops the server and cleans up the temp directory.
+// Shutdown immediately stops the server and closes the archive.
 // Useful in tests and programmatic usage; Wait() is preferred for CLI use.
 func (s *Server) Shutdown() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_ = s.httpServer.Shutdown(ctx)
 	<-s.done
-	_ = os.RemoveAll(s.tmpDir)
+	if s.ar != nil {
+		_ = s.ar.Close()
+	}
 }
 
-// Wait blocks until Ctrl+C / SIGTERM, then shuts the server down and cleans up.
+// Wait blocks until Ctrl+C / SIGTERM, then shuts the server down and closes the archive.
 func (s *Server) Wait() error {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
@@ -149,7 +146,9 @@ func (s *Server) Wait() error {
 		_ = s.httpServer.Shutdown(ctx)
 		<-s.done
 	}
-	_ = os.RemoveAll(s.tmpDir)
+	if s.ar != nil {
+		_ = s.ar.Close()
+	}
 	return nil
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -19,7 +19,7 @@ import (
 func buildTestArchive(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	outPath := filepath.Join(dir, "test.tar.gz")
+	outPath := filepath.Join(dir, "test.khsrk")
 
 	podList := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
 	now := time.Now().UTC()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -42,14 +42,21 @@ func buildTestArchive(t *testing.T) string {
 	}
 	idx := capture.Index{
 		"/api/v1/namespaces/default/pods": {
-			APIPath:   "/api/v1/namespaces/default/pods",
-			RecordIDs: []string{"rec-001"},
-			Times:     []time.Time{now},
+			APIPath: "/api/v1/namespaces/default/pods",
+			Seqs:    []int{0},
+			Times:   []time.Time{now},
 		},
 	}
 
-	if err := archive.Write(outPath, meta, rec, idx); err != nil {
-		t.Fatalf("archive.Write: %v", err)
+	sw, err := archive.NewStreamWriter(outPath)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	if err := sw.WriteRecord(rec[0]); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+	if err := sw.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("archive Finish: %v", err)
 	}
 	return outPath
 }

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -1,26 +1,61 @@
 package server
 
 import (
+	"container/list"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
 )
 
-// CaptureStore holds the in-memory index and provides record lookups.
+// CaptureStore holds the in-memory index and provides record lookups against
+// a ZIP+Zstd archive opened without extraction to disk.
 type CaptureStore struct {
-	Dir          string
+	ar           *archive.Archive
 	Metadata     capture.CaptureMetadata
 	Index        capture.Index
 	WatchIndex   capture.WatchIndex
 	resourceInfo map[string]*ResourceInfo
-	recordCache  sync.Map // key: record ID string → capture.Record
+
+	// Record LRU cache (bounded by recordCacheMax entries).
+	recordCacheMu   sync.Mutex
+	recordCacheMap  map[recordKey]*list.Element
+	recordCacheList *list.List
+
+	// Response cache: (path, at) → marshalled body + code.
+	// Entries are valid for responseCacheTTL.
+	responseCacheMu  sync.RWMutex
+	responseCacheMap map[responseCacheKey]*responseCacheEntry
+}
+
+const recordCacheMax = 2048
+
+type recordKey struct {
+	apiPath string
+	seq     int
+}
+
+type responseCacheKey struct {
+	path string
+	at   time.Time
+}
+
+type responseCacheEntry struct {
+	body    []byte
+	code    int
+	created time.Time
+}
+
+const responseCacheTTL = 10 * time.Second
+
+type recordCacheEntry struct {
+	key recordKey
+	rec capture.Record
 }
 
 // ResourceInfo describes a single captured resource type.
@@ -34,54 +69,50 @@ type ResourceInfo struct {
 	SingularName string
 }
 
-// LoadStore reads metadata.json and index.json from an extracted archive
-// directory and returns an in-memory CaptureStore.
-func LoadStore(dir string) (*CaptureStore, error) {
-	metaData, err := os.ReadFile(filepath.Join(dir, "k8shark-capture", "metadata.json"))
-	if err != nil {
+// LoadStore reads metadata and index from the archive and returns a ready
+// CaptureStore. The archive must remain open for the lifetime of the store;
+// call ar.Close() when done (the server's Shutdown does this).
+func LoadStore(ar *archive.Archive) (*CaptureStore, error) {
+	var meta capture.CaptureMetadata
+	if err := ar.ReadMetadata(&meta); err != nil {
 		return nil, fmt.Errorf("reading metadata: %w", err)
 	}
-	var meta capture.CaptureMetadata
-	if err := json.Unmarshal(metaData, &meta); err != nil {
-		return nil, fmt.Errorf("parsing metadata: %w", err)
-	}
 
-	idxData, err := os.ReadFile(filepath.Join(dir, "k8shark-capture", "index.json"))
-	if err != nil {
-		return nil, fmt.Errorf("reading index: %w", err)
-	}
 	var idx capture.Index
-	if err := json.Unmarshal(idxData, &idx); err != nil {
-		return nil, fmt.Errorf("parsing index: %w", err)
+	if err := ar.ReadIndex(&idx); err != nil {
+		return nil, fmt.Errorf("reading index: %w", err)
 	}
 
 	s := &CaptureStore{
-		Dir:          dir,
-		Metadata:     meta,
-		Index:        idx,
-		WatchIndex:   make(capture.WatchIndex),
-		resourceInfo: make(map[string]*ResourceInfo),
+		ar:               ar,
+		Metadata:         meta,
+		Index:            idx,
+		WatchIndex:       make(capture.WatchIndex),
+		resourceInfo:     make(map[string]*ResourceInfo),
+		recordCacheMap:   make(map[recordKey]*list.Element),
+		recordCacheList:  list.New(),
+		responseCacheMap: make(map[responseCacheKey]*responseCacheEntry),
 	}
 
-	// Load watch-index.json if present. Older archives without it are treated
-	// as snapshot-only — this is the primary backward-compatibility mechanism.
-	if wiData, rerr := os.ReadFile(filepath.Join(dir, "k8shark-capture", "watch-index.json")); rerr == nil {
-		var wi capture.WatchIndex
-		if jerr := json.Unmarshal(wiData, &wi); jerr == nil && wi != nil {
-			s.WatchIndex = wi
-		}
+	// Load watch index if present.
+	var wi capture.WatchIndex
+	if found, err := ar.ReadWatchIndex(&wi); err == nil && found && wi != nil {
+		s.WatchIndex = wi
 	}
 
+	// Derive ResourceInfo from index keys synchronously (fast — no I/O).
 	s.buildResourceInfo()
+
+	// Enrich ResourceInfo from discovery records asynchronously.
+	go s.enrichResourceInfoFromDiscovery()
+
 	return s, nil
 }
 
-// buildResourceInfo derives ResourceInfo for each distinct resource type seen
-// in the index keys.
+// buildResourceInfo derives ResourceInfo for each distinct resource type in
+// the index. It does not read any record data.
 func (s *CaptureStore) buildResourceInfo() {
 	for path := range s.Index {
-		// Skip Table-format index keys (they use "?as=Table" suffix which is
-		// not a valid path component and would produce bogus ResourceInfo entries).
 		if strings.Contains(path, "?") {
 			continue
 		}
@@ -91,7 +122,6 @@ func (s *CaptureStore) buildResourceInfo() {
 		}
 		key := g + "/" + v + "/" + r
 		if existing, ok := s.resourceInfo[key]; ok {
-			// Mark namespaced if we see any namespace-scoped path for this resource.
 			if ns != "" {
 				existing.Namespaced = true
 			}
@@ -105,15 +135,11 @@ func (s *CaptureStore) buildResourceInfo() {
 			Namespaced: ns != "",
 		}
 	}
-	// Second pass: enrich ResourceInfo from captured /apis/<group>/<version>
-	// discovery records. This gives us real shortNames, singularName, and kind
-	// for CRD-backed resources that the static maps in handler.go don't cover.
-	s.enrichResourceInfoFromDiscovery()
 }
 
 // enrichResourceInfoFromDiscovery reads captured APIResourceList bodies from
-// the index (paths matching /apis/<g>/<v> and /api/v1) and updates
-// ShortNames, SingularName, and Kind for each known ResourceInfo entry.
+// the archive and back-fills Kind, ShortNames, SingularName into resourceInfo.
+// Runs in a background goroutine; store is usable before this completes.
 func (s *CaptureStore) enrichResourceInfoFromDiscovery() {
 	type apiResourceEntry struct {
 		Name         string   `json:"name"`
@@ -127,7 +153,6 @@ func (s *CaptureStore) enrichResourceInfoFromDiscovery() {
 	}
 
 	for path, entry := range s.Index {
-		// Only process group-version discovery paths, not resource paths.
 		if strings.Contains(path, "?") {
 			continue
 		}
@@ -141,14 +166,13 @@ func (s *CaptureStore) enrichResourceInfoFromDiscovery() {
 		default:
 			continue
 		}
-
-		if len(entry.RecordIDs) == 0 {
+		if len(entry.Seqs) == 0 {
 			continue
 		}
-		// Use the latest record that we can read.
+		// Use the latest record.
 		var body []byte
-		for i := len(entry.RecordIDs) - 1; i >= 0; i-- {
-			rec, err := s.readRecord(entry.RecordIDs[i])
+		for i := len(entry.Seqs) - 1; i >= 0; i-- {
+			rec, err := s.readRecord(path, entry.Seqs[i])
 			if err != nil || rec.ResponseCode != 200 {
 				continue
 			}
@@ -158,17 +182,11 @@ func (s *CaptureStore) enrichResourceInfoFromDiscovery() {
 		if body == nil {
 			continue
 		}
-
 		var resList apiResourceList
-		if err := json.Unmarshal(body, &resList); err != nil {
+		if err := json.Unmarshal(body, &resList); err != nil || resList.Kind != "APIResourceList" {
 			continue
 		}
-		if resList.Kind != "APIResourceList" {
-			continue
-		}
-
 		for _, res := range resList.Resources {
-			// Skip sub-resources (they have '/' in the name).
 			if strings.Contains(res.Name, "/") {
 				continue
 			}
@@ -201,73 +219,98 @@ func (s *CaptureStore) Resources() []*ResourceInfo {
 
 // Latest returns the ResponseBody of the most recent record for apiPath.
 // If at is non-zero, it returns the latest record whose timestamp is <= at.
-// Returns (nil, 404, nil) when the path is not in the index.
 func (s *CaptureStore) Latest(apiPath string, at time.Time) ([]byte, int, error) {
 	entry, ok := s.Index[apiPath]
-	if !ok || len(entry.RecordIDs) == 0 {
+	if !ok || len(entry.Seqs) == 0 {
 		return nil, 404, nil
 	}
 
-	// Default to the most recent record.
-	id := entry.RecordIDs[len(entry.RecordIDs)-1]
-	if !at.IsZero() && len(entry.Times) == len(entry.RecordIDs) && len(entry.Times) > 0 {
-		idx := sort.Search(len(entry.Times), func(i int) bool {
+	idx := len(entry.Seqs) - 1
+	if !at.IsZero() && len(entry.Times) == len(entry.Seqs) {
+		pos := sort.Search(len(entry.Times), func(i int) bool {
 			return entry.Times[i].After(at)
 		})
-		if idx == 0 {
+		if pos == 0 {
 			return nil, 404, nil
 		}
-		id = entry.RecordIDs[idx-1]
+		idx = pos - 1
 	}
 
-	rec, err := s.readRecord(id)
+	rec, err := s.readRecord(apiPath, entry.Seqs[idx])
 	if err != nil {
 		return nil, 500, err
 	}
 	return rec.ResponseBody, rec.ResponseCode, nil
 }
 
-// readRecord reads and parses a single capture.Record by ID from the archive.
-// Results are cached in memory so repeated reads of the same record are free.
-func (s *CaptureStore) readRecord(id string) (capture.Record, error) {
-	if v, ok := s.recordCache.Load(id); ok {
-		return v.(capture.Record), nil
+// readRecord reads and parses a single capture.Record from the archive,
+// using a bounded LRU cache to avoid re-reading hot records.
+func (s *CaptureStore) readRecord(apiPath string, seq int) (capture.Record, error) {
+	k := recordKey{apiPath, seq}
+
+	s.recordCacheMu.Lock()
+	if el, ok := s.recordCacheMap[k]; ok {
+		s.recordCacheList.MoveToFront(el)
+		rec := el.Value.(*recordCacheEntry).rec
+		s.recordCacheMu.Unlock()
+		return rec, nil
 	}
-	data, err := os.ReadFile(filepath.Join(s.Dir, "k8shark-capture", "records", id+".json"))
+	s.recordCacheMu.Unlock()
+
+	data, err := s.ar.ReadRecord(apiPath, seq)
 	if err != nil {
-		return capture.Record{}, fmt.Errorf("reading record %s: %w", id, err)
+		return capture.Record{}, fmt.Errorf("reading record path=%s seq=%d: %w", apiPath, seq, err)
 	}
 	var rec capture.Record
 	if err := json.Unmarshal(data, &rec); err != nil {
-		return capture.Record{}, fmt.Errorf("parsing record %s: %w", id, err)
+		return capture.Record{}, fmt.Errorf("parsing record path=%s seq=%d: %w", apiPath, seq, err)
 	}
-	s.recordCache.Store(id, rec)
+
+	s.recordCacheMu.Lock()
+	// Evict LRU entry if at capacity.
+	for s.recordCacheList.Len() >= recordCacheMax {
+		back := s.recordCacheList.Back()
+		if back == nil {
+			break
+		}
+		s.recordCacheList.Remove(back)
+		delete(s.recordCacheMap, back.Value.(*recordCacheEntry).key)
+	}
+	el := s.recordCacheList.PushFront(&recordCacheEntry{key: k, rec: rec})
+	s.recordCacheMap[k] = el
+	s.recordCacheMu.Unlock()
+
 	return rec, nil
 }
 
+// ReadRecord reads a single record by apiPath and seq, exposed for callers
+// outside this package that need raw record access.
+func (s *CaptureStore) ReadRecord(apiPath string, seq int) (capture.Record, error) {
+	return s.readRecord(apiPath, seq)
+}
+
 // SnapshotAt returns the body, HTTP code, and capture time of the most recent
-// snapshot record (i.e. non-watch-event record) for apiPath at or before at.
-// Returns (nil, 404, time.Time{}, nil) when no snapshot exists.
+// snapshot record for apiPath at or before at.
 func (s *CaptureStore) SnapshotAt(apiPath string, at time.Time) ([]byte, int, time.Time, error) {
 	entry, ok := s.Index[apiPath]
-	if !ok || len(entry.RecordIDs) == 0 {
+	if !ok || len(entry.Seqs) == 0 {
 		return nil, 404, time.Time{}, nil
 	}
 
-	id := entry.RecordIDs[len(entry.RecordIDs)-1]
-	snapTime := entry.Times[len(entry.Times)-1]
-	if !at.IsZero() && len(entry.Times) == len(entry.RecordIDs) && len(entry.Times) > 0 {
-		idx := sort.Search(len(entry.Times), func(i int) bool {
+	idx := len(entry.Seqs) - 1
+	snapTime := entry.Times[idx]
+	if !at.IsZero() && len(entry.Times) == len(entry.Seqs) {
+		pos := sort.Search(len(entry.Times), func(i int) bool {
 			return entry.Times[i].After(at)
 		})
-		if idx == 0 {
+		if pos == 0 {
 			return nil, 404, time.Time{}, nil
 		}
-		id = entry.RecordIDs[idx-1]
-		snapTime = entry.Times[idx-1]
+		idx = pos - 1
+		snapTime = entry.Times[idx]
 	}
 
-	rec, err := s.readRecord(id)
+	rec, err := s.readRecord(apiPath, entry.Seqs[idx])
 	if err != nil {
 		return nil, 500, time.Time{}, err
 	}
@@ -275,7 +318,6 @@ func (s *CaptureStore) SnapshotAt(apiPath string, at time.Time) ([]byte, int, ti
 }
 
 // objectKey returns the stable identity key for a Kubernetes object JSON blob.
-// Namespaced objects use "namespace/name"; cluster-scoped use "name".
 func objectKey(raw json.RawMessage) string {
 	var meta struct {
 		Metadata struct {
@@ -293,18 +335,48 @@ func objectKey(raw json.RawMessage) string {
 }
 
 // ReconstructAt returns the reconstructed list body for apiPath at time T.
-// If a WatchIndex entry exists for the path, it applies ADDED/MODIFIED/DELETED
-// watch events from (snapshot_time, T] on top of the latest snapshot.
+// Watch events are applied on top of the snapshot in parallel to reduce latency.
 // Falls back to Latest for paths without watch events.
 func (s *CaptureStore) ReconstructAt(apiPath string, at time.Time) ([]byte, int, error) {
-	wi, hasWatch := s.WatchIndex[apiPath]
-	if !hasWatch || len(wi.RecordIDs) == 0 {
-		// No watch events for this path — fall back to snapshot lookup.
-		body, code, err := s.Latest(apiPath, at)
-		return body, code, err
+	// Check response cache first.
+	cacheKey := responseCacheKey{apiPath, at}
+	s.responseCacheMu.RLock()
+	if e, ok := s.responseCacheMap[cacheKey]; ok && time.Since(e.created) < responseCacheTTL {
+		body, code := e.body, e.code
+		s.responseCacheMu.RUnlock()
+		return body, code, nil
+	}
+	s.responseCacheMu.RUnlock()
+
+	body, code, err := s.reconstructAt(apiPath, at)
+	if err != nil {
+		return nil, code, err
 	}
 
-	// Get the latest snapshot at or before T.
+	// Cache the result.
+	s.responseCacheMu.Lock()
+	s.responseCacheMap[cacheKey] = &responseCacheEntry{body: body, code: code, created: time.Now()}
+	// Simple TTL cleanup on writes — keep map bounded.
+	if len(s.responseCacheMap) > 512 {
+		now := time.Now()
+		for k, v := range s.responseCacheMap {
+			if now.Sub(v.created) > responseCacheTTL {
+				delete(s.responseCacheMap, k)
+			}
+		}
+	}
+	s.responseCacheMu.Unlock()
+
+	return body, code, nil
+}
+
+// reconstructAt is the uncached implementation of ReconstructAt.
+func (s *CaptureStore) reconstructAt(apiPath string, at time.Time) ([]byte, int, error) {
+	wi, hasWatch := s.WatchIndex[apiPath]
+	if !hasWatch || len(wi.Seqs) == 0 {
+		return s.Latest(apiPath, at)
+	}
+
 	snapBody, snapCode, snapTime, err := s.SnapshotAt(apiPath, at)
 	if err != nil {
 		return nil, 500, err
@@ -316,9 +388,7 @@ func (s *CaptureStore) ReconstructAt(apiPath string, at time.Time) ([]byte, int,
 		Items      []json.RawMessage `json:"items"`
 	}
 	if snapCode == 200 {
-		// Parse snapshot into an ordered item map (preserves insertion order).
 		if err := json.Unmarshal(snapBody, &snapList); err != nil {
-			// Snapshot not a list body (e.g. single object) — fall through unchanged.
 			return snapBody, snapCode, nil
 		}
 	} else {
@@ -335,7 +405,44 @@ func (s *CaptureStore) ReconstructAt(apiPath string, at time.Time) ([]byte, int,
 		snapList.Metadata = json.RawMessage(`{"resourceVersion":"0"}`)
 	}
 
-	// Build ordered key list and object map from snapshot items.
+	// Determine which watch events fall in (snapTime, at].
+	type watchEvent struct {
+		idx  int
+		body json.RawMessage
+	}
+
+	// Collect in-range event indices first (no I/O).
+	var inRange []int
+	for i := range wi.Seqs {
+		if i >= len(wi.Times) || i >= len(wi.EventTypes) {
+			break
+		}
+		evTime := wi.Times[i]
+		if evTime.IsZero() || !evTime.After(snapTime) {
+			continue
+		}
+		if !at.IsZero() && evTime.After(at) {
+			break
+		}
+		inRange = append(inRange, i)
+	}
+
+	// Read watch event records in parallel.
+	events := make([]watchEvent, len(inRange))
+	var wg sync.WaitGroup
+	for pos, i := range inRange {
+		wg.Add(1)
+		go func(pos, i int) {
+			defer wg.Done()
+			rec, rerr := s.readRecord(apiPath, wi.Seqs[i])
+			if rerr == nil {
+				events[pos] = watchEvent{idx: i, body: rec.ResponseBody}
+			}
+		}(pos, i)
+	}
+	wg.Wait()
+
+	// Apply events in order.
 	itemOrder := make([]string, 0, len(snapList.Items))
 	items := make(map[string]json.RawMessage, len(snapList.Items))
 	for _, item := range snapList.Items {
@@ -347,46 +454,26 @@ func (s *CaptureStore) ReconstructAt(apiPath string, at time.Time) ([]byte, int,
 		itemOrder = append(itemOrder, k)
 	}
 
-	// Collect watch events from (snapTime, at] in index order.
-	for i, id := range wi.RecordIDs {
-		if i >= len(wi.Times) || i >= len(wi.EventTypes) {
-			break
-		}
-		evTime := wi.Times[i]
-		if evTime.IsZero() || !evTime.After(snapTime) {
+	for pos, i := range inRange {
+		ev := events[pos]
+		if ev.body == nil {
 			continue
 		}
-		if !at.IsZero() && evTime.After(at) {
-			break
-		}
-
-		eventType := wi.EventTypes[i]
-		rec, rerr := s.readRecord(id)
-		if rerr != nil {
-			continue
-		}
-		k := objectKey(rec.ResponseBody)
+		k := objectKey(ev.body)
 		if k == "" {
 			continue
 		}
-
-		switch eventType {
-		case "ADDED":
+		switch wi.EventTypes[i] {
+		case "ADDED", "MODIFIED":
 			if _, exists := items[k]; !exists {
 				itemOrder = append(itemOrder, k)
 			}
-			items[k] = rec.ResponseBody
-		case "MODIFIED":
-			if _, exists := items[k]; !exists {
-				itemOrder = append(itemOrder, k)
-			}
-			items[k] = rec.ResponseBody
+			items[k] = ev.body
 		case "DELETED":
 			delete(items, k)
 		}
 	}
 
-	// Reconstruct ordered items list (skip deleted).
 	reconstructed := make([]json.RawMessage, 0, len(itemOrder))
 	seen := make(map[string]bool, len(itemOrder))
 	for _, k := range itemOrder {
@@ -411,15 +498,9 @@ func (s *CaptureStore) ReconstructAt(apiPath string, at time.Time) ([]byte, int,
 	return out, 200, nil
 }
 
-// AggregateAcrossNamespaces aggregates list items from all namespaced paths
-// for the given cluster-scoped path (e.g. /api/v1/pods). Returns a merged
-// list JSON, the list kind/apiVersion taken from the first found namespace
-// list, and 404 if nothing is found.
+// AggregateAcrossNamespaces aggregates list items from all namespaced paths.
 func (s *CaptureStore) AggregateAcrossNamespaces(clusterPath string, at time.Time) ([]byte, int, error) {
 	g, v, resource, _ := parseAPIPath(clusterPath)
-
-	// Build the namespace-scoped path prefix to match: /api/v1/namespaces/*/resource
-	// or /apis/<g>/<v>/namespaces/*/resource
 	var pathPrefix string
 	if g == "" {
 		pathPrefix = "/api/" + v + "/namespaces/"
@@ -466,7 +547,6 @@ func (s *CaptureStore) AggregateAcrossNamespaces(clusterPath string, at time.Tim
 		allItems = []json.RawMessage{}
 	}
 
-	// Build list kind from resource if not captured (fallback).
 	if listKind == "" {
 		listKind = resourceToKind(resource) + "List"
 	}
@@ -491,14 +571,9 @@ func (s *CaptureStore) AggregateAcrossNamespaces(clusterPath string, at time.Tim
 	return out, 200, nil
 }
 
-// AggregateTableAcrossNamespaces merges per-namespace Table responses (stored
-// under "path?as=Table" keys) for a cluster-scoped path. It preserves the real
-// columnDefinitions from the first namespace's response and concatenates all
-// rows — so kubectl gets the full live-cluster column set for every resource
-// type with no resource-specific logic required.
+// AggregateTableAcrossNamespaces merges per-namespace Table responses.
 func (s *CaptureStore) AggregateTableAcrossNamespaces(clusterPath string, at time.Time) ([]byte, int, error) {
 	g, v, resource, _ := parseAPIPath(clusterPath)
-
 	var pathPrefix string
 	if g == "" {
 		pathPrefix = "/api/" + v + "/namespaces/"
@@ -557,11 +632,6 @@ func (s *CaptureStore) AggregateTableAcrossNamespaces(clusterPath string, at tim
 }
 
 // parseAPIPath extracts (group, version, resource, namespace) from a REST path.
-//
-//	/api/v1/pods                                  → ("", "v1", "pods", "")
-//	/api/v1/namespaces/default/pods               → ("", "v1", "pods", "default")
-//	/apis/apps/v1/deployments                     → ("apps", "v1", "deployments", "")
-//	/apis/apps/v1/namespaces/default/deployments  → ("apps", "v1", "deployments", "default")
 func parseAPIPath(path string) (group, version, resource, namespace string) {
 	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
 	switch {
@@ -629,7 +699,6 @@ func resourceToKind(resource string) string {
 	if k, ok := known[resource]; ok {
 		return k
 	}
-	// Fallback: strip trailing 's' and title-case.
 	s := strings.TrimSuffix(resource, "s")
 	if s == "" {
 		return resource

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -55,7 +55,7 @@ func TestResourceToKind(t *testing.T) {
 func buildTestStore(t *testing.T, records map[string][]byte) *CaptureStore {
 	t.Helper()
 	dir := t.TempDir()
-	outPath := filepath.Join(dir, "test.kshrk")
+	outPath := filepath.Join(dir, "test.khsrk")
 
 	sw, err := archive.NewStreamWriter(outPath)
 	if err != nil {
@@ -143,7 +143,7 @@ func TestStore_Latest_NotFound(t *testing.T) {
 
 func TestStore_Latest_AtTimestamp(t *testing.T) {
 	dir := t.TempDir()
-	outPath := filepath.Join(dir, "test.kshrk")
+	outPath := filepath.Join(dir, "test.khsrk")
 
 	path := "/api/v1/namespaces/default/pods"
 	t1 := time.Date(2026, 4, 9, 10, 40, 0, 0, time.UTC)
@@ -229,7 +229,7 @@ func containsString(s, sub string) bool { return strings.Contains(s, sub) }
 func buildTestStoreWithWatch(t *testing.T, snapshots map[string]watchTestRecord, events []watchTestEvent) *CaptureStore {
 	t.Helper()
 	dir := t.TempDir()
-	outPath := filepath.Join(dir, "test.kshrk")
+	outPath := filepath.Join(dir, "test.khsrk")
 
 	sw, err := archive.NewStreamWriter(outPath)
 	if err != nil {

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -2,12 +2,12 @@ package server
 
 import (
 	"encoding/json"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
 )
 
@@ -51,60 +51,56 @@ func TestResourceToKind(t *testing.T) {
 	}
 }
 
-// buildTestStore creates a temp directory with the k8shark-capture layout and
-// returns a loaded CaptureStore ready for use in tests.
+// buildTestStore creates a CaptureStore with the given per-path response bodies.
 func buildTestStore(t *testing.T, records map[string][]byte) *CaptureStore {
 	t.Helper()
 	dir := t.TempDir()
-	recDir := filepath.Join(dir, "k8shark-capture", "records")
-	if err := os.MkdirAll(recDir, 0o750); err != nil {
-		t.Fatal(err)
+	outPath := filepath.Join(dir, "test.kshrk")
+
+	sw, err := archive.NewStreamWriter(outPath)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
 	}
 
 	index := make(capture.Index)
 	for apiPath, body := range records {
-		recID := "rec-" + apiPath[1:] // simple deterministic ID
-		// Replace slashes in ID with dashes for filesystem safety.
-		for i, c := range recID {
-			if c == '/' {
-				recID = recID[:i] + "-" + recID[i+1:]
-			}
-		}
+		now := time.Now().UTC()
 		rec := capture.Record{
-			ID:           recID,
-			CapturedAt:   time.Now().UTC(),
+			ID:           "rec-" + apiPath,
+			CapturedAt:   now,
 			APIPath:      apiPath,
 			HTTPMethod:   "GET",
 			ResponseCode: 200,
 			ResponseBody: json.RawMessage(body),
 		}
-		data, _ := json.Marshal(rec)
-		if err := os.WriteFile(filepath.Join(recDir, recID+".json"), data, 0o644); err != nil {
-			t.Fatal(err)
+		if err := sw.WriteRecord(&rec); err != nil {
+			t.Fatalf("WriteRecord: %v", err)
 		}
 		index[apiPath] = &capture.IndexEntry{
-			APIPath:   apiPath,
-			RecordIDs: []string{recID},
-			Times:     []time.Time{rec.CapturedAt},
+			APIPath: apiPath,
+			Seqs:    []int{0},
+			Times:   []time.Time{now},
 		}
 	}
 
-	metaJSON, _ := json.Marshal(capture.CaptureMetadata{
+	meta := capture.CaptureMetadata{
 		CaptureID:         "test-capture-id",
 		KubernetesVersion: "v1.29.0",
 		CapturedAt:        time.Now().UTC().Add(-time.Minute),
 		CapturedUntil:     time.Now().UTC(),
 		RecordCount:       len(records),
-	})
-	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "metadata.json"), metaJSON, 0o644); err != nil {
-		t.Fatal(err)
 	}
-	idxJSON, _ := json.Marshal(index)
-	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "index.json"), idxJSON, 0o644); err != nil {
-		t.Fatal(err)
+	if err := sw.Finish(&meta, index, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
 	}
 
-	store, err := LoadStore(dir)
+	ar, err := archive.Open(outPath)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	t.Cleanup(func() { ar.Close() })
+
+	store, err := LoadStore(ar)
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}
@@ -147,10 +143,7 @@ func TestStore_Latest_NotFound(t *testing.T) {
 
 func TestStore_Latest_AtTimestamp(t *testing.T) {
 	dir := t.TempDir()
-	recDir := filepath.Join(dir, "k8shark-capture", "records")
-	if err := os.MkdirAll(recDir, 0o750); err != nil {
-		t.Fatal(err)
-	}
+	outPath := filepath.Join(dir, "test.kshrk")
 
 	path := "/api/v1/namespaces/default/pods"
 	t1 := time.Date(2026, 4, 9, 10, 40, 0, 0, time.UTC)
@@ -159,37 +152,41 @@ func TestStore_Latest_AtTimestamp(t *testing.T) {
 		{ID: "rec-1", CapturedAt: t1, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(`{"kind":"PodList","items":[{"metadata":{"name":"before"}}]}`)},
 		{ID: "rec-2", CapturedAt: t2, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(`{"kind":"PodList","items":[{"metadata":{"name":"after"}}]}`)},
 	}
+
+	sw, err := archive.NewStreamWriter(outPath)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
 	for _, rec := range records {
-		data, err := json.Marshal(rec)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(recDir, rec.ID+".json"), data, 0o644); err != nil {
-			t.Fatal(err)
+		rcopy := rec
+		if err := sw.WriteRecord(&rcopy); err != nil {
+			t.Fatalf("WriteRecord: %v", err)
 		}
 	}
-
-	metaJSON, _ := json.Marshal(capture.CaptureMetadata{
+	idx := capture.Index{
+		path: {
+			APIPath: path,
+			Seqs:    []int{0, 1},
+			Times:   []time.Time{t1, t2},
+		},
+	}
+	meta := capture.CaptureMetadata{
 		CaptureID:     "test-capture-id",
 		CapturedAt:    t1,
 		CapturedUntil: t2,
 		RecordCount:   len(records),
-	})
-	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "metadata.json"), metaJSON, 0o644); err != nil {
-		t.Fatal(err)
 	}
-	idxJSON, _ := json.Marshal(capture.Index{
-		path: {
-			APIPath:   path,
-			RecordIDs: []string{"rec-1", "rec-2"},
-			Times:     []time.Time{t1, t2},
-		},
-	})
-	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "index.json"), idxJSON, 0o644); err != nil {
-		t.Fatal(err)
+	if err := sw.Finish(&meta, idx, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
 	}
 
-	store, err := LoadStore(dir)
+	ar, err := archive.Open(outPath)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	t.Cleanup(func() { ar.Close() })
+
+	store, err := LoadStore(ar)
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}
@@ -232,9 +229,11 @@ func containsString(s, sub string) bool { return strings.Contains(s, sub) }
 func buildTestStoreWithWatch(t *testing.T, snapshots map[string]watchTestRecord, events []watchTestEvent) *CaptureStore {
 	t.Helper()
 	dir := t.TempDir()
-	recDir := filepath.Join(dir, "k8shark-capture", "records")
-	if err := os.MkdirAll(recDir, 0o750); err != nil {
-		t.Fatal(err)
+	outPath := filepath.Join(dir, "test.kshrk")
+
+	sw, err := archive.NewStreamWriter(outPath)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
 	}
 
 	index := make(capture.Index)
@@ -249,17 +248,21 @@ func buildTestStoreWithWatch(t *testing.T, snapshots map[string]watchTestRecord,
 			ResponseCode: 200,
 			ResponseBody: json.RawMessage(s.body),
 		}
-		data, _ := json.Marshal(rec)
-		if err := os.WriteFile(filepath.Join(recDir, s.id+".json"), data, 0o644); err != nil {
-			t.Fatal(err)
+		if err := sw.WriteRecord(&rec); err != nil {
+			t.Fatalf("WriteRecord(snap): %v", err)
 		}
 		index[apiPath] = &capture.IndexEntry{
-			APIPath:   apiPath,
-			RecordIDs: []string{s.id},
-			Times:     []time.Time{s.at},
+			APIPath: apiPath,
+			Seqs:    []int{0},
+			Times:   []time.Time{s.at},
 		}
 	}
 
+	// Track per-path seq counter for ALL records (snap + watch share path namespace).
+	allSeq := map[string]int{}
+	for apiPath := range snapshots {
+		allSeq[apiPath] = 1 // snapshot already wrote seq=0
+	}
 	for _, ev := range events {
 		rec := capture.Record{
 			ID:           ev.id,
@@ -270,37 +273,40 @@ func buildTestStoreWithWatch(t *testing.T, snapshots map[string]watchTestRecord,
 			ResponseCode: 200,
 			ResponseBody: json.RawMessage(ev.objectBody),
 		}
-		data, _ := json.Marshal(rec)
-		if err := os.WriteFile(filepath.Join(recDir, ev.id+".json"), data, 0o644); err != nil {
-			t.Fatal(err)
+		if err := sw.WriteRecord(&rec); err != nil {
+			t.Fatalf("WriteRecord(watch %s): %v", ev.id, err)
 		}
 		wi := watchIndex[ev.apiPath]
 		if wi == nil {
 			wi = &capture.WatchIndexEntry{APIPath: ev.apiPath}
 			watchIndex[ev.apiPath] = wi
 		}
-		wi.RecordIDs = append(wi.RecordIDs, ev.id)
+		seq := allSeq[ev.apiPath]
+		allSeq[ev.apiPath] = seq + 1
+		wi.Seqs = append(wi.Seqs, seq)
 		wi.Times = append(wi.Times, ev.at)
 		wi.EventTypes = append(wi.EventTypes, ev.eventType)
 	}
 
-	metaJSON, _ := json.Marshal(capture.CaptureMetadata{
+	meta := capture.CaptureMetadata{
 		CaptureID: "test-watch-id", KubernetesVersion: "v1.29.0",
 		CapturedAt: time.Now().UTC().Add(-time.Minute), CapturedUntil: time.Now().UTC(),
-	})
-	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "metadata.json"), metaJSON, 0o644); err != nil {
-		t.Fatal(err)
 	}
-	idxJSON, _ := json.Marshal(index)
-	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "index.json"), idxJSON, 0o644); err != nil {
-		t.Fatal(err)
+	var wi any
+	if len(watchIndex) > 0 {
+		wi = watchIndex
 	}
-	wiJSON, _ := json.Marshal(watchIndex)
-	if err := os.WriteFile(filepath.Join(dir, "k8shark-capture", "watch-index.json"), wiJSON, 0o644); err != nil {
-		t.Fatal(err)
+	if err := sw.Finish(&meta, index, wi); err != nil {
+		t.Fatalf("Finish: %v", err)
 	}
 
-	store, err := LoadStore(dir)
+	ar, err := archive.Open(outPath)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	t.Cleanup(func() { ar.Close() })
+
+	store, err := LoadStore(ar)
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}

--- a/internal/transitions/transitions.go
+++ b/internal/transitions/transitions.go
@@ -3,8 +3,6 @@ package transitions
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -46,32 +44,20 @@ type FilterOpts struct {
 //   - Poll-only paths: consecutive snapshot pairs are diff'd by object identity
 //     to detect additions, modifications, and deletions.
 func LoadTransitions(archivePath string, opts FilterOpts) ([]Transition, error) {
-	tmpDir, err := os.MkdirTemp("", "k8shark-transitions-*")
+	ar, err := archive.Open(archivePath)
 	if err != nil {
-		return nil, fmt.Errorf("creating temp dir: %w", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	if err := archive.Open(archivePath, tmpDir); err != nil {
 		return nil, fmt.Errorf("opening archive: %w", err)
 	}
+	defer ar.Close()
 
-	base := filepath.Join(tmpDir, "k8shark-capture")
-
-	idxData, err := os.ReadFile(filepath.Join(base, "index.json"))
-	if err != nil {
-		return nil, fmt.Errorf("reading index: %w", err)
-	}
 	var idx capture.Index
-	if err := json.Unmarshal(idxData, &idx); err != nil {
-		return nil, fmt.Errorf("parsing index: %w", err)
+	if err := ar.ReadIndex(&idx); err != nil {
+		return nil, fmt.Errorf("reading index: %w", err)
 	}
 
 	// Watch-index may be absent for older archives.
 	var wi capture.WatchIndex
-	if wiData, rerr := os.ReadFile(filepath.Join(base, "watch-index.json")); rerr == nil {
-		_ = json.Unmarshal(wiData, &wi)
-	}
+	_, _ = ar.ReadWatchIndex(&wi)
 
 	var all []Transition
 
@@ -88,14 +74,14 @@ func LoadTransitions(archivePath string, opts FilterOpts) ([]Transition, error) 
 			continue
 		}
 
-		if wiEntry, hasWatch := wi[apiPath]; hasWatch && len(wiEntry.RecordIDs) > 0 {
-			ts, err := watchTransitions(base, apiPath, wiEntry, g, v, r, ns, opts)
+		if wiEntry, hasWatch := wi[apiPath]; hasWatch && len(wiEntry.Seqs) > 0 {
+			ts, err := watchTransitions(ar, apiPath, wiEntry, g, v, r, ns, opts)
 			if err != nil {
 				return nil, err
 			}
 			all = append(all, ts...)
 		} else {
-			ts, err := pollTransitions(base, apiPath, entry, g, v, r, ns, opts)
+			ts, err := pollTransitions(ar, apiPath, entry, g, v, r, ns, opts)
 			if err != nil {
 				return nil, err
 			}
@@ -113,13 +99,13 @@ func LoadTransitions(archivePath string, opts FilterOpts) ([]Transition, error) 
 // watchTransitions emits transitions for a watch-captured API path by walking
 // the watch-index entries in chronological order. Per-object state is tracked
 // so that Before is populated accurately for MODIFIED and DELETED events.
-func watchTransitions(base, apiPath string, wi *capture.WatchIndexEntry, g, v, r, ns string, opts FilterOpts) ([]Transition, error) {
+func watchTransitions(ar *archive.Archive, apiPath string, wi *capture.WatchIndexEntry, g, v, r, ns string, opts FilterOpts) ([]Transition, error) {
 	// lastState tracks the most recently seen body per object key so we can
 	// populate Before for MODIFIED and DELETED events.
 	lastState := make(map[string]json.RawMessage)
 
 	var out []Transition
-	for i, id := range wi.RecordIDs {
+	for i, seq := range wi.Seqs {
 		if i >= len(wi.Times) || i >= len(wi.EventTypes) {
 			break
 		}
@@ -131,7 +117,7 @@ func watchTransitions(base, apiPath string, wi *capture.WatchIndexEntry, g, v, r
 			break
 		}
 
-		rec, err := readRecord(base, id)
+		rec, err := readRecord(ar, apiPath, seq)
 		if err != nil {
 			// Tolerate individual record read failures.
 			continue
@@ -181,16 +167,16 @@ func watchTransitions(base, apiPath string, wi *capture.WatchIndexEntry, g, v, r
 // pollTransitions emits transitions for a poll-only API path by diffing
 // consecutive snapshot pairs. The transition timestamp is that of the newer
 // snapshot in each pair.
-func pollTransitions(base, apiPath string, entry *capture.IndexEntry, g, v, r, ns string, opts FilterOpts) ([]Transition, error) {
+func pollTransitions(ar *archive.Archive, apiPath string, entry *capture.IndexEntry, g, v, r, ns string, opts FilterOpts) ([]Transition, error) {
 	var out []Transition
 
 	var prevItems map[string]json.RawMessage
 	var prevOrder []string
 
-	for i, id := range entry.RecordIDs {
-		rec, err := readRecord(base, id)
+	for i, seq := range entry.Seqs {
+		rec, err := readRecord(ar, apiPath, seq)
 		if err != nil {
-			return nil, fmt.Errorf("reading record %s: %w", id, err)
+			return nil, fmt.Errorf("reading record seq %d: %w", seq, err)
 		}
 
 		var list struct {
@@ -299,15 +285,15 @@ func diffItems(
 	return out
 }
 
-// readRecord reads and parses a single capture.Record by ID from the archive.
-func readRecord(base, id string) (capture.Record, error) {
-	data, err := os.ReadFile(filepath.Join(base, "records", id+".json"))
+// readRecord reads and parses a single capture.Record by seq from the archive.
+func readRecord(ar *archive.Archive, apiPath string, seq int) (capture.Record, error) {
+	data, err := ar.ReadRecord(apiPath, seq)
 	if err != nil {
-		return capture.Record{}, fmt.Errorf("reading record %s: %w", id, err)
+		return capture.Record{}, fmt.Errorf("reading record seq %d: %w", seq, err)
 	}
 	var rec capture.Record
 	if err := json.Unmarshal(data, &rec); err != nil {
-		return capture.Record{}, fmt.Errorf("parsing record %s: %w", id, err)
+		return capture.Record{}, fmt.Errorf("parsing record seq %d: %w", seq, err)
 	}
 	return rec, nil
 }

--- a/internal/transitions/transitions_test.go
+++ b/internal/transitions/transitions_test.go
@@ -20,7 +20,7 @@ import (
 func buildPollArchive(t *testing.T, apiPath string, bodies []string) string {
 	t.Helper()
 	dir := t.TempDir()
-	outPath := filepath.Join(dir, "test.tar.gz")
+	outPath := filepath.Join(dir, "test.khsrk")
 
 	t0 := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
 	idx := make(capture.Index)
@@ -70,7 +70,7 @@ func buildPollArchive(t *testing.T, apiPath string, bodies []string) string {
 func buildWatchArchive(t *testing.T, apiPath, snapBody string, events []watchEvent) string {
 	t.Helper()
 	dir := t.TempDir()
-	outPath := filepath.Join(dir, "test.tar.gz")
+	outPath := filepath.Join(dir, "test.khsrk")
 
 	t0 := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
 

--- a/internal/transitions/transitions_test.go
+++ b/internal/transitions/transitions_test.go
@@ -24,27 +24,32 @@ func buildPollArchive(t *testing.T, apiPath string, bodies []string) string {
 
 	t0 := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
 	idx := make(capture.Index)
-	var recs []*capture.Record
+
+	w, err := archive.NewStreamWriter(outPath)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
 
 	for i, body := range bodies {
-		id := fmt.Sprintf("snap-%d", i)
 		at := t0.Add(time.Duration(i) * time.Minute)
 		rec := &capture.Record{
-			ID:           id,
+			ID:           fmt.Sprintf("snap-%d", i),
 			CapturedAt:   at,
 			APIPath:      apiPath,
 			HTTPMethod:   "GET",
 			ResponseCode: 200,
 			ResponseBody: json.RawMessage(body),
 		}
-		recs = append(recs, rec)
+		if err := w.WriteRecord(rec); err != nil {
+			t.Fatalf("WriteRecord: %v", err)
+		}
 
 		e := idx[apiPath]
 		if e == nil {
 			e = &capture.IndexEntry{APIPath: apiPath}
 			idx[apiPath] = e
 		}
-		e.RecordIDs = append(e.RecordIDs, id)
+		e.Seqs = append(e.Seqs, i)
 		e.Times = append(e.Times, at)
 	}
 
@@ -52,10 +57,10 @@ func buildPollArchive(t *testing.T, apiPath string, bodies []string) string {
 		CaptureID:     "poll-test",
 		CapturedAt:    t0,
 		CapturedUntil: t0.Add(time.Duration(len(bodies)) * time.Minute),
-		RecordCount:   len(recs),
+		RecordCount:   len(bodies),
 	}
-	if err := archive.Write(outPath, meta, recs, idx); err != nil {
-		t.Fatalf("buildPollArchive: %v", err)
+	if err := w.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("buildPollArchive Finish: %v", err)
 	}
 	return outPath
 }
@@ -80,9 +85,9 @@ func buildWatchArchive(t *testing.T, apiPath, snapBody string, events []watchEve
 
 	idx := capture.Index{
 		apiPath: {
-			APIPath:   apiPath,
-			RecordIDs: []string{snapRec.ID},
-			Times:     []time.Time{t0},
+			APIPath: apiPath,
+			Seqs:    []int{0},
+			Times:   []time.Time{t0},
 		},
 	}
 
@@ -113,7 +118,7 @@ func buildWatchArchive(t *testing.T, apiPath, snapBody string, events []watchEve
 		if err := w.WriteRecord(rec); err != nil {
 			t.Fatalf("WriteRecord(watch %d): %v", i, err)
 		}
-		wiEntry.RecordIDs = append(wiEntry.RecordIDs, id)
+		wiEntry.Seqs = append(wiEntry.Seqs, i+1) // seq continues after snap (seq 0)
 		wiEntry.Times = append(wiEntry.Times, at)
 		wiEntry.EventTypes = append(wiEntry.EventTypes, ev.eventType)
 	}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"
@@ -31,7 +30,6 @@ type OpenOptions struct {
 
 type Server struct {
 	address    string
-	tmpDir     string
 	httpServer *http.Server
 	done       chan struct{}
 }
@@ -109,25 +107,20 @@ type listItem struct {
 }
 
 func Open(opts OpenOptions) (*Server, error) {
-	tmpDir, err := os.MkdirTemp("", "k8shark-ui-*")
+	ar, err := archive.Open(opts.ArchivePath)
 	if err != nil {
-		return nil, fmt.Errorf("creating temp dir: %w", err)
+		return nil, fmt.Errorf("opening archive: %w", err)
 	}
 
-	if err := archive.Open(opts.ArchivePath, tmpDir); err != nil {
-		_ = os.RemoveAll(tmpDir)
-		return nil, fmt.Errorf("extracting archive: %w", err)
-	}
-
-	store, err := server.LoadStore(tmpDir)
+	store, err := server.LoadStore(ar)
 	if err != nil {
-		_ = os.RemoveAll(tmpDir)
+		_ = ar.Close()
 		return nil, fmt.Errorf("loading capture: %w", err)
 	}
 
 	at, err := parseReplayAt(store.Metadata.CapturedAt, store.Metadata.CapturedUntil, opts.At)
 	if err != nil {
-		_ = os.RemoveAll(tmpDir)
+		_ = ar.Close()
 		return nil, err
 	}
 
@@ -137,7 +130,7 @@ func Open(opts OpenOptions) (*Server, error) {
 	}
 	ln, err := net.Listen("tcp", "127.0.0.1:"+port)
 	if err != nil {
-		_ = os.RemoveAll(tmpDir)
+		_ = ar.Close()
 		return nil, fmt.Errorf("listening: %w", err)
 	}
 
@@ -161,7 +154,7 @@ func Open(opts OpenOptions) (*Server, error) {
 	}()
 
 	addr := fmt.Sprintf("http://127.0.0.1:%d", ln.Addr().(*net.TCPAddr).Port)
-	return &Server{address: addr, tmpDir: tmpDir, httpServer: httpSrv, done: done}, nil
+	return &Server{address: addr, httpServer: httpSrv, done: done}, nil
 }
 
 func (s *Server) Address() string { return s.address }
@@ -171,7 +164,6 @@ func (s *Server) Shutdown() {
 	defer cancel()
 	_ = s.httpServer.Shutdown(ctx)
 	<-s.done
-	_ = os.RemoveAll(s.tmpDir)
 }
 
 func (s *Server) Wait() error {
@@ -185,7 +177,6 @@ func (s *Server) Wait() error {
 		_ = s.httpServer.Shutdown(ctx)
 		<-s.done
 	}
-	_ = os.RemoveAll(s.tmpDir)
 	return nil
 }
 
@@ -892,13 +883,13 @@ func (h *explorerHandler) responseBodiesAt(path string, at time.Time) ([][]byte,
 	}
 
 	entry, ok := h.store.Index[path]
-	if !ok || len(entry.RecordIDs) == 0 {
+	if !ok || len(entry.Seqs) == 0 {
 		return nil, false
 	}
 
-	bodies := make([][]byte, 0, len(entry.RecordIDs))
-	for _, id := range entry.RecordIDs {
-		body, ok := h.readRecordBody(id)
+	bodies := make([][]byte, 0, len(entry.Seqs))
+	for _, seq := range entry.Seqs {
+		body, ok := h.readRecordBody(path, seq)
 		if !ok {
 			continue
 		}
@@ -973,13 +964,9 @@ func sampleTimes(times []time.Time, limit int) []time.Time {
 	return selected
 }
 
-func (h *explorerHandler) readRecordBody(id string) ([]byte, bool) {
-	data, err := os.ReadFile(filepath.Join(h.store.Dir, "k8shark-capture", "records", id+".json"))
+func (h *explorerHandler) readRecordBody(apiPath string, seq int) ([]byte, bool) {
+	rec, err := h.store.ReadRecord(apiPath, seq)
 	if err != nil {
-		return nil, false
-	}
-	var rec capture.Record
-	if err := json.Unmarshal(data, &rec); err != nil {
 		return nil, false
 	}
 	if rec.ResponseCode != http.StatusOK {

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -231,9 +230,9 @@ func TestCollectTimestamps_Sampled(t *testing.T) {
 		path := "/api/v1/namespaces/default/pods?snapshot=" + time.Duration(i).String()
 		ts := base.Add(time.Duration(i) * time.Minute)
 		index[path] = &capture.IndexEntry{
-			APIPath:   path,
-			RecordIDs: []string{"r"},
-			Times:     []time.Time{ts},
+			APIPath: path,
+			Seqs:    []int{0},
+			Times:   []time.Time{ts},
 		}
 	}
 
@@ -294,6 +293,38 @@ func TestServeTree_AtInvalid(t *testing.T) {
 	}
 }
 
+// buildStoreFromArchive writes records via StreamWriter, opens the archive, and
+// returns a CaptureStore. wIdx may be nil for archives without watch data.
+func buildStoreFromArchive(t *testing.T, out string, recs []*capture.Record, idx capture.Index, wIdx capture.WatchIndex, meta *capture.CaptureMetadata) *server.CaptureStore {
+	t.Helper()
+	sw, err := archive.NewStreamWriter(out)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	for _, r := range recs {
+		if err := sw.WriteRecord(r); err != nil {
+			t.Fatalf("WriteRecord: %v", err)
+		}
+	}
+	var wi any
+	if len(wIdx) > 0 {
+		wi = wIdx
+	}
+	if err := sw.Finish(meta, idx, wi); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	ar, err := archive.Open(out)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	t.Cleanup(func() { ar.Close() })
+	store, err := server.LoadStore(ar)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	return store
+}
+
 func buildTestStore(t *testing.T) *server.CaptureStore {
 	t.Helper()
 	dir := t.TempDir()
@@ -310,27 +341,12 @@ func buildTestStore(t *testing.T) *server.CaptureStore {
 		{ID: "r3", CapturedAt: now, APIPath: "/api/v1/nodes", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(nodeList)},
 	}
 	idx := capture.Index{
-		"/apis/apps/v1/namespaces/default/deployments": {APIPath: "/apis/apps/v1/namespaces/default/deployments", RecordIDs: []string{"r1"}, Times: []time.Time{now}},
-		"/api/v1/namespaces/default/pods":              {APIPath: "/api/v1/namespaces/default/pods", RecordIDs: []string{"r2"}, Times: []time.Time{now}},
-		"/api/v1/nodes":                                {APIPath: "/api/v1/nodes", RecordIDs: []string{"r3"}, Times: []time.Time{now}},
+		"/apis/apps/v1/namespaces/default/deployments": {APIPath: "/apis/apps/v1/namespaces/default/deployments", Seqs: []int{0}, Times: []time.Time{now}},
+		"/api/v1/namespaces/default/pods":              {APIPath: "/api/v1/namespaces/default/pods", Seqs: []int{0}, Times: []time.Time{now}},
+		"/api/v1/nodes":                                {APIPath: "/api/v1/nodes", Seqs: []int{0}, Times: []time.Time{now}},
 	}
 	meta := &capture.CaptureMetadata{CaptureID: "ui-test", CapturedAt: now.Add(-5 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
-	if err := archive.Write(out, meta, recs, idx); err != nil {
-		t.Fatalf("archive.Write: %v", err)
-	}
-
-	extractDir := filepath.Join(dir, "extract")
-	if err := os.MkdirAll(extractDir, 0o750); err != nil {
-		t.Fatalf("mkdir extract: %v", err)
-	}
-	if err := archive.Open(out, extractDir); err != nil {
-		t.Fatalf("archive.Open: %v", err)
-	}
-	store, err := server.LoadStore(extractDir)
-	if err != nil {
-		t.Fatalf("LoadStore: %v", err)
-	}
-	return store
+	return buildStoreFromArchive(t, out, recs, idx, nil, meta)
 }
 
 func buildQueryOnlyStore(t *testing.T) *server.CaptureStore {
@@ -346,28 +362,13 @@ func buildQueryOnlyStore(t *testing.T) *server.CaptureStore {
 	}
 	idx := capture.Index{
 		"/api/v1/namespaces/default/configmaps?labelSelector=app%3Ddemo": {
-			APIPath:   "/api/v1/namespaces/default/configmaps?labelSelector=app%3Ddemo",
-			RecordIDs: []string{"q1"},
-			Times:     []time.Time{now},
+			APIPath: "/api/v1/namespaces/default/configmaps?labelSelector=app%3Ddemo",
+			Seqs:    []int{0},
+			Times:   []time.Time{now},
 		},
 	}
 	meta := &capture.CaptureMetadata{CaptureID: "ui-query-test", CapturedAt: now.Add(-2 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
-	if err := archive.Write(out, meta, recs, idx); err != nil {
-		t.Fatalf("archive.Write: %v", err)
-	}
-
-	extractDir := filepath.Join(dir, "extract")
-	if err := os.MkdirAll(extractDir, 0o750); err != nil {
-		t.Fatalf("mkdir extract: %v", err)
-	}
-	if err := archive.Open(out, extractDir); err != nil {
-		t.Fatalf("archive.Open: %v", err)
-	}
-	store, err := server.LoadStore(extractDir)
-	if err != nil {
-		t.Fatalf("LoadStore: %v", err)
-	}
-	return store
+	return buildStoreFromArchive(t, out, recs, idx, nil, meta)
 }
 
 func buildPreferredQueryStore(t *testing.T) *server.CaptureStore {
@@ -385,33 +386,18 @@ func buildPreferredQueryStore(t *testing.T) *server.CaptureStore {
 	}
 	idx := capture.Index{
 		"/api/v1/namespaces/default/pods": {
-			APIPath:   "/api/v1/namespaces/default/pods",
-			RecordIDs: []string{"p1"},
-			Times:     []time.Time{now},
+			APIPath: "/api/v1/namespaces/default/pods",
+			Seqs:    []int{0},
+			Times:   []time.Time{now},
 		},
 		"/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo": {
-			APIPath:   "/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo",
-			RecordIDs: []string{"p2"},
-			Times:     []time.Time{now},
+			APIPath: "/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo",
+			Seqs:    []int{0},
+			Times:   []time.Time{now},
 		},
 	}
 	meta := &capture.CaptureMetadata{CaptureID: "ui-preferred-query-test", CapturedAt: now.Add(-2 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
-	if err := archive.Write(out, meta, recs, idx); err != nil {
-		t.Fatalf("archive.Write: %v", err)
-	}
-
-	extractDir := filepath.Join(dir, "extract")
-	if err := os.MkdirAll(extractDir, 0o750); err != nil {
-		t.Fatalf("mkdir extract: %v", err)
-	}
-	if err := archive.Open(out, extractDir); err != nil {
-		t.Fatalf("archive.Open: %v", err)
-	}
-	store, err := server.LoadStore(extractDir)
-	if err != nil {
-		t.Fatalf("LoadStore: %v", err)
-	}
-	return store
+	return buildStoreFromArchive(t, out, recs, idx, nil, meta)
 }
 
 func buildMergedQueryStore(t *testing.T) *server.CaptureStore {
@@ -429,33 +415,18 @@ func buildMergedQueryStore(t *testing.T) *server.CaptureStore {
 	}
 	idx := capture.Index{
 		"/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo-a": {
-			APIPath:   "/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo-a",
-			RecordIDs: []string{"m1"},
-			Times:     []time.Time{now},
+			APIPath: "/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo-a",
+			Seqs:    []int{0},
+			Times:   []time.Time{now},
 		},
 		"/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo-b": {
-			APIPath:   "/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo-b",
-			RecordIDs: []string{"m2"},
-			Times:     []time.Time{now},
+			APIPath: "/api/v1/namespaces/default/pods?labelSelector=app%3Ddemo-b",
+			Seqs:    []int{0},
+			Times:   []time.Time{now},
 		},
 	}
 	meta := &capture.CaptureMetadata{CaptureID: "ui-merged-query-test", CapturedAt: now.Add(-2 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
-	if err := archive.Write(out, meta, recs, idx); err != nil {
-		t.Fatalf("archive.Write: %v", err)
-	}
-
-	extractDir := filepath.Join(dir, "extract")
-	if err := os.MkdirAll(extractDir, 0o750); err != nil {
-		t.Fatalf("mkdir extract: %v", err)
-	}
-	if err := archive.Open(out, extractDir); err != nil {
-		t.Fatalf("archive.Open: %v", err)
-	}
-	store, err := server.LoadStore(extractDir)
-	if err != nil {
-		t.Fatalf("LoadStore: %v", err)
-	}
-	return store
+	return buildStoreFromArchive(t, out, recs, idx, nil, meta)
 }
 
 func buildItemOnlyStore(t *testing.T) *server.CaptureStore {
@@ -471,28 +442,13 @@ func buildItemOnlyStore(t *testing.T) *server.CaptureStore {
 	}
 	idx := capture.Index{
 		"/api/v1/namespaces/default/configmaps/demo-config": {
-			APIPath:   "/api/v1/namespaces/default/configmaps/demo-config",
-			RecordIDs: []string{"i1"},
-			Times:     []time.Time{now},
+			APIPath: "/api/v1/namespaces/default/configmaps/demo-config",
+			Seqs:    []int{0},
+			Times:   []time.Time{now},
 		},
 	}
 	meta := &capture.CaptureMetadata{CaptureID: "ui-item-only-test", CapturedAt: now.Add(-2 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
-	if err := archive.Write(out, meta, recs, idx); err != nil {
-		t.Fatalf("archive.Write: %v", err)
-	}
-
-	extractDir := filepath.Join(dir, "extract")
-	if err := os.MkdirAll(extractDir, 0o750); err != nil {
-		t.Fatalf("mkdir extract: %v", err)
-	}
-	if err := archive.Open(out, extractDir); err != nil {
-		t.Fatalf("archive.Open: %v", err)
-	}
-	store, err := server.LoadStore(extractDir)
-	if err != nil {
-		t.Fatalf("LoadStore: %v", err)
-	}
-	return store
+	return buildStoreFromArchive(t, out, recs, idx, nil, meta)
 }
 
 func buildTableOnlyStore(t *testing.T) *server.CaptureStore {
@@ -508,28 +464,13 @@ func buildTableOnlyStore(t *testing.T) *server.CaptureStore {
 	}
 	idx := capture.Index{
 		"/api/v1/namespaces/default/configmaps?as=Table": {
-			APIPath:   "/api/v1/namespaces/default/configmaps?as=Table",
-			RecordIDs: []string{"t1"},
-			Times:     []time.Time{now},
+			APIPath: "/api/v1/namespaces/default/configmaps?as=Table",
+			Seqs:    []int{0},
+			Times:   []time.Time{now},
 		},
 	}
 	meta := &capture.CaptureMetadata{CaptureID: "ui-table-only-test", CapturedAt: now.Add(-2 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
-	if err := archive.Write(out, meta, recs, idx); err != nil {
-		t.Fatalf("archive.Write: %v", err)
-	}
-
-	extractDir := filepath.Join(dir, "extract")
-	if err := os.MkdirAll(extractDir, 0o750); err != nil {
-		t.Fatalf("mkdir extract: %v", err)
-	}
-	if err := archive.Open(out, extractDir); err != nil {
-		t.Fatalf("archive.Open: %v", err)
-	}
-	store, err := server.LoadStore(extractDir)
-	if err != nil {
-		t.Fatalf("LoadStore: %v", err)
-	}
-	return store
+	return buildStoreFromArchive(t, out, recs, idx, nil, meta)
 }
 
 func buildMultiSnapshotStore(t *testing.T) *server.CaptureStore {
@@ -548,42 +489,23 @@ func buildMultiSnapshotStore(t *testing.T) *server.CaptureStore {
 	}
 	idx := capture.Index{
 		"/api/v1/namespaces/default/pods": {
-			APIPath:   "/api/v1/namespaces/default/pods",
-			RecordIDs: []string{"s1", "s2"},
-			Times:     []time.Time{t1, t2},
+			APIPath: "/api/v1/namespaces/default/pods",
+			Seqs:    []int{0, 1},
+			Times:   []time.Time{t1, t2},
 		},
 	}
 	meta := &capture.CaptureMetadata{CaptureID: "ui-multi-snapshot-test", CapturedAt: t1, CapturedUntil: t2, RecordCount: len(recs)}
-	if err := archive.Write(out, meta, recs, idx); err != nil {
-		t.Fatalf("archive.Write: %v", err)
-	}
-
-	extractDir := filepath.Join(dir, "extract")
-	if err := os.MkdirAll(extractDir, 0o750); err != nil {
-		t.Fatalf("mkdir extract: %v", err)
-	}
-	if err := archive.Open(out, extractDir); err != nil {
-		t.Fatalf("archive.Open: %v", err)
-	}
-	store, err := server.LoadStore(extractDir)
-	if err != nil {
-		t.Fatalf("LoadStore: %v", err)
-	}
-	return store
+	return buildStoreFromArchive(t, out, recs, idx, nil, meta)
 }
 
 func buildWatchOnlyStore(t *testing.T) *server.CaptureStore {
 	t.Helper()
 	dir := t.TempDir()
-	base := filepath.Join(dir, "k8shark-capture")
-	recDir := filepath.Join(base, "records")
-	if err := os.MkdirAll(recDir, 0o750); err != nil {
-		t.Fatalf("mkdir records: %v", err)
-	}
+	out := filepath.Join(dir, "capture-watch-only.tar.gz")
 
 	t0 := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
 	t1 := t0.Add(30 * time.Second)
-	rec := capture.Record{
+	watchRec := &capture.Record{
 		ID:           "watch-1",
 		CapturedAt:   t1,
 		APIPath:      "/api/v1/namespaces/default/pods",
@@ -592,45 +514,25 @@ func buildWatchOnlyStore(t *testing.T) *server.CaptureStore {
 		ResponseCode: http.StatusOK,
 		ResponseBody: json.RawMessage(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"redis","namespace":"default","uid":"pod-redis"},"spec":{"containers":[{"name":"main"}]},"status":{"phase":"Running"}}`),
 	}
-	recData, _ := json.Marshal(rec)
-	if err := os.WriteFile(filepath.Join(recDir, rec.ID+".json"), recData, 0o644); err != nil {
-		t.Fatalf("write record: %v", err)
-	}
 
-	meta := capture.CaptureMetadata{CaptureID: "ui-watch-only-test", CapturedAt: t0, CapturedUntil: t1.Add(time.Second), RecordCount: 1}
-	metaData, _ := json.Marshal(meta)
-	if err := os.WriteFile(filepath.Join(base, "metadata.json"), metaData, 0o644); err != nil {
-		t.Fatalf("write metadata: %v", err)
-	}
-
-	indexData, _ := json.Marshal(capture.Index{
+	recs := []*capture.Record{watchRec}
+	idx := capture.Index{
 		"/api/v1/namespaces/default/pods": {
-			APIPath:   "/api/v1/namespaces/default/pods",
-			RecordIDs: []string{},
-			Times:     []time.Time{},
+			APIPath: "/api/v1/namespaces/default/pods",
+			Seqs:    []int{},
+			Times:   []time.Time{},
 		},
-	})
-	if err := os.WriteFile(filepath.Join(base, "index.json"), indexData, 0o644); err != nil {
-		t.Fatalf("write index: %v", err)
 	}
-
-	watchIndexData, _ := json.Marshal(capture.WatchIndex{
+	wi := capture.WatchIndex{
 		"/api/v1/namespaces/default/pods": {
 			APIPath:    "/api/v1/namespaces/default/pods",
-			RecordIDs:  []string{"watch-1"},
+			Seqs:       []int{0},
 			Times:      []time.Time{t1},
 			EventTypes: []string{"ADDED"},
 		},
-	})
-	if err := os.WriteFile(filepath.Join(base, "watch-index.json"), watchIndexData, 0o644); err != nil {
-		t.Fatalf("write watch-index: %v", err)
 	}
-
-	store, err := server.LoadStore(dir)
-	if err != nil {
-		t.Fatalf("LoadStore: %v", err)
-	}
-	return store
+	meta := &capture.CaptureMetadata{CaptureID: "ui-watch-only-test", CapturedAt: t0, CapturedUntil: t1.Add(time.Second), RecordCount: 1}
+	return buildStoreFromArchive(t, out, recs, idx, wi, meta)
 }
 
 func contains(values []string, want string) bool {

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -328,7 +328,7 @@ func buildStoreFromArchive(t *testing.T, out string, recs []*capture.Record, idx
 func buildTestStore(t *testing.T) *server.CaptureStore {
 	t.Helper()
 	dir := t.TempDir()
-	out := filepath.Join(dir, "capture.tar.gz")
+	out := filepath.Join(dir, "capture.khsrk")
 	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
 
 	deployList := `{"apiVersion":"apps/v1","kind":"DeploymentList","items":[{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"demo-deploy","namespace":"default","labels":{"app":"demo"}}}]}`
@@ -352,7 +352,7 @@ func buildTestStore(t *testing.T) *server.CaptureStore {
 func buildQueryOnlyStore(t *testing.T) *server.CaptureStore {
 	t.Helper()
 	dir := t.TempDir()
-	out := filepath.Join(dir, "capture-query-only.tar.gz")
+	out := filepath.Join(dir, "capture-query-only.khsrk")
 	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
 
 	configMapList := `{"apiVersion":"v1","kind":"ConfigMapList","items":[{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"demo-config","namespace":"default","labels":{"app":"demo"}}}]}`
@@ -374,7 +374,7 @@ func buildQueryOnlyStore(t *testing.T) *server.CaptureStore {
 func buildPreferredQueryStore(t *testing.T) *server.CaptureStore {
 	t.Helper()
 	dir := t.TempDir()
-	out := filepath.Join(dir, "capture-preferred-query.tar.gz")
+	out := filepath.Join(dir, "capture-preferred-query.khsrk")
 	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
 
 	emptyPodList := `{"apiVersion":"v1","kind":"PodList","items":[]}`
@@ -403,7 +403,7 @@ func buildPreferredQueryStore(t *testing.T) *server.CaptureStore {
 func buildMergedQueryStore(t *testing.T) *server.CaptureStore {
 	t.Helper()
 	dir := t.TempDir()
-	out := filepath.Join(dir, "capture-merged-query.tar.gz")
+	out := filepath.Join(dir, "capture-merged-query.khsrk")
 	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
 
 	queryA := `{"apiVersion":"v1","kind":"PodList","items":[{"apiVersion":"v1","kind":"Pod","metadata":{"name":"demo-a","namespace":"default","uid":"uid-a","labels":{"app":"demo-a"}},"spec":{"containers":[{"name":"main"}]},"status":{"phase":"Running"}}]}`
@@ -432,7 +432,7 @@ func buildMergedQueryStore(t *testing.T) *server.CaptureStore {
 func buildItemOnlyStore(t *testing.T) *server.CaptureStore {
 	t.Helper()
 	dir := t.TempDir()
-	out := filepath.Join(dir, "capture-item-only.tar.gz")
+	out := filepath.Join(dir, "capture-item-only.khsrk")
 	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
 
 	configMap := `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"demo-config","namespace":"default","uid":"cfg-1","labels":{"app":"demo"}},"data":{"k":"v"}}`
@@ -454,7 +454,7 @@ func buildItemOnlyStore(t *testing.T) *server.CaptureStore {
 func buildTableOnlyStore(t *testing.T) *server.CaptureStore {
 	t.Helper()
 	dir := t.TempDir()
-	out := filepath.Join(dir, "capture-table-only.tar.gz")
+	out := filepath.Join(dir, "capture-table-only.khsrk")
 	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
 
 	table := `{"apiVersion":"meta.k8s.io/v1","kind":"Table","columnDefinitions":[],"rows":[{"object":{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"table-config","namespace":"default","uid":"tbl-1"}}}]}`
@@ -476,7 +476,7 @@ func buildTableOnlyStore(t *testing.T) *server.CaptureStore {
 func buildMultiSnapshotStore(t *testing.T) *server.CaptureStore {
 	t.Helper()
 	dir := t.TempDir()
-	out := filepath.Join(dir, "capture-multi-snapshot.tar.gz")
+	out := filepath.Join(dir, "capture-multi-snapshot.khsrk")
 	t1 := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
 	t2 := t1.Add(5 * time.Minute)
 
@@ -501,7 +501,7 @@ func buildMultiSnapshotStore(t *testing.T) *server.CaptureStore {
 func buildWatchOnlyStore(t *testing.T) *server.CaptureStore {
 	t.Helper()
 	dir := t.TempDir()
-	out := filepath.Join(dir, "capture-watch-only.tar.gz")
+	out := filepath.Join(dir, "capture-watch-only.khsrk")
 
 	t0 := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
 	t1 := t0.Add(30 * time.Second)


### PR DESCRIPTION
## Summary

Replaces the tar.gz-with-full-disk-extraction approach with a ZIP+Zstd archive format that supports fast random access without any temporary files.

## Changes

### Archive format
- New format: ZIP container with per-entry Zstd compression
- `archive.Open(path)` returns `*Archive` (in-memory ZIP reader) — no disk extraction
- `NewStreamWriter` writes ZIP+Zstd; per-path sequential seq numbers replace UUIDs
- `IndexEntry.RecordIDs []string` → `Seqs []int` (compact per-path counters)

### Runtime performance
- **LRU record cache** (2048 entries) in `CaptureStore` — decompression only happens once per record
- **Response cache** (10s TTL, 512 entries) — repeated `ReconstructAt` queries served from memory
- **Parallel watch reconstruction** — goroutine fan-out for watch event record reads  
- **Async discovery enrichment** — `LoadStore` returns immediately; API discovery runs in background

### Other
- `StreamWriter.WriteRecordRaw(apiPath, data)` returns the assigned seq (used by redact)
- `CaptureStore.ReadRecord(apiPath, seq)` public accessor
- All callers updated: server, inspect, diff, transitions, redact, ui
- All tests and benchmarks updated to new API
- No backwards compatibility: archives must be re-captured