### PR TITLE
feat(ui+server+capture): web UI improvements, memory fixes, OLM resource handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ export KUBECONFIG=~/.kube/k8shark-<id>.yaml
 kubectl get pods -A
 ```
 
+## Web UI (Experimental)
+
+⚠️ **Note:** The web UI for cluster exploration is experimental. Large cluster captures may consume significant amounts of RAM (1-2+ GB) during replay. For large clusters, consider using an explicit resource list in your config file rather than `all: true` for auto-discovery to reduce the capture size.
+
 ## Documentation
 
 | Doc | Description |

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -1126,33 +1126,49 @@ func (e *Engine) expandWildcardNamespaces(ctx context.Context) error {
 		return nil
 	}
 
-	// Fetch the namespace list from the cluster.
-	nsBody, code := e.doFetch(ctx, "/api/v1/namespaces", "", true)
-	if code != http.StatusOK || nsBody == nil {
-		if code == 0 {
-			if err := ctx.Err(); err != nil {
-				return fmt.Errorf("namespace discovery failed: request cancelled before completion (try a longer --duration): %w", err)
+	// Fetch the namespace list from the cluster, following pagination tokens so
+	// that clusters with more than 500 namespaces are fully enumerated.
+	// (Kubernetes defaults to a page size of 500 when no ?limit= is specified.)
+	var allNS []string
+	continueToken := ""
+	for {
+		path := "/api/v1/namespaces?limit=500"
+		if continueToken != "" {
+			path += "&continue=" + continueToken
+		}
+		nsBody, code := e.doFetch(ctx, path, "", true)
+		if code != http.StatusOK || nsBody == nil {
+			if code == 0 {
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("namespace discovery failed: request cancelled before completion (try a longer --duration): %w", err)
+				}
+				return fmt.Errorf("namespace discovery failed (HTTP 0): request could not be completed; check kubeconfig/context and cluster connectivity")
 			}
-			return fmt.Errorf("namespace discovery failed (HTTP 0): request could not be completed; check kubeconfig/context and cluster connectivity")
+			if code == http.StatusForbidden {
+				return fmt.Errorf("namespace discovery failed (HTTP %d): check cluster permissions", code)
+			}
+			return fmt.Errorf("namespace discovery failed (HTTP %d): unable to list namespaces", code)
 		}
-		if code == http.StatusForbidden {
-			return fmt.Errorf("namespace discovery failed (HTTP %d): check cluster permissions", code)
-		}
-		return fmt.Errorf("namespace discovery failed (HTTP %d): unable to list namespaces", code)
-	}
-	var nsList struct {
-		Items []struct {
+		var nsList struct {
 			Metadata struct {
-				Name string `json:"name"`
+				Continue string `json:"continue"`
 			} `json:"metadata"`
-		} `json:"items"`
-	}
-	if err := json.Unmarshal(nsBody, &nsList); err != nil {
-		return fmt.Errorf("parsing namespace list: %w", err)
-	}
-	allNS := make([]string, 0, len(nsList.Items))
-	for _, item := range nsList.Items {
-		allNS = append(allNS, item.Metadata.Name)
+			Items []struct {
+				Metadata struct {
+					Name string `json:"name"`
+				} `json:"metadata"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal(nsBody, &nsList); err != nil {
+			return fmt.Errorf("parsing namespace list: %w", err)
+		}
+		for _, item := range nsList.Items {
+			allNS = append(allNS, item.Metadata.Name)
+		}
+		continueToken = nsList.Metadata.Continue
+		if continueToken == "" {
+			break
+		}
 	}
 
 	// Expand each resource entry that contains "*".

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -310,6 +310,103 @@ func wildcardServer(t *testing.T, discoveredNS []string, reqPaths chan<- string)
 	return srv
 }
 
+// wildcardServerPaginated serves /api/v1/namespaces in two pages of pageSize,
+// simulating Kubernetes pagination for clusters with many namespaces.
+func wildcardServerPaginated(t *testing.T, allNS []string, pageSize int) *httptest.Server {
+	t.Helper()
+	const tok = "page2token"
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+		case "/api/v1/namespaces":
+			cont := r.URL.Query().Get("continue")
+			if cont == "" {
+				// First page
+				page := allNS
+				var continueVal string
+				if len(allNS) > pageSize {
+					page = allNS[:pageSize]
+					continueVal = tok
+				}
+				b, _ := buildNsList(page, continueVal)
+				fmt.Fprint(w, b)
+			} else if cont == tok {
+				// Second page
+				page := allNS[pageSize:]
+				b, _ := buildNsList(page, "")
+				fmt.Fprint(w, b)
+			} else {
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		default:
+			fmt.Fprintf(w, `{"kind":"List","items":[]}`)
+		}
+	}))
+	return srv
+}
+
+func buildNsList(names []string, continueToken string) (string, error) {
+	type item struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+	type list struct {
+		Kind     string `json:"kind"`
+		Metadata struct {
+			Continue string `json:"continue,omitempty"`
+		} `json:"metadata"`
+		Items []item `json:"items"`
+	}
+	l := list{Kind: "NamespaceList"}
+	l.Metadata.Continue = continueToken
+	for _, n := range names {
+		var it item
+		it.Metadata.Name = n
+		l.Items = append(l.Items, it)
+	}
+	b, err := json.Marshal(l)
+	return string(b), err
+}
+
+func TestExpandWildcard_Pagination(t *testing.T) {
+	// Simulate a cluster with 3 namespaces split across two pages (pageSize=2).
+	allNS := []string{"default", "kube-system", "portworx"}
+	srv := wildcardServerPaginated(t, allNS, 2)
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw: "500ms",
+		Duration:    500 * time.Millisecond,
+		Output:      filepath.Join(outDir, "capture.khsrk"),
+		Resources: []config.Resource{
+			{Version: "v1", Resource: "pods", Namespaces: []string{"*"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	got := cfg.Resources[0].Namespaces
+	if len(got) != len(allNS) {
+		t.Fatalf("expected %d namespaces (all pages), got %d: %v", len(allNS), len(got), got)
+	}
+	gotSet := make(map[string]bool, len(got))
+	for _, ns := range got {
+		gotSet[ns] = true
+	}
+	for _, want := range allNS {
+		if !gotSet[want] {
+			t.Errorf("namespace %q missing from expanded list %v", want, got)
+		}
+	}
+}
+
 func TestExpandWildcard_NoWildcard(t *testing.T) {
 	paths := make(chan string, 100)
 	srv := wildcardServer(t, []string{"default", "kube-system"}, paths)

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -345,11 +345,16 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 	}
 
 	if code == 404 {
-		// Try all-namespaces aggregation: kubectl -A issues /api/v1/pods etc.
-		body, code, err = h.store.AggregateAcrossNamespaces(path, at)
-		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, statusObj(500, err.Error()))
-			return
+		// Try all-namespaces aggregation: kubectl -A issues cluster-wide paths
+		// like /api/v1/pods or /apis/apps/v1/deployments. Only fire for paths
+		// with no namespace segment; namespace-scoped 404s fall through to the
+		// cluster-scoped fallback below, which correctly filters by namespace.
+		if _, _, _, reqNS := parseAPIPath(path); reqNS == "" {
+			body, code, err = h.store.AggregateAcrossNamespaces(path, at)
+			if err != nil {
+				writeJSON(w, http.StatusInternalServerError, statusObj(500, err.Error()))
+				return
+			}
 		}
 	}
 
@@ -455,12 +460,14 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 				}
 			}
 		}
