### PR TITLE
fix(ui): exclude cluster-spanning resources from namespace card counts

### DIFF
--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -268,7 +268,7 @@ func (h *explorerHandler) serveTree(w http.ResponseWriter, r *http.Request) {
 	for ns := range nsSet {
 		node := namespaceNode{Name: ns}
 		if byResource, ok := rawCounts[ns]; ok {
-			c := categorizeNamespaceCounts(byResource)
+			c := categorizeNamespaceCounts(byResource, h.clusterSpanning)
 			node.Counts = &c
 		}
 		namespaces = append(namespaces, node)
@@ -551,7 +551,7 @@ func (h *explorerHandler) buildTreeAt(at time.Time) (*treeResponse, error) {
 	for ns := range nsSet {
 		node := namespaceNode{Name: ns}
 		if byResource, ok := rawCounts[ns]; ok {
-			c := categorizeNamespaceCounts(byResource)
+			c := categorizeNamespaceCounts(byResource, h.clusterSpanning)
 			node.Counts = &c
 		}
 		namespaces = append(namespaces, node)
@@ -1185,9 +1185,19 @@ var uiWorkloadResources = map[string]bool{
 // categorizeNamespaceCounts maps raw per-resource counts into the three
 // chip categories shown on namespace cards. Pods get their own bucket;
 // recognised workload resources are summed; everything else is "resources".
-func categorizeNamespaceCounts(byResource map[string]int) namespaceCardCounts {
+//
+// skipResources is the set of resource names to exclude — typically the
+// cluster-spanning set (PackageManifests and similar resources that
+// technically have namespace scope but return the same cluster-wide list
+// for every namespace). The drill-down view applies the same filter, so
+// excluding them here keeps the card chip totals in sync with what the
+// user sees after navigating in.
+func categorizeNamespaceCounts(byResource map[string]int, skipResources map[string]bool) namespaceCardCounts {
 	var c namespaceCardCounts
 	for resource, n := range byResource {
+		if skipResources[resource] {
+			continue
+		}
 		switch {
 		case uiWorkloadResources[resource]:
 			c.Workloads += n

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -715,3 +715,96 @@ func TestServeObjectHistory_MissingName(t *testing.T) {
 		t.Fatalf("expected 400, got %d", rr.Code)
 	}
 }
+
+// TestBuildTreeAt_NamespaceCountsExcludeClusterSpanning verifies that the
+// per-namespace card counts in the /api/ui/tree response apply the same
+// cluster-spanning filter as the drill-down (buildNamespaceAt). Without
+// this filter, OLM-style resources like packagemanifests inflate the
+// initial card count, and the card flips to "empty" (or a smaller number)
+// once the user drills in and the drill-down's filtered list takes over.
+func TestBuildTreeAt_NamespaceCountsExcludeClusterSpanning(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "spanning.khsrk")
+	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+
+	// Five namespaces, each with the same packagemanifests entries
+	// (OLM-style behaviour). 5/5 = 100% of namespaces trips the spanning
+	// detection (threshold is 30% with a min of 3). Each namespace also
+	// gets a UNIQUE resource type that only exists in that one namespace —
+	// so the unique resource stays at 1/5 = 20% and is NOT flagged.
+	pkgList := `{"apiVersion":"packages.operators.coreos.com/v1","kind":"PackageManifestList","items":[` +
+		`{"metadata":{"name":"pkg-a","namespace":"x"}},` +
+		`{"metadata":{"name":"pkg-b","namespace":"x"}}` +
+		`]}`
+	uniqueList := func(ns, resource string) string {
+		return `{"apiVersion":"example.io/v1","kind":"WidgetList","items":[{"apiVersion":"example.io/v1","kind":"Widget","metadata":{"name":"w-1","namespace":"` + ns + `"}}]}`
+	}
+
+	recs := []*capture.Record{}
+	idx := capture.Index{}
+	type nsSpec struct{ name, uniqueRes string }
+	specs := []nsSpec{
+		{"openshift-config", "configonly"},
+		{"openshift-config-managed", "managedonly"},
+		{"kube-system", "kubeonly"},
+		{"openshift-operators", "operatorsonly"},
+		{"default", "defaultonly"},
+	}
+	for _, s := range specs {
+		pmPath := "/apis/packages.operators.coreos.com/v1/namespaces/" + s.name + "/packagemanifests"
+		uPath := "/apis/example.io/v1/namespaces/" + s.name + "/" + s.uniqueRes
+		recs = append(recs,
+			&capture.Record{ID: "r" + s.name + "-pm", CapturedAt: now, APIPath: pmPath, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(pkgList)},
+			&capture.Record{ID: "r" + s.name + "-u", CapturedAt: now, APIPath: uPath, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(uniqueList(s.name, s.uniqueRes))},
+		)
+		// Seqs are per-path, not global; the archive writer assigns 0..N per path.
+		idx[pmPath] = &capture.IndexEntry{APIPath: pmPath, Seqs: []int{0}, Times: []time.Time{now}, Counts: []int{2}}
+		idx[uPath] = &capture.IndexEntry{APIPath: uPath, Seqs: []int{0}, Times: []time.Time{now}, Counts: []int{1}}
+	}
+
+	meta := &capture.CaptureMetadata{
+		CaptureID:     "spanning-test",
+		CapturedAt:    now.Add(-1 * time.Minute),
+		CapturedUntil: now,
+		RecordCount:   len(recs),
+	}
+	store := buildStoreFromArchive(t, out, recs, idx, nil, meta)
+
+	h := &explorerHandler{store: store, at: now}
+	h.clusterSpanning = computeClusterSpanningResources(store)
+
+	if !h.clusterSpanning["packagemanifests"] {
+		t.Fatalf("test setup invalid: expected packagemanifests to be flagged cluster-spanning, got %v", h.clusterSpanning)
+	}
+	for _, s := range specs {
+		if h.clusterSpanning[s.uniqueRes] {
+			t.Fatalf("test setup invalid: unique resource %q should not be cluster-spanning", s.uniqueRes)
+		}
+	}
+
+	tree, err := h.buildTreeAt(now)
+	if err != nil {
+		t.Fatalf("buildTreeAt: %v", err)
+	}
+
+	// Each card should show only the 1 unique-resource (not 2 packagemanifests
+	// + 1 unique = 3), and the drill-down must agree to avoid the
+	// "count then empty" flicker the user reported.
+	for _, n := range tree.Namespaces {
+		if n.Counts == nil {
+			t.Errorf("namespace %s missing counts", n.Name)
+			continue
+		}
+		if got := n.Counts.Resources; got != 1 {
+			t.Errorf("namespace %s card chip resources=%d, want 1 (packagemanifests must be filtered)", n.Name, got)
+		}
+		nsDetail, err := h.buildNamespaceAt(n.Name, now)
+		if err != nil {
+			t.Fatalf("buildNamespaceAt(%s): %v", n.Name, err)
+		}
+		if drilldown := len(nsDetail.Resources); drilldown != n.Counts.Resources {
+			t.Errorf("namespace %s: card chip=%d but drill-down resources=%d (mismatch causes the empty-after-visit bug)",
+				n.Name, n.Counts.Resources, drilldown)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #82. The namespace card chips computed from index counts were over-counting in namespaces dominated by OLM-style resources (PackageManifests etc.), then flipping to "empty" once visited — because the drill-down's filtered list took over the chip values via `nsCache`.

`openshift-config` and `openshift-config-managed` were the two namespaces the user spotted.

## Root cause

`buildNamespaceAt` skips resources flagged by `computeClusterSpanningResources` (the OLM-style ones that show the same cluster-wide list in every namespace). The new index-counts path in `serveTree` did **not** apply that filter, so:

- Initial card render → unfiltered count from `IndexEntry.Counts` → looks non-empty
- User drills in → `buildNamespaceAt` filters → drill-down shows fewer (often zero) items
- User goes back → card now uses `nsCache.<live arrays>.length` → shows the filtered total
- Net effect: count → drill-in → "empty" flicker

## Fix

`categorizeNamespaceCounts` now takes the cluster-spanning set as a second argument and skips those resources when summing. Both call sites in `serveTree` and `buildTreeAt` pass `h.clusterSpanning`. The card and the drill-down now agree by construction.

## Test plan

- [x] `go test -race ./...` passes
- [x] `gofmt`, `go vet` clean
- [x] New test `TestBuildTreeAt_NamespaceCountsExcludeClusterSpanning`:
  - 5 namespaces each with shared `packagemanifests` (5/5 → cluster-spanning) plus a per-namespace unique resource (1/5 → not cluster-spanning).
  - Asserts the card chip count equals the drill-down count exactly — the invariant the bug violated.
- [x] Existing UI tests pass without modification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)