### PR TITLE
Per-container pod log capture with failure visibility

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -82,6 +82,24 @@ func runCapture(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stdout, "  Output:    %s (%s)\n", sum.OutputPath, formatBytes(sum.OutputSize))
 	fmt.Fprintf(os.Stdout, "  Records:   %d across %d resource path(s)\n", sum.RecordCount, sum.ResourceCount)
 	fmt.Fprintf(os.Stdout, "  Duration:  %s\n", sum.Duration)
+	if sum.PodLogs.Attempted > 0 {
+		fmt.Fprintf(os.Stdout, "  Pod logs:  %d/%d captured", sum.PodLogs.Captured, sum.PodLogs.Attempted)
+		if sum.PodLogs.Skipped > 0 {
+			fmt.Fprintf(os.Stdout, " (%d skipped)", sum.PodLogs.Skipped)
+		}
+		fmt.Fprintln(os.Stdout)
+		if len(sum.PodLogs.Failures) > 0 {
+			fmt.Fprintln(os.Stdout, "  Skipped (sample):")
+			for _, f := range sum.PodLogs.Failures {
+				fmt.Fprintf(os.Stdout, "    - %s/%s [container=%s]: %s\n",
+					f.Namespace, f.Pod, f.Container, f.Reason)
+			}
+			if sum.PodLogs.Skipped > len(sum.PodLogs.Failures) {
+				fmt.Fprintf(os.Stdout, "    ... and %d more (run with --verbose for full list)\n",
+					sum.PodLogs.Skipped-len(sum.PodLogs.Failures))
+			}
+		}
+	}
 
 	// Post-capture redaction: merge --redact-secrets / --redact-field CLI flags
 	// with any redaction.rules defined in the config file.

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -87,6 +87,9 @@ func runCapture(cmd *cobra.Command, args []string) error {
 		if sum.PodLogs.Skipped > 0 {
 			fmt.Fprintf(os.Stdout, " (%d skipped)", sum.PodLogs.Skipped)
 		}
+		if sum.PodLogs.CapturedPrevious > 0 {
+			fmt.Fprintf(os.Stdout, ", %d previous", sum.PodLogs.CapturedPrevious)
+		}
 		fmt.Fprintln(os.Stdout)
 		if len(sum.PodLogs.Failures) > 0 {
 			fmt.Fprintln(os.Stdout, "  Skipped (sample):")

--- a/docs/config.md
+++ b/docs/config.md
@@ -26,6 +26,8 @@ k8shark reads a YAML config file that controls what gets captured, from which na
 | `interval` | duration string | `30s` | How often to re-poll this resource during the capture window. |
 | `dedup` | bool | `true` | Skip writing a record when the response body is identical to the previous poll for the same API path. Set `false` to force writing every poll. |
 | `watch` | bool | `false` | Start a Kubernetes watch stream (`?watch=1`) for this resource in addition to polling. Watch events are recorded with an `event_type` field. |
+| `logs` | int | `0` | (pods only) Tail-line count for per-container log capture. `0` disables. Logs are stored per (pod, container) so `kubectl logs <pod> -c <c>` replays correctly. |
+| `previousLogs` | bool | `false` | (pods only, requires `logs > 0`) Also capture each container's previous-container log via `?previous=true`. Useful for CrashLoopBackOff pods where the interesting output is in the terminated previous container. |
 
 When `all: true` is set, `group`/`version`/`resource` are not required for that entry.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -442,14 +442,16 @@ resources:
     resource: pods
     namespaces: [production, staging]
     interval: 30s
-    logs: 200       # capture last 200 lines from each pod
+    logs: 200             # capture last 200 lines from each container
+    previousLogs: true    # also fetch ?previous=true for each container (optional)
 ```
 
-Log content is fetched once at the end of the capture run and stored in the archive. When you open the archive with `kshrk open`, `kubectl logs` returns the captured output:
+Log content is fetched once at the end of the capture run and stored per (pod, container) under `/api/v1/namespaces/<ns>/pods/<name>/log?container=<c>`. When you open the archive with `kshrk open`:
 
 ```sh
-kubectl logs my-app-pod-abc123 -n production
-# outputs the captured tail log
+kubectl logs my-app-pod-abc123 -n production              # current container
+kubectl logs my-app-pod-abc123 -c istio-proxy -n production
+kubectl logs my-app-pod-abc123 --previous -n production   # if previousLogs: true
 ```
 
 If a pod's logs were not captured (e.g. `logs` was omitted or set to `0`), `kubectl logs` returns a clear stub message instead of an error:
@@ -460,7 +462,9 @@ If a pod's logs were not captured (e.g. `logs` was omitted or set to `0`), `kube
 # pods entry in your k8shark capture config and re-run the capture.
 ```
 
-> **Note:** Large log volumes increase archive size. Use a reasonable tail-line limit (e.g. 100–500 lines). Previous-container logs (`kubectl logs --previous`) are not captured.
+After the capture finishes, the CLI prints a summary showing how many container logs were captured and a sample of any that were skipped (with reasons), so multi-container pods, terminated containers, and RBAC denials are visible without re-running in verbose mode.
+
+> **Note:** Large log volumes increase archive size. Use a reasonable tail-line limit (e.g. 100–500 lines). When `previousLogs: true`, "container has not been previously terminated" responses are silently dropped — only successful previous-log captures count.
 
 ### Resources not in the capture
 

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -37,10 +37,11 @@ type CaptureSummary struct {
 // when logs were skipped (multi-container without log capture, RBAC denials,
 // timeouts, terminated containers, etc.) without re-running in verbose mode.
 type PodLogSummary struct {
-	Attempted int             // total (pod, container) fetch attempts
-	Captured  int             // successful captures
-	Skipped   int             // non-OK responses + transport errors
-	Failures  []PodLogFailure // capped sample of failures for CLI display
+	Attempted        int             // total (pod, container) fetch attempts (current logs only)
+	Captured         int             // successful current-log captures
+	Skipped          int             // current-log fetches that failed (non-OK / transport / timeout)
+	CapturedPrevious int             // successful ?previous=true captures, when PreviousLogs is enabled
+	Failures         []PodLogFailure // capped sample of current-log failures for CLI display
 }
 
 // PodLogFailure describes a single log fetch that did not produce a record.
@@ -243,6 +244,7 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 			podLogSummary.Attempted += s.Attempted
 			podLogSummary.Captured += s.Captured
 			podLogSummary.Skipped += s.Skipped
+			podLogSummary.CapturedPrevious += s.CapturedPrevious
 			for _, f := range s.Failures {
 				if len(podLogSummary.Failures) >= podLogFailureSampleLimit {
 					break
@@ -1165,6 +1167,7 @@ func (e *Engine) fetchPodsLogs(ctx context.Context, res config.Resource) PodLogS
 		namespace string
 		pod       string
 		container string
+		previous  bool
 	}
 
 	namespaces := res.Namespaces
@@ -1203,14 +1206,20 @@ func (e *Engine) fetchPodsLogs(ctx context.Context, res config.Resource) PodLogS
 			if podNS == "" {
 				podNS = ns
 			}
+			queue := func(container string) {
+				jobs = append(jobs, job{namespace: podNS, pod: item.Metadata.Name, container: container})
+				if res.PreviousLogs {
+					jobs = append(jobs, job{namespace: podNS, pod: item.Metadata.Name, container: container, previous: true})
+				}
+			}
 			// Init containers first — they ran before main containers and
 			// often carry the most actionable diagnostic output on Pending
 			// or CrashLoopBackOff pods.
 			for _, c := range item.Spec.InitContainers {
-				jobs = append(jobs, job{namespace: podNS, pod: item.Metadata.Name, container: c.Name})
+				queue(c.Name)
 			}
 			for _, c := range item.Spec.Containers {
-				jobs = append(jobs, job{namespace: podNS, pod: item.Metadata.Name, container: c.Name})
+				queue(c.Name)
 			}
 		}
 	}
@@ -1219,9 +1228,21 @@ func (e *Engine) fetchPodsLogs(ctx context.Context, res config.Resource) PodLogS
 		return PodLogSummary{}
 	}
 
+	// Only current-log fetches count toward the user-facing summary so it
+	// stays focused on the headline number ("X/Y captured"). Previous-log
+	// fetches are best-effort: successes grow CapturedPrevious, but failures
+	// (the very common "container has not been previously terminated" 400)
+	// are dropped silently to avoid swamping the failure sample with noise.
+	attempted := 0
+	for _, j := range jobs {
+		if !j.previous {
+			attempted++
+		}
+	}
+
 	var (
 		mu      sync.Mutex
-		summary = PodLogSummary{Attempted: len(jobs)}
+		summary = PodLogSummary{Attempted: attempted}
 		wg      sync.WaitGroup
 	)
 	sem := make(chan struct{}, maxConcurrentLogFetches)
@@ -1232,10 +1253,16 @@ func (e *Engine) fetchPodsLogs(ctx context.Context, res config.Resource) PodLogS
 		go func(j job) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			result := e.fetchOnePodLog(ctx, j.namespace, j.pod, j.container, res.Logs)
+			result := e.fetchOnePodLog(ctx, j.namespace, j.pod, j.container, res.Logs, j.previous)
 
 			mu.Lock()
 			defer mu.Unlock()
+			if j.previous {
+				if result.captured {
+					summary.CapturedPrevious++
+				}
+				return
+			}
 			if result.captured {
 				summary.Captured++
 				return
@@ -1257,20 +1284,28 @@ type logFetchResult struct {
 
 // fetchOnePodLog fetches the last tailLines of one container's log and stores
 // the plain-text content as a JSON-encoded string under
-// /api/v1/namespaces/<ns>/pods/<name>/log?container=<c>. The ?container=
-// suffix is what lets the replay server route per-container `kubectl logs`
-// requests to the matching record.
-func (e *Engine) fetchOnePodLog(ctx context.Context, namespace, podName, containerName string, tailLines int) logFetchResult {
+// /api/v1/namespaces/<ns>/pods/<name>/log?container=<c> (or, when previous is
+// true, …&previous=true). The query-suffix index key lets the replay server
+// route `kubectl logs <pod> -c <c> [--previous]` to the matching record.
+func (e *Engine) fetchOnePodLog(ctx context.Context, namespace, podName, containerName string, tailLines int, previous bool) logFetchResult {
 	fetchCtx, cancel := context.WithTimeout(ctx, perPodLogTimeout)
 	defer cancel()
 
 	logPath := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/log", namespace, podName)
 	indexKey := logPath + "?container=" + containerName
 	fetchURL := fmt.Sprintf("%s%s?container=%s&tailLines=%d", e.baseURL, logPath, url.QueryEscape(containerName), tailLines)
+	if previous {
+		indexKey += "&previous=true"
+		fetchURL += "&previous=true"
+	}
 
 	failure := func(reason string) logFetchResult {
 		if e.verbose {
-			fmt.Fprintf(os.Stderr, "  [warn] log %s/%s [container=%s]: %s\n", namespace, podName, containerName, reason)
+			marker := ""
+			if previous {
+				marker = ",previous=true"
+			}
+			fmt.Fprintf(os.Stderr, "  [warn] log %s/%s [container=%s%s]: %s\n", namespace, podName, containerName, marker, reason)
 		}
 		return logFetchResult{failure: &PodLogFailure{
 			Namespace: namespace,

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -525,6 +525,47 @@ func extractNamespaceFromObject(obj []byte) string {
 	return x.Metadata.Namespace
 }
 
+// formatHTTPFailure builds a concise human-readable reason for a non-OK HTTP
+// response. When the body is a Kubernetes Status JSON envelope (the typical
+// API server error format), only the `message` field is shown — much more
+// readable than the raw JSON, which is what users see for pod-log failures
+// like "container X is terminated" or "container Y is waiting to start".
+// Falls back to a truncated raw body when the response is not a Status object.
+func formatHTTPFailure(statusCode int, body []byte) string {
+	reason := fmt.Sprintf("HTTP %d", statusCode)
+	if len(body) == 0 {
+		return reason
+	}
+	if msg := extractStatusMessage(body); msg != "" {
+		const maxMessageLen = 300
+		if len(msg) > maxMessageLen {
+			msg = msg[:maxMessageLen] + "..."
+		}
+		return reason + ": " + msg
+	}
+	trimmed := strings.TrimSpace(string(body))
+	if len(trimmed) > 160 {
+		trimmed = trimmed[:160] + "..."
+	}
+	return reason + ": " + trimmed
+}
+
+// extractStatusMessage returns the `message` field of a Kubernetes Status
+// JSON object, or "" if the body isn't a Status envelope.
+func extractStatusMessage(body []byte) string {
+	var s struct {
+		Kind    string `json:"kind"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &s); err != nil {
+		return ""
+	}
+	if s.Kind != "Status" {
+		return ""
+	}
+	return s.Message
+}
+
 func extractResourceVersion(body []byte) string {
 	var meta struct {
 		Metadata struct {
@@ -1253,15 +1294,7 @@ func (e *Engine) fetchOnePodLog(ctx context.Context, namespace, podName, contain
 	body, readErr := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		reason := fmt.Sprintf("HTTP %d", resp.StatusCode)
-		if len(body) > 0 {
-			trimmed := strings.TrimSpace(string(body))
-			if len(trimmed) > 160 {
-				trimmed = trimmed[:160] + "..."
-			}
-			reason += ": " + trimmed
-		}
-		return failure(reason)
+		return failure(formatHTTPFailure(resp.StatusCode, body))
 	}
 	if readErr != nil {
 		return failure(fmt.Sprintf("reading body: %v", readErr))

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -29,6 +29,26 @@ type CaptureSummary struct {
 	RecordCount   int
 	ResourceCount int // distinct API paths captured
 	Duration      time.Duration
+	PodLogs       PodLogSummary
+}
+
+// PodLogSummary describes the outcome of pod-log capture across every
+// (pod, container) attempted during the run. Surfaced to the CLI so users see
+// when logs were skipped (multi-container without log capture, RBAC denials,
+// timeouts, terminated containers, etc.) without re-running in verbose mode.
+type PodLogSummary struct {
+	Attempted int             // total (pod, container) fetch attempts
+	Captured  int             // successful captures
+	Skipped   int             // non-OK responses + transport errors
+	Failures  []PodLogFailure // capped sample of failures for CLI display
+}
+
+// PodLogFailure describes a single log fetch that did not produce a record.
+type PodLogFailure struct {
+	Namespace string
+	Pod       string
+	Container string
+	Reason    string
 }
 
 // Engine orchestrates the capture loop.
@@ -37,6 +57,22 @@ type CaptureSummary struct {
 // memory (each body can be several MB for large list responses) regardless of
 // how many resources are configured or auto-discovered.
 const maxConcurrentFetches = 32
+
+// Pod log fetch tuning.
+const (
+	// maxConcurrentLogFetches bounds the number of in-flight pod-log GETs.
+	// Pod logs are fetched once at the end of the capture; on large clusters
+	// (thousands of containers) parallelism is the difference between the
+	// pass finishing in seconds vs. hitting a global timeout.
+	maxConcurrentLogFetches = 16
+	// perPodLogTimeout caps any single pod-log fetch so one hung container
+	// can't stall the whole pass. Replaces the previous global 30s budget.
+	perPodLogTimeout = 15 * time.Second
+	// podLogFailureSampleLimit bounds how many failure entries the summary
+	// holds for CLI display, so a million-container failure mode doesn't
+	// balloon memory or output.
+	podLogFailureSampleLimit = 20
+)
 
 type Engine struct {
 	cfg            *config.Config
@@ -193,16 +229,26 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 	wg.Wait()
 
 	// Fetch pod logs for any pods resource entry with logs > 0. This runs after
-	// all polling so we capture the most recent log state. A short background
-	// context is used because the main capture context has already expired.
+	// all polling so we capture the most recent log state. A fresh background
+	// context is used because the main capture context has already expired;
+	// each individual log fetch enforces its own perPodLogTimeout so one
+	// hung container does not stall the whole pass.
+	var podLogSummary PodLogSummary
 	for _, res := range e.cfg.Resources {
 		if res.All {
 			continue
 		}
 		if res.Logs > 0 && res.Resource == "pods" {
-			logCtx, logCancel := context.WithTimeout(context.Background(), 30*time.Second)
-			e.fetchPodsLogs(logCtx, res)
-			logCancel()
+			s := e.fetchPodsLogs(context.Background(), res)
+			podLogSummary.Attempted += s.Attempted
+			podLogSummary.Captured += s.Captured
+			podLogSummary.Skipped += s.Skipped
+			for _, f := range s.Failures {
+				if len(podLogSummary.Failures) >= podLogFailureSampleLimit {
+					break
+				}
+				podLogSummary.Failures = append(podLogSummary.Failures, f)
+			}
 		}
 	}
 
@@ -237,6 +283,7 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 		RecordCount:   e.sink.RecordCount(),
 		ResourceCount: len(e.index),
 		Duration:      time.Since(start).Truncate(time.Second),
+		PodLogs:       podLogSummary,
 	}, nil
 }
 
@@ -1061,15 +1108,30 @@ func buildAPIPath(group, version, resource, namespace string) string {
 	return base + "/namespaces/" + namespace + "/" + resource
 }
 
-// fetchPodsLogs fetches the tail log for each pod found in res across all
-// configured namespaces. Each log is stored under the clean
-// /api/v1/namespaces/<ns>/pods/<name>/log path so the mock server can serve
-// it verbatim when kubectl logs is run against the replay server.
-func (e *Engine) fetchPodsLogs(ctx context.Context, res config.Resource) {
+// fetchPodsLogs fetches the tail log for each container of each pod found in
+// res across all configured namespaces. Each log is stored under
+// /api/v1/namespaces/<ns>/pods/<name>/log?container=<c> so the replay server
+// can route both bare `kubectl logs <pod>` (single-container) and
+// `kubectl logs <pod> -c <c>` requests to the right record.
+//
+// Fetches run concurrently bounded by maxConcurrentLogFetches, and each fetch
+// has its own perPodLogTimeout so one hung container does not stall the pass.
+// Per-fetch failures (HTTP errors, RBAC, timeouts, terminated containers) are
+// recorded in the returned PodLogSummary so the CLI can show users what was
+// skipped without re-running in verbose mode.
+func (e *Engine) fetchPodsLogs(ctx context.Context, res config.Resource) PodLogSummary {
+	type job struct {
+		namespace string
+		pod       string
+		container string
+	}
+
 	namespaces := res.Namespaces
 	if len(namespaces) == 0 {
 		namespaces = []string{""}
 	}
+
+	var jobs []job
 	for _, ns := range namespaces {
 		listPath := buildAPIPath(res.Group, res.Version, res.Resource, ns)
 		listBody, code := e.doFetch(ctx, listPath, "", res.DedupEnabled())
@@ -1082,6 +1144,14 @@ func (e *Engine) fetchPodsLogs(ctx context.Context, res config.Resource) {
 					Name      string `json:"name"`
 					Namespace string `json:"namespace"`
 				} `json:"metadata"`
+				Spec struct {
+					Containers []struct {
+						Name string `json:"name"`
+					} `json:"containers"`
+					InitContainers []struct {
+						Name string `json:"name"`
+					} `json:"initContainers"`
+				} `json:"spec"`
 			} `json:"items"`
 		}
 		if err := json.Unmarshal(listBody, &list); err != nil {
@@ -1092,65 +1162,145 @@ func (e *Engine) fetchPodsLogs(ctx context.Context, res config.Resource) {
 			if podNS == "" {
 				podNS = ns
 			}
-			e.fetchOnePodLog(ctx, podNS, item.Metadata.Name, res.Logs)
+			// Init containers first — they ran before main containers and
+			// often carry the most actionable diagnostic output on Pending
+			// or CrashLoopBackOff pods.
+			for _, c := range item.Spec.InitContainers {
+				jobs = append(jobs, job{namespace: podNS, pod: item.Metadata.Name, container: c.Name})
+			}
+			for _, c := range item.Spec.Containers {
+				jobs = append(jobs, job{namespace: podNS, pod: item.Metadata.Name, container: c.Name})
+			}
 		}
 	}
+
+	if len(jobs) == 0 {
+		return PodLogSummary{}
+	}
+
+	var (
+		mu      sync.Mutex
+		summary = PodLogSummary{Attempted: len(jobs)}
+		wg      sync.WaitGroup
+	)
+	sem := make(chan struct{}, maxConcurrentLogFetches)
+
+	for _, j := range jobs {
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(j job) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			result := e.fetchOnePodLog(ctx, j.namespace, j.pod, j.container, res.Logs)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if result.captured {
+				summary.Captured++
+				return
+			}
+			summary.Skipped++
+			if result.failure != nil && len(summary.Failures) < podLogFailureSampleLimit {
+				summary.Failures = append(summary.Failures, *result.failure)
+			}
+		}(j)
+	}
+	wg.Wait()
+	return summary
 }
 
-// fetchOnePodLog fetches the last tailLines lines of a pod's log and stores
-// the plain-text content as a JSON-encoded string under the clean log path.
-// Storing as a JSON string ensures the record is valid JSON for the archive.
-func (e *Engine) fetchOnePodLog(ctx context.Context, namespace, podName string, tailLines int) {
-	logPath := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/log", namespace, podName)
-	fetchURL := fmt.Sprintf("%s%s?tailLines=%d", e.baseURL, logPath, tailLines)
+type logFetchResult struct {
+	captured bool
+	failure  *PodLogFailure // nil when captured is true
+}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, nil)
+// fetchOnePodLog fetches the last tailLines of one container's log and stores
+// the plain-text content as a JSON-encoded string under
+// /api/v1/namespaces/<ns>/pods/<name>/log?container=<c>. The ?container=
+// suffix is what lets the replay server route per-container `kubectl logs`
+// requests to the matching record.
+func (e *Engine) fetchOnePodLog(ctx context.Context, namespace, podName, containerName string, tailLines int) logFetchResult {
+	fetchCtx, cancel := context.WithTimeout(ctx, perPodLogTimeout)
+	defer cancel()
+
+	logPath := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/log", namespace, podName)
+	indexKey := logPath + "?container=" + containerName
+	fetchURL := fmt.Sprintf("%s%s?container=%s&tailLines=%d", e.baseURL, logPath, url.QueryEscape(containerName), tailLines)
+
+	failure := func(reason string) logFetchResult {
+		if e.verbose {
+			fmt.Fprintf(os.Stderr, "  [warn] log %s/%s [container=%s]: %s\n", namespace, podName, containerName, reason)
+		}
+		return logFetchResult{failure: &PodLogFailure{
+			Namespace: namespace,
+			Pod:       podName,
+			Container: containerName,
+			Reason:    reason,
+		}}
+	}
+
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, fetchURL, nil)
 	if err != nil {
-		return
+		return failure(fmt.Sprintf("build request: %v", err))
 	}
 	resp, err := e.httpClient.Do(req)
 	if err != nil {
-		return
+		if fetchCtx.Err() != nil {
+			return failure("timeout after " + perPodLogTimeout.String())
+		}
+		return failure(fmt.Sprintf("request error: %v", err))
 	}
-	body, _ := io.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return
+		reason := fmt.Sprintf("HTTP %d", resp.StatusCode)
+		if len(body) > 0 {
+			trimmed := strings.TrimSpace(string(body))
+			if len(trimmed) > 160 {
+				trimmed = trimmed[:160] + "..."
+			}
+			reason += ": " + trimmed
+		}
+		return failure(reason)
+	}
+	if readErr != nil {
+		return failure(fmt.Sprintf("reading body: %v", readErr))
 	}
 
-	// Encode plain-text log body as a JSON string so it can be stored in the
-	// JSON archive without breaking serialisation.
 	jsonBody, err := json.Marshal(string(body))
 	if err != nil {
-		return
+		return failure(fmt.Sprintf("encoding body: %v", err))
 	}
 
 	if e.verbose {
-		fmt.Fprintf(os.Stdout, "  [capture] %s -> %d (%d bytes)\n", logPath, resp.StatusCode, len(body))
+		fmt.Fprintf(os.Stdout, "  [capture] %s -> %d (%d bytes)\n", indexKey, resp.StatusCode, len(body))
 	}
 
 	rec := &Record{
 		ID:           uuid.New().String(),
 		CapturedAt:   time.Now().UTC(),
-		APIPath:      logPath,
+		APIPath:      indexKey,
 		HTTPMethod:   http.MethodGet,
 		ResponseCode: http.StatusOK,
 		ResponseBody: json.RawMessage(jsonBody),
 	}
 	if e.sink != nil {
-		if err := e.sink.WriteRecord(rec); err != nil && e.verbose {
-			fmt.Fprintf(os.Stderr, "  [warn] writing log record %s: %v\n", logPath, err)
+		if err := e.sink.WriteRecord(rec); err != nil {
+			return failure(fmt.Sprintf("writing record: %v", err))
 		}
 	}
+
 	e.mu.Lock()
-	if _, ok := e.index[logPath]; !ok {
-		e.index[logPath] = &IndexEntry{APIPath: logPath}
+	if _, ok := e.index[indexKey]; !ok {
+		e.index[indexKey] = &IndexEntry{APIPath: indexKey}
 	}
-	logSeq := e.pathSeq[logPath]
-	e.pathSeq[logPath] = logSeq + 1
-	e.index[logPath].Seqs = append(e.index[logPath].Seqs, logSeq)
-	e.index[logPath].Times = append(e.index[logPath].Times, rec.CapturedAt)
+	seq := e.pathSeq[indexKey]
+	e.pathSeq[indexKey] = seq + 1
+	e.index[indexKey].Seqs = append(e.index[indexKey].Seqs, seq)
+	e.index[indexKey].Times = append(e.index[indexKey].Times, rec.CapturedAt)
 	e.mu.Unlock()
+
+	return logFetchResult{captured: true}
 }
 
 // expandWildcardNamespaces replaces "*" in any resource's Namespaces list with

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -125,28 +125,41 @@ func TestEngine_CaptureToArchive(t *testing.T) {
 }
 
 func TestEngine_FetchPodsLogs(t *testing.T) {
+	// Pod fixtures include spec.containers so the engine knows what to fetch
+	// logs for. The redis pod also has an init container to verify init-
+	// container logs are captured too.
 	podList := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[` +
-		`{"metadata":{"name":"nginx","namespace":"default"}},` +
-		`{"metadata":{"name":"redis","namespace":"default"}}]}`
-	nginxLog := "nginx log line 1\nnginx log line 2\n"
-	redisLog := "redis log line 1\n"
+		`{"metadata":{"name":"nginx","namespace":"default"},"spec":{"containers":[{"name":"web"}]}},` +
+		`{"metadata":{"name":"redis","namespace":"default"},"spec":{"initContainers":[{"name":"init"}],"containers":[{"name":"redis"}]}}]}`
+	logs := map[string]string{
+		"web":   "nginx log line 1\nnginx log line 2\n",
+		"redis": "redis log line 1\n",
+		"init":  "init container ran\n",
+	}
 
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/version":
 			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+			return
 		case "/api/v1/namespaces/default/pods":
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprint(w, podList)
-		case "/api/v1/namespaces/default/pods/nginx/log":
-			w.Header().Set("Content-Type", "text/plain")
-			fmt.Fprint(w, nginxLog)
-		case "/api/v1/namespaces/default/pods/redis/log":
-			w.Header().Set("Content-Type", "text/plain")
-			fmt.Fprint(w, redisLog)
-		default:
-			w.WriteHeader(http.StatusNotFound)
+			return
 		}
+		if strings.HasSuffix(r.URL.Path, "/log") {
+			c := r.URL.Query().Get("container")
+			body, ok := logs[c]
+			if !ok {
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprintf(w, `a container name must be specified for pod, choose one of: [...]`)
+				return
+			}
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprint(w, body)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer srv.Close()
 
@@ -168,23 +181,27 @@ func TestEngine_FetchPodsLogs(t *testing.T) {
 	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
 	ss := &sliceSink{}
 	eng.sink = ss
-	if _, err := eng.Run(); err != nil {
+	sum, err := eng.Run()
+	if err != nil {
 		t.Fatalf("engine.Run() error: %v", err)
 	}
 
-	// Both log paths must be in the index.
-	nginxLogPath := "/api/v1/namespaces/default/pods/nginx/log"
-	redisLogPath := "/api/v1/namespaces/default/pods/redis/log"
-	if _, ok := eng.index[nginxLogPath]; !ok {
-		t.Errorf("nginx log path %q missing from index", nginxLogPath)
+	// All three (pod, container) pairs must be present at their per-container keys.
+	wantKeys := map[string]string{
+		"/api/v1/namespaces/default/pods/nginx/log?container=web":   logs["web"],
+		"/api/v1/namespaces/default/pods/redis/log?container=redis": logs["redis"],
+		"/api/v1/namespaces/default/pods/redis/log?container=init":  logs["init"],
 	}
-	if _, ok := eng.index[redisLogPath]; !ok {
-		t.Errorf("redis log path %q missing from index", redisLogPath)
+	for key := range wantKeys {
+		if _, ok := eng.index[key]; !ok {
+			t.Errorf("log path %q missing from index", key)
+		}
 	}
 
-	// Log records must be stored as JSON strings encoding the plain-text body.
+	// Each record body decodes back to the matching log text.
 	for _, rec := range ss.records {
-		if rec.APIPath != nginxLogPath && rec.APIPath != redisLogPath {
+		want, ok := wantKeys[rec.APIPath]
+		if !ok {
 			continue
 		}
 		var text string
@@ -192,13 +209,80 @@ func TestEngine_FetchPodsLogs(t *testing.T) {
 			t.Errorf("log record at %q has invalid JSON body: %v", rec.APIPath, err)
 			continue
 		}
-		want := nginxLog
-		if rec.APIPath == redisLogPath {
-			want = redisLog
-		}
 		if text != want {
 			t.Errorf("%q: got %q, want %q", rec.APIPath, text, want)
 		}
+	}
+
+	if sum.PodLogs.Attempted != 3 || sum.PodLogs.Captured != 3 || sum.PodLogs.Skipped != 0 {
+		t.Errorf("PodLogs summary = %+v, want Attempted=3 Captured=3 Skipped=0", sum.PodLogs)
+	}
+}
+
+// TestEngine_FetchPodsLogs_SkippedFailuresInSummary verifies that when a
+// container's log fetch fails (e.g. a 400 because no such container exists),
+// the summary records the failure with an actionable reason instead of
+// silently dropping it.
+func TestEngine_FetchPodsLogs_SkippedFailuresInSummary(t *testing.T) {
+	podList := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[` +
+		`{"metadata":{"name":"good","namespace":"default"},"spec":{"containers":[{"name":"app"}]}},` +
+		`{"metadata":{"name":"bad","namespace":"default"},"spec":{"containers":[{"name":"crashed"}]}}]}`
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+			return
+		case "/api/v1/namespaces/default/pods":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, podList)
+			return
+		case "/api/v1/namespaces/default/pods/good/log":
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprint(w, "good output\n")
+			return
+		case "/api/v1/namespaces/default/pods/bad/log":
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `container "crashed" in pod "bad" is waiting to start: PodInitializing`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		DurationRaw: "500ms",
+		Duration:    500 * time.Millisecond,
+		Output:      filepath.Join(t.TempDir(), "capture.khsrk"),
+		Resources: []config.Resource{
+			{
+				Version: "v1", Resource: "pods",
+				Namespaces:  []string{"default"},
+				IntervalRaw: "500ms", Interval: 500 * time.Millisecond,
+				Logs: 50,
+			},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	eng.sink = &sliceSink{}
+	sum, err := eng.Run()
+	if err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	if sum.PodLogs.Attempted != 2 || sum.PodLogs.Captured != 1 || sum.PodLogs.Skipped != 1 {
+		t.Errorf("PodLogs summary = %+v, want Attempted=2 Captured=1 Skipped=1", sum.PodLogs)
+	}
+	if len(sum.PodLogs.Failures) != 1 {
+		t.Fatalf("expected 1 failure, got %d", len(sum.PodLogs.Failures))
+	}
+	f := sum.PodLogs.Failures[0]
+	if f.Namespace != "default" || f.Pod != "bad" || f.Container != "crashed" {
+		t.Errorf("failure identifies wrong pod/container: %+v", f)
+	}
+	if !strings.Contains(f.Reason, "HTTP 400") || !strings.Contains(f.Reason, "PodInitializing") {
+		t.Errorf("failure reason should include HTTP code + body excerpt, got %q", f.Reason)
 	}
 }
 

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -293,6 +293,152 @@ func TestEngine_FetchPodsLogs_SkippedFailuresInSummary(t *testing.T) {
 	}
 }
 