-		// Aggregated Table across namespaces (for -A / cluster-scoped paths).
-		if tb, tbCode, _ := h.store.AggregateTableAcrossNamespaces(path, at); tbCode == 200 {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(200)
-			_, _ = w.Write(tableFiltered(tb))
-			return
+		// Aggregated Table across namespaces (for -A / cluster-scoped paths only).
+		if _, _, _, reqNS := parseAPIPath(path); reqNS == "" {
+			if tb, tbCode, _ := h.store.AggregateTableAcrossNamespaces(path, at); tbCode == 200 {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(200)
+				_, _ = w.Write(tableFiltered(tb))
+				return
+			}
 		}
 		// Last resort: synthesize a minimal Table from the list body (old captures).
 		// body is already selector-filtered above, so buildTable sees filtered items.
@@ -671,10 +678,13 @@ func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path strin
 	}
 
 	if code == 404 {
-		rawBody, code, err = h.store.AggregateAcrossNamespaces(watchPath, at)
-		if err != nil {
-			h.writeStatus(w, http.StatusInternalServerError, err.Error())
-			return
+		// Only aggregate across namespaces for cluster-wide watch paths.
+		if _, _, _, reqNS := parseAPIPath(watchPath); reqNS == "" {
+			rawBody, code, err = h.store.AggregateAcrossNamespaces(watchPath, at)
+			if err != nil {
+				h.writeStatus(w, http.StatusInternalServerError, err.Error())
+				return
+			}
 		}
 	}
 

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -514,6 +514,23 @@ func (s *CaptureStore) reconstructAt(apiPath string, at time.Time) ([]byte, int,
 	return out, 200, nil
 }
 
+// itemDedupeKey returns a short string that uniquely identifies a raw JSON
+// item by uid (preferred) or namespace/name fallback. Used to deduplicate
+// items when aggregating across namespaces.
+func itemDedupeKey(raw json.RawMessage) string {
+	var obj struct {
+		Metadata struct {
+			UID       string `json:"uid"`
+			Namespace string `json:"namespace"`
+			Name      string `json:"name"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(raw, &obj); err != nil || obj.Metadata.UID == "" {
+		return obj.Metadata.Namespace + "/" + obj.Metadata.Name
+	}
+	return obj.Metadata.UID
+}
+
 // AggregateAcrossNamespaces aggregates list items from all namespaced paths.
 func (s *CaptureStore) AggregateAcrossNamespaces(clusterPath string, at time.Time) ([]byte, int, error) {
 	g, v, resource, _ := parseAPIPath(clusterPath)
@@ -525,11 +542,20 @@ func (s *CaptureStore) AggregateAcrossNamespaces(clusterPath string, at time.Tim
 	}
 	suffix := "/" + resource
 
+	// Safety cap: resources like packagemanifests return the full cluster list
+	// for every namespace (OLM behaviour). Aggregating across all namespaces
+	// would multiply the item count by the number of namespaces and materialise
+	// hundreds of millions of items. Cap the aggregate at 10 000 unique items
+	// (keyed by uid or name) to prevent unbounded memory use.
+	const aggregateItemCap = 10_000
+
 	var (
 		allItems   []json.RawMessage
 		listKind   string
 		apiVersion string
 		found      bool
+		seen       = make(map[string]struct{})
+		capped     bool
 	)
 
 	for indexPath := range s.Index {
@@ -553,7 +579,25 @@ func (s *CaptureStore) AggregateAcrossNamespaces(clusterPath string, at time.Tim
 			apiVersion = list.APIVersion
 			found = true
 		}
-		allItems = append(allItems, list.Items...)
+		for _, raw := range list.Items {
+			if capped {
+				break
+			}
+			// Deduplicate by uid or name so OLM-style resources that return the
+			// full cluster list for every namespace don't multiply item count.
+			key := itemDedupeKey(raw)
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			allItems = append(allItems, raw)
+			if len(allItems) >= aggregateItemCap {
+				capped = true
+			}
+		}
+		if capped {
+			break
+		}
 	}
 
 	if !found {

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -515,18 +515,25 @@ func (s *CaptureStore) reconstructAt(apiPath string, at time.Time) ([]byte, int,
 }
 
 // itemDedupeKey returns a short string that uniquely identifies a raw JSON
-// item by uid (preferred) or namespace/name fallback. Used to deduplicate
-// items when aggregating across namespaces.
+// item by uid (preferred) or name-only fallback. Used to deduplicate items
+// when aggregating across namespaces.
+//
+// Name-only (not namespace/name) is intentional for the no-UID case: OLM
+// resources like PackageManifests have no uid and are stamped with the
+// requested namespace on every namespace-scoped response, so the same package
+// appears as "adani/prometheus-operator", "kube-system/prometheus-operator",
+// etc. Using just the name correctly collapses these duplicates. Resources that
+// have genuinely distinct same-named items in different namespaces (pods,
+// services…) always carry a uid and therefore never hit this fallback.
 func itemDedupeKey(raw json.RawMessage) string {
 	var obj struct {
 		Metadata struct {
-			UID       string `json:"uid"`
-			Namespace string `json:"namespace"`
-			Name      string `json:"name"`
+			UID  string `json:"uid"`
+			Name string `json:"name"`
 		} `json:"metadata"`
 	}
 	if err := json.Unmarshal(raw, &obj); err != nil || obj.Metadata.UID == "" {
-		return obj.Metadata.Namespace + "/" + obj.Metadata.Name
+		return obj.Metadata.Name
 	}
 	return obj.Metadata.UID
 }

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -22,18 +22,26 @@ type CaptureStore struct {
 	WatchIndex   capture.WatchIndex
 	resourceInfo map[string]*ResourceInfo
 
-	// Record LRU cache (bounded by recordCacheMax entries).
-	recordCacheMu   sync.Mutex
-	recordCacheMap  map[recordKey]*list.Element
-	recordCacheList *list.List
+	// Record LRU cache (bounded by recordCacheMaxBytes total body bytes).
+	recordCacheMu    sync.Mutex
+	recordCacheMap   map[recordKey]*list.Element
+	recordCacheList  *list.List
+	recordCacheBytes int64
 
 	// Response cache: (path, at) → marshalled body + code.
-	// Entries are valid for responseCacheTTL.
-	responseCacheMu  sync.RWMutex
-	responseCacheMap map[responseCacheKey]*responseCacheEntry
+	// Entries are valid for responseCacheTTL, bounded by responseCacheMaxBytes.
+	responseCacheMu    sync.RWMutex
+	responseCacheMap   map[responseCacheKey]*responseCacheEntry
+	responseCacheBytes int64
 }
 
-const recordCacheMax = 2048
+// recordCacheMaxBytes caps the total in-memory size of cached record bodies.
+// Large cluster captures can have response bodies of hundreds of KB each;
+// a count-based cap of 2048 was the primary driver of the v0.2.0 memory regression.
+const recordCacheMaxBytes = 128 * 1024 * 1024 // 128 MiB
+
+// responseCacheMaxBytes caps the total in-memory size of cached response bodies.
+const responseCacheMaxBytes = 32 * 1024 * 1024 // 32 MiB
 
 type recordKey struct {
 	apiPath string
@@ -54,8 +62,9 @@ type responseCacheEntry struct {
 const responseCacheTTL = 10 * time.Second
 
 type recordCacheEntry struct {
-	key recordKey
-	rec capture.Record
+	key  recordKey
+	rec  capture.Record
+	size int64 // len(rec.ResponseBody)
 }
 
 // ResourceInfo describes a single captured resource type.
@@ -266,18 +275,23 @@ func (s *CaptureStore) readRecord(apiPath string, seq int) (capture.Record, erro
 		return capture.Record{}, fmt.Errorf("parsing record path=%s seq=%d: %w", apiPath, seq, err)
 	}
 
+	entry := &recordCacheEntry{key: k, rec: rec, size: int64(len(rec.ResponseBody))}
+
 	s.recordCacheMu.Lock()
-	// Evict LRU entry if at capacity.
-	for s.recordCacheList.Len() >= recordCacheMax {
+	// Evict LRU entries until the new entry fits within the byte budget.
+	for s.recordCacheBytes+entry.size > recordCacheMaxBytes {
 		back := s.recordCacheList.Back()
 		if back == nil {
 			break
 		}
+		evicted := back.Value.(*recordCacheEntry)
 		s.recordCacheList.Remove(back)
-		delete(s.recordCacheMap, back.Value.(*recordCacheEntry).key)
+		delete(s.recordCacheMap, evicted.key)
+		s.recordCacheBytes -= evicted.size
 	}
-	el := s.recordCacheList.PushFront(&recordCacheEntry{key: k, rec: rec})
+	el := s.recordCacheList.PushFront(entry)
 	s.recordCacheMap[k] = el
+	s.recordCacheBytes += entry.size
 	s.recordCacheMu.Unlock()
 
 	return rec, nil
@@ -356,11 +370,13 @@ func (s *CaptureStore) ReconstructAt(apiPath string, at time.Time) ([]byte, int,
 	// Cache the result.
 	s.responseCacheMu.Lock()
 	s.responseCacheMap[cacheKey] = &responseCacheEntry{body: body, code: code, created: time.Now()}
-	// Simple TTL cleanup on writes — keep map bounded.
-	if len(s.responseCacheMap) > 512 {
+	s.responseCacheBytes += int64(len(body))
+	// Evict expired entries when over the byte budget.
+	if s.responseCacheBytes > responseCacheMaxBytes {
 		now := time.Now()
 		for k, v := range s.responseCacheMap {
 			if now.Sub(v.created) > responseCacheTTL {
+				s.responseCacheBytes -= int64(len(v.body))
 				delete(s.responseCacheMap, k)
 			}
 		}

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -638,6 +638,24 @@ func (s *CaptureStore) AggregateAcrossNamespaces(clusterPath string, at time.Tim
 	return out, 200, nil
 }
 
+// tableRowDedupeKey returns a deduplication key for a Table row using the
+// embedded object's uid (preferred) or name-only fallback. Mirrors the logic
+// of itemDedupeKey for Table-format responses.
+func tableRowDedupeKey(row json.RawMessage) string {
+	var r struct {
+		Object struct {
+			Metadata struct {
+				UID  string `json:"uid"`
+				Name string `json:"name"`
+			} `json:"metadata"`
+		} `json:"object"`
+	}
+	if err := json.Unmarshal(row, &r); err != nil || r.Object.Metadata.UID == "" {
+		return r.Object.Metadata.Name
+	}
+	return r.Object.Metadata.UID
+}
+
 // AggregateTableAcrossNamespaces merges per-namespace Table responses.
 func (s *CaptureStore) AggregateTableAcrossNamespaces(clusterPath string, at time.Time) ([]byte, int, error) {
 	g, v, resource, _ := parseAPIPath(clusterPath)
@@ -653,6 +671,7 @@ func (s *CaptureStore) AggregateTableAcrossNamespaces(clusterPath string, at tim
 		allRows []json.RawMessage
 		colDefs json.RawMessage
 		found   bool
+		seen    = make(map[string]struct{})
 	)
 
 	for indexPath := range s.Index {
@@ -674,7 +693,14 @@ func (s *CaptureStore) AggregateTableAcrossNamespaces(clusterPath string, at tim
 			colDefs = table.ColumnDefinitions
 			found = true
 		}
-		allRows = append(allRows, table.Rows...)
+		for _, row := range table.Rows {
+			key := tableRowDedupeKey(row)
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			allRows = append(allRows, row)
+		}
 	}
 
 	if !found {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -578,8 +578,11 @@ func (h *explorerHandler) buildNamespaceAt(targetNS string, at time.Time) (*name
 			if targetNS == "" && itemNS != "" {
 				continue
 			}
-			// named-namespace view: skip items from a different namespace
-			if targetNS != "" && itemNS != "" && itemNS != targetNS {
+			// named-namespace view: skip items with no namespace (truly
+			// cluster-scoped resources like ClusterRoles that happen to be
+			// returned by cluster-wide list endpoints) and items from a
+			// different namespace
+			if targetNS != "" && itemNS != targetNS {
 				continue
 			}
 			if workloadKinds[resource] {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -35,11 +35,10 @@ type Server struct {
 }
 
 type explorerHandler struct {
-	store          *server.CaptureStore
-	at             time.Time
-	verbose        bool
-	archivePath    string
-	allTransitions []transitions.Transition
+	store       *server.CaptureStore
+	at          time.Time
+	verbose     bool
+	archivePath string
 }
 
 type treeResponse struct {
@@ -134,10 +133,7 @@ func Open(opts OpenOptions) (*Server, error) {
 		return nil, fmt.Errorf("listening: %w", err)
 	}
 
-	// Pre-compute transitions for the archive (best-effort; empty on error).
-	allTrans, _ := transitions.LoadTransitions(opts.ArchivePath, transitions.FilterOpts{})
-
-	h := &explorerHandler{store: store, at: at, verbose: opts.Verbose, archivePath: opts.ArchivePath, allTransitions: allTrans}
+	h := &explorerHandler{store: store, at: at, verbose: opts.Verbose, archivePath: opts.ArchivePath}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", h.serveIndex)
 	mux.HandleFunc("/api/ui/tree", h.serveTree)
@@ -301,14 +297,17 @@ func (h *explorerHandler) serveTransitions(w http.ResponseWriter, r *http.Reques
 	resource := r.URL.Query().Get("resource")
 	namespace := r.URL.Query().Get("namespace")
 
-	markers := make([]transitionMarker, 0, len(h.allTransitions))
-	for _, t := range h.allTransitions {
-		if resource != "" && !strings.Contains(t.Resource, resource) {
-			continue
-		}
-		if namespace != "" && t.Namespace != namespace {
-			continue
-		}
+	all, err := transitions.LoadTransitions(h.archivePath, transitions.FilterOpts{
+		Resource:  resource,
+		Namespace: namespace,
+	})
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	markers := make([]transitionMarker, 0, len(all))
+	for _, t := range all {
 		markers = append(markers, transitionMarker{
 			Time:      t.Time.UTC().Format(time.RFC3339),
 			EventType: t.EventType,
@@ -337,17 +336,18 @@ func (h *explorerHandler) serveObjectHistory(w http.ResponseWriter, r *http.Requ
 	resource := r.URL.Query().Get("resource")
 	namespace := r.URL.Query().Get("namespace")
 
-	entries := make([]objectHistoryEntry, 0)
-	for _, t := range h.allTransitions {
-		if t.Name != name {
-			continue
-		}
-		if resource != "" && !strings.Contains(t.Resource, resource) {
-			continue
-		}
-		if namespace != "" && t.Namespace != namespace {
-			continue
-		}
+	all, err := transitions.LoadTransitions(h.archivePath, transitions.FilterOpts{
+		Name:      name,
+		Resource:  resource,
+		Namespace: namespace,
+	})
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	entries := make([]objectHistoryEntry, 0, len(all))
+	for _, t := range all {
 		entries = append(entries, objectHistoryEntry{
 			Time:      t.Time.UTC().Format(time.RFC3339),
 			EventType: t.EventType,

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1294,6 +1294,22 @@ const indexHTML = `<!doctype html>
 	<div id="toasts" class="toast-stack" aria-live="polite"></div>
   <script>
     let treeData = null;
+    let nsCache = {};
+    async function loadNsDetail(nsName) {
+      if (nsCache[nsName] && !nsCache[nsName]._loading) return;
+      nsCache[nsName] = { _loading: true };
+      try {
+        const q = withAtQuery(new URLSearchParams());
+        q.set('ns', nsName === '' ? ':cluster' : nsName);
+        const res = await fetch('/api/ui/tree/namespace?' + q.toString());
+        const data = await res.json();
+        nsCache[nsName] = data;
+      } catch (_) {
+        delete nsCache[nsName];
+        return;
+      }
+      render();
+    }
     let activeKinds = new Set();
 	let activeKindsInitialized = false;
     let selected = null;
@@ -1952,10 +1968,15 @@ const indexHTML = `<!doctype html>
 
 			const cs = document.createElement('details');
 			cs.open = sectionOpen('cluster-scoped', true);
-			cs.innerHTML = '<summary>Cluster-scoped resources <span class="muted">(' + treeData.cluster_scoped.length + ')</span></summary>';
+			const csDetail = nsCache[':cluster'] || {};
+			const csCount = (csDetail.resources || []).length;
+			const csLabel = csDetail._loading ? '...' : csCount;
+			cs.innerHTML = '<summary>Cluster-scoped resources <span class="muted">(' + csLabel + ')</span></summary>';
 			bindSectionState(cs, 'cluster-scoped');
+			cs.addEventListener('toggle', () => { if (cs.open) loadNsDetail(':cluster'); });
+			if (cs.open) loadNsDetail(':cluster');
 			let clusterShown = 0;
-      for (const node of treeData.cluster_scoped) {
+      for (const node of (csDetail.resources || [])) {
 				if (!kindEnabled(node.kind) || !nodeMatches(node, q, '')) continue;
 				cs.appendChild(mkNode(node, ['Cluster', node.kind, node.name], 0, ''));
 				renderedNodes++;
@@ -1971,13 +1992,17 @@ const indexHTML = `<!doctype html>
 				const nsMatches = !!q && ns.name.toLowerCase().includes(q);
         const ds = document.createElement('details');
 				ds.open = sectionOpen('ns:' + ns.name, treeData.namespaces.length <= 20);
-				const nsCount = (ns.workloads || []).length + (ns.pods || []).length + (ns.resources || []).length;
-				ds.innerHTML = '<summary>Namespace: <strong>' + ns.name + '</strong> <span class="muted">(' + nsCount + ')</span></summary>';
+				const nsDetail = nsCache[ns.name] || {};
+				const nsCount = (nsDetail.workloads || []).length + (nsDetail.pods || []).length + (nsDetail.resources || []).length;
+				const nsLabel = nsDetail._loading ? '...' : nsCount;
+				ds.innerHTML = '<summary>Namespace: <strong>' + ns.name + '</strong> <span class="muted">(' + nsLabel + ')</span></summary>';
 				bindSectionState(ds, 'ns:' + ns.name);
+				ds.addEventListener('toggle', () => { if (ds.open) loadNsDetail(ns.name); });
+				if (ds.open) loadNsDetail(ns.name);
 
 				const nsNodes = [];
 
-			for (const w of (ns.workloads || [])) {
+			for (const w of (nsDetail.workloads || [])) {
 				const workloadVisible = kindEnabled(w.kind) && (nsMatches || nodeMatches(w, q, ns.name));
 				if (workloadVisible) {
 					nsNodes.push(mkNode(w, ['Cluster', ns.name, w.kind, w.name], 0, ''));
@@ -2002,7 +2027,7 @@ const indexHTML = `<!doctype html>
 				}
 			}
 
-			for (const p of (ns.pods || [])) {
+			for (const p of (nsDetail.pods || [])) {
 				if (!kindEnabled(p.kind) || !(nsMatches || nodeMatches(p, q, ns.name))) continue;
 					nsNodes.push(mkNode(p, ['Cluster', ns.name, 'Pod', p.name], 0, ''));
           for (const c of (p.containers || [])) {
@@ -2012,7 +2037,7 @@ const indexHTML = `<!doctype html>
           }
         }
 
-			for (const r of (ns.resources || [])) {
+			for (const r of (nsDetail.resources || [])) {
 				if (!kindEnabled(r.kind) || !(nsMatches || nodeMatches(r, q, ns.name))) continue;
 					nsNodes.push(mkNode(r, ['Cluster', ns.name, r.kind, r.name], 0, ''));
         }
@@ -2357,6 +2382,7 @@ const indexHTML = `<!doctype html>
 					throw new Error(msg);
 				}
 				treeData = data;
+				nsCache = {};
 				namespacesVisibleLimit = namespacesPageSize;
 				lastLoadedAt = normalizedAt();
 				updateMetaLine();

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -227,6 +227,27 @@ func (h *explorerHandler) serveTree(w http.ResponseWriter, r *http.Request) {
 		}
 		nsSet[ns] = struct{}{}
 	}
+	// Also enumerate namespaces from the captured /api/v1/namespaces list.
+	// This surfaces namespaces that exist in the cluster but have no per-resource
+	// paths in the capture (e.g. empty namespaces or ones not included in the
+	// capture config). We do a best-effort read; if the record is absent we
+	// gracefully skip.
+	if nsListBody, code, err := h.store.ReconstructAt("/api/v1/namespaces", h.at); err == nil && code == 200 {
+		var nsList struct {
+			Items []struct {
+				Metadata struct {
+					Name string `json:"name"`
+				} `json:"metadata"`
+			} `json:"items"`
+		}
+		if json.Unmarshal(nsListBody, &nsList) == nil {
+			for _, item := range nsList.Items {
+				if item.Metadata.Name != "" {
+					nsSet[item.Metadata.Name] = struct{}{}
+				}
+			}
+		}
+	}
 	namespaces := make([]namespaceNode, 0, len(nsSet))
 	for ns := range nsSet {
 		namespaces = append(namespaces, namespaceNode{Name: ns})

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1970,7 +1970,7 @@ const indexHTML = `<!doctype html>
 			cs.open = sectionOpen('cluster-scoped', true);
 			const csDetail = nsCache[':cluster'] || {};
 			const csCount = (csDetail.resources || []).length;
-			const csLabel = csDetail._loading ? '...' : csCount;
+			const csLabel = !nsCache[':cluster'] ? '-' : (csDetail._loading ? '...' : csCount);
 			cs.innerHTML = '<summary>Cluster-scoped resources <span class="muted">(' + csLabel + ')</span></summary>';
 			bindSectionState(cs, 'cluster-scoped');
 			cs.addEventListener('toggle', () => { if (cs.open) loadNsDetail(':cluster'); });
@@ -1994,7 +1994,7 @@ const indexHTML = `<!doctype html>
 				ds.open = sectionOpen('ns:' + ns.name, treeData.namespaces.length <= 20);
 				const nsDetail = nsCache[ns.name] || {};
 				const nsCount = (nsDetail.workloads || []).length + (nsDetail.pods || []).length + (nsDetail.resources || []).length;
-				const nsLabel = nsDetail._loading ? '...' : nsCount;
+				const nsLabel = !nsCache[ns.name] ? '-' : (nsDetail._loading ? '...' : nsCount);
 				ds.innerHTML = '<summary>Namespace: <strong>' + ns.name + '</strong> <span class="muted">(' + nsLabel + ')</span></summary>';
 				bindSectionState(ds, 'ns:' + ns.name);
 				ds.addEventListener('toggle', () => { if (ds.open) loadNsDetail(ns.name); });

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -45,7 +45,7 @@ type treeResponse struct {
 	CapturedAt    time.Time       `json:"captured_at"`
 	CapturedUntil time.Time       `json:"captured_until"`
 	Namespaces    []namespaceNode `json:"namespaces"`
-	ClusterScoped []resourceNode  `json:"cluster_scoped"`
+	ClusterScoped []string        `json:"cluster_scoped"` // resource kind names only; items loaded on demand
 	ResourceKinds []string        `json:"resource_kinds"`
 }
 
@@ -59,10 +59,7 @@ type timestampsResponse struct {
 }
 
 type namespaceNode struct {
-	Name      string         `json:"name"`
-	Workloads []workloadNode `json:"workloads"`
-	Pods      []podNode      `json:"pods"`
-	Resources []resourceNode `json:"resources"`
+	Name string `json:"name"`
 }
 
 type workloadNode struct {
@@ -98,6 +95,13 @@ type resourceNode struct {
 	Age      string            `json:"age,omitempty"`
 	ListPath string            `json:"list_path"`
 	Labels   map[string]string `json:"labels,omitempty"`
+}
+
+type namespaceDetailResponse struct {
+	Name      string         `json:"name"`
+	Workloads []workloadNode `json:"workloads"`
+	Pods      []podNode      `json:"pods"`
+	Resources []resourceNode `json:"resources"`
 }
 
 type listItem struct {
@@ -137,6 +141,7 @@ func Open(opts OpenOptions) (*Server, error) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", h.serveIndex)
 	mux.HandleFunc("/api/ui/tree", h.serveTree)
+	mux.HandleFunc("/api/ui/tree/namespace", h.serveTreeNamespace)
 	mux.HandleFunc("/api/ui/detail", h.serveDetail)
 	mux.HandleFunc("/api/ui/timestamps", h.serveTimestamps)
 	mux.HandleFunc("/api/ui/transitions", h.serveTransitions)
@@ -186,18 +191,72 @@ func (h *explorerHandler) serveIndex(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *explorerHandler) serveTree(w http.ResponseWriter, r *http.Request) {
+	// Index-only walk: no record bodies are read.
+	// Returns the namespace list, cluster-scoped resource kinds, and all resource kinds.
+	// Clients load individual namespace items on demand via /api/ui/tree/namespace.
+	nsSet := map[string]struct{}{}
+	clusterKindSet := map[string]struct{}{}
+	kindSet := map[string]struct{}{}
+	for path := range h.store.Index {
+		_, _, resource, ns, _ := parseAPIPath(baseAPIPath(path))
+		if resource == "" {
+			continue
+		}
+		kind := kindFromResource(resource)
+		kindSet[kind] = struct{}{}
+		if ns == "" {
+			clusterKindSet[kind] = struct{}{}
+		} else {
+			nsSet[ns] = struct{}{}
+		}
+	}
+	namespaces := make([]namespaceNode, 0, len(nsSet))
+	for ns := range nsSet {
+		namespaces = append(namespaces, namespaceNode{Name: ns})
+	}
+	sort.Slice(namespaces, func(i, j int) bool { return namespaces[i].Name < namespaces[j].Name })
+
+	clusterKinds := make([]string, 0, len(clusterKindSet))
+	for k := range clusterKindSet {
+		clusterKinds = append(clusterKinds, k)
+	}
+	sort.Strings(clusterKinds)
+
+	kinds := make([]string, 0, len(kindSet))
+	for k := range kindSet {
+		kinds = append(kinds, k)
+	}
+	sort.Strings(kinds)
+
+	writeJSON(w, http.StatusOK, treeResponse{
+		CapturedAt:    h.store.Metadata.CapturedAt,
+		CapturedUntil: h.store.Metadata.CapturedUntil,
+		Namespaces:    namespaces,
+		ClusterScoped: clusterKinds,
+		ResourceKinds: kinds,
+	})
+}
+
+// serveTreeNamespace loads all items for a single namespace (or cluster-scoped
+// resources when ns="" / ns=":cluster") and returns the full workloads/pods/resources
+// breakdown. This is called on demand as the user expands a namespace in the UI.
+func (h *explorerHandler) serveTreeNamespace(w http.ResponseWriter, r *http.Request) {
 	at, err := h.resolveRequestAt(r)
 	if err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
+	ns := r.URL.Query().Get("ns")
+	if ns == ":cluster" {
+		ns = ""
+	}
 
-	resp, err := h.buildTreeAt(at)
+	node, err := h.buildNamespaceAt(ns, at)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
-	writeJSON(w, http.StatusOK, resp)
+	writeJSON(w, http.StatusOK, node)
 }
 
 func (h *explorerHandler) serveDetail(w http.ResponseWriter, r *http.Request) {
@@ -409,135 +468,125 @@ func (h *explorerHandler) buildTree() (*treeResponse, error) {
 	return h.buildTreeAt(h.at)
 }
 
+// buildTreeAt is kept for tests; it reconstructs the full tree the old way.
+// New callers should use the split serveTree + serveTreeNamespace endpoints.
 func (h *explorerHandler) buildTreeAt(at time.Time) (*treeResponse, error) {
-	nsMap := map[string]*namespaceNode{}
-	clusterScoped := make([]resourceNode, 0)
-	kindSet := map[string]bool{}
-	workloadKinds := map[string]bool{
-		"deployments":  true,
-		"statefulsets": true,
-		"daemonsets":   true,
-		"jobs":         true,
-		"replicasets":  true,
-	}
-	// Map of (namespace, resource) -> all candidate index paths
-	byNSRes := map[string]map[string][]string{}
+	nsSet := map[string]struct{}{}
+	clusterKindSet := map[string]struct{}{}
+	kindSet := map[string]struct{}{}
 	for path := range h.store.Index {
-		group, version, resource, ns, _ := parseAPIPath(baseAPIPath(path))
+		_, _, resource, ns, _ := parseAPIPath(baseAPIPath(path))
 		if resource == "" {
 			continue
 		}
-		if byNSRes[ns] == nil {
-			byNSRes[ns] = map[string][]string{}
-		}
-		byNSRes[ns][resource] = append(byNSRes[ns][resource], path)
-		_ = group
-		_ = version
-	}
-	ensureNamespace := func(name string) *namespaceNode {
-		node, ok := nsMap[name]
-		if !ok {
-			node = &namespaceNode{
-				Name:      name,
-				Workloads: []workloadNode{},
-				Pods:      []podNode{},
-				Resources: []resourceNode{},
-			}
-			nsMap[name] = node
-		}
-		return node
-	}
-	appendNamespacedItem := func(targetNS, resource string, entry listItem) {
-		node := ensureNamespace(targetNS)
-		if workloadKinds[resource] {
-			w := workloadNode{
-				Kind:     firstNonEmpty(asString(entry.item["kind"]), kindFromResource(resource)),
-				Name:     getMetaName(entry.item),
-				Status:   summarizeStatus(entry.item),
-				Age:      summarizeAge(entry.item),
-				ListPath: entry.path,
-				Labels:   getMetaLabels(entry.item),
-			}
-			node.Workloads = append(node.Workloads, w)
-			kindSet[w.Kind] = true
-			return
-		}
-		if resource == "pods" {
-			p := toPodNode(entry.path, entry.item)
-			node.Pods = append(node.Pods, p)
-			kindSet[p.Kind] = true
-			return
-		}
-		rn := toResourceNode(resource, entry.path, entry.item)
-		node.Resources = append(node.Resources, rn)
-		kindSet[rn.Kind] = true
-	}
-	for ns, resMap := range byNSRes {
-		for resource, candidates := range resMap {
-			items, ok := h.loadResourceItemsAt(candidates, at)
-			if !ok {
-				continue
-			}
-			if ns == "" {
-				for _, entry := range items {
-					if itemNS := getMetaNamespace(entry.item); itemNS != "" {
-						appendNamespacedItem(itemNS, resource, entry)
-						continue
-					}
-					node := toResourceNode(resource, entry.path, entry.item)
-					clusterScoped = append(clusterScoped, node)
-					kindSet[node.Kind] = true
-				}
-				continue
-			}
-			for _, entry := range items {
-				targetNS := ns
-				if itemNS := getMetaNamespace(entry.item); itemNS != "" {
-					targetNS = itemNS
-				}
-				appendNamespacedItem(targetNS, resource, entry)
-			}
+		kind := kindFromResource(resource)
+		kindSet[kind] = struct{}{}
+		if ns == "" {
+			clusterKindSet[kind] = struct{}{}
+		} else {
+			nsSet[ns] = struct{}{}
 		}
 	}
-	for ns := range nsMap {
-		attachPodsToWorkloads(nsMap[ns])
-	}
-	namespaces := make([]namespaceNode, 0, len(nsMap))
-	for _, ns := range nsMap {
-		sort.Slice(ns.Workloads, func(i, j int) bool {
-			if ns.Workloads[i].Kind == ns.Workloads[j].Kind {
-				return ns.Workloads[i].Name < ns.Workloads[j].Name
-			}
-			return ns.Workloads[i].Kind < ns.Workloads[j].Kind
-		})
-		sort.Slice(ns.Pods, func(i, j int) bool { return ns.Pods[i].Name < ns.Pods[j].Name })
-		sort.Slice(ns.Resources, func(i, j int) bool {
-			if ns.Resources[i].Kind == ns.Resources[j].Kind {
-				return ns.Resources[i].Name < ns.Resources[j].Name
-			}
-			return ns.Resources[i].Kind < ns.Resources[j].Kind
-		})
-		namespaces = append(namespaces, *ns)
+	namespaces := make([]namespaceNode, 0, len(nsSet))
+	for ns := range nsSet {
+		namespaces = append(namespaces, namespaceNode{Name: ns})
 	}
 	sort.Slice(namespaces, func(i, j int) bool { return namespaces[i].Name < namespaces[j].Name })
-	sort.Slice(clusterScoped, func(i, j int) bool {
-		if clusterScoped[i].Kind == clusterScoped[j].Kind {
-			return clusterScoped[i].Name < clusterScoped[j].Name
-		}
-		return clusterScoped[i].Kind < clusterScoped[j].Kind
-	})
+
+	clusterKinds := make([]string, 0, len(clusterKindSet))
+	for k := range clusterKindSet {
+		clusterKinds = append(clusterKinds, k)
+	}
+	sort.Strings(clusterKinds)
+
 	kinds := make([]string, 0, len(kindSet))
 	for k := range kindSet {
 		kinds = append(kinds, k)
 	}
 	sort.Strings(kinds)
+
 	return &treeResponse{
 		CapturedAt:    h.store.Metadata.CapturedAt,
 		CapturedUntil: h.store.Metadata.CapturedUntil,
 		Namespaces:    namespaces,
-		ClusterScoped: clusterScoped,
+		ClusterScoped: clusterKinds,
 		ResourceKinds: kinds,
 	}, nil
+}
+
+// buildNamespaceAt loads all items for the given namespace (empty = cluster-scoped)
+// and returns the full workloads / pods / resources breakdown.
+func (h *explorerHandler) buildNamespaceAt(targetNS string, at time.Time) (*namespaceDetailResponse, error) {
+	workloadKinds := map[string]bool{
+		"deployments": true, "statefulsets": true, "daemonsets": true,
+		"jobs": true, "replicasets": true,
+	}
+
+	// Collect candidate paths for this namespace.
+	byRes := map[string][]string{}
+	for path := range h.store.Index {
+		_, _, resource, ns, _ := parseAPIPath(baseAPIPath(path))
+		if resource == "" {
+			continue
+		}
+		if ns != targetNS {
+			continue
+		}
+		byRes[resource] = append(byRes[resource], path)
+	}
+
+	node := &namespaceDetailResponse{
+		Name:      targetNS,
+		Workloads: []workloadNode{},
+		Pods:      []podNode{},
+		Resources: []resourceNode{},
+	}
+
+	for resource, candidates := range byRes {
+		items, ok := h.loadResourceItemsAt(candidates, at)
+		if !ok {
+			continue
+		}
+		for _, entry := range items {
+			itemNS := getMetaNamespace(entry.item)
+			if targetNS != "" && itemNS != "" && itemNS != targetNS {
+				continue
+			}
+			if workloadKinds[resource] {
+				node.Workloads = append(node.Workloads, workloadNode{
+					Kind:     firstNonEmpty(asString(entry.item["kind"]), kindFromResource(resource)),
+					Name:     getMetaName(entry.item),
+					Status:   summarizeStatus(entry.item),
+					Age:      summarizeAge(entry.item),
+					ListPath: entry.path,
+					Labels:   getMetaLabels(entry.item),
+				})
+				continue
+			}
+			if resource == "pods" {
+				node.Pods = append(node.Pods, toPodNode(entry.path, entry.item))
+				continue
+			}
+			node.Resources = append(node.Resources, toResourceNode(resource, entry.path, entry.item))
+		}
+	}
+
+	attachPodsToWorkloads(node)
+
+	sort.Slice(node.Workloads, func(i, j int) bool {
+		if node.Workloads[i].Kind == node.Workloads[j].Kind {
+			return node.Workloads[i].Name < node.Workloads[j].Name
+		}
+		return node.Workloads[i].Kind < node.Workloads[j].Kind
+	})
+	sort.Slice(node.Pods, func(i, j int) bool { return node.Pods[i].Name < node.Pods[j].Name })
+	sort.Slice(node.Resources, func(i, j int) bool {
+		if node.Resources[i].Kind == node.Resources[j].Kind {
+			return node.Resources[i].Name < node.Resources[j].Name
+		}
+		return node.Resources[i].Kind < node.Resources[j].Kind
+	})
+	return node, nil
 }
 
 func toResourceNode(resource, listPath string, item map[string]any) resourceNode {
@@ -576,7 +625,7 @@ func toPodNode(listPath string, item map[string]any) podNode {
 	}
 }
 
-func attachPodsToWorkloads(ns *namespaceNode) {
+func attachPodsToWorkloads(ns *namespaceDetailResponse) {
 	byOwner := map[string]*workloadNode{}
 	for i := range ns.Workloads {
 		k := ns.Workloads[i].Kind + "/" + ns.Workloads[i].Name

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -210,6 +210,16 @@ func (h *explorerHandler) serveTree(w http.ResponseWriter, r *http.Request) {
 			nsSet[ns] = struct{}{}
 		}
 	}
+	// Also collect namespaces from watch-event paths, which are always
+	// namespace-scoped and may reveal namespaces absent from the REST index
+	// (e.g. when resources were only captured via cluster-wide list endpoints).
+	for path := range h.store.WatchIndex {
+		_, _, resource, ns, _ := parseAPIPath(baseAPIPath(path))
+		if resource == "" || ns == "" {
+			continue
+		}
+		nsSet[ns] = struct{}{}
+	}
 	namespaces := make([]namespaceNode, 0, len(nsSet))
 	for ns := range nsSet {
 		namespaces = append(namespaces, namespaceNode{Name: ns})
@@ -523,14 +533,29 @@ func (h *explorerHandler) buildNamespaceAt(targetNS string, at time.Time) (*name
 	}
 
 	// Collect candidate paths for this namespace.
+	// For a named namespace we include both namespace-scoped paths
+	// (/api/v1/namespaces/<ns>/pods) AND cluster-wide list paths
+	// (/apis/apps/v1/deployments) — the latter are filtered by item
+	// metadata.namespace when the records are loaded below.
+	// For the synthetic cluster-scoped view (targetNS == "") we only
+	// include paths that have no /namespaces/ segment.
 	byRes := map[string][]string{}
 	for path := range h.store.Index {
 		_, _, resource, ns, _ := parseAPIPath(baseAPIPath(path))
 		if resource == "" {
 			continue
 		}
-		if ns != targetNS {
-			continue
+		if targetNS == "" {
+			// cluster-scoped view: only true cluster-wide paths
+			if ns != "" {
+				continue
+			}
+		} else {
+			// named namespace: accept namespace-scoped paths for this ns
+			// OR cluster-wide paths (ns=="") that may contain our items
+			if ns != "" && ns != targetNS {
+				continue
+			}
 		}
 		byRes[resource] = append(byRes[resource], path)
 	}
@@ -549,6 +574,11 @@ func (h *explorerHandler) buildNamespaceAt(targetNS string, at time.Time) (*name
 		}
 		for _, entry := range items {
 			itemNS := getMetaNamespace(entry.item)
+			// cluster-scoped view: skip any item that belongs to a namespace
+			if targetNS == "" && itemNS != "" {
+				continue
+			}
+			// named-namespace view: skip items from a different namespace
 			if targetNS != "" && itemNS != "" && itemNS != targetNS {
 				continue
 			}
@@ -1986,10 +2016,7 @@ const indexHTML = `<!doctype html>
 				const chips = document.createElement('div');
 				chips.className = 'ns-card-chips';
 				if (!loaded) {
-					const c = document.createElement('span');
-					c.className = 'ns-card-chip';
-					c.textContent = 'loading…';
-					chips.appendChild(c);
+					// show nothing until the user opens this namespace
 				} else {
 					if (workloads) { const c = document.createElement('span'); c.className = 'ns-card-chip'; c.textContent = workloads + ' workload' + (workloads !== 1 ? 's' : ''); chips.appendChild(c); }
 					if (pods)      { const c = document.createElement('span'); c.className = 'ns-card-chip'; c.textContent = pods + ' pod' + (pods !== 1 ? 's' : '');      chips.appendChild(c); }
@@ -2005,9 +2032,6 @@ const indexHTML = `<!doctype html>
 				card.onkeydown = (ev) => { if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); openNS(); } };
 				grid.appendChild(card);
 				shown++;
-
-				// trigger background fetch so chips populate as cards render
-				if (!nsCache[ns.name]) loadNsDetail(ns.name);
 			}
 
 			if (shown === 0) {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -533,31 +533,48 @@ func (h *explorerHandler) buildNamespaceAt(targetNS string, at time.Time) (*name
 	}
 
 	// Collect candidate paths for this namespace.
-	// For a named namespace we include both namespace-scoped paths
-	// (/api/v1/namespaces/<ns>/pods) AND cluster-wide list paths
-	// (/apis/apps/v1/deployments) — the latter are filtered by item
-	// metadata.namespace when the records are loaded below.
-	// For the synthetic cluster-scoped view (targetNS == "") we only
-	// include paths that have no /namespaces/ segment.
+	// For a named namespace:
+	//   - Always include namespace-scoped paths (/api/v1/namespaces/<ns>/pods).
+	//   - Include cluster-wide paths (/apis/apps/v1/deployments) ONLY for
+	//     resource types that have no namespace-scoped path for this namespace
+	//     in the index (e.g. portworx resources captured only at cluster scope).
+	//     This prevents truly cluster-scoped resources (ClusterRoles, Nodes…)
+	//     from appearing in the namespace drill-down.
+	// For the cluster-scoped view (targetNS == ""):
+	//   - Only include paths with no /namespaces/ segment.
 	byRes := map[string][]string{}
-	for path := range h.store.Index {
-		_, _, resource, ns, _ := parseAPIPath(baseAPIPath(path))
-		if resource == "" {
-			continue
-		}
-		if targetNS == "" {
-			// cluster-scoped view: only true cluster-wide paths
-			if ns != "" {
+	if targetNS == "" {
+		// cluster-scoped: only true cluster-wide paths
+		for path := range h.store.Index {
+			_, _, resource, ns, _ := parseAPIPath(baseAPIPath(path))
+			if resource == "" || ns != "" {
 				continue
 			}
-		} else {
-			// named namespace: accept namespace-scoped paths for this ns
-			// OR cluster-wide paths (ns=="") that may contain our items
-			if ns != "" && ns != targetNS {
+			byRes[resource] = append(byRes[resource], path)
+		}
+	} else {
+		// named namespace: first pass — collect namespace-scoped paths
+		nsScopedResources := map[string]bool{}
+		for path := range h.store.Index {
+			_, _, resource, ns, _ := parseAPIPath(baseAPIPath(path))
+			if resource == "" || ns != targetNS {
 				continue
 			}
+			byRes[resource] = append(byRes[resource], path)
+			nsScopedResources[resource] = true
 		}
-		byRes[resource] = append(byRes[resource], path)
+		// second pass — add cluster-wide paths only for resources not already
+		// found via namespace-scoped paths
+		for path := range h.store.Index {
+			_, _, resource, ns, _ := parseAPIPath(baseAPIPath(path))
+			if resource == "" || ns != "" {
+				continue
+			}
+			if nsScopedResources[resource] {
+				continue // already covered by ns-scoped path; skip to avoid cluster-scoped pollution
+			}
+			byRes[resource] = append(byRes[resource], path)
+		}
 	}
 
 	node := &namespaceDetailResponse{

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1225,6 +1225,21 @@ const indexHTML = `<!doctype html>
 		.diff-line-del { color:#fca5a5; }
 		.diff-line-hdr { color:#94a3b8; }
 		.history-empty { padding:16px; color:var(--muted); font-size:13px; }
+
+	/* --- namespace card grid --- */
+	.ns-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(200px,1fr)); gap:12px; padding:14px; }
+	.ns-card { background:rgba(15,23,42,.75); border:1px solid #1f2937; border-radius:10px; padding:14px 16px; cursor:pointer; transition:border-color .15s,box-shadow .15s; user-select:none; }
+	.ns-card:hover { border-color:#334155; box-shadow:0 2px 12px rgba(0,0,0,.35); }
+	.ns-card:focus-visible { outline:none; border-color:#22c55e; box-shadow:0 0 0 2px rgba(34,197,94,.2); }
+	.ns-card.cluster { border-color:rgba(59,130,246,.3); background:rgba(15,23,42,.9); }
+	.ns-card-name { font-weight:700; font-size:14px; margin-bottom:8px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+	.ns-card-chips { display:flex; flex-wrap:wrap; gap:4px; }
+	.ns-card-chip { font-size:10px; padding:2px 6px; border-radius:999px; background:#1f2937; color:var(--muted); }
+	.ns-back { display:inline-flex; align-items:center; gap:6px; padding:5px 10px; border-radius:7px; border:1px solid #334155; background:#0f172a; color:#cbd5e1; cursor:pointer; font-size:12px; margin:10px 12px 2px; }
+	.ns-back:hover { border-color:#64748b; }
+	.ns-drilldown { padding-bottom:12px; }
+	.ns-section { margin:0 12px 8px; }
+	.ns-section-header { font-size:11px; color:var(--muted); text-transform:uppercase; letter-spacing:.6px; padding:6px 0 4px; border-bottom:1px solid #1f2937; margin-bottom:4px; }
   </style>
 </head>
 <body>
@@ -1262,11 +1277,7 @@ const indexHTML = `<!doctype html>
     </aside>
     <main class="panel tree">
 			<div class="tree-head">
-				<span class="toggle-head-title">Tree</span>
-				<span class="tree-actions">
-					<button id="expandAll" type="button">Expand All</button>
-					<button id="collapseAll" type="button">Collapse All</button>
-				</span>
+				<span class="toggle-head-title" id="treeHeadLabel">Namespaces</span>
 			</div>
       <div class="crumbs" id="crumbs">Cluster</div>
       <div id="tree"></div>
@@ -1334,14 +1345,9 @@ const indexHTML = `<!doctype html>
     let activeTab = 'json';
 	let visibleNodes = [];
 	let activeNodeIdx = -1;
-	const namespacePageSize = 120;
-	let namespaceVisibleLimit = {};
-	const namespacesPageSize = 50;
-	let namespacesVisibleLimit = namespacesPageSize;
 	const storageKindsKey = 'kshrk.ui.activeKinds.v1';
-	const storageExpandedKey = 'kshrk.ui.expandedSections.v1';
-	let expandedSections = {};
 	let currentAt = '';
+	let currentNS = null; // null = card grid, ':cluster' = cluster-scoped, string = namespace name
 	let timelinePoints = [];
 	let scrubDebounce = null;
 	let lastLoadedAt = '';
@@ -1364,8 +1370,7 @@ const indexHTML = `<!doctype html>
 			downloadDetail: document.getElementById('downloadDetail'),
 			toggleAll: document.getElementById('toggleAll'),
 			toggleNone: document.getElementById('toggleNone'),
-			expandAll: document.getElementById('expandAll'),
-			collapseAll: document.getElementById('collapseAll'),
+			treeHeadLabel: document.getElementById('treeHeadLabel'),
 			snapshotPrev: document.getElementById('snapshotPrev'),
 			snapshotAt: document.getElementById('snapshotAt'),
 			snapshotNext: document.getElementById('snapshotNext'),
@@ -1389,8 +1394,6 @@ const indexHTML = `<!doctype html>
     el.search.oninput = render;
 		el.toggleAll.onclick = () => setAllKinds(true);
 		el.toggleNone.onclick = () => setAllKinds(false);
-	el.expandAll.onclick = () => setAllTreeDetails(true);
-	el.collapseAll.onclick = () => setAllTreeDetails(false);
 	el.snapshotPrev.onclick = () => stepSnapshot(1);
 	el.snapshotAt.onchange = () => {
 		currentAt = el.snapshotAt.value || '';
@@ -1686,16 +1689,6 @@ const indexHTML = `<!doctype html>
 			el.tree.appendChild(box);
 		}
 
-		function namespaceLimit(name) {
-			if (!namespaceVisibleLimit[name]) namespaceVisibleLimit[name] = namespacePageSize;
-			return namespaceVisibleLimit[name];
-		}
-
-		function showMoreNamespace(name) {
-			namespaceVisibleLimit[name] = namespaceLimit(name) + namespacePageSize;
-			render();
-		}
-
 		function showToast(type, message, timeoutMs) {
 			const toast = document.createElement('div');
 			toast.className = 'toast ' + type;
@@ -1764,40 +1757,12 @@ const indexHTML = `<!doctype html>
 					}
 				}
 			} catch (_) {}
-			try {
-				const expandedRaw = window.localStorage.getItem(storageExpandedKey);
-				if (expandedRaw) {
-					const parsed = JSON.parse(expandedRaw);
-					if (parsed && typeof parsed === 'object') expandedSections = parsed;
-				}
-			} catch (_) {}
 		}
 
 		function persistKinds() {
 			try {
 				window.localStorage.setItem(storageKindsKey, JSON.stringify(Array.from(activeKinds)));
 			} catch (_) {}
-		}
-
-		function persistExpandedSections() {
-			try {
-				window.localStorage.setItem(storageExpandedKey, JSON.stringify(expandedSections));
-			} catch (_) {}
-		}
-
-		function sectionOpen(sectionKey, fallbackOpen) {
-			if (Object.prototype.hasOwnProperty.call(expandedSections, sectionKey)) {
-				return !!expandedSections[sectionKey];
-			}
-			return fallbackOpen;
-		}
-
-		function bindSectionState(details, sectionKey) {
-			details.onToggle = null;
-			details.addEventListener('toggle', () => {
-				expandedSections[sectionKey] = details.open;
-				persistExpandedSections();
-			});
 		}
 
     function statusClass(status) {
@@ -1978,156 +1943,205 @@ const indexHTML = `<!doctype html>
 				setTreeState('loading', 'Loading captured resources...');
 				return;
 			}
-		const desiredKey = selected && selected.node ? nodeIdentity(selected.node) : '';
-      el.tree.innerHTML = '';
-      const q = el.search.value.trim().toLowerCase();
-			let renderedNodes = 0;
-			let renderedSections = 0;
-
-			const cs = document.createElement('details');
-			cs.open = sectionOpen('cluster-scoped', true);
-			const csDetail = nsCache[':cluster'] || {};
-			const csCount = (csDetail.resources || []).length;
-			const csLabel = !nsCache[':cluster'] ? '-' : (csDetail._loading ? '...' : csCount);
-			cs.innerHTML = '<summary>Cluster-scoped resources <span class="muted">(' + csLabel + ')</span></summary>';
-			bindSectionState(cs, 'cluster-scoped');
-			cs.addEventListener('toggle', () => { if (cs.open) loadNsDetail(':cluster'); });
-			if (cs.open) loadNsDetail(':cluster');
-			let clusterShown = 0;
-      for (const node of (csDetail.resources || [])) {
-				if (!kindEnabled(node.kind) || !nodeMatches(node, q, '')) continue;
-				cs.appendChild(mkNode(node, ['Cluster', node.kind, node.name], 0, ''));
-				renderedNodes++;
-				clusterShown++;
-      }
-			if (!q || clusterShown > 0) {
-				el.tree.appendChild(cs);
-				renderedSections++;
+			el.tree.innerHTML = '';
+			if (currentNS === null) {
+				renderCardGrid();
+			} else {
+				renderNsDrilldown();
 			}
+		}
 
-      const visibleNamespaces = q ? treeData.namespaces : treeData.namespaces.slice(0, namespacesVisibleLimit);
-			for (const ns of visibleNamespaces) {
-				const nsMatches = !!q && ns.name.toLowerCase().includes(q);
-        const ds = document.createElement('details');
-				ds.open = sectionOpen('ns:' + ns.name, treeData.namespaces.length <= 20);
-				const nsDetail = nsCache[ns.name] || {};
-				const nsCount = (nsDetail.workloads || []).length + (nsDetail.pods || []).length + (nsDetail.resources || []).length;
-				const nsLabel = !nsCache[ns.name] ? '-' : (nsDetail._loading ? '...' : nsCount);
-				ds.innerHTML = '<summary>Namespace: <strong>' + ns.name + '</strong> <span class="muted">(' + nsLabel + ')</span></summary>';
-				bindSectionState(ds, 'ns:' + ns.name);
-				ds.addEventListener('toggle', () => { if (ds.open) loadNsDetail(ns.name); });
-				if (ds.open) loadNsDetail(ns.name);
+		// ── card grid ────────────────────────────────────────────────────────────
+		function renderCardGrid() {
+			el.treeHeadLabel.textContent = 'Namespaces';
+			el.crumbs.textContent = 'Cluster';
+			const q = el.search.value.trim().toLowerCase();
 
-				const nsNodes = [];
+			const grid = document.createElement('div');
+			grid.className = 'ns-grid';
 
-			for (const w of (nsDetail.workloads || [])) {
-				const workloadVisible = kindEnabled(w.kind) && (nsMatches || nodeMatches(w, q, ns.name));
-				if (workloadVisible) {
-					nsNodes.push(mkNode(w, ['Cluster', ns.name, w.kind, w.name], 0, ''));
-				}
-				for (const p of (w.pods || [])) {
-					const podVisible = kindEnabled(p.kind) && (nsMatches || nodeMatches(p, q, ns.name));
-					if (podVisible) {
-						const podCrumbs = workloadVisible
-							? ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name]
-							: ['Cluster', ns.name, 'Pod', p.name];
-						nsNodes.push(mkNode(p, podCrumbs, workloadVisible ? 1 : 0, ''));
-					}
-					for (const c of (p.containers || [])) {
-						const fake = {kind:'Container',name:c.name,status:'',age:'',labels:{},list_path:p.list_path};
-						if (!kindEnabled('Container') || !(nsMatches || nodeMatches(fake, q, ns.name))) continue;
-						const containerDepth = workloadVisible ? 2 : (podVisible ? 1 : 0);
-						const containerCrumbs = workloadVisible
-							? ['Cluster', ns.name, w.kind, w.name, 'Pod', p.name, 'Container', c.name]
-							: ['Cluster', ns.name, 'Pod', p.name, 'Container', c.name];
-						nsNodes.push(mkNode(fake, containerCrumbs, containerDepth, ''));
+			// cluster-scoped card
+			const allNS = [{ name: ':cluster', _cluster: true }].concat(treeData.namespaces || []);
+			let shown = 0;
+			for (const ns of allNS) {
+				const label = ns._cluster ? 'Cluster-scoped' : ns.name;
+				if (q && !label.toLowerCase().includes(q)) continue;
+				const detail = nsCache[ns.name] || {};
+				const workloads = (detail.workloads || []).length;
+				const pods = (detail.pods || []).length;
+				const resources = (detail.resources || []).length;
+				const loaded = nsCache[ns.name] && !detail._loading;
+
+				const card = document.createElement('div');
+				card.className = 'ns-card' + (ns._cluster ? ' cluster' : '');
+				card.tabIndex = 0;
+				card.setAttribute('role', 'button');
+				card.title = 'Open ' + label;
+
+				const nameEl = document.createElement('div');
+				nameEl.className = 'ns-card-name';
+				nameEl.textContent = label;
+				card.appendChild(nameEl);
+
+				const chips = document.createElement('div');
+				chips.className = 'ns-card-chips';
+				if (!loaded) {
+					const c = document.createElement('span');
+					c.className = 'ns-card-chip';
+					c.textContent = 'loading…';
+					chips.appendChild(c);
+				} else {
+					if (workloads) { const c = document.createElement('span'); c.className = 'ns-card-chip'; c.textContent = workloads + ' workload' + (workloads !== 1 ? 's' : ''); chips.appendChild(c); }
+					if (pods)      { const c = document.createElement('span'); c.className = 'ns-card-chip'; c.textContent = pods + ' pod' + (pods !== 1 ? 's' : '');      chips.appendChild(c); }
+					if (resources) { const c = document.createElement('span'); c.className = 'ns-card-chip'; c.textContent = resources + ' resource' + (resources !== 1 ? 's' : ''); chips.appendChild(c); }
+					if (!workloads && !pods && !resources) {
+						const c = document.createElement('span'); c.className = 'ns-card-chip'; c.textContent = 'empty'; chips.appendChild(c);
 					}
 				}
+				card.appendChild(chips);
+
+				const openNS = () => navigateToNS(ns.name);
+				card.onclick = openNS;
+				card.onkeydown = (ev) => { if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); openNS(); } };
+				grid.appendChild(card);
+				shown++;
+
+				// trigger background fetch so chips populate as cards render
+				if (!nsCache[ns.name]) loadNsDetail(ns.name);
 			}
 
-			for (const p of (nsDetail.pods || [])) {
-				if (!kindEnabled(p.kind) || !(nsMatches || nodeMatches(p, q, ns.name))) continue;
-					nsNodes.push(mkNode(p, ['Cluster', ns.name, 'Pod', p.name], 0, ''));
-          for (const c of (p.containers || [])) {
-            const fake = {kind:'Container',name:c.name,status:'',age:'',labels:{},list_path:p.list_path};
-					if (!kindEnabled('Container') || !(nsMatches || nodeMatches(fake, q, ns.name))) continue;
-						nsNodes.push(mkNode(fake, ['Cluster', ns.name, 'Pod', p.name, 'Container', c.name], 1, ''));
-          }
-        }
-
-			for (const r of (nsDetail.resources || [])) {
-				if (!kindEnabled(r.kind) || !(nsMatches || nodeMatches(r, q, ns.name))) continue;
-					nsNodes.push(mkNode(r, ['Cluster', ns.name, r.kind, r.name], 0, ''));
-        }
-
-				if (q && nsNodes.length === 0 && !nsMatches) {
-					continue;
-				}
-
-				const limit = q ? nsNodes.length : namespaceLimit(ns.name);
-				const shown = nsNodes.slice(0, limit);
-				for (const nodeEl of shown) {
-					ds.appendChild(nodeEl);
-					renderedNodes++;
-				}
-				if (!q && nsNodes.length > shown.length) {
-					const pager = document.createElement('div');
-					pager.className = 'ns-pager';
-					const hidden = nsNodes.length - shown.length;
-					const meta = document.createElement('span');
-					meta.className = 'muted';
-					meta.textContent = hidden + ' more hidden';
-					const btn = document.createElement('button');
-					btn.type = 'button';
-					btn.textContent = 'Show more';
-					btn.onclick = () => showMoreNamespace(ns.name);
-					pager.appendChild(meta);
-					pager.appendChild(btn);
-					ds.appendChild(pager);
-				}
-        el.tree.appendChild(ds);
-				renderedSections++;
-      }
-
-			if (!q && treeData.namespaces.length > namespacesVisibleLimit) {
-				const nsPager = document.createElement('div');
-				nsPager.className = 'ns-pager';
-				const nsMeta = document.createElement('span');
-				nsMeta.className = 'muted';
-				nsMeta.textContent = (treeData.namespaces.length - namespacesVisibleLimit) + ' more namespaces hidden';
-				const nsBtn = document.createElement('button');
-				nsBtn.type = 'button';
-				nsBtn.textContent = 'Show more namespaces';
-				nsBtn.onclick = () => { namespacesVisibleLimit += namespacesPageSize; render(); };
-				nsPager.appendChild(nsMeta);
-				nsPager.appendChild(nsBtn);
-				el.tree.appendChild(nsPager);
-				renderedSections++;
+			if (shown === 0) {
+				setTreeState('empty', q ? 'No namespaces match "' + q + '".' : 'No namespaces found in this capture.');
+				visibleNodes = [];
+				activeNodeIdx = -1;
+				return;
 			}
+			el.tree.appendChild(grid);
+			visibleNodes = [];
+			activeNodeIdx = -1;
+		}
 
-			if (renderedNodes === 0 && renderedSections === 0) {
-				const msg = q
-					? 'No resources match the current search/filter selection.'
-					: 'No resources were found in this capture at the selected time.';
-				setTreeState('empty', msg);
+		function navigateToNS(nsName) {
+			currentNS = nsName;
+			render();
+		}
+
+		function navigateBack() {
+			currentNS = null;
+			render();
+		}
+
+		// ── ns drill-down ─────────────────────────────────────────────────────────
+		function renderNsDrilldown() {
+			const nsLabel = currentNS === ':cluster' ? 'Cluster-scoped' : currentNS;
+			el.treeHeadLabel.textContent = nsLabel;
+			el.crumbs.textContent = 'Cluster / ' + nsLabel;
+
+			// back button
+			const back = document.createElement('button');
+			back.className = 'ns-back';
+			back.type = 'button';
+			back.innerHTML = '&#8592; All namespaces';
+			back.onclick = navigateBack;
+			el.tree.appendChild(back);
+
+			const detail = nsCache[currentNS];
+			if (!detail || detail._loading) {
+				loadNsDetail(currentNS);
+				setTreeState('loading', 'Loading ' + nsLabel + '…');
+				el.tree.appendChild(document.querySelector('.tree-state') || document.createElement('div'));
 				visibleNodes = [];
 				activeNodeIdx = -1;
 				return;
 			}
 
-			visibleNodes = Array.from(el.tree.querySelectorAll('.node'));
-			if (visibleNodes.length === 0) {
+			const q = el.search.value.trim().toLowerCase();
+			const desiredKey = selected && selected.node ? nodeIdentity(selected.node) : '';
+			const drilldown = document.createElement('div');
+			drilldown.className = 'ns-drilldown';
+
+			const workloads = detail.workloads || [];
+			const pods = detail.pods || [];
+			const resources = detail.resources || [];
+			let renderedNodes = 0;
+
+			// helper: build a section for a group of nodes
+			function appendSection(title, items) {
+				if (items.length === 0) return;
+				const sec = document.createElement('div');
+				sec.className = 'ns-section';
+				const hdr = document.createElement('div');
+				hdr.className = 'ns-section-header';
+				hdr.textContent = title + ' (' + items.length + ')';
+				sec.appendChild(hdr);
+				for (const el of items) {
+					sec.appendChild(el);
+					renderedNodes++;
+				}
+				drilldown.appendChild(sec);
+			}
+
+			// workloads (with nested pods)
+			const workloadNodes = [];
+			for (const w of workloads) {
+				const visible = kindEnabled(w.kind) && nodeMatches(w, q, currentNS === ':cluster' ? '' : currentNS);
+				if (visible) workloadNodes.push(mkNode(w, ['Cluster', nsLabel, w.kind, w.name], 0, ''));
+				for (const p of (w.pods || [])) {
+					if (!kindEnabled(p.kind) || !nodeMatches(p, q, currentNS === ':cluster' ? '' : currentNS)) continue;
+					const podCrumbs = visible
+						? ['Cluster', nsLabel, w.kind, w.name, 'Pod', p.name]
+						: ['Cluster', nsLabel, 'Pod', p.name];
+					workloadNodes.push(mkNode(p, podCrumbs, visible ? 1 : 0, ''));
+					for (const c of (p.containers || [])) {
+						const fake = { kind:'Container', name:c.name, status:'', age:'', labels:{}, list_path:p.list_path };
+						if (!kindEnabled('Container') || !nodeMatches(fake, q, currentNS === ':cluster' ? '' : currentNS)) continue;
+						const depth = visible ? 2 : 1;
+						const cc = visible ? ['Cluster', nsLabel, w.kind, w.name, 'Pod', p.name, 'Container', c.name] : ['Cluster', nsLabel, 'Pod', p.name, 'Container', c.name];
+						workloadNodes.push(mkNode(fake, cc, depth, ''));
+					}
+				}
+			}
+			appendSection('Workloads', workloadNodes);
+
+			// standalone pods
+			const podNodes = [];
+			for (const p of pods) {
+				if (!kindEnabled(p.kind) || !nodeMatches(p, q, currentNS === ':cluster' ? '' : currentNS)) continue;
+				podNodes.push(mkNode(p, ['Cluster', nsLabel, 'Pod', p.name], 0, ''));
+				for (const c of (p.containers || [])) {
+					const fake = { kind:'Container', name:c.name, status:'', age:'', labels:{}, list_path:p.list_path };
+					if (!kindEnabled('Container') || !nodeMatches(fake, q, currentNS === ':cluster' ? '' : currentNS)) continue;
+					podNodes.push(mkNode(fake, ['Cluster', nsLabel, 'Pod', p.name, 'Container', c.name], 1, ''));
+				}
+			}
+			appendSection('Pods', podNodes);
+
+			// remaining resources grouped by kind
+			const byKind = {};
+			for (const r of resources) {
+				if (!kindEnabled(r.kind) || !nodeMatches(r, q, currentNS === ':cluster' ? '' : currentNS)) continue;
+				(byKind[r.kind] = byKind[r.kind] || []).push(mkNode(r, ['Cluster', nsLabel, r.kind, r.name], 0, ''));
+			}
+			for (const kind of Object.keys(byKind).sort()) {
+				appendSection(kind, byKind[kind]);
+			}
+
+			if (renderedNodes === 0) {
+				const msg = q ? 'No resources match "' + q + '" in ' + nsLabel + '.' : nsLabel + ' has no resources at this snapshot.';
+				setTreeState('empty', msg);
+				el.tree.appendChild(drilldown);
+				visibleNodes = [];
 				activeNodeIdx = -1;
 				return;
 			}
-			if (activeNodeIdx < 0 || activeNodeIdx >= visibleNodes.length) {
-				activeNodeIdx = 0;
-			}
-			if (restoreSelectionByKey(desiredKey)) {
-				return;
-			}
+
+			el.tree.appendChild(drilldown);
+			visibleNodes = Array.from(el.tree.querySelectorAll('.node'));
+			if (visibleNodes.length === 0) { activeNodeIdx = -1; return; }
+			if (activeNodeIdx < 0 || activeNodeIdx >= visibleNodes.length) activeNodeIdx = 0;
+			if (restoreSelectionByKey(desiredKey)) return;
 			selectNodeAt(activeNodeIdx, false);
-    }
+		}
 
     function renderToggles(kinds) {
 			if (!activeKindsInitialized) {
@@ -2172,20 +2186,6 @@ const indexHTML = `<!doctype html>
 			}
 			persistKinds();
 			render();
-		}
-
-		function setAllTreeDetails(open) {
-			for (const details of el.tree.querySelectorAll('details')) {
-				details.open = open;
-				const summary = details.querySelector('summary');
-				if (summary && summary.textContent.startsWith('Namespace:')) {
-					const strong = summary.querySelector('strong');
-					if (strong) expandedSections['ns:' + strong.textContent] = open;
-				} else {
-					expandedSections['cluster-scoped'] = open;
-				}
-			}
-			persistExpandedSections();
 		}
 
 		async function loadTimestamps() {
@@ -2402,7 +2402,7 @@ const indexHTML = `<!doctype html>
 				treeData = data;
 				nsCache = {};
 				nsFetchQueue.length = 0;
-				namespacesVisibleLimit = namespacesPageSize;
+				currentNS = null;
 				lastLoadedAt = normalizedAt();
 				updateMetaLine();
 				renderToggles((treeData.resource_kinds || []).concat(['Container']));

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -839,7 +839,10 @@ func computeClusterSpanningResources(store *server.CaptureStore) map[string]bool
 		resNS[resource][ns] = struct{}{}
 		totalNS[ns] = struct{}{}
 	}
-	threshold := len(totalNS) / 2
+	// Use 30% of namespaces as the spanning threshold. 50% was too high: OLM's
+	// packagemanifests appear in ~45% of namespaces in typical OpenShift captures
+	// (because OLM queries it for every namespace it manages) but not quite 50%.
+	threshold := len(totalNS) * 30 / 100
 	if threshold < 3 {
 		threshold = 3
 	}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -39,6 +39,12 @@ type explorerHandler struct {
 	at          time.Time
 	verbose     bool
 	archivePath string
+	// clusterSpanning is the set of resource names (plural, lowercase) that
+	// appear as namespace-scoped index paths in the majority of namespaces.
+	// These are OLM-style resources (e.g. packagemanifests) that technically
+	// have a namespace scope but return the full cluster list for any namespace.
+	// They are excluded from individual namespace drill-downs.
+	clusterSpanning map[string]bool
 }
 
 type treeResponse struct {
@@ -138,6 +144,7 @@ func Open(opts OpenOptions) (*Server, error) {
 	}
 
 	h := &explorerHandler{store: store, at: at, verbose: opts.Verbose, archivePath: opts.ArchivePath}
+	h.clusterSpanning = computeClusterSpanningResources(store)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", h.serveIndex)
 	mux.HandleFunc("/api/ui/tree", h.serveTree)
@@ -560,6 +567,11 @@ func (h *explorerHandler) buildNamespaceAt(targetNS string, at time.Time) (*name
 			if resource == "" || ns != targetNS {
 				continue
 			}
+			// Skip OLM-style resources that appear across the majority of
+			// namespaces — they belong only in the cluster-scoped card.
+			if h.clusterSpanning[resource] {
+				continue
+			}
 			byRes[resource] = append(byRes[resource], path)
 			nsScopedResources[resource] = true
 		}
@@ -804,6 +816,40 @@ func getOwner(item map[string]any) (string, string) {
 		}
 	}
 	return "", ""
+}
+
+// computeClusterSpanningResources scans the index and returns the set of
+// resource names (plural, lowercase) that appear as namespace-scoped paths in
+// at least half of all discovered namespaces. These are resources like
+// PackageManifests (OLM) that technically have a namespace scope but return
+// the full cluster-wide list for any namespace. We exclude them from
+// individual namespace drill-downs to avoid every namespace showing the same
+// huge list.
+func computeClusterSpanningResources(store *server.CaptureStore) map[string]bool {
+	resNS := map[string]map[string]struct{}{} // resource → distinct namespaces
+	totalNS := map[string]struct{}{}
+	for path := range store.Index {
+		_, _, resource, ns, _ := parseAPIPath(baseAPIPath(path))
+		if resource == "" || ns == "" {
+			continue
+		}
+		if resNS[resource] == nil {
+			resNS[resource] = map[string]struct{}{}
+		}
+		resNS[resource][ns] = struct{}{}
+		totalNS[ns] = struct{}{}
+	}
+	threshold := len(totalNS) / 2
+	if threshold < 3 {
+		threshold = 3
+	}
+	out := map[string]bool{}
+	for res, nsSet := range resNS {
+		if len(nsSet) >= threshold {
+			out[res] = true
+		}
+	}
+	return out
 }
 
 func kindFromResource(resource string) string {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1295,12 +1295,30 @@ const indexHTML = `<!doctype html>
   <script>
     let treeData = null;
     let nsCache = {};
-    async function loadNsDetail(nsName) {
+    const nsFetchConcurrency = 3;
+    let nsFetchActive = 0;
+    const nsFetchQueue = [];
+    function loadNsDetail(nsName) {
       if (nsCache[nsName] && !nsCache[nsName]._loading) return;
+      if (nsCache[nsName] && nsCache[nsName]._loading) return; // already queued/in-flight
       nsCache[nsName] = { _loading: true };
+      nsFetchQueue.push(nsName);
+      nsDrainQueue();
+    }
+    function nsDrainQueue() {
+      while (nsFetchActive < nsFetchConcurrency && nsFetchQueue.length > 0) {
+        const nsName = nsFetchQueue.shift();
+        nsFetchActive++;
+        nsFetchOne(nsName).finally(() => {
+          nsFetchActive--;
+          nsDrainQueue();
+        });
+      }
+    }
+    async function nsFetchOne(nsName) {
       try {
         const q = withAtQuery(new URLSearchParams());
-        q.set('ns', nsName === '' ? ':cluster' : nsName);
+        q.set('ns', nsName === ':cluster' ? ':cluster' : nsName);
         const res = await fetch('/api/ui/tree/namespace?' + q.toString());
         const data = await res.json();
         nsCache[nsName] = data;
@@ -2383,6 +2401,7 @@ const indexHTML = `<!doctype html>
 				}
 				treeData = data;
 				nsCache = {};
+				nsFetchQueue.length = 0;
 				namespacesVisibleLimit = namespacesPageSize;
 				lastLoadedAt = normalizedAt();
 				updateMetaLine();

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -24,7 +24,10 @@ func TestBuildTree_Hierarchy(t *testing.T) {
 	if len(tree.Namespaces) != 1 || tree.Namespaces[0].Name != "default" {
 		t.Fatalf("expected one default namespace, got %+v", tree.Namespaces)
 	}
-	ns := tree.Namespaces[0]
+	ns, err := h.buildNamespaceAt("default", time.Time{})
+	if err != nil {
+		t.Fatalf("buildNamespaceAt: %v", err)
+	}
 	if len(ns.Workloads) == 0 {
 		t.Fatal("expected workloads in namespace")
 	}
@@ -78,14 +81,18 @@ func TestServeDetail_ItemFromWatchOnlyAddedResource(t *testing.T) {
 func TestBuildTree_IncludesWatchOnlyAddedResource(t *testing.T) {
 	store := buildWatchOnlyStore(t)
 	h := &explorerHandler{store: store}
-	tree, err := h.buildTreeAt(time.Date(2026, 4, 10, 10, 0, 31, 0, time.UTC))
+	at := time.Date(2026, 4, 10, 10, 0, 31, 0, time.UTC)
+	tree, err := h.buildTreeAt(at)
 	if err != nil {
 		t.Fatalf("buildTreeAt: %v", err)
 	}
 	if len(tree.Namespaces) != 1 || tree.Namespaces[0].Name != "default" {
 		t.Fatalf("expected one default namespace, got %+v", tree.Namespaces)
 	}
-	ns := tree.Namespaces[0]
+	ns, err := h.buildNamespaceAt("default", at)
+	if err != nil {
+		t.Fatalf("buildNamespaceAt: %v", err)
+	}
 	if len(ns.Pods) != 1 || ns.Pods[0].Name != "redis" {
 		t.Fatalf("expected watch-only pod to appear, got %+v", ns.Pods)
 	}
@@ -101,7 +108,10 @@ func TestBuildTree_IncludesQueryOnlyListPath(t *testing.T) {
 	if len(tree.Namespaces) != 1 || tree.Namespaces[0].Name != "default" {
 		t.Fatalf("expected one default namespace, got %+v", tree.Namespaces)
 	}
-	ns := tree.Namespaces[0]
+	ns, err := h.buildNamespaceAt("default", time.Time{})
+	if err != nil {
+		t.Fatalf("buildNamespaceAt: %v", err)
+	}
 	found := false
 	for _, r := range ns.Resources {
 		if r.Kind == "ConfigMap" && r.Name == "demo-config" {
@@ -124,7 +134,10 @@ func TestBuildTree_PrefersNonEmptyQueryListOverEmptyBaseList(t *testing.T) {
 	if len(tree.Namespaces) != 1 || tree.Namespaces[0].Name != "default" {
 		t.Fatalf("expected one default namespace, got %+v", tree.Namespaces)
 	}
-	ns := tree.Namespaces[0]
+	ns, err := h.buildNamespaceAt("default", time.Time{})
+	if err != nil {
+		t.Fatalf("buildNamespaceAt: %v", err)
+	}
 	if len(ns.Pods) != 1 || ns.Pods[0].Name != "demo-pod" {
 		t.Fatalf("expected pod from non-empty query list, got %+v", ns.Pods)
 	}
@@ -143,7 +156,10 @@ func TestBuildTree_MergesItemsAcrossCapturedQueryLists(t *testing.T) {
 	if len(tree.Namespaces) != 1 || tree.Namespaces[0].Name != "default" {
 		t.Fatalf("expected one default namespace, got %+v", tree.Namespaces)
 	}
-	ns := tree.Namespaces[0]
+	ns, err := h.buildNamespaceAt("default", time.Time{})
+	if err != nil {
+		t.Fatalf("buildNamespaceAt: %v", err)
+	}
 	if len(ns.Pods) != 2 {
 		t.Fatalf("expected two merged pods, got %+v", ns.Pods)
 	}
@@ -163,7 +179,10 @@ func TestBuildTree_IncludesItemOnlyPaths(t *testing.T) {
 	if len(tree.Namespaces) != 1 || tree.Namespaces[0].Name != "default" {
 		t.Fatalf("expected one default namespace, got %+v", tree.Namespaces)
 	}
-	ns := tree.Namespaces[0]
+	ns, err := h.buildNamespaceAt("default", time.Time{})
+	if err != nil {
+		t.Fatalf("buildNamespaceAt: %v", err)
+	}
 	if len(ns.Resources) != 1 || ns.Resources[0].Name != "demo-config" {
 		t.Fatalf("expected item-only ConfigMap to appear, got %+v", ns.Resources)
 	}
@@ -182,7 +201,10 @@ func TestBuildTree_IncludesTableRows(t *testing.T) {
 	if len(tree.Namespaces) != 1 || tree.Namespaces[0].Name != "default" {
 		t.Fatalf("expected one default namespace, got %+v", tree.Namespaces)
 	}
-	ns := tree.Namespaces[0]
+	ns, err := h.buildNamespaceAt("default", time.Time{})
+	if err != nil {
+		t.Fatalf("buildNamespaceAt: %v", err)
+	}
 	if len(ns.Resources) != 1 || ns.Resources[0].Name != "table-config" {
 		t.Fatalf("expected table row object to appear, got %+v", ns.Resources)
 	}
@@ -259,13 +281,14 @@ func TestCollectTimestamps_Sampled(t *testing.T) {
 }
 
 func TestServeTree_AtOverride(t *testing.T) {
-	store := buildMultiSnapshotStore(t)
-	h := &explorerHandler{store: store}
+	store, out := buildMultiSnapshotArchive(t)
+	h := &explorerHandler{store: store, archivePath: out}
 	target := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	// Verify the skeleton tree still works.
 	req := httptest.NewRequest(http.MethodGet, "/api/ui/tree?at="+target, nil)
 	rr := httptest.NewRecorder()
 	h.serveTree(rr, req)
-
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
@@ -273,20 +296,37 @@ func TestServeTree_AtOverride(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &tree); err != nil {
 		t.Fatalf("unmarshal tree: %v", err)
 	}
-	if len(tree.Namespaces) != 1 || len(tree.Namespaces[0].Pods) != 1 {
-		t.Fatalf("expected one namespace with one pod, got %+v", tree.Namespaces)
+	if len(tree.Namespaces) != 1 || tree.Namespaces[0].Name != "default" {
+		t.Fatalf("expected one default namespace, got %+v", tree.Namespaces)
 	}
-	if tree.Namespaces[0].Pods[0].Name != "demo-old" {
-		t.Fatalf("expected older pod at selected timestamp, got %q", tree.Namespaces[0].Pods[0].Name)
+
+	// Verify the namespace detail endpoint respects the at= override.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/ui/tree/namespace?ns=default&at="+target, nil)
+	rr2 := httptest.NewRecorder()
+	h.serveTreeNamespace(rr2, req2)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr2.Code)
+	}
+	var ns namespaceDetailResponse
+	if err := json.Unmarshal(rr2.Body.Bytes(), &ns); err != nil {
+		t.Fatalf("unmarshal namespace detail: %v", err)
+	}
+	if len(ns.Pods) != 1 {
+		t.Fatalf("expected one pod, got %+v", ns.Pods)
+	}
+	if ns.Pods[0].Name != "demo-old" {
+		t.Fatalf("expected older pod at selected timestamp, got %q", ns.Pods[0].Name)
 	}
 }
 
 func TestServeTree_AtInvalid(t *testing.T) {
 	store := buildTestStore(t)
 	h := &explorerHandler{store: store}
-	req := httptest.NewRequest(http.MethodGet, "/api/ui/tree?at=not-a-time", nil)
+	// serveTree is now index-only and ignores the at= param; invalid value on
+	// serveTreeNamespace (where at is actually used) should return 400.
+	req := httptest.NewRequest(http.MethodGet, "/api/ui/tree/namespace?ns=default&at=not-a-time", nil)
 	rr := httptest.NewRecorder()
-	h.serveTree(rr, req)
+	h.serveTreeNamespace(rr, req)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rr.Code)
 	}
@@ -473,6 +513,11 @@ func buildTableOnlyStore(t *testing.T) *server.CaptureStore {
 }
 
 func buildMultiSnapshotStore(t *testing.T) *server.CaptureStore {
+	store, _ := buildMultiSnapshotArchive(t)
+	return store
+}
+
+func buildMultiSnapshotArchive(t *testing.T) (*server.CaptureStore, string) {
 	t.Helper()
 	dir := t.TempDir()
 	out := filepath.Join(dir, "capture-multi-snapshot.khsrk")
@@ -494,7 +539,7 @@ func buildMultiSnapshotStore(t *testing.T) *server.CaptureStore {
 		},
 	}
 	meta := &capture.CaptureMetadata{CaptureID: "ui-multi-snapshot-test", CapturedAt: t1, CapturedUntil: t2, RecordCount: len(recs)}
-	return buildStoreFromArchive(t, out, recs, idx, nil, meta)
+	return buildStoreFromArchive(t, out, recs, idx, nil, meta), out
 }
 
 func buildWatchOnlyStore(t *testing.T) *server.CaptureStore {

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
 	"github.com/phenixblue/k8shark/internal/server"
-	"github.com/phenixblue/k8shark/internal/transitions"
 )
 
 func TestBuildTree_Hierarchy(t *testing.T) {
@@ -544,18 +543,62 @@ func contains(values []string, want string) bool {
 	return false
 }
 
-func TestServeTransitions(t *testing.T) {
-	store := buildTestStore(t)
-	h := &explorerHandler{
-		store: store,
-		allTransitions: []transitions.Transition{
-			{Time: time.Date(2026, 4, 10, 10, 0, 5, 0, time.UTC), EventType: "ADDED", Resource: "pods", Namespace: "default", Name: "nginx"},
-			{Time: time.Date(2026, 4, 10, 10, 0, 10, 0, time.UTC), EventType: "MODIFIED", Resource: "pods", Namespace: "default", Name: "nginx"},
-			{Time: time.Date(2026, 4, 10, 10, 0, 15, 0, time.UTC), EventType: "ADDED", Resource: "deployments", Namespace: "kube-system", Name: "coredns"},
+// buildTransitionsArchive creates a minimal archive with watch events for
+// transition-related handler tests. It returns the store and the archive path.
+// Archive layout:
+//
+//	/api/v1/namespaces/default/pods      — watch: nginx ADDED(seq0), nginx MODIFIED(seq1), redis ADDED(seq2)
+//	/apis/apps/v1/namespaces/kube-system/deployments — watch: coredns ADDED(seq0)
+func buildTransitionsArchive(t *testing.T) (store *server.CaptureStore, archivePath string) {
+	t.Helper()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "capture-transitions.khsrk")
+
+	t1 := time.Date(2026, 4, 10, 10, 0, 5, 0, time.UTC)
+	t2 := time.Date(2026, 4, 10, 10, 0, 10, 0, time.UTC)
+	t3 := time.Date(2026, 4, 10, 10, 0, 15, 0, time.UTC)
+
+	nginxV1 := json.RawMessage(`{"metadata":{"name":"nginx","namespace":"default","uid":"nginx-1"}}`)
+	nginxV2 := json.RawMessage(`{"metadata":{"name":"nginx","namespace":"default","uid":"nginx-1"},"status":{"phase":"Running"}}`)
+	redisBody := json.RawMessage(`{"metadata":{"name":"redis","namespace":"default","uid":"redis-1"}}`)
+	corednsBody := json.RawMessage(`{"metadata":{"name":"coredns","namespace":"kube-system","uid":"coredns-1"}}`)
+
+	recs := []*capture.Record{
+		// /api/v1/namespaces/default/pods — seq 0, 1, 2
+		{ID: "w1", CapturedAt: t1, APIPath: "/api/v1/namespaces/default/pods", EventType: "ADDED", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: nginxV1},
+		{ID: "w2", CapturedAt: t2, APIPath: "/api/v1/namespaces/default/pods", EventType: "MODIFIED", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: nginxV2},
+		{ID: "w3", CapturedAt: t3, APIPath: "/api/v1/namespaces/default/pods", EventType: "ADDED", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: redisBody},
+		// /apis/apps/v1/namespaces/kube-system/deployments — seq 0
+		{ID: "w4", CapturedAt: t3, APIPath: "/apis/apps/v1/namespaces/kube-system/deployments", EventType: "ADDED", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: corednsBody},
+	}
+	idx := capture.Index{
+		"/api/v1/namespaces/default/pods":                  {APIPath: "/api/v1/namespaces/default/pods", Seqs: []int{}, Times: []time.Time{}},
+		"/apis/apps/v1/namespaces/kube-system/deployments": {APIPath: "/apis/apps/v1/namespaces/kube-system/deployments", Seqs: []int{}, Times: []time.Time{}},
+	}
+	wi := capture.WatchIndex{
+		"/api/v1/namespaces/default/pods": {
+			APIPath:    "/api/v1/namespaces/default/pods",
+			Seqs:       []int{0, 1, 2},
+			Times:      []time.Time{t1, t2, t3},
+			EventTypes: []string{"ADDED", "MODIFIED", "ADDED"},
+		},
+		"/apis/apps/v1/namespaces/kube-system/deployments": {
+			APIPath:    "/apis/apps/v1/namespaces/kube-system/deployments",
+			Seqs:       []int{0},
+			Times:      []time.Time{t3},
+			EventTypes: []string{"ADDED"},
 		},
 	}
+	meta := &capture.CaptureMetadata{CaptureID: "transitions-test", CapturedAt: t1, CapturedUntil: t3}
+	store = buildStoreFromArchive(t, out, recs, idx, wi, meta)
+	return store, out
+}
 
-	// Unfiltered — returns all 3.
+func TestServeTransitions(t *testing.T) {
+	store, archivePath := buildTransitionsArchive(t)
+	h := &explorerHandler{store: store, archivePath: archivePath}
+
+	// Unfiltered — returns all 4 events (nginx ADDED, nginx MODIFIED, redis ADDED, coredns ADDED).
 	req := httptest.NewRequest(http.MethodGet, "/api/ui/transitions", nil)
 	rr := httptest.NewRecorder()
 	h.serveTransitions(rr, req)
@@ -566,21 +609,21 @@ func TestServeTransitions(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &markers); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(markers) != 3 {
-		t.Fatalf("expected 3 markers, got %d", len(markers))
+	if len(markers) != 4 {
+		t.Fatalf("expected 4 markers, got %d", len(markers))
 	}
 
-	// Filter by resource.
+	// Filter by resource=pods — should return 3 (nginx x2, redis x1).
 	req2 := httptest.NewRequest(http.MethodGet, "/api/ui/transitions?resource=pods", nil)
 	rr2 := httptest.NewRecorder()
 	h.serveTransitions(rr2, req2)
 	var filtered []map[string]any
 	_ = json.Unmarshal(rr2.Body.Bytes(), &filtered)
-	if len(filtered) != 2 {
-		t.Fatalf("expected 2 pod markers, got %d", len(filtered))
+	if len(filtered) != 3 {
+		t.Fatalf("expected 3 pod markers, got %d", len(filtered))
 	}
 
-	// Filter by namespace.
+	// Filter by namespace=kube-system — should return 1 (coredns).
 	req3 := httptest.NewRequest(http.MethodGet, "/api/ui/transitions?namespace=kube-system", nil)
 	rr3 := httptest.NewRecorder()
 	h.serveTransitions(rr3, req3)
@@ -592,15 +635,8 @@ func TestServeTransitions(t *testing.T) {
 }
 
 func TestServeObjectHistory(t *testing.T) {
-	store := buildTestStore(t)
-	h := &explorerHandler{
-		store: store,
-		allTransitions: []transitions.Transition{
-			{Time: time.Date(2026, 4, 10, 10, 0, 5, 0, time.UTC), EventType: "ADDED", Resource: "pods", Namespace: "default", Name: "nginx", After: json.RawMessage(`{"metadata":{"name":"nginx"}}`)},
-			{Time: time.Date(2026, 4, 10, 10, 0, 10, 0, time.UTC), EventType: "MODIFIED", Resource: "pods", Namespace: "default", Name: "nginx", Before: json.RawMessage(`{"metadata":{"name":"nginx"}}`), After: json.RawMessage(`{"metadata":{"name":"nginx"},"status":{"phase":"Running"}}`)},
-			{Time: time.Date(2026, 4, 10, 10, 0, 15, 0, time.UTC), EventType: "ADDED", Resource: "pods", Namespace: "default", Name: "redis"},
-		},
-	}
+	store, archivePath := buildTransitionsArchive(t)
+	h := &explorerHandler{store: store, archivePath: archivePath}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/ui/object-history?name=nginx", nil)
 	rr := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

A collection of fixes addressing memory regressions, incorrect data display, and a capture-time bug discovered while testing against a large OpenShift cluster (517 namespaces, OLM installed).

---

## Changes

### Web UI — namespace card grid + drill-down
- Replaced expandable tree with a namespace card grid; click a card to drill into a namespace
- Resources grouped by kind with workloads, pods, and other resources separated
- Lazy-load namespace detail via `/api/ui/tree/namespace` on demand (eliminates startup memory spike)
- Namespace list now also populated from the captured `/api/v1/namespaces` record, surfacing all 517 namespaces instead of only 197 with indexed paths

### OLM / cluster-spanning resource fixes
- Detect resources that appear as namespace-scoped paths in ≥30% of namespaces (OLM-style, e.g. PackageManifests) and exclude them from individual namespace drill-downs in the UI
- `AggregateAcrossNamespaces`: cap at 10,000 items, deduplicate by UID or name-only (items without UID are namespace-stamped duplicates)
- `AggregateTableAcrossNamespaces`: same dedup for Table-format responses (used by `kubectl` via Accept header)
- Guard all aggregate call sites to only fire for cluster-wide paths (no namespace segment) — namespace-scoped 404s no longer fall into the aggregate path and return 88×640 rows

### Memory regressions (server)
- Byte-bounded LRU record cache (128 MiB) and response cache (32 MiB)
- Removed eager `allTransitions` field from UI handler; load lazily per-request

### Capture — namespace pagination bug
- `expandWildcardNamespaces` did a single non-paginated `GET /api/v1/namespaces`; Kubernetes returns max 500 per page. Clusters with >500 namespaces silently excluded the tail (portworx at index 515 was never captured)
- Fixed to follow `metadata.continue` pagination tokens until all pages are consumed
- Added `TestExpandWildcard_Pagination` test

---

## Testing
- All existing tests pass: `go test ./...`
- New tests: `TestExpandWildcard_Pagination`
- Validated against real 517-namespace OpenShift capture (hsbc-pxe-cap-4)