### PR TITLE
Cluster-wide watch for wildcard-namespace resources

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -36,7 +37,7 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default: ./k8shark.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default: ./config.yaml, then ~/.config/kshrk/config.yaml)")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "enable verbose output")
 	_ = viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
 }
@@ -45,8 +46,14 @@ func initConfig() {
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
 	} else {
+		// Search the current directory first, then the XDG-style
+		// ~/.config/kshrk directory. Viper returns the first match in
+		// the order the paths are added.
 		viper.AddConfigPath(".")
-		viper.SetConfigName("k8shark")
+		if home, err := os.UserHomeDir(); err == nil {
+			viper.AddConfigPath(filepath.Join(home, ".config", "kshrk"))
+		}
+		viper.SetConfigName("config")
 		viper.SetConfigType("yaml")
 	}
 	viper.AutomaticEnv()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,7 +56,7 @@ Capture complete
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--config` | | `./k8shark.yaml` | Path to config file |
+| `--config` | | `./config.yaml`, then `~/.config/kshrk/config.yaml` | Path to config file |
 | `--output` | `-o` | `./k8shark-<timestamp>.tar.gz` | Output archive path |
 | `--duration` | | from config | Override capture duration (e.g. `5m`) |
 | `--kubeconfig` | | `$KUBECONFIG` / `~/.kube/config` | Source cluster kubeconfig |
@@ -66,7 +66,7 @@ Capture complete
 | `--allow-secret` | | | `namespace/name` of secret to preserve when `--redact-secrets` is set (repeatable) |
 | `--redact-field` | | | Field redaction rule applied after capture: `<path>:<Kind>:<replacement>[:<type>]` (repeatable) |
 
-The `--config` flag auto-discovers `./k8shark.yaml` if not specified.
+If `--config` is not specified, k8shark looks for `./config.yaml` in the current directory first, then falls back to `~/.config/kshrk/config.yaml`.
 
 For full-cluster capture without enumerating resources manually, prefer config syntax:
 

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -297,9 +297,21 @@ func (e *Engine) pollResource(ctx context.Context, res config.Resource) {
 	}
 }
 
-// watchResource starts one watch loop per configured namespace for the given
-// resource. For cluster-scoped resources, a single watch loop is used.
+// watchResource starts watch loops for the given resource. By default one
+// watch loop runs per configured namespace, but when the resource was
+// originally configured with a wildcard namespace ("*") a single cluster-wide
+// watch stream is used instead. This matches how in-cluster controllers
+// watch resources and avoids opening N streams against the API server on
+// clusters with many namespaces. For cluster-scoped resources a single watch
+// loop is used.
 func (e *Engine) watchResource(ctx context.Context, res config.Resource) {
+	if res.WildcardNamespaces {
+		// One cluster-wide stream; streamWatch demuxes events back to per-
+		// namespace API paths via metadata.namespace on each event object.
+		e.watchResourcePath(ctx, res, "")
+		return
+	}
+
 	namespaces := res.Namespaces
 	if len(namespaces) == 0 {
 		namespaces = []string{""}
@@ -329,7 +341,7 @@ func (e *Engine) watchResourcePath(ctx context.Context, res config.Resource, nam
 			resourceVersion = extractResourceVersion(body)
 		}
 
-		if err := e.streamWatch(ctx, apiPath, resourceVersion); err != nil && ctx.Err() == nil && e.verbose {
+		if err := e.streamWatch(ctx, res, apiPath, resourceVersion); err != nil && ctx.Err() == nil && e.verbose {
 			fmt.Fprintf(os.Stderr, "  [watch] %s: %v\n", apiPath, err)
 		}
 
@@ -346,12 +358,18 @@ func (e *Engine) watchResourcePath(ctx context.Context, res config.Resource, nam
 	}
 }
 
-func (e *Engine) streamWatch(ctx context.Context, apiPath, resourceVersion string) error {
+func (e *Engine) streamWatch(ctx context.Context, res config.Resource, apiPath, resourceVersion string) error {
 	q := url.Values{}
 	q.Set("watch", "1")
 	if resourceVersion != "" {
 		q.Set("resourceVersion", resourceVersion)
 	}
+
+	// Wildcard-namespace watches open a single cluster-wide stream but rewrite
+	// each event's stored APIPath to /api/.../namespaces/<ns>/<resource> so the
+	// replay server's per-namespace reconstruction logic continues to work
+	// without changes.
+	demuxPerNamespace := res.WildcardNamespaces && apiPath == buildAPIPath(res.Group, res.Version, res.Resource, "")
 
 	watchURL := e.baseURL + apiPath + "?" + q.Encode()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, watchURL, nil)
@@ -400,10 +418,23 @@ func (e *Engine) streamWatch(ctx context.Context, apiPath, resourceVersion strin
 			continue
 		}
 
+		recordPath := apiPath
+		if demuxPerNamespace {
+			ns := extractNamespaceFromObject(event.Object)
+			if ns == "" {
+				// Namespaced resources should always have metadata.namespace
+				// set on watch events. Skip rather than store an unattributable
+				// event under the cluster-wide path where the replay server
+				// won't find it.
+				continue
+			}
+			recordPath = buildAPIPath(res.Group, res.Version, res.Resource, ns)
+		}
+
 		rec := &Record{
 			ID:           uuid.New().String(),
 			CapturedAt:   time.Now().UTC(),
-			APIPath:      apiPath,
+			APIPath:      recordPath,
 			EventType:    event.Type,
 			HTTPMethod:   http.MethodGet,
 			ResponseCode: http.StatusOK,
@@ -413,23 +444,38 @@ func (e *Engine) streamWatch(ctx context.Context, apiPath, resourceVersion strin
 		if e.sink != nil {
 			if err := e.sink.WriteRecord(rec); err != nil {
 				if e.verbose {
-					fmt.Fprintf(os.Stderr, "  [warn] writing watch record %s: %v\n", apiPath, err)
+					fmt.Fprintf(os.Stderr, "  [warn] writing watch record %s: %v\n", recordPath, err)
 				}
 				continue
 			}
 		}
 
 		e.mu.Lock()
-		if _, ok := e.watchIndex[apiPath]; !ok {
-			e.watchIndex[apiPath] = &WatchIndexEntry{APIPath: apiPath}
+		if _, ok := e.watchIndex[recordPath]; !ok {
+			e.watchIndex[recordPath] = &WatchIndexEntry{APIPath: recordPath}
 		}
-		seq := e.pathSeq[apiPath]
-		e.pathSeq[apiPath] = seq + 1
-		e.watchIndex[apiPath].Seqs = append(e.watchIndex[apiPath].Seqs, seq)
-		e.watchIndex[apiPath].Times = append(e.watchIndex[apiPath].Times, rec.CapturedAt)
-		e.watchIndex[apiPath].EventTypes = append(e.watchIndex[apiPath].EventTypes, rec.EventType)
+		seq := e.pathSeq[recordPath]
+		e.pathSeq[recordPath] = seq + 1
+		e.watchIndex[recordPath].Seqs = append(e.watchIndex[recordPath].Seqs, seq)
+		e.watchIndex[recordPath].Times = append(e.watchIndex[recordPath].Times, rec.CapturedAt)
+		e.watchIndex[recordPath].EventTypes = append(e.watchIndex[recordPath].EventTypes, rec.EventType)
 		e.mu.Unlock()
 	}
+}
+
+// extractNamespaceFromObject reads metadata.namespace from a Kubernetes
+// object body returned in a watch event. Returns "" if the body can't be
+// parsed or the field is absent.
+func extractNamespaceFromObject(obj []byte) string {
+	var x struct {
+		Metadata struct {
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(obj, &x); err != nil {
+		return ""
+	}
+	return x.Metadata.Namespace
 }
 
 func extractResourceVersion(body []byte) string {
@@ -787,6 +833,12 @@ func (e *Engine) validateWatchConcurrency() error {
 	watchStreams := 0
 	for _, r := range e.cfg.Resources {
 		if !r.Watch || r.All {
+			continue
+		}
+		if r.WildcardNamespaces {
+			// Wildcard-namespace watches collapse to a single cluster-wide stream
+			// regardless of how many namespaces the wildcard expanded to.
+			watchStreams++
 			continue
 		}
 		if len(r.Namespaces) == 0 {
@@ -1210,6 +1262,9 @@ func (e *Engine) expandWildcardNamespaces(ctx context.Context) error {
 			}
 		}
 		r.Namespaces = expanded
+		// Remember that this entry was wildcarded so watchResource can open a
+		// single cluster-wide watch stream instead of one per expanded namespace.
+		r.WildcardNamespaces = true
 
 		if e.verbose {
 			fmt.Fprintf(os.Stdout,

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -1486,6 +1486,179 @@ func TestWatchResource_Reconnects(t *testing.T) {
 	}
 }
 
+// TestWatchResource_WildcardOpensSingleClusterWideStream verifies that when a
+// resource is marked WildcardNamespaces=true (originally configured with
+// namespaces: ["*"]), watchResource opens a single cluster-wide watch stream
+// instead of one stream per expanded namespace, and each emitted event is
+// stored under its per-namespace API path (read from metadata.namespace) so
+// the replay server's per-namespace reconstruction works unchanged.
+func TestWatchResource_WildcardOpensSingleClusterWideStream(t *testing.T) {
+	var clusterWideHits int32
+	var perNamespaceHits int32
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+			return
+		case "/api/v1/pods":
+			if r.URL.Query().Get("watch") == "1" {
+				atomic.AddInt32(&clusterWideHits, 1)
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w,
+					`{"type":"ADDED","object":{"metadata":{"name":"p1","namespace":"ns-a"}}}`+"\n"+
+						`{"type":"ADDED","object":{"metadata":{"name":"p2","namespace":"ns-b"}}}`+"\n"+
+						`{"type":"MODIFIED","object":{"metadata":{"name":"p1","namespace":"ns-a"}}}`+"\n")
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+				// Hold the connection open until the test cancels.
+				<-r.Context().Done()
+				return
+			}
+			fmt.Fprint(w, `{"kind":"PodList","metadata":{"resourceVersion":"10"},"items":[]}`)
+			return
+		}
+		if strings.Contains(r.URL.Path, "/namespaces/") && strings.HasSuffix(r.URL.Path, "/pods") {
+			atomic.AddInt32(&perNamespaceHits, 1)
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	eng := newEngineWith(&config.Config{}, srv.Client(), srv.URL, false)
+	ss := &sliceSink{}
+	eng.sink = ss
+
+	res := config.Resource{
+		Version:            "v1",
+		Resource:           "pods",
+		Namespaces:         []string{"ns-a", "ns-b"},
+		Watch:              true,
+		WildcardNamespaces: true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		eng.watchResource(ctx, res)
+	}()
+
+	deadline := time.Now().Add(1500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		ss.mu.Lock()
+		n := len(ss.records)
+		ss.mu.Unlock()
+		if n >= 3 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	if got := atomic.LoadInt32(&perNamespaceHits); got != 0 {
+		t.Fatalf("expected zero per-namespace watch requests, got %d", got)
+	}
+	if got := atomic.LoadInt32(&clusterWideHits); got == 0 {
+		t.Fatal("expected at least one cluster-wide watch connection")
+	}
+
+	eng.mu.Lock()
+	defer eng.mu.Unlock()
+
+	if _, ok := eng.watchIndex["/api/v1/pods"]; ok {
+		t.Errorf("expected no events stored under cluster-wide path /api/v1/pods (events should be demuxed per namespace)")
+	}
+	for _, want := range []string{"/api/v1/namespaces/ns-a/pods", "/api/v1/namespaces/ns-b/pods"} {
+		wi, ok := eng.watchIndex[want]
+		if !ok {
+			t.Errorf("expected watchIndex entry for %s", want)
+			continue
+		}
+		if len(wi.Seqs) == 0 {
+			t.Errorf("expected at least one event recorded for %s", want)
+		}
+	}
+}
+
+// TestRun_WildcardWatchBypassesConcurrencyCap verifies that a config using
+// namespaces: ["*"] with watch: true does not trip the watch concurrency
+// guard even on clusters with more than maxConcurrentWatchStreams namespaces,
+// because wildcard watches collapse to a single cluster-wide stream.
+func TestRun_WildcardWatchBypassesConcurrencyCap(t *testing.T) {
+	nsCount := maxConcurrentWatchStreams + 50
+	var nsItems strings.Builder
+	for i := 0; i < nsCount; i++ {
+		if i > 0 {
+			nsItems.WriteString(",")
+		}
+		fmt.Fprintf(&nsItems, `{"metadata":{"name":"ns-%d"}}`, i)
+	}
+	nsList := fmt.Sprintf(`{"kind":"NamespaceList","metadata":{},"items":[%s]}`, nsItems.String())
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+		case "/api":
+			fmt.Fprint(w, `{"versions":["v1"]}`)
+		case "/api/v1":
+			fmt.Fprint(w, `{"kind":"APIResourceList","resources":[]}`)
+		case "/apis":
+			fmt.Fprint(w, `{"kind":"APIGroupList","groups":[]}`)
+		case "/openapi/v2":
+			fmt.Fprint(w, `{}`)
+		case "/openapi/v3":
+			fmt.Fprint(w, `{"paths":{}}`)
+		case "/api/v1/namespaces":
+			fmt.Fprint(w, nsList)
+		case "/api/v1/pods":
+			if r.URL.Query().Get("watch") == "1" {
+				w.WriteHeader(http.StatusOK)
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+				<-r.Context().Done()
+				return
+			}
+			fmt.Fprint(w, `{"kind":"PodList","metadata":{"resourceVersion":"1"},"items":[]}`)
+		default:
+			fmt.Fprint(w, `{"kind":"List","items":[]}`)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		DurationRaw: "300ms",
+		Duration:    300 * time.Millisecond,
+		Output:      filepath.Join(t.TempDir(), "capture.khsrk"),
+		Resources: []config.Resource{
+			{
+				Version:     "v1",
+				Resource:    "pods",
+				Namespaces:  []string{"*"},
+				Watch:       true,
+				IntervalRaw: "1s",
+				Interval:    1 * time.Second,
+			},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("expected wildcard watch to bypass concurrency cap, got error: %v", err)
+	}
+	if !cfg.Resources[0].WildcardNamespaces {
+		t.Fatal("expected wildcard expansion to flag resource as WildcardNamespaces=true")
+	}
+}
+
 // TestFetchResource_AutoDiscoveredSilentFallback verifies that when a resource
 // was added via auto-discovery (AutoDiscovered=true) and every namespace-scoped
 // fetch returns 404, the engine falls back to the cluster-scoped path silently

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,12 @@ type Resource struct {
 	// AutoDiscovered is set to true by the engine when this entry was generated
 	// via auto-discovery (all: true). It is not a user-facing config field.
 	AutoDiscovered bool `mapstructure:"-"`
+	// WildcardNamespaces is set to true by the engine when this entry was
+	// originally configured with a wildcard ("*") in Namespaces. After wildcard
+	// expansion the engine still needs to know the original intent so watch
+	// streams can use a single cluster-wide watch instead of one per expanded
+	// namespace. Not a user-facing config field.
+	WildcardNamespaces bool `mapstructure:"-"`
 }
 
 // DedupEnabled reports whether polling responses for this resource should be


### PR DESCRIPTION
## Summary

- Wildcard-namespace watches (`namespaces: ["*"]` with `watch: true`) now open a single cluster-wide watch stream per resource instead of one per expanded namespace. Each event is demuxed back to the per-namespace API path via `metadata.namespace`, so the replay server's per-namespace reconstruction works unchanged.
- Adds XDG-style config discovery: `kshrk` now looks for `~/.config/kshrk/config.yaml` when `--config` is not supplied (current directory still takes precedence).

## Why

On a ~100-namespace cluster, an 8-resource watched config used to fan out to 800+ watch streams and tripped the engine's 256 concurrency cap. The new behaviour mirrors how kube-controller-manager and similar in-cluster clients watch resources — one stream per resource type, cluster-wide.

## Implementation notes

- `config.Resource` gains an internal-only `WildcardNamespaces` flag (not user-facing; set during expansion).
- `expandWildcardNamespaces` flags any resource whose original `namespaces:` list contained `*`.
- `watchResource` short-circuits to a single cluster-wide stream when the flag is set.
- `streamWatch` rewrites each event's stored `APIPath` to the per-namespace form using `metadata.namespace`. Events without a namespace are skipped (defensively — namespaced resources always have one).
- `validateWatchConcurrency` counts wildcard watches as 1 stream.
- Server-side code is **unchanged** — events still land under per-namespace paths.

## Test plan

- [x] `go test -race ./...` passes
- [x] `gofmt`, `go vet`, `golangci-lint` clean
- [x] New tests:
  - `TestWatchResource_WildcardOpensSingleClusterWideStream` — proves only the cluster-wide path is watched and events are demuxed to per-namespace `watchIndex` entries
  - `TestRun_WildcardWatchBypassesConcurrencyCap` — proves a 300+ namespace cluster with `["*"]` watch config runs without tripping the cap
- [x] Existing tests (`TestWatchResource_Reconnects`, `TestRun_FailsWhenWatchConcurrencyTooHigh`, etc.) still pass without modification
- [x] End-to-end: 5m capture against a real ~100-namespace cluster completed successfully (348k records, 951 MiB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)