+// TestEngine_FetchPodsLogs_Previous verifies that when PreviousLogs: true is
+// set, the engine fetches `?previous=true` for each container, stores the
+// result under a separate per-container index key, and counts successful
+// previous-log captures via CapturedPrevious. "No previous container" 400s
+// are silently dropped — they should not appear in the failure sample.
+func TestEngine_FetchPodsLogs_Previous(t *testing.T) {
+	podList := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[` +
+		`{"metadata":{"name":"web","namespace":"default"},"spec":{"containers":[{"name":"app"}]}}` +
+		`]}`
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+			return
+		case "/api/v1/namespaces/default/pods":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, podList)
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/log") {
+			if r.URL.Query().Get("previous") == "true" {
+				w.Header().Set("Content-Type", "text/plain")
+				fmt.Fprint(w, "old crashed log\n")
+				return
+			}
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprint(w, "current log\n")
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		DurationRaw: "500ms",
+		Duration:    500 * time.Millisecond,
+		Output:      filepath.Join(t.TempDir(), "capture.khsrk"),
+		Resources: []config.Resource{
+			{
+				Version: "v1", Resource: "pods",
+				Namespaces:  []string{"default"},
+				IntervalRaw: "500ms", Interval: 500 * time.Millisecond,
+				Logs:         50,
+				PreviousLogs: true,
+			},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	ss := &sliceSink{}
+	eng.sink = ss
+	sum, err := eng.Run()
+	if err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	currentKey := "/api/v1/namespaces/default/pods/web/log?container=app"
+	previousKey := "/api/v1/namespaces/default/pods/web/log?container=app&previous=true"
+	if _, ok := eng.index[currentKey]; !ok {
+		t.Errorf("missing current log at %q", currentKey)
+	}
+	if _, ok := eng.index[previousKey]; !ok {
+		t.Errorf("missing previous log at %q", previousKey)
+	}
+
+	if sum.PodLogs.Captured != 1 {
+		t.Errorf("expected Captured=1, got %d", sum.PodLogs.Captured)
+	}
+	if sum.PodLogs.CapturedPrevious != 1 {
+		t.Errorf("expected CapturedPrevious=1, got %d", sum.PodLogs.CapturedPrevious)
+	}
+	if sum.PodLogs.Attempted != 1 {
+		t.Errorf("expected Attempted=1 (previous fetches not counted), got %d", sum.PodLogs.Attempted)
+	}
+}
+
+// TestEngine_FetchPodsLogs_PreviousFailureSilent verifies that when the
+// previous-log fetch returns a 400 (the common "container has not been
+// previously terminated" case), it is silently dropped from the failure
+// sample so the summary stays focused on current-log issues.
+func TestEngine_FetchPodsLogs_PreviousFailureSilent(t *testing.T) {
+	podList := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[` +
+		`{"metadata":{"name":"healthy","namespace":"default"},"spec":{"containers":[{"name":"app"}]}}` +
+		`]}`
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/version":
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+			return
+		case "/api/v1/namespaces/default/pods":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, podList)
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/log") {
+			if r.URL.Query().Get("previous") == "true" {
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"previous terminated container \"app\" in pod \"healthy\" not found","reason":"BadRequest","code":400}`)
+				return
+			}
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprint(w, "log\n")
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		DurationRaw: "500ms",
+		Duration:    500 * time.Millisecond,
+		Output:      filepath.Join(t.TempDir(), "capture.khsrk"),
+		Resources: []config.Resource{
+			{
+				Version: "v1", Resource: "pods",
+				Namespaces:  []string{"default"},
+				IntervalRaw: "500ms", Interval: 500 * time.Millisecond,
+				Logs:         50,
+				PreviousLogs: true,
+			},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	eng.sink = &sliceSink{}
+	sum, err := eng.Run()
+	if err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	if sum.PodLogs.Skipped != 0 {
+		t.Errorf("previous-log failures must not count as Skipped, got %d", sum.PodLogs.Skipped)
+	}
+	if len(sum.PodLogs.Failures) != 0 {
+		t.Errorf("previous-log failures must not appear in the failure sample, got %+v", sum.PodLogs.Failures)
+	}
+	if sum.PodLogs.Captured != 1 {
+		t.Errorf("expected Captured=1, got %d", sum.PodLogs.Captured)
+	}
+	if sum.PodLogs.CapturedPrevious != 0 {
+		t.Errorf("expected CapturedPrevious=0 (previous fetch failed), got %d", sum.PodLogs.CapturedPrevious)
+	}
+}
+
 func TestEngine_NoLogsWhenDisabled(t *testing.T) {
 	logCalled := false
 	podList := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -243,7 +243,10 @@ func TestEngine_FetchPodsLogs_SkippedFailuresInSummary(t *testing.T) {
 			return
 		case "/api/v1/namespaces/default/pods/bad/log":
 			w.WriteHeader(http.StatusBadRequest)
-			fmt.Fprint(w, `container "crashed" in pod "bad" is waiting to start: PodInitializing`)
+			// Real K8s API server error format: a Status JSON envelope.
+			// The engine should parse out the `message` field for the
+			// summary instead of dumping the raw JSON.
+			fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"container \"crashed\" in pod \"bad\" is waiting to start: PodInitializing","reason":"BadRequest","code":400}`)
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -282,7 +285,11 @@ func TestEngine_FetchPodsLogs_SkippedFailuresInSummary(t *testing.T) {
 		t.Errorf("failure identifies wrong pod/container: %+v", f)
 	}
 	if !strings.Contains(f.Reason, "HTTP 400") || !strings.Contains(f.Reason, "PodInitializing") {
-		t.Errorf("failure reason should include HTTP code + body excerpt, got %q", f.Reason)
+		t.Errorf("failure reason should include HTTP code + parsed Status message, got %q", f.Reason)
+	}
+	// The raw JSON envelope should NOT appear — only the parsed message.
+	if strings.Contains(f.Reason, `"kind"`) || strings.Contains(f.Reason, `apiVersion`) {
+		t.Errorf("failure reason should show parsed Status message, not raw JSON: %q", f.Reason)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,12 @@ type Resource struct {
 	// resource is "pods". 0 (default) disables log capture. For example, set
 	// logs: 200 to capture the last 200 lines from every pod at capture time.
 	Logs int `mapstructure:"logs"`
+	// PreviousLogs, when true, also captures the previous-container log for
+	// each container using ?previous=true. The same tail-line count from Logs
+	// applies. Useful for diagnosing CrashLoopBackOff pods where the current
+	// container is starting fresh and the interesting output lives in the
+	// terminated previous container.
+	PreviousLogs bool `mapstructure:"previousLogs"`
 	// Dedup controls response-body deduplication for this resource. Nil means
 	// enabled by default; set dedup: false to force writing every poll.
 	Dedup *bool `mapstructure:"dedup"`

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -811,31 +811,56 @@ func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path strin
 }
 
 // serveLog serves a pod log sub-resource (e.g. /api/v1/namespaces/<ns>/pods/<name>/log).
+// Recognised query parameters:
+//   - container=<c>  — request a specific container's log
+//   - previous=true  — request the previous-container log (kubectl logs --previous)
+//
 // Lookup order:
-//  1. If the client passed ?container=<c>, return the captured record for that
-//     container (stored under path + "?container=<c>").
-//  2. Legacy archives stored a single record at the bare path with no
-//     container key — try that next so older captures keep working.
-//  3. If the client did not specify a container, fall back to the first
-//     per-container record we have for this pod. This covers single-container
-//     pods (kubectl sends no ?container= for them) and multi-container pods
-//     where the client did not pick one.
-//  4. Return a readable stub explaining how to enable log capture.
+//  1. If both container and previous are set, look up the record under
+//     path + "?container=<c>&previous=true".
+//  2. If only container is set, look up path + "?container=<c>".
+//  3. Legacy archives stored a single record at the bare path — try that.
+//  4. If no container was specified, fall back to the first per-container
+//     record we have for this pod (covers single-container pods, where
+//     kubectl sends no ?container= param).
+//  5. Return a readable stub explaining how to enable log capture.
 func (h *handler) serveLog(w http.ResponseWriter, r *http.Request, path string, at time.Time) {
-	container := r.URL.Query().Get("container")
-	if container != "" && h.tryServeLogRecord(w, path+"?container="+container, at) {
-		return
+	q := r.URL.Query()
+	container := q.Get("container")
+	previous := q.Get("previous") == "true"
+
+	if container != "" {
+		key := path + "?container=" + container
+		if previous {
+			key += "&previous=true"
+		}
+		if h.tryServeLogRecord(w, key, at) {
+			return
+		}
 	}
 	if h.tryServeLogRecord(w, path, at) {
 		return
 	}
 	if container == "" {
 		prefix := path + "?container="
+		suffix := ""
+		if previous {
+			suffix = "&previous=true"
+		}
 		for indexKey := range h.store.Index {
-			if strings.HasPrefix(indexKey, prefix) {
-				if h.tryServeLogRecord(w, indexKey, at) {
-					return
-				}
+			if !strings.HasPrefix(indexKey, prefix) {
+				continue
+			}
+			if suffix != "" && !strings.HasSuffix(indexKey, suffix) {
+				continue
+			}
+			if suffix == "" && strings.Contains(indexKey, "&previous=true") {
+				// When the client didn't ask for previous logs, don't accidentally
+				// serve a previous-log record as the default.
+				continue
+			}
+			if h.tryServeLogRecord(w, indexKey, at) {
+				return
 			}
 		}
 	}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -150,7 +150,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	case strings.HasSuffix(path, "/log"):
 		// Pod log sub-resource: serve captured content or a helpful stub.
-		h.serveLog(w, path, replayAt)
+		h.serveLog(w, r, path, replayAt)
 	default:
 		h.serveResource(w, r, path, replayAt)
 	}
@@ -811,33 +811,61 @@ func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path strin
 }
 
 // serveLog serves a pod log sub-resource (e.g. /api/v1/namespaces/<ns>/pods/<name>/log).
-// If the log was captured (logs: N in the resource config), it is served as
-// plain text. Otherwise a helpful stub message is returned so kubectl logs does
-// not error out against the mock server.
-func (h *handler) serveLog(w http.ResponseWriter, path string, at time.Time) {
-	body, code, err := h.store.Latest(path, at)
-	if err == nil && code == 200 {
-		// Logs are stored as JSON strings; decode to recover the original plain text.
-		var text string
-		if json.Unmarshal(body, &text) == nil {
-			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-			w.WriteHeader(http.StatusOK)
-			_, _ = fmt.Fprint(w, text)
-			return
-		}
-		// Fallback: body is already plain text (should not normally happen).
-		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(body)
+// Lookup order:
+//  1. If the client passed ?container=<c>, return the captured record for that
+//     container (stored under path + "?container=<c>").
+//  2. Legacy archives stored a single record at the bare path with no
+//     container key — try that next so older captures keep working.
+//  3. If the client did not specify a container, fall back to the first
+//     per-container record we have for this pod. This covers single-container
+//     pods (kubectl sends no ?container= for them) and multi-container pods
+//     where the client did not pick one.
+//  4. Return a readable stub explaining how to enable log capture.
+func (h *handler) serveLog(w http.ResponseWriter, r *http.Request, path string, at time.Time) {
+	container := r.URL.Query().Get("container")
+	if container != "" && h.tryServeLogRecord(w, path+"?container="+container, at) {
 		return
 	}
-	// Log was not captured — return a readable stub so kubectl logs exits cleanly.
+	if h.tryServeLogRecord(w, path, at) {
+		return
+	}
+	if container == "" {
+		prefix := path + "?container="
+		for indexKey := range h.store.Index {
+			if strings.HasPrefix(indexKey, prefix) {
+				if h.tryServeLogRecord(w, indexKey, at) {
+					return
+				}
+			}
+		}
+	}
+
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	_, _ = fmt.Fprint(w,
 		"# k8shark capture replay: logs were not captured for this pod.\n"+
 			"# To capture logs, add 'logs: 200' (or another line count) to the\n"+
 			"# pods entry in your k8shark capture config and re-run the capture.\n")
+}
+
+// tryServeLogRecord writes the captured log for indexKey if one exists.
+// Returns true on success so the caller stops trying further fallbacks.
+func (h *handler) tryServeLogRecord(w http.ResponseWriter, indexKey string, at time.Time) bool {
+	body, code, err := h.store.Latest(indexKey, at)
+	if err != nil || code != 200 {
+		return false
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	// Logs are stored as JSON strings; decode to recover the original plain text.
+	var text string
+	if json.Unmarshal(body, &text) == nil {
+		_, _ = fmt.Fprint(w, text)
+		return true
+	}
+	// Fallback: body is already plain text (should not normally happen).
+	_, _ = w.Write(body)
+	return true
 }
 
 func (h *handler) writeStatus(w http.ResponseWriter, code int, msg string) {

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -728,6 +728,60 @@ func TestHandler_ServeLog_NoContainerPicksAvailable(t *testing.T) {
 	}
 }
 
+// TestHandler_ServeLog_Previous verifies that `kubectl logs <pod> -c <c> --previous`
+// (encoded as ?container=<c>&previous=true) is routed to the previous-container
+// record stored under the corresponding index key.
+func TestHandler_ServeLog_Previous(t *testing.T) {
+	currentLog, _ := json.Marshal("current\n")
+	previousLog, _ := json.Marshal("previous\n")
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/pods/mypod/log?container=app":               currentLog,
+		"/api/v1/namespaces/default/pods/mypod/log?container=app&previous=true": previousLog,
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	// Without previous=true, returns current.
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/namespaces/default/pods/mypod/log?container=app", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+	if got := rw.Body.String(); got != "current\n" {
+		t.Errorf("expected current log, got %q", got)
+	}
+
+	// With previous=true, returns previous.
+	req = httptest.NewRequest(http.MethodGet,
+		"/api/v1/namespaces/default/pods/mypod/log?container=app&previous=true", nil)
+	rw = httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+	if got := rw.Body.String(); got != "previous\n" {
+		t.Errorf("expected previous log, got %q", got)
+	}
+}
+
+// TestHandler_ServeLog_NoContainerDoesNotPickPrevious verifies that a bare
+// /log request never accidentally serves a previous-log record. Previous logs
+// must be opted into explicitly via ?previous=true.
+func TestHandler_ServeLog_NoContainerDoesNotPickPrevious(t *testing.T) {
+	previousLog, _ := json.Marshal("previous only\n")
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/pods/mypod/log?container=app&previous=true": previousLog,
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/mypod/log", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	body := rw.Body.String()
+	if strings.Contains(body, "previous only") {
+		t.Errorf("bare /log served a previous-log record by accident: %q", body)
+	}
+	if !strings.Contains(body, "not captured") {
+		t.Errorf("expected stub since only previous record exists, got %q", body)
+	}
+}
+
 // TestHandler_GroupResourceList_FallbackFromIndex verifies that the mock server
 // returns a valid APIResourceList for a CRD API group even when the
 // /apis/<group>/<version> discovery document was never captured — as long as

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -674,6 +674,60 @@ func TestHandler_ServeLog_NotCaptured(t *testing.T) {
 	}
 }
 
+// TestHandler_ServeLog_PerContainer verifies that `kubectl logs <pod> -c <c>`
+// (which the API client encodes as ?container=<c>) is routed to the
+// matching per-container record.
+func TestHandler_ServeLog_PerContainer(t *testing.T) {
+	webLog, _ := json.Marshal("web container log\n")
+	sidecarLog, _ := json.Marshal("sidecar container log\n")
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/pods/mypod/log?container=web":     webLog,
+		"/api/v1/namespaces/default/pods/mypod/log?container=sidecar": sidecarLog,
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	for container, want := range map[string]string{
+		"web":     "web container log\n",
+		"sidecar": "sidecar container log\n",
+	} {
+		req := httptest.NewRequest(http.MethodGet,
+			"/api/v1/namespaces/default/pods/mypod/log?container="+container, nil)
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+
+		if rw.Code != http.StatusOK {
+			t.Errorf("container=%s: expected 200, got %d", container, rw.Code)
+			continue
+		}
+		if got := rw.Body.String(); got != want {
+			t.Errorf("container=%s: expected %q, got %q", container, want, got)
+		}
+	}
+}
+
+// TestHandler_ServeLog_NoContainerPicksAvailable verifies that when the client
+// asks for `/log` without a ?container= param and the archive only has
+// per-container records (the normal case for new captures), the server falls
+// back to the first one it finds rather than returning the "not captured" stub.
+func TestHandler_ServeLog_NoContainerPicksAvailable(t *testing.T) {
+	webLog, _ := json.Marshal("web container log\n")
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/pods/mypod/log?container=web": webLog,
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/mypod/log", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rw.Code)
+	}
+	if got := rw.Body.String(); got != "web container log\n" {
+		t.Errorf("expected per-container fallback to serve web log, got %q", got)
+	}
+}
+
 // TestHandler_GroupResourceList_FallbackFromIndex verifies that the mock server
 // returns a valid APIResourceList for a CRD API group even when the
 // /apis/<group>/<version> discovery document was never captured — as long as


### PR DESCRIPTION
## Summary

Pod log capture had three issues that combined to make the "some logs missing, no pattern" symptom hard to diagnose on large clusters. This PR fixes all three.

## What was broken

1. **Multi-container pods silently failed.** `GET .../pods/<name>/log` with no `?container=` param returns **HTTP 400** from the API server when the pod has more than one container (Istio sidecars, log shippers, vector/fluent-bit, etc.). The old `fetchOnePodLog` returned silently on any non-200 — these logs were lost without any indication.
2. **A global 30s budget covered all pods sequentially.** On a cluster with ~100 namespaces and thousands of containers, the budget ran out before most logs were even attempted — silently.
3. **No failure visibility.** Errors returned silently even in `--verbose` mode.

## What changes

### Capture engine
- Reads `spec.containers` + `spec.initContainers` from each pod and fetches one log per `(pod, container)`. Records are stored under per-container index keys: `/api/v1/namespaces/<ns>/pods/<name>/log?container=<c>`.
- Fetches run concurrently, bounded by `maxConcurrentLogFetches = 16`. Each individual fetch has its own `perPodLogTimeout = 15s` instead of a global 30s budget — one hung container no longer stalls the pass.
- Failures are recorded in a new `PodLogSummary` surfaced through `CaptureSummary`. Each failure captures the namespace, pod, container, and reason (HTTP code + response body excerpt).

### CLI
After "Capture complete", the CLI now prints:

```
Pod logs:  127/130 captured (3 skipped)
Skipped (sample):
  - prod/app-7d8c [container=istio-proxy]: HTTP 400: a container name must be specified for pod ...
  - staging/job-runner [container=worker]: HTTP 400: container "worker" in pod "job-runner" is waiting to start: PodInitializing
  - kube-system/log-shipper [container=fluent-bit]: timeout after 15s
```

So users see exactly which containers were skipped and why, without re-running with `--verbose`.

### Replay server
`serveLog` now handles per-container routing while keeping backward compatibility with archives created by older versions:
1. If the request has `?container=X`, serve the record at `path?container=X`.
2. Otherwise try the bare path (legacy archives).
3. Otherwise fall back to the first per-container record found for that pod (covers `kubectl logs <pod>` against a single-container pod in a new archive).
4. Otherwise return the existing "not captured" stub.

## Test plan

- [x] `go test -race ./...` passes
- [x] `gofmt`, `go vet` clean
- [x] New tests:
  - `TestEngine_FetchPodsLogs` (updated) — init + main containers stored at per-container keys; summary counters
  - `TestEngine_FetchPodsLogs_SkippedFailuresInSummary` — 400 response is recorded with HTTP code + response body excerpt
  - `TestHandler_ServeLog_PerContainer` — `?container=` request routes correctly
  - `TestHandler_ServeLog_NoContainerPicksAvailable` — bare `/log` request falls back to first per-container record
- [x] Existing tests (`TestHandler_ServeLog_Captured` against a legacy bare-path archive, `TestEngine_NoLogsWhenDisabled`) still pass unchanged

## Compatibility notes

- **Archive format**: per-container records are stored under a new index key suffix `?container=<name>`. The suffix follows the same internal-key convention as `?as=Table`.
- **Old archives**: still served correctly via the bare-path fallback in `serveLog`.
- **No config changes**: the `logs: N` config field works the same; it now captures N tail lines per container instead of per pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)