### PR TITLE
Show namespace card counts on initial UI load

### DIFF
--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -1325,6 +1325,7 @@ func (e *Engine) storeRecord(indexKey string, body []byte, statusCode int, dedup
 			fmt.Fprintf(os.Stderr, "  [warn] writing record %s: %v\n", indexKey, err)
 		}
 	}
+	itemCount := countListItems(body)
 	e.mu.Lock()
 	if _, ok := e.index[indexKey]; !ok {
 		e.index[indexKey] = &IndexEntry{APIPath: indexKey}
@@ -1333,7 +1334,28 @@ func (e *Engine) storeRecord(indexKey string, body []byte, statusCode int, dedup
 	e.pathSeq[indexKey] = seq + 1
 	e.index[indexKey].Seqs = append(e.index[indexKey].Seqs, seq)
 	e.index[indexKey].Times = append(e.index[indexKey].Times, rec.CapturedAt)
+	e.index[indexKey].Counts = append(e.index[indexKey].Counts, itemCount)
 	e.mu.Unlock()
+}
+
+// countListItems peeks at a JSON response body and returns the number of
+// top-level items in it. Recognises both standard <Kind>List responses
+// (items[]) and meta.k8s.io/v1 Table responses (rows[]). Returns 0 for
+// non-list bodies (single objects, discovery, OpenAPI). Used to populate
+// IndexEntry.Counts so the UI can show namespace card counts without
+// loading each record body.
+func countListItems(body []byte) int {
+	var probe struct {
+		Items []json.RawMessage `json:"items"`
+		Rows  []json.RawMessage `json:"rows"`
+	}
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return 0
+	}
+	if probe.Items != nil {
+		return len(probe.Items)
+	}
+	return len(probe.Rows)
 }
 
 // fetchServerVersion attempts to retrieve the server version string.

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -1620,6 +1620,39 @@ func TestFetchResource_WildcardTableDemuxedPerNamespace(t *testing.T) {
 	}
 }
 
