### PR TITLE
fix(ui): preserve back button when drilled-down namespace is empty

### DIFF
--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -2151,7 +2151,10 @@ const indexHTML = `<!doctype html>
 			el.treeHeadLabel.textContent = nsLabel;
 			el.crumbs.textContent = 'Cluster / ' + nsLabel;
 
-			// back button
+			// Build the back button once; we re-append it whenever a state
+			// transition (loading / empty) clears the tree, so the user can
+			// always return to the namespace list — including when the
+			// drill-down has nothing to show.
 			const back = document.createElement('button');
 			back.className = 'ns-back';
 			back.type = 'button';
@@ -2159,11 +2162,17 @@ const indexHTML = `<!doctype html>
 			back.onclick = navigateBack;
 			el.tree.appendChild(back);
 
+			// Local helper: setTreeState wipes el.tree, so wrap it to preserve
+			// the back button in loading/empty states.
+			const setStateWithBack = (type, message) => {
+				setTreeState(type, message);
+				el.tree.insertBefore(back, el.tree.firstChild);
+			};
+
 			const detail = nsCache[currentNS];
 			if (!detail || detail._loading) {
 				loadNsDetail(currentNS);
-				setTreeState('loading', 'Loading ' + nsLabel + '…');
-				el.tree.appendChild(document.querySelector('.tree-state') || document.createElement('div'));
+				setStateWithBack('loading', 'Loading ' + nsLabel + '…');
 				visibleNodes = [];
 				activeNodeIdx = -1;
 				return;
@@ -2242,8 +2251,7 @@ const indexHTML = `<!doctype html>
 
 			if (renderedNodes === 0) {
 				const msg = q ? 'No resources match "' + q + '" in ' + nsLabel + '.' : nsLabel + ' has no resources at this snapshot.';
-				setTreeState('empty', msg);
-				el.tree.appendChild(drilldown);
+				setStateWithBack('empty', msg);
 				visibleNodes = [];
 				activeNodeIdx = -1;
 				return;


### PR DESCRIPTION
## Summary

Clicking into a namespace card that has no resources at the selected snapshot lost the "← All namespaces" back button. The user was stranded with no way back to the namespace list short of a page reload.

## Root cause

In `renderNsDrilldown` the back button is appended to `el.tree` first, then the function falls through to render content. When the drill-down ends up with zero rendered nodes, the code calls `setTreeState('empty', msg)` — and `setTreeState` does `el.tree.innerHTML = ''` before writing the state box. That wipes the back button.

Same shape of bug affected:
- the loading branch (waiting on `loadNsDetail`)
- the search-no-match branch (empty after filter)

## Fix

A small `setStateWithBack(type, message)` helper inside `renderNsDrilldown`: call `setTreeState` as before, then `insertBefore(back, el.tree.firstChild)` so the back button is preserved at the top of the tree. All three transition branches now route through it.

## Test plan

- [x] `gofmt`, `go vet`, `go test ./internal/ui/` pass
- [x] Manual: opened a capture with `kshrk ui`, clicked into a namespace with no resources, "← All namespaces" button is present and working
- [x] Manual: navigating into a loading namespace also keeps the button
- [x] Manual: searching with a query that matches nothing keeps the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)