+// TestStoreRecord_PopulatesItemCounts verifies that storeRecord counts the
+// items[] (or rows[] for Table) in each stored body and appends to
+// IndexEntry.Counts in lockstep with Seqs and Times. The UI namespace-card
+// chips depend on these counts being correct.
+func TestStoreRecord_PopulatesItemCounts(t *testing.T) {
+	eng := newEngineWith(&config.Config{}, nil, "", false)
+	ss := &sliceSink{}
+	eng.sink = ss
+
+	threeItems := []byte(`{"kind":"PodList","items":[{"metadata":{"name":"a"}},{"metadata":{"name":"b"}},{"metadata":{"name":"c"}}]}`)
+	zeroItems := []byte(`{"kind":"PodList","items":[]}`)
+	tableTwo := []byte(`{"kind":"Table","columnDefinitions":[],"rows":[{"object":{}},{"object":{}}]}`)
+	singleObj := []byte(`{"kind":"Pod","metadata":{"name":"x"}}`)
+
+	eng.storeRecord("/api/v1/namespaces/default/pods", threeItems, 200, false)
+	eng.storeRecord("/api/v1/namespaces/default/pods", zeroItems, 200, false)
+	eng.storeRecord("/api/v1/namespaces/default/pods?as=Table", tableTwo, 200, false)
+	eng.storeRecord("/api/v1/namespaces/default/pods/foo", singleObj, 200, false)
+
+	plain := eng.index["/api/v1/namespaces/default/pods"]
+	if got := plain.Counts; len(got) != 2 || got[0] != 3 || got[1] != 0 {
+		t.Errorf("plain Counts = %v, want [3 0]", got)
+	}
+	table := eng.index["/api/v1/namespaces/default/pods?as=Table"]
+	if got := table.Counts; len(got) != 1 || got[0] != 2 {
+		t.Errorf("table Counts = %v, want [2]", got)
+	}
+	single := eng.index["/api/v1/namespaces/default/pods/foo"]
+	if got := single.Counts; len(got) != 1 || got[0] != 0 {
+		t.Errorf("single-object Counts = %v, want [0]", got)
+	}
+}
+
 func TestDoFetch_DedupAllSame_FirstAlwaysWritten(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/capture/record.go
+++ b/internal/capture/record.go
@@ -35,6 +35,12 @@ type IndexEntry struct {
 	APIPath string      `json:"api_path"`
 	Seqs    []int       `json:"seqs"`
 	Times   []time.Time `json:"times"`
+	// Counts[i] is the number of top-level items in record i. Populated for
+	// list-shaped responses (anything with an items[] field or rows[] for
+	// Table responses); 0 for non-list records (single objects, discovery
+	// documents, OpenAPI specs). Optional — older archives omit this field
+	// and consumers must treat a nil/short Counts as "unknown" rather than 0.
+	Counts []int `json:"counts,omitempty"`
 }
 
 // Index is the top-level index.json written inside the archive.

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -331,6 +331,59 @@ func (s *CaptureStore) SnapshotAt(apiPath string, at time.Time) ([]byte, int, ti
 	return rec.ResponseBody, rec.ResponseCode, snapTime, nil
 }
 
+// NamespaceItemCountsAt returns a map of namespace → resource → item count at
+// the given time, derived purely from IndexEntry.Counts so no record bodies
+// are read. Only namespaced LIST paths (plain JSON, not ?as=Table) contribute;
+// cluster-scoped paths and per-item GETs are skipped. Counts from records
+// whose IndexEntry.Counts slice is not populated (older archives) are
+// treated as unknown and contribute nothing — the caller can still render
+// the card grid with no chips for those entries.
+func (s *CaptureStore) NamespaceItemCountsAt(at time.Time) map[string]map[string]int {
+	out := make(map[string]map[string]int)
+	for path, entry := range s.Index {
+		if entry == nil || len(entry.Seqs) == 0 {
+			continue
+		}
+		// Skip Table-formatted records: we already count the plain LIST form.
+		if strings.Contains(path, "?") {
+			continue
+		}
+		_, _, resource, ns := parseAPIPath(path)
+		if resource == "" || ns == "" {
+			continue
+		}
+		// Skip per-item paths (e.g. .../pods/<name>) — parseAPIPath returns
+		// resource="" for these in this codebase, but be defensive.
+
+		// Pick the latest record at or before `at`.
+		idx := len(entry.Seqs) - 1
+		if !at.IsZero() && len(entry.Times) == len(entry.Seqs) {
+			pos := sort.Search(len(entry.Times), func(i int) bool {
+				return entry.Times[i].After(at)
+			})
+			if pos == 0 {
+				continue
+			}
+			idx = pos - 1
+		}
+
+		if idx >= len(entry.Counts) {
+			continue // Counts not populated for this record (older archive)
+		}
+		count := entry.Counts[idx]
+		if count <= 0 {
+			continue
+		}
+		byResource, ok := out[ns]
+		if !ok {
+			byResource = make(map[string]int)
+			out[ns] = byResource
+		}
+		byResource[resource] += count
+	}
+	return out
+}
+
 // objectKey returns the stable identity key for a Kubernetes object JSON blob.
 func objectKey(raw json.RawMessage) string {
 	var meta struct {

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -105,6 +106,90 @@ func buildTestStore(t *testing.T, records map[string][]byte) *CaptureStore {
 		t.Fatalf("LoadStore: %v", err)
 	}
 	return store
+}
+
+// TestStore_NamespaceItemCountsAt verifies that NamespaceItemCountsAt reads
+// IndexEntry.Counts (no body reads) and returns the correct per-(ns,
+// resource) totals, picking the latest record at or before the requested
+// time. Older archives whose IndexEntry omits Counts contribute nothing.
+func TestStore_NamespaceItemCountsAt(t *testing.T) {
+	t0 := time.Now().UTC()
+	t1 := t0.Add(30 * time.Second)
+	t2 := t0.Add(60 * time.Second)
+
+	store := &CaptureStore{
+		Index: capture.Index{
+			// Two records at different times — only the latest before `at` counts.
+			"/api/v1/namespaces/team-a/pods": {
+				APIPath: "/api/v1/namespaces/team-a/pods",
+				Seqs:    []int{0, 1},
+				Times:   []time.Time{t0, t2},
+				Counts:  []int{3, 5},
+			},
+			"/apis/apps/v1/namespaces/team-a/deployments": {
+				APIPath: "/apis/apps/v1/namespaces/team-a/deployments",
+				Seqs:    []int{0},
+				Times:   []time.Time{t1},
+				Counts:  []int{2},
+			},
+			"/apis/kubevirt.io/v1/namespaces/team-b/virtualmachines": {
+				APIPath: "/apis/kubevirt.io/v1/namespaces/team-b/virtualmachines",
+				Seqs:    []int{0},
+				Times:   []time.Time{t1},
+				Counts:  []int{4},
+			},
+			// Older archive: no Counts → must be skipped, not counted as 0.
+			"/api/v1/namespaces/team-c/configmaps": {
+				APIPath: "/api/v1/namespaces/team-c/configmaps",
+				Seqs:    []int{0},
+				Times:   []time.Time{t1},
+			},
+			// Cluster-scoped — must not appear in the per-namespace map.
+			"/api/v1/nodes": {
+				APIPath: "/api/v1/nodes",
+				Seqs:    []int{0},
+				Times:   []time.Time{t1},
+				Counts:  []int{6},
+			},
+			// Table records — same data as plain LIST; must not double-count.
+			"/api/v1/namespaces/team-a/pods?as=Table": {
+				APIPath: "/api/v1/namespaces/team-a/pods?as=Table",
+				Seqs:    []int{0},
+				Times:   []time.Time{t2},
+				Counts:  []int{5},
+			},
+		},
+	}
+
+	// At t2: pods/team-a uses the t2 record (5), deployments/team-a still 2,
+	// virtualmachines/team-b 4. team-c contributes nothing (no Counts).
+	got := store.NamespaceItemCountsAt(t2)
+	wantTeamA := map[string]int{"pods": 5, "deployments": 2}
+	wantTeamB := map[string]int{"virtualmachines": 4}
+	if !reflect.DeepEqual(got["team-a"], wantTeamA) {
+		t.Errorf("team-a = %v, want %v", got["team-a"], wantTeamA)
+	}
+	if !reflect.DeepEqual(got["team-b"], wantTeamB) {
+		t.Errorf("team-b = %v, want %v", got["team-b"], wantTeamB)
+	}
+	if _, ok := got["team-c"]; ok {
+		t.Errorf("team-c should be absent (no Counts in archive), got %v", got["team-c"])
+	}
+
+	// At t1 (between t0 and t2): pods/team-a uses the t0 record (3).
+	got = store.NamespaceItemCountsAt(t1)
+	if got["team-a"]["pods"] != 3 {
+		t.Errorf("team-a pods at t1 = %d, want 3", got["team-a"]["pods"])
+	}
+
+	// At t0 (before deployments was recorded): only pods/team-a present.
+	got = store.NamespaceItemCountsAt(t0)
+	if got["team-a"]["pods"] != 3 {
+		t.Errorf("team-a pods at t0 = %d, want 3", got["team-a"]["pods"])
+	}
+	if _, ok := got["team-a"]["deployments"]; ok {
+		t.Error("deployments should not be present at t0 (recorded later)")
+	}
 }
 
 func TestStore_Latest_Found(t *testing.T) {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -66,6 +66,17 @@ type timestampsResponse struct {
 
 type namespaceNode struct {
 	Name string `json:"name"`
+	// Counts is populated for new archives (where IndexEntry.Counts exists)
+	// and lets the UI render namespace-card chips on initial load instead of
+	// waiting for the user to drill in. Omitted entirely for older archives —
+	// the UI then falls back to its current "no chips until visited" behavior.
+	Counts *namespaceCardCounts `json:"counts,omitempty"`
+}
+
+type namespaceCardCounts struct {
+	Workloads int `json:"workloads"`
+	Pods      int `json:"pods"`
+	Resources int `json:"resources"`
 }
 
 type workloadNode struct {
@@ -248,9 +259,19 @@ func (h *explorerHandler) serveTree(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	// Pull per-(ns, resource) counts from IndexEntry.Counts (no body reads).
+	// Older archives have no Counts in their index entries; nsCounts will
+	// simply be empty for those namespaces and the card chips stay blank
+	// until the user drills in, matching the prior behavior.
+	rawCounts := h.store.NamespaceItemCountsAt(h.at)
 	namespaces := make([]namespaceNode, 0, len(nsSet))
 	for ns := range nsSet {
-		namespaces = append(namespaces, namespaceNode{Name: ns})
+		node := namespaceNode{Name: ns}
+		if byResource, ok := rawCounts[ns]; ok {
+			c := categorizeNamespaceCounts(byResource)
+			node.Counts = &c
+		}
+		namespaces = append(namespaces, node)
 	}
 	sort.Slice(namespaces, func(i, j int) bool { return namespaces[i].Name < namespaces[j].Name })
 
@@ -525,9 +546,15 @@ func (h *explorerHandler) buildTreeAt(at time.Time) (*treeResponse, error) {
 			nsSet[ns] = struct{}{}
 		}
 	}
+	rawCounts := h.store.NamespaceItemCountsAt(at)
 	namespaces := make([]namespaceNode, 0, len(nsSet))
 	for ns := range nsSet {
-		namespaces = append(namespaces, namespaceNode{Name: ns})
+		node := namespaceNode{Name: ns}
+		if byResource, ok := rawCounts[ns]; ok {
+			c := categorizeNamespaceCounts(byResource)
+			node.Counts = &c
+		}
+		namespaces = append(namespaces, node)
 	}
 	sort.Slice(namespaces, func(i, j int) bool { return namespaces[i].Name < namespaces[j].Name })
 
@@ -1142,6 +1169,35 @@ func (h *explorerHandler) readRecordBody(apiPath string, seq int) ([]byte, bool)
 		return nil, false
 	}
 	return rec.ResponseBody, true
+}
+
+// uiWorkloadResources is the set of resource names categorized as
+// "workloads" by the namespace-card grid. Mirrors the workloadKinds set in
+// buildNamespaceAt so card chips and drill-down counts stay aligned.
+var uiWorkloadResources = map[string]bool{
+	"deployments":  true,
+	"statefulsets": true,
+	"daemonsets":   true,
+	"jobs":         true,
+	"replicasets":  true,
+}
+
+// categorizeNamespaceCounts maps raw per-resource counts into the three
+// chip categories shown on namespace cards. Pods get their own bucket;
+// recognised workload resources are summed; everything else is "resources".
+func categorizeNamespaceCounts(byResource map[string]int) namespaceCardCounts {
+	var c namespaceCardCounts
+	for resource, n := range byResource {
+		switch {
+		case uiWorkloadResources[resource]:
+			c.Workloads += n
+		case resource == "pods":
+			c.Pods += n
+		default:
+			c.Resources += n
+		}
+	}
+	return c
 }
 
 func baseAPIPath(path string) string {
@@ -2087,10 +2143,27 @@ const indexHTML = `<!doctype html>
 				const label = ns._cluster ? 'Cluster-scoped' : ns.name;
 				if (q && !label.toLowerCase().includes(q)) continue;
 				const detail = nsCache[ns.name] || {};
-				const workloads = (detail.workloads || []).length;
-				const pods = (detail.pods || []).length;
-				const resources = (detail.resources || []).length;
-				const loaded = nsCache[ns.name] && !detail._loading;
+				// If the user has drilled into this ns, the live arrays beat any
+				// precomputed counts (handles snapshot scrubbing edge cases).
+				// Otherwise fall back to the index-derived counts shipped on the
+				// namespace node, so cards show chips before any drill-down.
+				let workloads, pods, resources, loaded;
+				if (nsCache[ns.name] && !detail._loading) {
+					workloads = (detail.workloads || []).length;
+					pods = (detail.pods || []).length;
+					resources = (detail.resources || []).length;
+					loaded = true;
+				} else if (ns.counts) {
+					workloads = ns.counts.workloads || 0;
+					pods = ns.counts.pods || 0;
+					resources = ns.counts.resources || 0;
+					loaded = true;
+				} else {
+					workloads = 0;
+					pods = 0;
+					resources = 0;
+					loaded = false;
+				}
 
 				const card = document.createElement('div');
 				card.className = 'ns-card' + (ns._cluster ? ' cluster' : '');


### PR DESCRIPTION
## Summary

Namespace cards previously showed no chips (workloads / pods / resources counts) until the user drilled into each one — because counts were only available via `/api/ui/tree/namespace`, fetched lazily per card. On a 100-namespace cluster the user had to click every card to see what was populated and what wasn't.

This PR computes item counts **at capture time**, stores them in `index.json`, and ships them in the initial `/api/ui/tree` response. Card chips render immediately. No body reads needed at replay time.

## What changes

### Archive format (additive)

`capture.IndexEntry` gains a `Counts []int` parallel array — one entry per record, in lockstep with `Seqs` and `Times`. `Counts[i]` is the number of `items[]` in record `i` (or `rows[]` for `Table` responses); `0` for non-list records like single-object GETs, discovery docs, or OpenAPI specs.

The field is `omitempty`. **Older archives load unchanged**, and the UI falls back to its prior "no chips until visited" behavior for them. New captures get instant chips.

### Engine

`storeRecord` calls a small `countListItems` helper before stashing the record. Cost is one extra `json.Unmarshal` per record into a 2-field struct (`items` + `rows`) — negligible vs. the rest of the write path.

### Server

`CaptureStore.NamespaceItemCountsAt(at)` walks the index, picks the latest record at or before the requested time per per-namespace LIST path, and returns `ns → resource → count` without reading any record body. Records whose `Counts` slice is too short (older archive) are skipped — treated as unknown, not zero, so old captures don't get bogus empty-chip rendering.

Table records are skipped to avoid double-counting (the matching plain LIST covers the namespace already).

### UI

- `namespaceNode` gains a `Counts` pointer (`workloads`/`pods`/`resources`). Pointer-not-struct so old archives serialize the field as omitted, distinguishing "no data" from "all zero".
- `serveTree` (and the legacy `buildTreeAt` used by tests) populate `Counts` via `NamespaceItemCountsAt`, categorizing resources into chip buckets with the same `workloadKinds` set used by the drill-down.
- `renderCardGrid` uses `tree.namespaces[i].counts` to draw chips before any drill-down. Drilled-in data still wins so snapshot scrubbing reflects live values once cached.

## Test plan

- [x] `go test -race ./...` passes
- [x] `gofmt`, `go vet` clean
- [x] New tests:
  - `TestStoreRecord_PopulatesItemCounts` — `items[]` and `rows[]` both counted; single-object records get `0`; per-record alignment with `Seqs` is correct.
  - `TestStore_NamespaceItemCountsAt` — picks the right record per timestamp (time-travel), skips paths whose `Counts` is unset (older archives), excludes cluster-scoped paths and Table records.
- [x] All existing tests (server, capture, UI) pass without modification.

## Compatibility

- **No breaking format change.** `Counts` is `omitempty`. Existing captures are byte-for-byte compatible with old readers and load fine in the new server (cards stay empty until visited).
- New captures get chips immediately.
- No config changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)