### PR TITLE
feat(ui): Design C dashboard redesign at /v2/

### DIFF
--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -6,9 +6,11 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/phenixblue/k8shark/internal/config"
 	"github.com/phenixblue/k8shark/internal/server"
 	"github.com/phenixblue/k8shark/internal/ui"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var uiCmd = &cobra.Command{
@@ -35,6 +37,17 @@ func runUI(cmd *cobra.Command, args []string) error {
 	kubeconfigOut, _ := cmd.Flags().GetString("kubeconfig-out")
 	at, _ := cmd.Flags().GetString("at")
 	verbose, _ := cmd.Root().PersistentFlags().GetBool("verbose")
+
+	// Fall back to config-file ui.port / ui.api_port when the flags were left at
+	// their default; an explicitly-passed flag always wins.
+	if cfg, err := config.Load(viper.ConfigFileUsed()); err == nil && cfg != nil {
+		if !cmd.Flags().Changed("port") && cfg.UI.Port != "" {
+			uiPort = cfg.UI.Port
+		}
+		if !cmd.Flags().Changed("api-port") && cfg.UI.APIPort != "" {
+			apiPort = cfg.UI.APIPort
+		}
+	}
 
 	mockSrv, err := server.Open(server.OpenOptions{
 		ArchivePath:   archivePath,

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,6 +12,25 @@ k8shark reads a YAML config file that controls what gets captured, from which na
 | `resources` | list | required | Resource types to capture. See below. |
 | `auto_discover` | bool | `false` | Legacy global discovery toggle. Prefer `resources: - all: true` for fine-grained control. |
 | `redaction` | object | — | Optional field-level redaction rules applied after capture. See [Redaction](#redaction). |
+| `ui` | object | — | Ports for the `kshrk ui` web explorer. See [Web UI ports](#web-ui-ports). |
+
+## Web UI ports
+
+`kshrk ui` serves a local web UI plus a mock Kubernetes API server. By default
+both bind a random free port. Set the `ui` block to pin consistent ports:
+
+```yaml
+ui:
+  port: "8080"       # local web UI server
+  api_port: "8081"   # mock Kubernetes API server
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ui.port` | string | `0` (random) | Port for the local web UI. |
+| `ui.api_port` | string | `0` (random) | Port for the mock Kubernetes API server. |
+
+The `--port` and `--api-port` flags on `kshrk ui` override these when provided.
 
 ## Resource entry fields
 

--- a/examples/k8shark.yaml
+++ b/examples/k8shark.yaml
@@ -13,6 +13,13 @@ output: ./capture.tar.gz
 # Defaults to $KUBECONFIG env, then ~/.kube/config.
 # kubeconfig: ~/.kube/config
 
+# Web UI ("kshrk ui") server ports. Omit or "0" for a random free port; set
+# these to pin consistent ports across runs. The --port / --api-port CLI flags
+# override these when provided.
+# ui:
+#   port: "8080"       # local web UI
+#   api_port: "8081"   # mock Kubernetes API server
+
 resources:
   # ── Core workloads ───────────────────────────────────────────────────────────
 

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -23,6 +23,9 @@ type RecordSink interface {
 	// watch-index.json, then closes the archive.
 	Finish(meta, index, watchIndex any) error
 	RecordCount() int
+	// UncompressedBytes returns the running total of record JSON bytes written
+	// (before compression).
+	UncompressedBytes() int64
 }
 
 // pathDir returns a short, filesystem-safe directory name for an API path.
@@ -79,6 +82,7 @@ type StreamWriter struct {
 	f       *os.File
 	zw      *zip.Writer
 	n       int
+	bytes   int64          // running total of uncompressed record JSON bytes
 	pathSeq map[string]int // apiPath → next seq number for that path's directory
 }
 
@@ -129,6 +133,7 @@ func (w *StreamWriter) WriteRecord(rec any) error {
 		return err
 	}
 	w.n++
+	w.bytes += int64(len(data))
 	return nil
 }
 
@@ -155,6 +160,7 @@ func (w *StreamWriter) WriteRecordRaw(apiPath string, data any) (int, error) {
 		return 0, err
 	}
 	w.n++
+	w.bytes += int64(len(b))
 	return seq, nil
 }
 
@@ -196,13 +202,21 @@ func (w *StreamWriter) RecordCount() int {
 	return w.n
 }
 
+// UncompressedBytes returns the total uncompressed record JSON bytes written.
+func (w *StreamWriter) UncompressedBytes() int64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.bytes
+}
+
 // NDJSONWriter writes each record as a newline-delimited JSON object to an
 // io.Writer (typically os.Stdout). Finish is a no-op. Thread-safe.
 type NDJSONWriter struct {
-	mu  sync.Mutex
-	w   io.Writer
-	enc *json.Encoder
-	n   int
+	mu    sync.Mutex
+	w     io.Writer
+	enc   *json.Encoder
+	n     int
+	bytes int64
 }
 
 // NewNDJSONWriter creates an NDJSONWriter writing to w.
@@ -214,6 +228,9 @@ func NewNDJSONWriter(w io.Writer) *NDJSONWriter {
 func (w *NDJSONWriter) WriteRecord(rec any) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if b, err := json.Marshal(rec); err == nil {
+		w.bytes += int64(len(b))
+	}
 	if err := w.enc.Encode(rec); err != nil {
 		return err
 	}
@@ -229,6 +246,13 @@ func (w *NDJSONWriter) RecordCount() int {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.n
+}
+
+// UncompressedBytes returns the total record JSON bytes written.
+func (w *NDJSONWriter) UncompressedBytes() int64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.bytes
 }
 
 // Archive provides random-access reads into a k8shark ZIP+Zstd capture archive.

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -18,6 +18,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -79,6 +84,7 @@ type Engine struct {
 	cfg            *config.Config
 	verbose        bool
 	httpClient     *http.Client
+	dynClient      dynamic.Interface // client-go dynamic client used for watch streams
 	baseURL        string
 	mu             sync.Mutex
 	index          Index
@@ -122,10 +128,21 @@ func NewEngine(cfg *config.Config, verbose bool) (*Engine, error) {
 		return nil, fmt.Errorf("building HTTP client: %w", err)
 	}
 
+	// Watch streams go through client-go's dynamic client (which uses the proper
+	// streaming watch decoder) rather than a hand-rolled HTTP request. It gets
+	// its OWN transport/connection (NewForConfig, not the shared httpClient) so
+	// long-lived watch streams don't contend with poll requests for HTTP/2
+	// streams on a single connection.
+	dynClient, err := dynamic.NewForConfig(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("building dynamic client: %w", err)
+	}
+
 	return &Engine{
 		cfg:                       cfg,
 		verbose:                   verbose,
 		httpClient:                httpClient,
+		dynClient:                 dynClient,
 		baseURL:                   restCfg.Host,
 		index:                     make(Index),
 		watchIndex:                make(WatchIndex),
@@ -141,10 +158,16 @@ func NewEngine(cfg *config.Config, verbose bool) (*Engine, error) {
 // newEngineWith constructs an Engine with a pre-built HTTP client and base URL.
 // Used in tests to inject a fake API server.
 func newEngineWith(cfg *config.Config, client *http.Client, baseURL string, verbose bool) *Engine {
+	// Build a dynamic client backed by the injected test client/server so watch
+	// streams resolve against the fake API server. Errors are ignored because
+	// the watch-streaming tests that need it construct against a valid baseURL;
+	// non-watch tests never touch dynClient.
+	dynClient, _ := dynamic.NewForConfigAndClient(&rest.Config{Host: baseURL}, client)
 	return &Engine{
 		cfg:                       cfg,
 		verbose:                   verbose,
 		httpClient:                client,
+		dynClient:                 dynClient,
 		baseURL:                   baseURL,
 		index:                     make(Index),
 		watchIndex:                make(WatchIndex),
@@ -393,12 +416,7 @@ func (e *Engine) watchResourcePath(ctx context.Context, res config.Resource, nam
 			return
 		}
 
-		resourceVersion := ""
-		if body, code := e.doFetch(ctx, apiPath, "", res.DedupEnabled()); code == http.StatusOK && body != nil {
-			resourceVersion = extractResourceVersion(body)
-		}
-
-		if err := e.streamWatch(ctx, res, apiPath, resourceVersion); err != nil && ctx.Err() == nil && e.verbose {
+		if err := e.streamWatch(ctx, res, apiPath, namespace); err != nil && ctx.Err() == nil && e.verbose {
 			fmt.Fprintf(os.Stderr, "  [watch] %s: %v\n", apiPath, err)
 		}
 
@@ -415,108 +433,141 @@ func (e *Engine) watchResourcePath(ctx context.Context, res config.Resource, nam
 	}
 }
 
-func (e *Engine) streamWatch(ctx context.Context, res config.Resource, apiPath, resourceVersion string) error {
-	q := url.Values{}
-	q.Set("watch", "1")
-	if resourceVersion != "" {
-		q.Set("resourceVersion", resourceVersion)
-	}
-
+// streamWatch opens a single watch stream via client-go's dynamic client and
+// records each ADDED/MODIFIED/DELETED event. Using the dynamic client (rather
+// than a hand-rolled HTTP request + json.Decoder) means watch events are
+// decoded by client-go's StreamWatcher, which negotiates the correct content
+// type and reliably streams events over HTTP/2 — a raw request would connect
+// but never receive any frames against some API servers.
+//
+// namespace is "" for a cluster-wide stream (cluster-scoped resources and the
+// single stream used for wildcard-namespaced resources); otherwise it is the
+// specific namespace to watch. Returning nil/err drives watchResourcePath's
+// reconnect loop, which re-bootstraps a fresh resourceVersion before retrying.
+func (e *Engine) streamWatch(ctx context.Context, res config.Resource, apiPath, namespace string) error {
 	// Wildcard-namespace watches open a single cluster-wide stream but rewrite
 	// each event's stored APIPath to /api/.../namespaces/<ns>/<resource> so the
 	// replay server's per-namespace reconstruction logic continues to work
 	// without changes.
 	demuxPerNamespace := res.WildcardNamespaces && apiPath == buildAPIPath(res.Group, res.Version, res.Resource, "")
 
-	watchURL := e.baseURL + apiPath + "?" + q.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, watchURL, nil)
-	if err != nil {
-		return err
+	gvr := schema.GroupVersionResource{Group: res.Group, Version: res.Version, Resource: res.Resource}
+
+	var ri dynamic.ResourceInterface = e.dynClient.Resource(gvr)
+	if namespace != "" {
+		ri = e.dynClient.Resource(gvr).Namespace(namespace)
 	}
 
-	resp, err := e.httpClient.Do(req)
+	// Bootstrap a starting resourceVersion with a cheap one-item list so the
+	// watch streams only changes from this point forward rather than replaying
+	// every existing object as an ADDED event. The list metadata carries the
+	// collection resourceVersion regardless of how many items are returned.
+	opts := metav1.ListOptions{}
+	if l, err := ri.List(ctx, metav1.ListOptions{Limit: 1}); err == nil {
+		opts.ResourceVersion = l.GetResourceVersion()
+	} else if ctx.Err() != nil {
+		return nil
+	}
+
+	w, err := ri.Watch(ctx, opts)
 	if err != nil {
 		if ctx.Err() != nil {
 			return nil
 		}
 		return err
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("watch status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
+	defer w.Stop()
 
 	if e.verbose {
 		fmt.Fprintf(os.Stdout, "  [watch] %s connected\n", apiPath)
 	}
 
-	dec := json.NewDecoder(resp.Body)
 	for {
-		var event struct {
-			Type   string          `json:"type"`
-			Object json.RawMessage `json:"object"`
-		}
-		if err := dec.Decode(&event); err != nil {
-			if err == io.EOF || ctx.Err() != nil {
+		select {
+		case <-ctx.Done():
+			return nil
+		case event, ok := <-w.ResultChan():
+			if !ok {
+				// Server closed the stream; the caller re-lists and reconnects.
 				return nil
 			}
-			return err
-		}
 
-		switch event.Type {
-		case "ADDED", "MODIFIED", "DELETED":
-			// Keep these event types.
-		default:
-			continue
-		}
-		if len(event.Object) == 0 {
-			continue
-		}
-
-		recordPath := apiPath
-		if demuxPerNamespace {
-			ns := extractNamespaceFromObject(event.Object)
-			if ns == "" {
-				// Namespaced resources should always have metadata.namespace
-				// set on watch events. Skip rather than store an unattributable
-				// event under the cluster-wide path where the replay server
-				// won't find it.
-				continue
-			}
-			recordPath = buildAPIPath(res.Group, res.Version, res.Resource, ns)
-		}
-
-		rec := &Record{
-			ID:           uuid.New().String(),
-			CapturedAt:   time.Now().UTC(),
-			APIPath:      recordPath,
-			EventType:    event.Type,
-			HTTPMethod:   http.MethodGet,
-			ResponseCode: http.StatusOK,
-			ResponseBody: event.Object,
-		}
-
-		if e.sink != nil {
-			if err := e.sink.WriteRecord(rec); err != nil {
+			var eventType string
+			switch event.Type {
+			case watch.Added:
+				eventType = "ADDED"
+			case watch.Modified:
+				eventType = "MODIFIED"
+			case watch.Deleted:
+				eventType = "DELETED"
+			case watch.Error:
+				// Typically a 410 Expired Status. Log and let the channel close
+				// so watchResourcePath re-lists for a fresh resourceVersion.
 				if e.verbose {
-					fmt.Fprintf(os.Stderr, "  [warn] writing watch record %s: %v\n", recordPath, err)
+					msg := "unknown watch error"
+					if st, ok := event.Object.(*metav1.Status); ok && st.Message != "" {
+						msg = st.Message
+					}
+					fmt.Fprintf(os.Stderr, "  [watch] %s: error event: %s\n", apiPath, msg)
 				}
 				continue
+			default:
+				// Bookmark and any other types are not transitions.
+				continue
 			}
-		}
 
-		e.mu.Lock()
-		if _, ok := e.watchIndex[recordPath]; !ok {
-			e.watchIndex[recordPath] = &WatchIndexEntry{APIPath: recordPath}
+			u, ok := event.Object.(*unstructured.Unstructured)
+			if !ok {
+				continue
+			}
+			body, err := u.MarshalJSON()
+			if err != nil {
+				continue
+			}
+
+			recordPath := apiPath
+			if demuxPerNamespace {
+				ns := u.GetNamespace()
+				if ns == "" {
+					// Namespaced resources should always have metadata.namespace
+					// set on watch events. Skip rather than store an unattributable
+					// event under the cluster-wide path where the replay server
+					// won't find it.
+					continue
+				}
+				recordPath = buildAPIPath(res.Group, res.Version, res.Resource, ns)
+			}
+
+			rec := &Record{
+				ID:           uuid.New().String(),
+				CapturedAt:   time.Now().UTC(),
+				APIPath:      recordPath,
+				EventType:    eventType,
+				HTTPMethod:   http.MethodGet,
+				ResponseCode: http.StatusOK,
+				ResponseBody: body,
+			}
+
+			if e.sink != nil {
+				if err := e.sink.WriteRecord(rec); err != nil {
+					if e.verbose {
+						fmt.Fprintf(os.Stderr, "  [warn] writing watch record %s: %v\n", recordPath, err)
+					}
+					continue
+				}
+			}
+
+			e.mu.Lock()
+			if _, ok := e.watchIndex[recordPath]; !ok {
+				e.watchIndex[recordPath] = &WatchIndexEntry{APIPath: recordPath}
+			}
+			seq := e.pathSeq[recordPath]
+			e.pathSeq[recordPath] = seq + 1
+			e.watchIndex[recordPath].Seqs = append(e.watchIndex[recordPath].Seqs, seq)
+			e.watchIndex[recordPath].Times = append(e.watchIndex[recordPath].Times, rec.CapturedAt)
+			e.watchIndex[recordPath].EventTypes = append(e.watchIndex[recordPath].EventTypes, rec.EventType)
+			e.mu.Unlock()
 		}
-		seq := e.pathSeq[recordPath]
-		e.pathSeq[recordPath] = seq + 1
-		e.watchIndex[recordPath].Seqs = append(e.watchIndex[recordPath].Seqs, seq)
-		e.watchIndex[recordPath].Times = append(e.watchIndex[recordPath].Times, rec.CapturedAt)
-		e.watchIndex[recordPath].EventTypes = append(e.watchIndex[recordPath].EventTypes, rec.EventType)
-		e.mu.Unlock()
 	}
 }
 
@@ -574,18 +625,6 @@ func extractStatusMessage(body []byte) string {
 		return ""
 	}
 	return s.Message
-}
-
-func extractResourceVersion(body []byte) string {
-	var meta struct {
-		Metadata struct {
-			ResourceVersion string `json:"resourceVersion"`
-		} `json:"metadata"`
-	}
-	if err := json.Unmarshal(body, &meta); err != nil {
-		return ""
-	}
-	return meta.Metadata.ResourceVersion
 }
 
 // tableIndexKey is the virtual index key used to store Table-format responses

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -64,6 +64,13 @@ type PodLogFailure struct {
 // how many resources are configured or auto-discovered.
 const maxConcurrentFetches = 32
 
+// perFetchTimeout caps any single list/discovery fetch (request + body read).
+// Without it a stalled HTTP/2 stream can leave io.ReadAll blocked indefinitely
+// while holding a fetchSem slot, starving every other fetch and stalling
+// capture startup. The cap lets the fetch fail fast; polling retries on its
+// next interval. Generous enough for large list responses on slow links.
+const perFetchTimeout = 30 * time.Second
+
 // Pod log fetch tuning.
 const (
 	// maxConcurrentLogFetches bounds the number of in-flight pod-log GETs.
@@ -96,6 +103,7 @@ type Engine struct {
 	warnedFallback map[string]bool // dedup set for allNotFound cluster-scoped fallback warnings
 	pathSeq        map[string]int  // per-path record sequence counter (matches archive on-disk seq)
 	fetchSem       chan struct{}   // semaphore bounding concurrent body reads
+	fetchTimeout   time.Duration   // per-fetch cap (request + body read); 0 means perFetchTimeout
 	// clusterListNamespacesSeen tracks, per wildcard-namespaced resource path,
 	// the set of namespaces that have produced items in any prior cluster-wide
 	// LIST response. Used by the demux so a namespace that empties out between
@@ -131,8 +139,8 @@ func NewEngine(cfg *config.Config, verbose bool) (*Engine, error) {
 	// Watch streams go through client-go's dynamic client (which uses the proper
 	// streaming watch decoder) rather than a hand-rolled HTTP request. It gets
 	// its OWN transport/connection (NewForConfig, not the shared httpClient) so
-	// long-lived watch streams don't contend with poll requests for HTTP/2
-	// streams on a single connection.
+	// long-lived watch streams don't contend with poll requests on a single
+	// connection.
 	dynClient, err := dynamic.NewForConfig(restCfg)
 	if err != nil {
 		return nil, fmt.Errorf("building dynamic client: %w", err)
@@ -151,6 +159,7 @@ func NewEngine(cfg *config.Config, verbose bool) (*Engine, error) {
 		warnedFallback:            make(map[string]bool),
 		pathSeq:                   make(map[string]int),
 		fetchSem:                  make(chan struct{}, maxConcurrentFetches),
+		fetchTimeout:              perFetchTimeout,
 		clusterListNamespacesSeen: make(map[string]map[string]bool),
 	}, nil
 }
@@ -176,6 +185,7 @@ func newEngineWith(cfg *config.Config, client *http.Client, baseURL string, verb
 		warnedFallback:            make(map[string]bool),
 		pathSeq:                   make(map[string]int),
 		fetchSem:                  make(chan struct{}, maxConcurrentFetches),
+		fetchTimeout:              perFetchTimeout,
 		clusterListNamespacesSeen: make(map[string]map[string]bool),
 	}
 }
@@ -655,12 +665,16 @@ func (e *Engine) fetchResource(ctx context.Context, res config.Resource) {
 	// Track whether every explicitly-namespaced fetch returned 404. If so, the
 	// resource is likely cluster-scoped and the config has 'namespaces:' set by
 	// mistake — warn and also capture the cluster-scoped path as a fallback.
+	// Only a genuine 404 counts as evidence of cluster scope: a code of 0 means
+	// the fetch failed transiently (timeout/transport/cancellation), which must
+	// not be mistaken for "this resource isn't served per-namespace" or every
+	// flaky fetch would trigger a spurious cluster-wide fallback.
 	allNotFound := len(res.Namespaces) > 0
 	dedupEnabled := res.DedupEnabled()
 	for _, ns := range namespaces {
 		apiPath := buildAPIPath(res.Group, res.Version, res.Resource, ns)
 		_, code := e.doFetch(ctx, apiPath, "", dedupEnabled)
-		if code != 0 && code != http.StatusNotFound {
+		if code != http.StatusNotFound {
 			allNotFound = false
 		}
 		e.doFetch(ctx, apiPath, tableIndexKeySuffix, dedupEnabled)
@@ -1216,14 +1230,19 @@ func (e *Engine) fetchDiscovery(ctx context.Context) {
 	e.doFetch(ctx, "/openapi/v2", "", true)
 	openapiV3Body, _ := e.doFetch(ctx, "/openapi/v3", "", true)
 	if openapiV3Body != nil {
-		// Parse the v3 path index and fetch each per-group spec.
+		// Parse the v3 path index and fetch each per-group spec. These are
+		// numerous (100+ on OpenShift) and independent, so fetch them
+		// concurrently — done sequentially they can dominate (or exhaust) the
+		// whole capture window before polling/watching even begins.
 		var v3Index struct {
 			Paths map[string]json.RawMessage `json:"paths"`
 		}
 		if err := json.Unmarshal(openapiV3Body, &v3Index); err == nil {
+			paths := make([]string, 0, len(v3Index.Paths))
 			for p := range v3Index.Paths {
-				e.doFetch(ctx, "/openapi/v3/"+p, "", true)
+				paths = append(paths, "/openapi/v3/"+p)
 			}
+			e.fetchDiscoveryPaths(ctx, paths, false)
 		}
 	}
 
@@ -1241,15 +1260,42 @@ func (e *Engine) fetchDiscovery(ctx context.Context) {
 	if err := json.Unmarshal(apisBody, &groupList); err != nil {
 		return
 	}
+	gvPaths := make([]string, 0, len(groupList.Groups))
 	for _, g := range groupList.Groups {
 		for _, v := range g.Versions {
-			gvPath := "/apis/" + v.GroupVersion
-			gvBody, _ := e.doFetch(ctx, gvPath, "", true)
-			if gvBody != nil {
-				e.discoveryCache[gvPath] = gvBody
-			}
+			gvPaths = append(gvPaths, "/apis/"+v.GroupVersion)
 		}
 	}
+	e.fetchDiscoveryPaths(ctx, gvPaths, true)
+}
+
+// fetchDiscoveryPaths GETs each path concurrently (bounded), recording every
+// response via doFetch. When cache is true, successful bodies are also stored
+// in discoveryCache keyed by path so autoDiscoverResources can reuse them
+// without re-fetching. Concurrency keeps discovery from dominating short
+// captures on clusters with many API groups.
+func (e *Engine) fetchDiscoveryPaths(ctx context.Context, paths []string, cache bool) {
+	const discoveryWorkers = 16
+	sem := make(chan struct{}, discoveryWorkers)
+	var wg sync.WaitGroup
+	for _, p := range paths {
+		if ctx.Err() != nil {
+			break
+		}
+		wg.Add(1)
+		go func(path string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			body, _ := e.doFetch(ctx, path, "", true)
+			if cache && body != nil {
+				e.mu.Lock()
+				e.discoveryCache[path] = body
+				e.mu.Unlock()
+			}
+		}(p)
+	}
+	wg.Wait()
 }
 
 // doFetch issues one GET for apiPath. When tableKeySuffix is non-empty the
@@ -1274,7 +1320,17 @@ func (e *Engine) doFetch(ctx context.Context, apiPath, tableKeySuffix string, de
 func (e *Engine) rawFetch(ctx context.Context, apiPath, tableKeySuffix string) ([]byte, int) {
 	url := e.baseURL + apiPath
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	// Bound this fetch independently so a stalled HTTP/2 stream can't hang
+	// io.ReadAll forever (see perFetchTimeout). The deadline covers both the
+	// request and the body read because it rides on the request context.
+	timeout := e.fetchTimeout
+	if timeout <= 0 {
+		timeout = perFetchTimeout
+	}
+	fetchCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, url, nil)
 	if err != nil {
 		if e.verbose {
 			fmt.Fprintf(os.Stderr, "  [warn] build request %s: %v\n", apiPath, err)
@@ -1296,11 +1352,17 @@ func (e *Engine) rawFetch(ctx context.Context, apiPath, tableKeySuffix string) (
 		}
 		return nil, 0
 	}
+	defer resp.Body.Close()
 
-	e.fetchSem <- struct{}{}
+	// Acquire a read slot without blocking past this fetch's deadline, so a
+	// saturated semaphore can't pin a timed-out fetch indefinitely.
+	select {
+	case e.fetchSem <- struct{}{}:
+	case <-fetchCtx.Done():
+		return nil, 0
+	}
 	body, err := io.ReadAll(resp.Body)
 	<-e.fetchSem
-	resp.Body.Close()
 	if err != nil {
 		if e.verbose {
 			fmt.Fprintf(os.Stderr, "  [warn] read body %s: %v\n", apiPath, err)

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -303,6 +303,10 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 		ServerAddress:     serverAddr,
 		RecordCount:       e.sink.RecordCount(),
 		DeduplicatedCount: e.dedupSkipped,
+		AutoDiscovered:    e.cfg.AutoDiscover || hasAllDirective(e.cfg.Resources),
+		WatchEnabled:      anyWatchEnabled(e.cfg.Resources),
+		Intervals:         distinctIntervals(e.cfg.Resources),
+		UncompressedBytes: e.sink.UncompressedBytes(),
 	}
 
 	if e.verbose {
@@ -1177,6 +1181,31 @@ func hasAllDirective(resources []config.Resource) bool {
 		}
 	}
 	return false
+}
+
+// anyWatchEnabled reports whether any configured resource requested a watch.
+func anyWatchEnabled(resources []config.Resource) bool {
+	for _, r := range resources {
+		if r.Watch {
+			return true
+		}
+	}
+	return false
+}
+
+// distinctIntervals collects the unique human-readable poll intervals across
+// configured resources, for display in the capture-details panel.
+func distinctIntervals(resources []config.Resource) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, r := range resources {
+		if r.IntervalRaw == "" || seen[r.IntervalRaw] {
+			continue
+		}
+		seen[r.IntervalRaw] = true
+		out = append(out, r.IntervalRaw)
+	}
+	return out
 }
 
 func (e *Engine) validateWatchConcurrency() error {

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -41,6 +41,7 @@ func (s *sliceSink) RecordCount() int {
 	defer s.mu.Unlock()
 	return len(s.records)
 }
+func (s *sliceSink) UncompressedBytes() int64 { return 0 }
 
 // fakeK8sServer returns an httptest.TLSServer that responds to the paths used by
 // a minimal capture config (pods in default, nodes cluster-scoped).

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -1843,11 +1843,11 @@ func TestWatchResource_RecordsEvents(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/api/v1/namespaces/default/pods":
-			if r.URL.Query().Get("watch") == "1" {
+			if r.URL.Query().Get("watch") != "" {
 				atomic.AddInt32(&watchHits, 1)
 				w.WriteHeader(http.StatusOK)
-				_, _ = io.WriteString(w, `{"type":"ADDED","object":{"metadata":{"name":"p1"}}}`+"\n")
-				_, _ = io.WriteString(w, `{"type":"DELETED","object":{"metadata":{"name":"p2"}}}`+"\n")
+				_, _ = io.WriteString(w, `{"type":"ADDED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"name":"p1"}}}`+"\n")
+				_, _ = io.WriteString(w, `{"type":"DELETED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"name":"p2"}}}`+"\n")
 				if f, ok := w.(http.Flusher); ok {
 					f.Flush()
 				}
@@ -1913,13 +1913,13 @@ func TestWatchResource_Reconnects(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/api/v1/namespaces/default/pods":
-			if r.URL.Query().Get("watch") == "1" {
+			if r.URL.Query().Get("watch") != "" {
 				n := atomic.AddInt32(&watchConn, 1)
 				w.WriteHeader(http.StatusOK)
 				if n == 1 {
-					_, _ = io.WriteString(w, `{"type":"ADDED","object":{"metadata":{"name":"first"}}}`+"\n")
+					_, _ = io.WriteString(w, `{"type":"ADDED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"name":"first"}}}`+"\n")
 				} else {
-					_, _ = io.WriteString(w, `{"type":"MODIFIED","object":{"metadata":{"name":"second"}}}`+"\n")
+					_, _ = io.WriteString(w, `{"type":"MODIFIED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"name":"second"}}}`+"\n")
 				}
 				if f, ok := w.(http.Flusher); ok {
 					f.Flush()
@@ -1991,13 +1991,13 @@ func TestWatchResource_WildcardOpensSingleClusterWideStream(t *testing.T) {
 			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
 			return
 		case "/api/v1/pods":
-			if r.URL.Query().Get("watch") == "1" {
+			if r.URL.Query().Get("watch") != "" {
 				atomic.AddInt32(&clusterWideHits, 1)
 				w.WriteHeader(http.StatusOK)
 				_, _ = io.WriteString(w,
-					`{"type":"ADDED","object":{"metadata":{"name":"p1","namespace":"ns-a"}}}`+"\n"+
-						`{"type":"ADDED","object":{"metadata":{"name":"p2","namespace":"ns-b"}}}`+"\n"+
-						`{"type":"MODIFIED","object":{"metadata":{"name":"p1","namespace":"ns-a"}}}`+"\n")
+					`{"type":"ADDED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"name":"p1","namespace":"ns-a"}}}`+"\n"+
+						`{"type":"ADDED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"name":"p2","namespace":"ns-b"}}}`+"\n"+
+						`{"type":"MODIFIED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"name":"p1","namespace":"ns-a"}}}`+"\n")
 				if f, ok := w.(http.Flusher); ok {
 					f.Flush()
 				}

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -1682,6 +1682,48 @@ func TestDoFetch_DedupAllSame_FirstAlwaysWritten(t *testing.T) {
 	}
 }
 
+// TestRawFetch_TimesOutOnStalledBody guards the per-fetch timeout: a server
+// that returns headers but never the body (a stalled HTTP/2 stream in the
+// wild) must not hang the fetch indefinitely. The fetch must return promptly,
+// and its fetchSem slot must be released so later fetches still succeed —
+// otherwise one stuck read starves every other fetch and stalls the capture.
+func TestRawFetch_TimesOutOnStalledBody(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/hang" {
+			// Send headers, then block without ever writing a body.
+			w.WriteHeader(http.StatusOK)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			<-r.Context().Done()
+			return
+		}
+		fmt.Fprint(w, `{"kind":"List","items":[]}`)
+	}))
+	defer srv.Close()
+
+	eng := newEngineWith(&config.Config{}, srv.Client(), srv.URL, false)
+	eng.sink = &sliceSink{}
+	eng.fetchTimeout = 200 * time.Millisecond
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		eng.doFetch(context.Background(), "/api/v1/hang", "", true)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("doFetch on a stalled endpoint did not return within 5s; per-fetch timeout not enforced")
+	}
+
+	// The stalled fetch must have released its read slot.
+	if _, code := eng.doFetch(context.Background(), "/api/v1/ok", "", true); code != http.StatusOK {
+		t.Fatalf("follow-up doFetch status = %d, want %d (fetchSem slot leaked?)", code, http.StatusOK)
+	}
+}
+
 func TestDoFetch_DedupAllDifferent(t *testing.T) {
 	count := 0
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/capture/record.go
+++ b/internal/capture/record.go
@@ -26,6 +26,16 @@ type CaptureMetadata struct {
 	ServerAddress     string    `json:"server_address"`
 	RecordCount       int       `json:"record_count"`
 	DeduplicatedCount int       `json:"deduplicated_count"`
+	// Capture configuration facts, recorded so the UI can describe how the
+	// archive was produced. Omitted (zero) in archives captured before these
+	// fields existed.
+	AutoDiscovered    bool     `json:"auto_discovered,omitempty"`
+	WatchEnabled      bool     `json:"watch_enabled,omitempty"`
+	Intervals         []string `json:"intervals,omitempty"`
+	UncompressedBytes int64    `json:"uncompressed_bytes,omitempty"`
+	Redacted          bool     `json:"redacted,omitempty"`
+	SecretsRedacted   int      `json:"secrets_redacted,omitempty"`
+	FieldsRedacted    int      `json:"fields_redacted,omitempty"`
 }
 
 // IndexEntry maps an API path to the ordered list of record sequence numbers.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -128,6 +128,19 @@ type Config struct {
 	// Redaction holds field-level redaction rules applied during capture and
 	// post-capture redact workflows.
 	Redaction RedactionConfig `mapstructure:"redaction"`
+	// UI holds settings for the `kshrk ui` web explorer. CLI flags override
+	// these when provided.
+	UI UIConfig `mapstructure:"ui"`
+}
+
+// UIConfig configures the `kshrk ui` servers. Ports are strings so "0" (a
+// random available port, the default) can be expressed; set them to pin a
+// consistent port across runs.
+type UIConfig struct {
+	// Port is the local web UI port. Empty or "0" means a random port.
+	Port string `mapstructure:"port"`
+	// APIPort is the mock Kubernetes API server port. Empty or "0" means random.
+	APIPort string `mapstructure:"api_port"`
 }
 
 // Load reads k8shark capture config. If configFile is empty, viper uses

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -153,6 +153,11 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 		newWI[apiPath] = newWIEntry
 	}
 
+	// Record that this archive was redacted so the UI / inspect can surface it.
+	meta.Redacted = true
+	meta.SecretsRedacted = result.SecretsRedacted
+	meta.FieldsRedacted = result.FieldsRedacted
+
 	if err := sw.Finish(&meta, newIdx, newWI); err != nil {
 		return Result{}, fmt.Errorf("finishing output archive: %w", err)
 	}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -158,7 +158,11 @@ func Open(opts OpenOptions) (*Server, error) {
 	h := &explorerHandler{store: store, at: at, verbose: opts.Verbose, archivePath: opts.ArchivePath}
 	h.clusterSpanning = computeClusterSpanningResources(store)
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", h.serveIndex)
+	// v2 is the default UI: "/" redirects to /v2/. The legacy v1 UI stays
+	// reachable at /v1/.
+	mux.HandleFunc("/", h.serveRoot)
+	mux.HandleFunc("/v1", h.serveLegacy)
+	mux.HandleFunc("/v1/", h.serveLegacy)
 	mux.HandleFunc("/api/ui/tree", h.serveTree)
 	mux.HandleFunc("/api/ui/tree/namespace", h.serveTreeNamespace)
 	mux.HandleFunc("/api/ui/detail", h.serveDetail)
@@ -210,8 +214,19 @@ func (s *Server) Wait() error {
 	return nil
 }
 
-func (h *explorerHandler) serveIndex(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/" {
+// serveRoot redirects the bare root to the v2 dashboard (the default UI) and
+// 404s any other unmatched path.
+func (h *explorerHandler) serveRoot(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/" {
+		http.Redirect(w, r, "/v2/", http.StatusFound)
+		return
+	}
+	http.NotFound(w, r)
+}
+
+// serveLegacy serves the original (v1) explorer UI at /v1/.
+func (h *explorerHandler) serveLegacy(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/v1" && r.URL.Path != "/v1/" {
 		http.NotFound(w, r)
 		return
 	}
@@ -1330,6 +1345,8 @@ const indexHTML = `<!doctype html>
     :root { --bg:#0b0f14; --panel:#111827; --text:#e5e7eb; --muted:#94a3b8; --line:#1f2937; --ok:#16a34a; --warn:#f59e0b; --bad:#dc2626; --accent:#22c55e; }
     body { margin:0; font-family: ui-sans-serif, -apple-system, Segoe UI, sans-serif; background:linear-gradient(145deg,#0b0f14,#0f172a); color:var(--text); }
 	header { padding:14px 18px; border-bottom:1px solid var(--line); display:flex; justify-content:space-between; align-items:center; gap:12px; }
+	.v2-link { margin-left:12px; font-size:12px; color:var(--accent); text-decoration:none; border:1px solid var(--line); padding:3px 8px; border-radius:5px; }
+	.v2-link:hover { border-color:var(--accent); background:rgba(34,197,94,.12); }
 	.head-right { display:flex; align-items:center; gap:10px; }
 	.snapshot-nav { display:flex; align-items:center; gap:6px; }
 	.snapshot-select { min-width:220px; max-width:340px; box-sizing:border-box; padding:6px 8px; border:1px solid #334155; border-radius:8px; background:#0f172a; color:var(--text); }
@@ -1441,7 +1458,9 @@ const indexHTML = `<!doctype html>
 </head>
 <body>
   <header>
-    <div><strong>kshrk capture explorer</strong></div>
+    <div><strong>kshrk capture explorer</strong>
+      <a href="/v2/" class="v2-link" title="Open the redesigned dashboard UI">Dashboard (v2) &rarr;</a>
+    </div>
 		<div class="head-right">
 			<span class="snapshot-label">Snapshot</span>
 			<div class="snapshot-nav">

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/phenixblue/k8shark/internal/capture"
 	"github.com/phenixblue/k8shark/internal/server"
 	"github.com/phenixblue/k8shark/internal/transitions"
+	v2 "github.com/phenixblue/k8shark/internal/ui/v2"
 	"gopkg.in/yaml.v3"
 )
 
@@ -164,6 +165,16 @@ func Open(opts OpenOptions) (*Server, error) {
 	mux.HandleFunc("/api/ui/timestamps", h.serveTimestamps)
 	mux.HandleFunc("/api/ui/transitions", h.serveTransitions)
 	mux.HandleFunc("/api/ui/object-history", h.serveObjectHistory)
+
+	// Mount the redesigned dashboard UI under /v2/. Lives alongside the
+	// original UI during the redesign; will eventually replace it.
+	v2h := &v2.Handler{
+		Store:       store,
+		At:          at,
+		ArchivePath: opts.ArchivePath,
+		Verbose:     opts.Verbose,
+	}
+	v2h.Mount(mux)
 
 	httpSrv := &http.Server{Handler: mux}
 	done := make(chan struct{})

--- a/internal/ui/v2/capinfo.go
+++ b/internal/ui/v2/capinfo.go
@@ -1,0 +1,98 @@
+package v2
+
+import (
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// CaptureInfo describes the capture archive for the overview "Capture details"
+// card. It combines metadata.json with values derived from the index and the
+// archive file on disk.
+type CaptureInfo struct {
+	CaptureID         string    `json:"capture_id"`
+	ServerAddress     string    `json:"server_address,omitempty"`
+	KubernetesVersion string    `json:"kubernetes_version,omitempty"`
+	CapturedAt        time.Time `json:"captured_at"`
+	CapturedUntil     time.Time `json:"captured_until"`
+	DurationSeconds   int       `json:"duration_seconds"`
+	RecordCount       int       `json:"record_count"`
+	DeduplicatedCount int       `json:"deduplicated_count"`
+	CompressedBytes   int64     `json:"compressed_bytes,omitempty"`
+	UncompressedBytes int64     `json:"uncompressed_bytes,omitempty"`
+	ResourcePaths     int       `json:"resource_paths"`
+	ResourceTypes     int       `json:"resource_types"`
+	Namespaces        int       `json:"namespaces"`
+	WatchEvents       int       `json:"watch_events"`
+	AutoDiscovered    bool      `json:"auto_discovered"`
+	WatchEnabled      bool      `json:"watch_enabled"`
+	Intervals         []string  `json:"intervals,omitempty"`
+	Redacted          bool      `json:"redacted"`
+	SecretsRedacted   int       `json:"secrets_redacted,omitempty"`
+	FieldsRedacted    int       `json:"fields_redacted,omitempty"`
+	ArchivePath       string    `json:"archive_path,omitempty"`
+	// HasConfigMeta is false for archives captured before the config-fact
+	// metadata fields existed; the UI then shows "not recorded" for them.
+	HasConfigMeta bool `json:"has_config_meta"`
+}
+
+func (h *Handler) serveCaptureInfo(w http.ResponseWriter, r *http.Request) {
+	if h.Store == nil {
+		writeError(w, http.StatusInternalServerError, "store not initialized")
+		return
+	}
+	m := h.Store.Metadata
+	info := CaptureInfo{
+		CaptureID:         m.CaptureID,
+		ServerAddress:     m.ServerAddress,
+		KubernetesVersion: m.KubernetesVersion,
+		CapturedAt:        m.CapturedAt,
+		CapturedUntil:     m.CapturedUntil,
+		RecordCount:       m.RecordCount,
+		DeduplicatedCount: m.DeduplicatedCount,
+		UncompressedBytes: m.UncompressedBytes,
+		AutoDiscovered:    m.AutoDiscovered,
+		WatchEnabled:      m.WatchEnabled,
+		Intervals:         m.Intervals,
+		Redacted:          m.Redacted,
+		SecretsRedacted:   m.SecretsRedacted,
+		FieldsRedacted:    m.FieldsRedacted,
+		ArchivePath:       h.ArchivePath,
+	}
+	if m.CapturedUntil.After(m.CapturedAt) {
+		info.DurationSeconds = int(m.CapturedUntil.Sub(m.CapturedAt).Round(time.Second).Seconds())
+	}
+	// New captures always record UncompressedBytes (every record has bytes);
+	// its presence is a reliable signal that the config-fact fields are real.
+	info.HasConfigMeta = m.UncompressedBytes > 0
+
+	// Compressed archive size from disk.
+	if h.ArchivePath != "" {
+		if fi, err := os.Stat(h.ArchivePath); err == nil {
+			info.CompressedBytes = fi.Size()
+		}
+	}
+
+	// Index-derived counts (no body reads).
+	info.ResourcePaths = len(h.Store.Index)
+	types := map[string]bool{}
+	for path, entry := range h.Store.Index {
+		if entry == nil || len(entry.Seqs) == 0 || strings.Contains(path, "?") {
+			continue
+		}
+		g, v, res, _ := parseAPIPath(path)
+		if res != "" {
+			types[g+"/"+v+"/"+res] = true
+		}
+	}
+	info.ResourceTypes = len(types)
+	info.Namespaces = len(h.Store.NamespaceItemCountsAt(time.Time{}))
+	for _, wi := range h.Store.WatchIndex {
+		if wi != nil {
+			info.WatchEvents += len(wi.Times)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, info)
+}

--- a/internal/ui/v2/diff.go
+++ b/internal/ui/v2/diff.go
@@ -1,0 +1,157 @@
+package v2
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/pmezard/go-difflib/difflib"
+	"gopkg.in/yaml.v3"
+)
+
+// DiffResponse is the result of /v2/api/diff?path=…&before=T1&after=T2.
+type DiffResponse struct {
+	Path          string     `json:"path"`
+	Name          string     `json:"name,omitempty"`
+	Before        string     `json:"before"`
+	After         string     `json:"after"`
+	HasDiff       bool       `json:"has_diff"`
+	Hunks         []DiffHunk `json:"hunks"`
+	BeforeMissing bool       `json:"before_missing,omitempty"`
+	AfterMissing  bool       `json:"after_missing,omitempty"`
+}
+
+// DiffHunk is one line of the unified diff with a type tag.
+type DiffHunk struct {
+	Type string `json:"type"` // "add" | "del" | "ctx" | "hunk"
+	Text string `json:"text"`
+}
+
+func (h *Handler) serveDiff(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Query().Get("path")
+	if path == "" {
+		writeError(w, http.StatusBadRequest, "missing path query parameter")
+		return
+	}
+	name := r.URL.Query().Get("name") // optional — narrow to a single item by metadata.name
+	beforeStr := r.URL.Query().Get("before")
+	afterStr := r.URL.Query().Get("after")
+
+	beforeAt, err := parseAt(beforeStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid before timestamp: "+err.Error())
+		return
+	}
+	afterAt, err := parseAt(afterStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid after timestamp: "+err.Error())
+		return
+	}
+
+	resp := &DiffResponse{Path: path, Name: name}
+	if !beforeAt.IsZero() {
+		resp.Before = beforeAt.UTC().Format(time.RFC3339)
+	}
+	if !afterAt.IsZero() {
+		resp.After = afterAt.UTC().Format(time.RFC3339)
+	}
+
+	beforeYAML, beforeOK := h.readObjectYAML(path, name, beforeAt)
+	afterYAML, afterOK := h.readObjectYAML(path, name, afterAt)
+	if !beforeOK {
+		resp.BeforeMissing = true
+	}
+	if !afterOK {
+		resp.AfterMissing = true
+	}
+	if beforeOK || afterOK {
+		resp.Hunks = unifiedDiffLines(beforeYAML, afterYAML, resp.Before, resp.After)
+		for _, line := range resp.Hunks {
+			if line.Type == "add" || line.Type == "del" {
+				resp.HasDiff = true
+				break
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func parseAt(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+	return time.Parse(time.RFC3339, s)
+}
+
+// readObjectYAML pulls the object at `path` (optionally filtered to a single
+// item by name from a list body) and renders it as YAML for diffing.
+func (h *Handler) readObjectYAML(path, name string, at time.Time) (string, bool) {
+	body, code, err := h.Store.ReconstructAt(path, at)
+	if err != nil || code != http.StatusOK || len(body) == 0 {
+		return "", false
+	}
+	if name != "" {
+		// Extract the matching item from the list.
+		var list struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		if err := json.Unmarshal(body, &list); err != nil {
+			return toYAML(body), true
+		}
+		for _, it := range list.Items {
+			if getName(it) == name {
+				return toYAML(it), true
+			}
+		}
+		return "", false
+	}
+	return toYAML(body), true
+}
+
+func toYAML(body []byte) string {
+	var obj any
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return string(body)
+	}
+	out, err := yaml.Marshal(obj)
+	if err != nil {
+		return string(body)
+	}
+	return string(out)
+}
+
+// unifiedDiffLines computes a unified diff and breaks it into typed lines so
+// the frontend can colour add/del/context distinctly.
+func unifiedDiffLines(before, after, beforeName, afterName string) []DiffHunk {
+	diff := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(before),
+		B:        difflib.SplitLines(after),
+		FromFile: "before",
+		ToFile:   "after",
+		FromDate: beforeName,
+		ToDate:   afterName,
+		Context:  3,
+	}
+	text, err := difflib.GetUnifiedDiffString(diff)
+	if err != nil {
+		return []DiffHunk{{Type: "ctx", Text: "diff error: " + err.Error()}}
+	}
+	var hunks []DiffHunk
+	for _, line := range strings.Split(strings.TrimRight(text, "\n"), "\n") {
+		switch {
+		case strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---"):
+			hunks = append(hunks, DiffHunk{Type: "hunk", Text: line})
+		case strings.HasPrefix(line, "@@"):
+			hunks = append(hunks, DiffHunk{Type: "hunk", Text: line})
+		case strings.HasPrefix(line, "+"):
+			hunks = append(hunks, DiffHunk{Type: "add", Text: line})
+		case strings.HasPrefix(line, "-"):
+			hunks = append(hunks, DiffHunk{Type: "del", Text: line})
+		default:
+			hunks = append(hunks, DiffHunk{Type: "ctx", Text: line})
+		}
+	}
+	return hunks
+}

--- a/internal/ui/v2/handlers.go
+++ b/internal/ui/v2/handlers.go
@@ -24,10 +24,6 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 
 // Stubs for endpoints that land in later commits on this branch.
 
-func (h *Handler) servePod(w http.ResponseWriter, r *http.Request) {
-	writeError(w, http.StatusNotImplemented, "pod not implemented yet")
-}
-
 func (h *Handler) serveEvents(w http.ResponseWriter, r *http.Request) {
 	writeError(w, http.StatusNotImplemented, "events not implemented yet")
 }

--- a/internal/ui/v2/handlers.go
+++ b/internal/ui/v2/handlers.go
@@ -24,10 +24,6 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 
 // Stubs for endpoints that land in later commits on this branch.
 
-func (h *Handler) serveNamespace(w http.ResponseWriter, r *http.Request) {
-	writeError(w, http.StatusNotImplemented, "namespace not implemented yet")
-}
-
 func (h *Handler) servePod(w http.ResponseWriter, r *http.Request) {
 	writeError(w, http.StatusNotImplemented, "pod not implemented yet")
 }

--- a/internal/ui/v2/handlers.go
+++ b/internal/ui/v2/handlers.go
@@ -22,24 +22,69 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, map[string]string{"error": msg})
 }
 
-// Stubs for endpoints that land in later commits on this branch.
-
+// serveEvents returns events filtered by involvedObject. Used by the pod
+// drilldown for its events panel.
 func (h *Handler) serveEvents(w http.ResponseWriter, r *http.Request) {
-	writeError(w, http.StatusNotImplemented, "events not implemented yet")
+	ns := r.URL.Query().Get("ns")
+	if ns == "" {
+		writeError(w, http.StatusBadRequest, "missing ns query parameter")
+		return
+	}
+	kind := r.URL.Query().Get("kind")
+	name := r.URL.Query().Get("name")
+	at := h.resolveAt(r)
+
+	listPath := "/api/v1/namespaces/" + ns + "/events"
+	body, code, err := h.Store.ReconstructAt(listPath, at)
+	if err != nil || code != 200 || len(body) == 0 {
+		writeJSON(w, http.StatusOK, map[string]any{"events": []any{}, "namespace": ns})
+		return
+	}
+	var list struct {
+		Items []eventObject `json:"items"`
+	}
+	if err := jsonUnmarshalBody(body, &list); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	var out []PodEvent
+	for _, ev := range list.Items {
+		if kind != "" && ev.InvolvedObject.Kind != kind {
+			continue
+		}
+		if name != "" && ev.InvolvedObject.Name != name {
+			continue
+		}
+		t := ev.LastTimestamp
+		if t.IsZero() {
+			t = ev.EventTime
+		}
+		if t.IsZero() {
+			t = ev.FirstTimestamp
+		}
+		sev := "normal"
+		if ev.Type == "Warning" {
+			sev = "warn"
+		}
+		if isBadEventReason(ev.Reason) {
+			sev = "bad"
+		}
+		out = append(out, PodEvent{
+			Severity: sev,
+			Reason:   ev.Reason,
+			Message:  ev.Message,
+			Time:     t.UTC().Format("2006-01-02T15:04:05Z"),
+			Count:    ev.Count,
+			Source:   ev.Source.Component,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"namespace": ns, "events": out})
 }
 
-func (h *Handler) serveLogs(w http.ResponseWriter, r *http.Request) {
-	writeError(w, http.StatusNotImplemented, "logs not implemented yet")
-}
+func jsonUnmarshalBody(b []byte, v any) error { return json.Unmarshal(b, v) }
 
-func (h *Handler) serveDiff(w http.ResponseWriter, r *http.Request) {
-	writeError(w, http.StatusNotImplemented, "diff not implemented yet")
-}
-
-func (h *Handler) serveObjectHistory(w http.ResponseWriter, r *http.Request) {
-	writeError(w, http.StatusNotImplemented, "object-history not implemented yet")
-}
-
+// serveTimestamps delegates to the scrubber timestamp endpoint defined in
+// timestamps.go.
 func (h *Handler) serveTimestamps(w http.ResponseWriter, r *http.Request) {
 	h.timestampsHandler(w, r)
 }

--- a/internal/ui/v2/handlers.go
+++ b/internal/ui/v2/handlers.go
@@ -1,0 +1,57 @@
+package v2
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// writeJSON marshals v and writes it as application/json with the given status.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(data)
+}
+
+// writeError sends a structured JSON error.
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+// Stubs — replaced as each endpoint is built out.
+
+func (h *Handler) serveOverview(w http.ResponseWriter, r *http.Request) {
+	writeError(w, http.StatusNotImplemented, "overview not implemented yet")
+}
+
+func (h *Handler) serveNamespace(w http.ResponseWriter, r *http.Request) {
+	writeError(w, http.StatusNotImplemented, "namespace not implemented yet")
+}
+
+func (h *Handler) servePod(w http.ResponseWriter, r *http.Request) {
+	writeError(w, http.StatusNotImplemented, "pod not implemented yet")
+}
+
+func (h *Handler) serveEvents(w http.ResponseWriter, r *http.Request) {
+	writeError(w, http.StatusNotImplemented, "events not implemented yet")
+}
+
+func (h *Handler) serveLogs(w http.ResponseWriter, r *http.Request) {
+	writeError(w, http.StatusNotImplemented, "logs not implemented yet")
+}
+
+func (h *Handler) serveDiff(w http.ResponseWriter, r *http.Request) {
+	writeError(w, http.StatusNotImplemented, "diff not implemented yet")
+}
+
+func (h *Handler) serveObjectHistory(w http.ResponseWriter, r *http.Request) {
+	writeError(w, http.StatusNotImplemented, "object-history not implemented yet")
+}
+
+func (h *Handler) serveTimestamps(w http.ResponseWriter, r *http.Request) {
+	writeError(w, http.StatusNotImplemented, "timestamps not implemented yet")
+}

--- a/internal/ui/v2/handlers.go
+++ b/internal/ui/v2/handlers.go
@@ -22,11 +22,7 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, map[string]string{"error": msg})
 }
 
-// Stubs — replaced as each endpoint is built out.
-
-func (h *Handler) serveOverview(w http.ResponseWriter, r *http.Request) {
-	writeError(w, http.StatusNotImplemented, "overview not implemented yet")
-}
+// Stubs for endpoints that land in later commits on this branch.
 
 func (h *Handler) serveNamespace(w http.ResponseWriter, r *http.Request) {
 	writeError(w, http.StatusNotImplemented, "namespace not implemented yet")
@@ -53,5 +49,5 @@ func (h *Handler) serveObjectHistory(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) serveTimestamps(w http.ResponseWriter, r *http.Request) {
-	writeError(w, http.StatusNotImplemented, "timestamps not implemented yet")
+	h.timestampsHandler(w, r)
 }

--- a/internal/ui/v2/health.go
+++ b/internal/ui/v2/health.go
@@ -1,0 +1,196 @@
+package v2
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// PodHealth is a compact summary of one pod's state, derived from the body of
+// a pod object. Used by issue detection, KPI counters, and the pod-drilldown
+// container cards.
+type PodHealth struct {
+	Phase      string            // "Running", "Pending", "Succeeded", "Failed", "Unknown"
+	Ready      int               // ready container count
+	Total      int               // total container count
+	Restarts   int               // sum of restart counts
+	Issues     []string          // unique reasons: "CrashLoopBackOff", "OOMKilled", "ImagePullBackOff", …
+	Containers []ContainerHealth // per-container detail
+}
+
+// ContainerHealth is the per-container slice of PodHealth.
+type ContainerHealth struct {
+	Name           string `json:"name"`
+	Image          string `json:"image,omitempty"`
+	Ready          bool   `json:"ready"`
+	RestartCount   int    `json:"restart_count"`
+	IsInit         bool   `json:"is_init,omitempty"`
+	State          string `json:"state"` // "Running" | "Waiting" | "Terminated"
+	StateReason    string `json:"state_reason,omitempty"`
+	StateMessage   string `json:"state_message,omitempty"`
+	LastTerminated string `json:"last_terminated,omitempty"` // reason of lastState.terminated if present
+	LastExitCode   int    `json:"last_exit_code,omitempty"`
+}
+
+// IsHealthy reports whether a pod is in a benign state for KPI counting.
+// A pod with zero issues is considered healthy.
+func (h PodHealth) IsHealthy() bool { return len(h.Issues) == 0 }
+
+// ClassifyPod parses a pod body and returns its PodHealth. Returns zero
+// PodHealth on a malformed body — callers should treat that as "unknown".
+func ClassifyPod(body []byte) PodHealth {
+	var pod struct {
+		Status struct {
+			Phase                 string            `json:"phase"`
+			ContainerStatuses     []containerStatus `json:"containerStatuses"`
+			InitContainerStatuses []containerStatus `json:"initContainerStatuses"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal(body, &pod); err != nil {
+		return PodHealth{}
+	}
+
+	h := PodHealth{Phase: pod.Status.Phase}
+	seenIssue := map[string]bool{}
+	addIssue := func(reason string) {
+		if reason == "" || seenIssue[reason] {
+			return
+		}
+		seenIssue[reason] = true
+		h.Issues = append(h.Issues, reason)
+	}
+
+	switch h.Phase {
+	case "Failed":
+		addIssue("Failed")
+	case "Unknown":
+		addIssue("Unknown")
+	case "Pending":
+		// Pending alone isn't an issue — that's just "still scheduling".
+		// We surface a container-level reason below if there is one.
+	}
+
+	consume := func(cs containerStatus, isInit bool) {
+		h.Total++
+		h.Restarts += cs.RestartCount
+		c := ContainerHealth{
+			Name:         cs.Name,
+			Image:        cs.Image,
+			Ready:        cs.Ready,
+			RestartCount: cs.RestartCount,
+			IsInit:       isInit,
+		}
+		if cs.Ready {
+			h.Ready++
+		}
+		switch {
+		case cs.State.Running != nil:
+			c.State = "Running"
+		case cs.State.Waiting != nil:
+			c.State = "Waiting"
+			c.StateReason = cs.State.Waiting.Reason
+			c.StateMessage = cs.State.Waiting.Message
+			addIssue(cs.State.Waiting.Reason)
+		case cs.State.Terminated != nil:
+			c.State = "Terminated"
+			c.StateReason = cs.State.Terminated.Reason
+			c.StateMessage = cs.State.Terminated.Message
+			c.LastExitCode = cs.State.Terminated.ExitCode
+			// A terminated init container that exited 0 is normal — don't flag.
+			if !isInit || cs.State.Terminated.ExitCode != 0 {
+				addIssue(cs.State.Terminated.Reason)
+			}
+		}
+		if cs.LastState.Terminated != nil {
+			c.LastTerminated = cs.LastState.Terminated.Reason
+			if c.LastExitCode == 0 {
+				c.LastExitCode = cs.LastState.Terminated.ExitCode
+			}
+			// CrashLoopBackOff usually pairs with a previous OOMKilled / Error.
+			// Don't add it as a top-level issue (it's stale) but keep the reason
+			// on the container card for context.
+		}
+		h.Containers = append(h.Containers, c)
+	}
+
+	for _, cs := range pod.Status.InitContainerStatuses {
+		consume(cs, true)
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		consume(cs, false)
+	}
+	return h
+}
+
+type containerStatus struct {
+	Name         string         `json:"name"`
+	Image        string         `json:"image"`
+	Ready        bool           `json:"ready"`
+	RestartCount int            `json:"restartCount"`
+	State        containerState `json:"state"`
+	LastState    containerState `json:"lastState"`
+}
+
+type containerState struct {
+	Running    *struct{}              `json:"running,omitempty"`
+	Waiting    *containerStateWaiting `json:"waiting,omitempty"`
+	Terminated *containerStateTerm    `json:"terminated,omitempty"`
+}
+
+type containerStateWaiting struct {
+	Reason  string `json:"reason"`
+	Message string `json:"message"`
+}
+
+type containerStateTerm struct {
+	Reason   string `json:"reason"`
+	Message  string `json:"message"`
+	ExitCode int    `json:"exitCode"`
+}
+
+// PodNamePrefix groups pods that share an owning ReplicaSet/Deployment by
+// stripping the trailing hash segment(s). "kubevirt-migration-controller-
+// 6c77fbf565-2rz8h" → "kubevirt-migration-controller-*". When the name has
+// no recognizable hash suffix the full name is returned with a "-*" suffix.
+func PodNamePrefix(name string) string {
+	parts := strings.Split(name, "-")
+	if len(parts) < 2 {
+		return name + "-*"
+	}
+	// Heuristic: strip from the right while the segment looks like a
+	// pod-template hash (lowercase alphanumeric, length 5..10).
+	trimmed := parts
+	for len(trimmed) > 1 {
+		last := trimmed[len(trimmed)-1]
+		if !looksLikeHash(last) {
+			break
+		}
+		trimmed = trimmed[:len(trimmed)-1]
+	}
+	if len(trimmed) == len(parts) {
+		// Nothing stripped — fall back to dropping just the last segment.
+		return strings.Join(parts[:len(parts)-1], "-") + "-*"
+	}
+	return strings.Join(trimmed, "-") + "-*"
+}
+
+func looksLikeHash(s string) bool {
+	if len(s) < 4 || len(s) > 10 {
+		return false
+	}
+	for _, r := range s {
+		if !(r >= '0' && r <= '9') && !(r >= 'a' && r <= 'z') {
+			return false
+		}
+	}
+	// Pod-template hashes mix letters and digits.
+	hasLetter, hasDigit := false, false
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' {
+			hasLetter = true
+		}
+		if r >= '0' && r <= '9' {
+			hasDigit = true
+		}
+	}
+	return hasLetter && hasDigit
+}

--- a/internal/ui/v2/health_test.go
+++ b/internal/ui/v2/health_test.go
@@ -1,0 +1,89 @@
+package v2
+
+import "testing"
+
+func TestClassifyPod_HealthyPod(t *testing.T) {
+	body := []byte(`{
+		"status": {
+			"phase": "Running",
+			"containerStatuses": [
+				{"name": "app", "image": "img", "ready": true, "restartCount": 0,
+				 "state": {"running": {}}}
+			]
+		}
+	}`)
+	ph := ClassifyPod(body)
+	if !ph.IsHealthy() {
+		t.Fatalf("expected healthy pod, got issues %v", ph.Issues)
+	}
+	if ph.Ready != 1 || ph.Total != 1 {
+		t.Errorf("ready/total = %d/%d, want 1/1", ph.Ready, ph.Total)
+	}
+}
+
+func TestClassifyPod_CrashLoopBackOff(t *testing.T) {
+	body := []byte(`{
+		"status": {
+			"phase": "Running",
+			"containerStatuses": [
+				{"name": "app", "ready": false, "restartCount": 17,
+				 "state": {"waiting": {"reason": "CrashLoopBackOff", "message": "back-off 5m0s"}},
+				 "lastState": {"terminated": {"reason": "OOMKilled", "exitCode": 137}}}
+			]
+		}
+	}`)
+	ph := ClassifyPod(body)
+	if ph.IsHealthy() {
+		t.Fatalf("expected unhealthy pod")
+	}
+	found := false
+	for _, x := range ph.Issues {
+		if x == "CrashLoopBackOff" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected CrashLoopBackOff in issues, got %v", ph.Issues)
+	}
+	if ph.Restarts != 17 {
+		t.Errorf("Restarts = %d, want 17", ph.Restarts)
+	}
+}
+
+func TestClassifyPod_InitContainerSuccess(t *testing.T) {
+	// Init container that exited 0 is not an issue.
+	body := []byte(`{
+		"status": {
+			"phase": "Running",
+			"initContainerStatuses": [
+				{"name": "init", "ready": true, "restartCount": 0,
+				 "state": {"terminated": {"reason": "Completed", "exitCode": 0}}}
+			],
+			"containerStatuses": [
+				{"name": "app", "ready": true, "restartCount": 0,
+				 "state": {"running": {}}}
+			]
+		}
+	}`)
+	ph := ClassifyPod(body)
+	if !ph.IsHealthy() {
+		t.Errorf("expected healthy, got %v", ph.Issues)
+	}
+}
+
+func TestPodNamePrefix(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"kubevirt-migration-controller-6c77fbf565-2rz8h", "kubevirt-migration-controller-*"},
+		{"nginx-deployment-abc123-xyz45", "nginx-deployment-*"},
+		{"single", "single-*"},
+		{"my-pod-static", "my-pod-*"},
+	}
+	for _, c := range cases {
+		got := PodNamePrefix(c.in)
+		if got != c.want {
+			t.Errorf("PodNamePrefix(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/ui/v2/history.go
+++ b/internal/ui/v2/history.go
@@ -1,0 +1,78 @@
+package v2
+
+import (
+	"net/http"
+	"sort"
+	"time"
+)
+
+// ObjectHistoryResponse is what /v2/api/object-history returns — a list of
+// all watch events for an object identified by (path, name).
+type ObjectHistoryResponse struct {
+	Path   string             `json:"path"`
+	Name   string             `json:"name,omitempty"`
+	Events []ObjectHistoryRow `json:"events"`
+	Total  int                `json:"total"`
+}
+
+// ObjectHistoryRow is one entry in the history list.
+type ObjectHistoryRow struct {
+	Time      string `json:"time"`
+	EventType string `json:"event_type"`
+	Detail    string `json:"detail,omitempty"`
+	Seq       int    `json:"seq"`
+}
+
+func (h *Handler) serveObjectHistory(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Query().Get("path")
+	if path == "" {
+		writeError(w, http.StatusBadRequest, "missing path query parameter")
+		return
+	}
+	name := r.URL.Query().Get("name")
+
+	wi := h.Store.WatchIndex[path]
+	resp := &ObjectHistoryResponse{Path: path, Name: name}
+	if wi == nil {
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+	for i := range wi.Seqs {
+		t := wi.Times[i]
+		evType := ""
+		if i < len(wi.EventTypes) {
+			evType = wi.EventTypes[i]
+		}
+		seq := wi.Seqs[i]
+		// Filter by name if requested — reads the record body to check.
+		if name != "" {
+			rec, err := h.Store.ReadRecord(path, seq)
+			if err != nil {
+				continue
+			}
+			if getName(rec.ResponseBody) != name {
+				continue
+			}
+			ph := ClassifyPod(rec.ResponseBody)
+			detail := ph.Phase
+			if !ph.IsHealthy() && len(ph.Issues) > 0 {
+				detail = ph.Issues[0]
+			}
+			resp.Events = append(resp.Events, ObjectHistoryRow{
+				Time:      t.UTC().Format(time.RFC3339),
+				EventType: evType,
+				Detail:    detail,
+				Seq:       seq,
+			})
+			continue
+		}
+		resp.Events = append(resp.Events, ObjectHistoryRow{
+			Time:      t.UTC().Format(time.RFC3339),
+			EventType: evType,
+			Seq:       seq,
+		})
+	}
+	sort.SliceStable(resp.Events, func(i, j int) bool { return resp.Events[i].Time > resp.Events[j].Time })
+	resp.Total = len(resp.Events)
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/ui/v2/issues.go
+++ b/internal/ui/v2/issues.go
@@ -188,6 +188,13 @@ func kindFromResource(resource string) string {
 		"virtualmachineinstances":   "VirtualMachineInstance",
 		"events":                    "Event",
 		"storageclasses":            "StorageClass",
+		"namespaces":                "Namespace",
+		"endpoints":                 "Endpoints",
+		"componentstatuses":         "ComponentStatus",
+		"serviceaccounts":           "ServiceAccount",
+		"replicationcontrollers":    "ReplicationController",
+		"networkpolicies":           "NetworkPolicy",
+		"poddisruptionbudgets":      "PodDisruptionBudget",
 	}
 	if k, ok := known[resource]; ok {
 		return k
@@ -195,13 +202,29 @@ func kindFromResource(resource string) string {
 	if resource == "" {
 		return ""
 	}
-	// Titlecase + strip plural "s".
-	s := strings.TrimSuffix(resource, "s")
+	return titleCase(singularize(resource))
+}
+
+// singularize converts a plural resource name to a best-effort singular using
+// common English rules (authoritative kinds come from API discovery; this is
+// only a fallback for callers that have just the resource name).
+func singularize(s string) string {
+	switch {
+	case strings.HasSuffix(s, "ies"):
+		return s[:len(s)-3] + "y" // policies -> policy
+	case strings.HasSuffix(s, "sses"), strings.HasSuffix(s, "shes"), strings.HasSuffix(s, "ches"),
+		strings.HasSuffix(s, "xes"), strings.HasSuffix(s, "zes"), strings.HasSuffix(s, "ses"):
+		return s[:len(s)-2] // statuses -> status, ingresses -> ingress, classes -> class
+	case strings.HasSuffix(s, "s") && len(s) > 1:
+		return s[:len(s)-1]
+	default:
+		return s
+	}
+}
+
+func titleCase(s string) string {
 	if s == "" {
-		s = resource
+		return s
 	}
-	if len(s) > 0 {
-		s = strings.ToUpper(s[:1]) + s[1:]
-	}
-	return s
+	return strings.ToUpper(s[:1]) + s[1:]
 }

--- a/internal/ui/v2/issues.go
+++ b/internal/ui/v2/issues.go
@@ -1,0 +1,207 @@
+package v2
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// groupKey identifies a deduplicated bucket of unhealthy pods.
+type groupKey struct {
+	ns     string
+	prefix string
+	reason string
+}
+
+// groupVal accumulates the pods that fell into one groupKey.
+type groupVal struct {
+	count    int
+	exemplar podHealthEntry
+	restarts int
+}
+
+// buildIssues groups unhealthy pods into a short, deduplicated list suitable
+// for the dashboard "Issues to investigate" card.
+//
+// Grouping rules:
+//   - pods in the same namespace with the same name prefix (computed by
+//     PodNamePrefix — strips ReplicaSet hash + per-replica suffix) and the
+//     same dominant issue reason collapse into a single grouped issue
+//     with Count > 1.
+//   - within a group, the link points to the first matching pod.
+//
+// Severity:
+//   - "bad"  for CrashLoopBackOff, OOMKilled, Failed, ImagePullBackOff, etc.
+//   - "warn" for everything else.
+//
+// Returns the top `limit` groups by severity then by Count desc.
+func buildIssues(pods []podHealthEntry, limit int) []Issue {
+	if len(pods) == 0 {
+		return nil
+	}
+	groups := map[groupKey]*groupVal{}
+	for _, p := range pods {
+		if p.health.IsHealthy() {
+			continue
+		}
+		reason := dominantIssue(p.health.Issues)
+		k := groupKey{ns: p.namespace, prefix: p.prefix, reason: reason}
+		g, ok := groups[k]
+		if !ok {
+			g = &groupVal{exemplar: p}
+			groups[k] = g
+		}
+		g.count++
+		g.restarts += p.health.Restarts
+	}
+	if len(groups) == 0 {
+		return nil
+	}
+
+	out := make([]Issue, 0, len(groups))
+	for k, g := range groups {
+		sev := severityFor(k.reason)
+		title := g.exemplar.name
+		if g.count > 1 {
+			title = k.prefix
+		}
+		sub := subtitleFor(k.reason, g)
+		out = append(out, Issue{
+			Severity:  sev,
+			Kind:      shortKindForPod(),
+			Title:     title,
+			Subtitle:  sub,
+			Namespace: k.ns,
+			Count:     g.count,
+			Link:      podLink(g.exemplar.namespace, g.exemplar.name),
+		})
+	}
+	// Bad first, then by count desc, then by namespace+title for stable order.
+	sort.Slice(out, func(i, j int) bool {
+		if (out[i].Severity == "bad") != (out[j].Severity == "bad") {
+			return out[i].Severity == "bad"
+		}
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		return out[i].Title < out[j].Title
+	})
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// dominantIssue picks the most actionable reason from a pod's issue list.
+// Order matters: a pod that is CrashLoopBackOff is interesting for that
+// reason, not for the underlying Error or OOMKilled (which we still capture
+// in the per-container card on the drilldown).
+func dominantIssue(issues []string) string {
+	if len(issues) == 0 {
+		return "Unknown"
+	}
+	priority := []string{
+		"CrashLoopBackOff",
+		"OOMKilled",
+		"ImagePullBackOff", "ErrImagePull",
+		"CreateContainerError", "CreateContainerConfigError",
+		"InvalidImageName",
+		"Error",
+		"Failed",
+		"Unknown",
+	}
+	have := map[string]bool{}
+	for _, x := range issues {
+		have[x] = true
+	}
+	for _, p := range priority {
+		if have[p] {
+			return p
+		}
+	}
+	return issues[0]
+}
+
+func severityFor(reason string) string {
+	switch reason {
+	case "CrashLoopBackOff", "OOMKilled", "Failed", "Error", "ImagePullBackOff", "ErrImagePull",
+		"CreateContainerError", "CreateContainerConfigError", "InvalidImageName":
+		return "bad"
+	}
+	return "warn"
+}
+
+func subtitleFor(reason string, g *groupVal) string {
+	switch reason {
+	case "CrashLoopBackOff":
+		if g.count > 1 {
+			return fmt.Sprintf("CrashLoopBackOff · %d restarts across %d pods", g.restarts, g.count)
+		}
+		return fmt.Sprintf("CrashLoopBackOff · %d restarts", g.restarts)
+	case "OOMKilled":
+		return fmt.Sprintf("OOMKilled · %d restarts", g.restarts)
+	case "ImagePullBackOff", "ErrImagePull":
+		return reason
+	case "Failed":
+		return "Pod phase = Failed"
+	}
+	return reason
+}
+
+func shortKindForPod() string { return "Pod" }
+
+func podLink(ns, name string) string {
+	return "#/ns/" + escapeHash(ns) + "/pod/" + escapeHash(name)
+}
+
+// escapeHash encodes path segments destined for the hash router. Avoids the
+// usual encodeURIComponent set but keeps the string visually readable.
+func escapeHash(s string) string {
+	r := strings.NewReplacer("/", "%2F", "#", "%23", "?", "%3F")
+	return r.Replace(s)
+}
+
+// kindFromResource is a small dictionary keeping the dashboard tiles and
+// recent-transitions labels human-readable. Falls back to titlecasing the
+// resource name.
+func kindFromResource(resource string) string {
+	known := map[string]string{
+		"deployments":               "Deployment",
+		"statefulsets":              "StatefulSet",
+		"daemonsets":                "DaemonSet",
+		"jobs":                      "Job",
+		"cronjobs":                  "CronJob",
+		"replicasets":               "ReplicaSet",
+		"pods":                      "Pod",
+		"services":                  "Service",
+		"configmaps":                "ConfigMap",
+		"secrets":                   "Secret",
+		"persistentvolumeclaims":    "PersistentVolumeClaim",
+		"persistentvolumes":         "PersistentVolume",
+		"nodes":                     "Node",
+		"ingresses":                 "Ingress",
+		"customresourcedefinitions": "CRD",
+		"virtualmachines":           "VirtualMachine",
+		"virtualmachineinstances":   "VirtualMachineInstance",
+		"events":                    "Event",
+		"storageclasses":            "StorageClass",
+	}
+	if k, ok := known[resource]; ok {
+		return k
+	}
+	if resource == "" {
+		return ""
+	}
+	// Titlecase + strip plural "s".
+	s := strings.TrimSuffix(resource, "s")
+	if s == "" {
+		s = resource
+	}
+	if len(s) > 0 {
+		s = strings.ToUpper(s[:1]) + s[1:]
+	}
+	return s
+}

--- a/internal/ui/v2/kind_test.go
+++ b/internal/ui/v2/kind_test.go
@@ -1,0 +1,26 @@
+package v2
+
+import "testing"
+
+func TestKindFromResource(t *testing.T) {
+	cases := map[string]string{
+		// Known map entries.
+		"pods":              "Pod",
+		"configmaps":        "ConfigMap",
+		"componentstatuses": "ComponentStatus",
+		"endpoints":         "Endpoints",
+		"networkpolicies":   "NetworkPolicy",
+		// Generic singularization fallback (not in the known map).
+		"widgets":  "Widget",  // simple plural
+		"gateways": "Gateway", // ...s
+		"policies": "Policy",  // ...ies -> y
+		"classes":  "Class",   // ...sses -> ...ss
+		"foxes":    "Fox",     // ...xes -> ...x  (best-effort; discovery is authoritative)
+		"":         "",
+	}
+	for in, want := range cases {
+		if got := kindFromResource(in); got != want {
+			t.Errorf("kindFromResource(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/ui/v2/lists.go
+++ b/internal/ui/v2/lists.go
@@ -1,0 +1,243 @@
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ClusterPodRow is a single pod in the cluster-wide pods list. It is PodRow
+// plus the namespace (and an Unhealthy flag matching the overview's
+// unhealthy_pods KPI definition) so the list can be filtered client-side.
+type ClusterPodRow struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	Phase     string `json:"phase"`
+	Status    string `json:"status"`
+	Severity  string `json:"severity"`
+	Ready     string `json:"ready"`
+	Restarts  int    `json:"restarts"`
+	Age       string `json:"age,omitempty"`
+	Link      string `json:"link"`
+	Unhealthy bool   `json:"unhealthy"`
+}
+
+// ClusterWorkloadRow is a single workload in the cluster-wide workloads list:
+// ResourceRow plus its namespace.
+type ClusterWorkloadRow struct {
+	Namespace string `json:"namespace"`
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Severity  string `json:"severity"`
+	Restarts  int    `json:"restarts,omitempty"`
+	Age       string `json:"age,omitempty"`
+	Link      string `json:"link,omitempty"`
+}
+
+// PodsList is the response from /v2/api/pods.
+type PodsList struct {
+	At        string          `json:"at,omitempty"`
+	Capture   CaptureMeta     `json:"capture"`
+	Total     int             `json:"total"`
+	Unhealthy int             `json:"unhealthy"`
+	Pods      []ClusterPodRow `json:"pods"`
+}
+
+// WorkloadsList is the response from /v2/api/workloads.
+type WorkloadsList struct {
+	At        string               `json:"at,omitempty"`
+	Capture   CaptureMeta          `json:"capture"`
+	Total     int                  `json:"total"`
+	Workloads []ClusterWorkloadRow `json:"workloads"`
+}
+
+func (h *Handler) captureMeta() CaptureMeta {
+	m := h.Store.Metadata
+	return CaptureMeta{
+		CaptureID:         m.CaptureID,
+		CapturedAt:        m.CapturedAt,
+		CapturedUntil:     m.CapturedUntil,
+		KubernetesVersion: m.KubernetesVersion,
+		ServerAddress:     m.ServerAddress,
+		RecordCount:       m.RecordCount,
+	}
+}
+
+// serveAllPods returns every pod across all namespaces at the resolved time,
+// sorted unhealthy-first. The frontend filters by namespace / health.
+func (h *Handler) serveAllPods(w http.ResponseWriter, r *http.Request) {
+	if h.Store == nil {
+		writeError(w, http.StatusInternalServerError, "store not initialized")
+		return
+	}
+	at := h.resolveAt(r)
+	rows, unhealthy := h.loadAllPodRows(at)
+	resp := PodsList{
+		Capture:   h.captureMeta(),
+		Total:     len(rows),
+		Unhealthy: unhealthy,
+		Pods:      rows,
+	}
+	if !at.IsZero() {
+		resp.At = at.UTC().Format(time.RFC3339)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// serveAllWorkloads returns every workload (Deployment/StatefulSet/DaemonSet/
+// ReplicaSet/Job/CronJob) across all namespaces at the resolved time.
+func (h *Handler) serveAllWorkloads(w http.ResponseWriter, r *http.Request) {
+	if h.Store == nil {
+		writeError(w, http.StatusInternalServerError, "store not initialized")
+		return
+	}
+	at := h.resolveAt(r)
+	rows := h.loadAllWorkloadRows(at)
+	resp := WorkloadsList{
+		Capture:   h.captureMeta(),
+		Total:     len(rows),
+		Workloads: rows,
+	}
+	if !at.IsZero() {
+		resp.At = at.UTC().Format(time.RFC3339)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// loadAllPodRows walks every per-namespace pod LIST in the index and builds a
+// flat, sorted slice of rows. Returns the rows and the count of unhealthy pods
+// (matching the overview unhealthy_pods KPI: pods whose health has issues).
+func (h *Handler) loadAllPodRows(at time.Time) ([]ClusterPodRow, int) {
+	store := h.Store
+	var rows []ClusterPodRow
+	unhealthy := 0
+	for path, entry := range store.Index {
+		if entry == nil || len(entry.Seqs) == 0 {
+			continue
+		}
+		if strings.Contains(path, "?") {
+			continue // skip Table and other query-suffix variants
+		}
+		_, _, resource, ns := parseAPIPath(path)
+		if resource != "pods" || ns == "" {
+			continue
+		}
+		body, code, err := store.ReconstructAt(path, at)
+		if err != nil || code != http.StatusOK || len(body) == 0 {
+			continue
+		}
+		var list struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		if err := json.Unmarshal(body, &list); err != nil {
+			continue
+		}
+		for _, raw := range list.Items {
+			name := getName(raw)
+			if name == "" {
+				continue
+			}
+			ph := ClassifyPod(raw)
+			sev, status := podSeverityAndStatus(ph)
+			uh := !ph.IsHealthy()
+			if uh {
+				unhealthy++
+			}
+			rows = append(rows, ClusterPodRow{
+				Namespace: ns,
+				Name:      name,
+				Phase:     ph.Phase,
+				Status:    status,
+				Severity:  sev,
+				Ready:     fmt.Sprintf("%d/%d", ph.Ready, ph.Total),
+				Restarts:  ph.Restarts,
+				Age:       humanAge(getCreationTimestamp(raw), at),
+				Link:      podLink(ns, name),
+				Unhealthy: uh,
+			})
+		}
+	}
+	sortClusterRows(rows)
+	return rows, unhealthy
+}
+
+// loadAllWorkloadRows walks every per-namespace workload LIST in the index and
+// builds a flat, sorted slice of rows.
+func (h *Handler) loadAllWorkloadRows(at time.Time) []ClusterWorkloadRow {
+	store := h.Store
+	// resource → (full kind, short label) for the workload kinds we surface.
+	kinds := map[string]struct{ kind, short string }{
+		"deployments":  {"Deployment", "Deploy"},
+		"statefulsets": {"StatefulSet", "SS"},
+		"daemonsets":   {"DaemonSet", "DS"},
+		"replicasets":  {"ReplicaSet", "RS"},
+		"jobs":         {"Job", "Job"},
+		"cronjobs":     {"CronJob", "CronJob"},
+	}
+	var rows []ClusterWorkloadRow
+	for path, entry := range store.Index {
+		if entry == nil || len(entry.Seqs) == 0 {
+			continue
+		}
+		if strings.Contains(path, "?") {
+			continue
+		}
+		_, _, resource, ns := parseAPIPath(path)
+		if ns == "" {
+			continue
+		}
+		k, ok := kinds[resource]
+		if !ok {
+			continue
+		}
+		body, code, err := store.ReconstructAt(path, at)
+		if err != nil || code != http.StatusOK || len(body) == 0 {
+			continue
+		}
+		var list struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		if err := json.Unmarshal(body, &list); err != nil {
+			continue
+		}
+		for _, raw := range list.Items {
+			row := classifyWorkload(k.short, k.kind, raw, at)
+			rows = append(rows, ClusterWorkloadRow{
+				Namespace: ns,
+				Kind:      k.kind,
+				Name:      row.Name,
+				Status:    row.Status,
+				Severity:  row.Severity,
+				Restarts:  row.Restarts,
+				Age:       row.Age,
+				Link:      "#/ns/" + escapeHash(ns),
+			})
+		}
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Severity != rows[j].Severity {
+			return podSeverityRank(rows[i].Severity) < podSeverityRank(rows[j].Severity)
+		}
+		if rows[i].Namespace != rows[j].Namespace {
+			return rows[i].Namespace < rows[j].Namespace
+		}
+		return rows[i].Name < rows[j].Name
+	})
+	return rows
+}
+
+func sortClusterRows(rows []ClusterPodRow) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Severity != rows[j].Severity {
+			return podSeverityRank(rows[i].Severity) < podSeverityRank(rows[j].Severity)
+		}
+		if rows[i].Namespace != rows[j].Namespace {
+			return rows[i].Namespace < rows[j].Namespace
+		}
+		return rows[i].Name < rows[j].Name
+	})
+}

--- a/internal/ui/v2/lists.go
+++ b/internal/ui/v2/lists.go
@@ -13,30 +13,32 @@ import (
 // plus the namespace (and an Unhealthy flag matching the overview's
 // unhealthy_pods KPI definition) so the list can be filtered client-side.
 type ClusterPodRow struct {
-	Namespace string `json:"namespace"`
-	Name      string `json:"name"`
-	Phase     string `json:"phase"`
-	Status    string `json:"status"`
-	Severity  string `json:"severity"`
-	Ready     string `json:"ready"`
-	Restarts  int    `json:"restarts"`
-	Age       string `json:"age,omitempty"`
-	Link      string `json:"link"`
-	Unhealthy bool   `json:"unhealthy"`
+	Namespace string            `json:"namespace"`
+	Name      string            `json:"name"`
+	Phase     string            `json:"phase"`
+	Status    string            `json:"status"`
+	Severity  string            `json:"severity"`
+	Ready     string            `json:"ready"`
+	Restarts  int               `json:"restarts"`
+	Age       string            `json:"age,omitempty"`
+	Link      string            `json:"link"`
+	Unhealthy bool              `json:"unhealthy"`
+	Labels    map[string]string `json:"labels,omitempty"`
 }
 
 // ClusterWorkloadRow is a single workload in the cluster-wide workloads list:
 // ResourceRow plus its namespace.
 type ClusterWorkloadRow struct {
-	Namespace string `json:"namespace"`
-	Kind      string `json:"kind"`
-	Resource  string `json:"resource"`
-	Name      string `json:"name"`
-	Status    string `json:"status"`
-	Severity  string `json:"severity"`
-	Restarts  int    `json:"restarts,omitempty"`
-	Age       string `json:"age,omitempty"`
-	Link      string `json:"link,omitempty"`
+	Namespace string            `json:"namespace"`
+	Kind      string            `json:"kind"`
+	Resource  string            `json:"resource"`
+	Name      string            `json:"name"`
+	Status    string            `json:"status"`
+	Severity  string            `json:"severity"`
+	Restarts  int               `json:"restarts,omitempty"`
+	Age       string            `json:"age,omitempty"`
+	Link      string            `json:"link,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
 }
 
 // PodsList is the response from /v2/api/pods.
@@ -159,6 +161,7 @@ func (h *Handler) loadAllPodRows(at time.Time) ([]ClusterPodRow, int) {
 				Age:       humanAge(getCreationTimestamp(raw), at),
 				Link:      podLink(ns, name),
 				Unhealthy: uh,
+				Labels:    getLabels(raw),
 			})
 		}
 	}
@@ -217,6 +220,7 @@ func (h *Handler) loadAllWorkloadRows(at time.Time) []ClusterWorkloadRow {
 				Restarts:  row.Restarts,
 				Age:       row.Age,
 				Link:      "#/ns/" + escapeHash(ns),
+				Labels:    getLabels(raw),
 			})
 		}
 	}

--- a/internal/ui/v2/lists.go
+++ b/internal/ui/v2/lists.go
@@ -30,6 +30,7 @@ type ClusterPodRow struct {
 type ClusterWorkloadRow struct {
 	Namespace string `json:"namespace"`
 	Kind      string `json:"kind"`
+	Resource  string `json:"resource"`
 	Name      string `json:"name"`
 	Status    string `json:"status"`
 	Severity  string `json:"severity"`
@@ -209,6 +210,7 @@ func (h *Handler) loadAllWorkloadRows(at time.Time) []ClusterWorkloadRow {
 			rows = append(rows, ClusterWorkloadRow{
 				Namespace: ns,
 				Kind:      k.kind,
+				Resource:  resource,
 				Name:      row.Name,
 				Status:    row.Status,
 				Severity:  row.Severity,

--- a/internal/ui/v2/logs.go
+++ b/internal/ui/v2/logs.go
@@ -1,0 +1,159 @@
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// LogsResponse is what /v2/api/logs returns. Aside from the requested
+// container's log text it also reports the other containers captured for
+// the pod so the UI can render a picker.
+type LogsResponse struct {
+	Namespace          string             `json:"namespace"`
+	Pod                string             `json:"pod"`
+	Container          string             `json:"container"`
+	Previous           bool               `json:"previous"`
+	Text               string             `json:"text"`
+	LineCount          int                `json:"line_count"`
+	HasPreviousVariant bool               `json:"has_previous_variant"`
+	Containers         []LogsContainerOpt `json:"containers"`
+}
+
+// LogsContainerOpt is one entry in the container picker.
+type LogsContainerOpt struct {
+	Name        string `json:"name"`
+	HasCurrent  bool   `json:"has_current"`
+	HasPrevious bool   `json:"has_previous"`
+}
+
+func (h *Handler) serveLogs(w http.ResponseWriter, r *http.Request) {
+	ns := r.URL.Query().Get("ns")
+	pod := r.URL.Query().Get("pod")
+	if ns == "" || pod == "" {
+		writeError(w, http.StatusBadRequest, "missing ns or pod query parameter")
+		return
+	}
+	container := r.URL.Query().Get("container")
+	previous := r.URL.Query().Get("previous") == "true"
+
+	resp, err := h.buildLogsResponse(ns, pod, container, previous)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if resp == nil {
+		writeError(w, http.StatusNotFound, "no captured logs for this pod")
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) buildLogsResponse(ns, pod, container string, previous bool) (*LogsResponse, error) {
+	store := h.Store
+	logPath := "/api/v1/namespaces/" + ns + "/pods/" + pod + "/log"
+
+	// Discover every container we have a log for, plus whether current and/or
+	// previous are present, by walking the index for matching keys.
+	options := map[string]*LogsContainerOpt{}
+	prefix := logPath + "?container="
+	for key := range store.Index {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(key, prefix)
+		isPrev := strings.HasSuffix(rest, "&previous=true")
+		c := strings.TrimSuffix(rest, "&previous=true")
+		if c == "" {
+			continue
+		}
+		opt, ok := options[c]
+		if !ok {
+			opt = &LogsContainerOpt{Name: c}
+			options[c] = opt
+		}
+		if isPrev {
+			opt.HasPrevious = true
+		} else {
+			opt.HasCurrent = true
+		}
+	}
+	if len(options) == 0 {
+		return nil, nil
+	}
+
+	// Default container = first that has the requested variant.
+	if container == "" {
+		// Prefer "main" looking containers (not init / sidecar).
+		var pick string
+		for _, k := range sortedKeys(options) {
+			c := options[k]
+			if previous && !c.HasPrevious {
+				continue
+			}
+			if !previous && !c.HasCurrent {
+				continue
+			}
+			pick = c.Name
+			if !isSidecarName(c.Name) {
+				break
+			}
+		}
+		container = pick
+	}
+	if container == "" {
+		return nil, fmt.Errorf("no container has a captured log matching the requested variant")
+	}
+
+	indexKey := prefix + container
+	if previous {
+		indexKey += "&previous=true"
+	}
+	body, code, err := store.Latest(indexKey, h.At)
+	if err != nil || code != http.StatusOK || len(body) == 0 {
+		return nil, nil
+	}
+	var text string
+	if err := json.Unmarshal(body, &text); err != nil {
+		text = string(body)
+	}
+
+	resp := &LogsResponse{
+		Namespace: ns,
+		Pod:       pod,
+		Container: container,
+		Previous:  previous,
+		Text:      text,
+		LineCount: countLines(text),
+	}
+	if opt, ok := options[container]; ok {
+		resp.HasPreviousVariant = opt.HasPrevious
+	}
+	resp.Containers = make([]LogsContainerOpt, 0, len(options))
+	for _, k := range sortedKeys(options) {
+		resp.Containers = append(resp.Containers, *options[k])
+	}
+	return resp, nil
+}
+
+func sortedKeys(m map[string]*LogsContainerOpt) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func countLines(s string) int {
+	if s == "" {
+		return 0
+	}
+	n := strings.Count(s, "\n")
+	if !strings.HasSuffix(s, "\n") {
+		n++
+	}
+	return n
+}

--- a/internal/ui/v2/namespace.go
+++ b/internal/ui/v2/namespace.go
@@ -144,7 +144,7 @@ func (h *Handler) buildNamespaceDetail(ns string, at time.Time) (*NamespaceDetai
 	d.VMs = h.loadVMRowsForNS(ns, at)
 
 	// Resource tiles: every non-workload, non-pod, non-vm resource.
-	d.Resources = buildNamespaceTiles(resTotal)
+	d.Resources = buildNamespaceTiles(ns, resTotal)
 
 	// Pod-state sparkline scoped to this namespace.
 	d.Sparkline = h.sparklineForNS(ns, sparkBucketCount)
@@ -436,7 +436,7 @@ func (h *Handler) loadNamespaceMetadata(ns string, at time.Time) NamespaceMetada
 
 // buildNamespaceTiles drops the workload/pod/vm resources (rendered as
 // separate cards) and turns the rest of the per-ns counts into tiles.
-func buildNamespaceTiles(byRes map[string]int) []ResourceTile {
+func buildNamespaceTiles(ns string, byRes map[string]int) []ResourceTile {
 	out := make([]ResourceTile, 0, len(byRes))
 	for res, n := range byRes {
 		if n <= 0 {
@@ -446,9 +446,10 @@ func buildNamespaceTiles(byRes map[string]int) []ResourceTile {
 			continue
 		}
 		out = append(out, ResourceTile{
-			Kind:  kindFromResource(res),
-			Count: n,
-			Link:  "#/namespaces",
+			Kind:     kindFromResource(res),
+			Resource: res,
+			Count:    n,
+			Link:     resourceLink(res, ns),
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Count > out[j].Count })

--- a/internal/ui/v2/namespace.go
+++ b/internal/ui/v2/namespace.go
@@ -1,0 +1,551 @@
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// NamespaceDetail is the response from /v2/api/namespace?ns=… — everything
+// the ns drill-down page needs.
+type NamespaceDetail struct {
+	Name      string            `json:"name"`
+	At        string            `json:"at,omitempty"`
+	Capture   CaptureMeta       `json:"capture"`
+	KPIs      NamespaceKPIs     `json:"kpis"`
+	Sparkline SparklineData     `json:"sparkline"`
+	Issues    []Issue           `json:"issues"`
+	Workloads []ResourceRow     `json:"workloads"`
+	Pods      []PodRow          `json:"pods"`
+	VMs       []ResourceRow     `json:"vms"`
+	Resources []ResourceTile    `json:"resources"`
+	Metadata  NamespaceMetadata `json:"metadata"`
+}
+
+type NamespaceKPIs struct {
+	Workloads       int `json:"workloads"`
+	Pods            int `json:"pods"`
+	UnhealthyPods   int `json:"unhealthy_pods"`
+	VirtualMachines int `json:"virtual_machines"`
+	ConfigMaps      int `json:"configmaps"`
+	Secrets         int `json:"secrets"`
+	Resources       int `json:"resources"`
+}
+
+// ResourceRow is a compact row in the workloads / VMs lists.
+type ResourceRow struct {
+	Kind     string `json:"kind"`
+	Name     string `json:"name"`
+	Status   string `json:"status"`
+	Severity string `json:"severity"`
+	Restarts int    `json:"restarts,omitempty"`
+	Age      string `json:"age,omitempty"`
+	Link     string `json:"link,omitempty"`
+}
+
+// PodRow is the per-pod row in the namespace drill-down pods table.
+type PodRow struct {
+	Name     string `json:"name"`
+	Phase    string `json:"phase"`
+	Status   string `json:"status"`
+	Severity string `json:"severity"`
+	Ready    string `json:"ready"`
+	Restarts int    `json:"restarts"`
+	Age      string `json:"age,omitempty"`
+	Link     string `json:"link"`
+}
+
+type NamespaceMetadata struct {
+	CreatedAt   string            `json:"created_at,omitempty"`
+	AgeHuman    string            `json:"age,omitempty"`
+	Phase       string            `json:"phase,omitempty"` // Active / Terminating
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+func (h *Handler) serveNamespace(w http.ResponseWriter, r *http.Request) {
+	ns := r.URL.Query().Get("ns")
+	if ns == "" {
+		writeError(w, http.StatusBadRequest, "missing ns query parameter")
+		return
+	}
+	at := h.resolveAt(r)
+	d, err := h.buildNamespaceDetail(ns, at)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if !at.IsZero() {
+		d.At = at.UTC().Format(time.RFC3339)
+	}
+	writeJSON(w, http.StatusOK, d)
+}
+
+func (h *Handler) buildNamespaceDetail(ns string, at time.Time) (*NamespaceDetail, error) {
+	store := h.Store
+	if store == nil {
+		return nil, fmt.Errorf("store not initialized")
+	}
+
+	d := &NamespaceDetail{
+		Name: ns,
+		Capture: CaptureMeta{
+			CaptureID:         store.Metadata.CaptureID,
+			CapturedAt:        store.Metadata.CapturedAt,
+			CapturedUntil:     store.Metadata.CapturedUntil,
+			KubernetesVersion: store.Metadata.KubernetesVersion,
+			ServerAddress:     store.Metadata.ServerAddress,
+			RecordCount:       store.Metadata.RecordCount,
+		},
+	}
+
+	// Per-resource counts scoped to this ns (no body reads).
+	byRes := store.NamespaceItemCountsAt(at)[ns]
+	resTotal := map[string]int{}
+	for res, n := range byRes {
+		resTotal[res] = n
+		d.KPIs.Resources += n
+		switch {
+		case workloadResources[res]:
+			d.KPIs.Workloads += n
+		case res == "pods":
+			d.KPIs.Pods += n
+		case vmResources[res]:
+			d.KPIs.VirtualMachines += n
+		case res == "configmaps":
+			d.KPIs.ConfigMaps += n
+		case res == "secrets":
+			d.KPIs.Secrets += n
+		}
+	}
+
+	// Load pods, classify, fill PodRow list + Unhealthy counter + Issues.
+	pods, podRows := h.loadPodsForNS(ns, at)
+	for _, p := range pods {
+		if !p.health.IsHealthy() {
+			d.KPIs.UnhealthyPods++
+		}
+	}
+	sort.SliceStable(podRows, func(i, j int) bool {
+		// Failing pods float to the top, otherwise alphabetical.
+		if podRows[i].Severity != podRows[j].Severity {
+			return podSeverityRank(podRows[i].Severity) < podSeverityRank(podRows[j].Severity)
+		}
+		return podRows[i].Name < podRows[j].Name
+	})
+	d.Pods = podRows
+	d.Issues = buildIssues(pods, 8)
+
+	// Workloads + VMs (read the per-ns list bodies and turn into compact rows).
+	d.Workloads = h.loadWorkloadRowsForNS(ns, at)
+	d.VMs = h.loadVMRowsForNS(ns, at)
+
+	// Resource tiles: every non-workload, non-pod, non-vm resource.
+	d.Resources = buildNamespaceTiles(resTotal)
+
+	// Pod-state sparkline scoped to this namespace.
+	d.Sparkline = h.sparklineForNS(ns, sparkBucketCount)
+
+	// Namespace metadata.
+	d.Metadata = h.loadNamespaceMetadata(ns, at)
+
+	return d, nil
+}
+
+// loadPodsForNS reads pods in the given namespace and returns both the
+// internal podHealthEntry slice (for issue grouping) and a UI-shaped PodRow
+// slice (for the drill-down table).
+func (h *Handler) loadPodsForNS(ns string, at time.Time) ([]podHealthEntry, []PodRow) {
+	listPath := "/api/v1/namespaces/" + ns + "/pods"
+	body, code, err := h.Store.ReconstructAt(listPath, at)
+	if err != nil || code != http.StatusOK || len(body) == 0 {
+		return nil, nil
+	}
+	var list struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(body, &list); err != nil {
+		return nil, nil
+	}
+	var (
+		entries []podHealthEntry
+		rows    []PodRow
+	)
+	for _, raw := range list.Items {
+		name := getName(raw)
+		if name == "" {
+			continue
+		}
+		ph := ClassifyPod(raw)
+		entries = append(entries, podHealthEntry{namespace: ns, name: name, prefix: PodNamePrefix(name), health: ph})
+
+		sev, status := podSeverityAndStatus(ph)
+		rows = append(rows, PodRow{
+			Name:     name,
+			Phase:    ph.Phase,
+			Status:   status,
+			Severity: sev,
+			Ready:    fmt.Sprintf("%d/%d", ph.Ready, ph.Total),
+			Restarts: ph.Restarts,
+			Age:      humanAge(getCreationTimestamp(raw), at),
+			Link:     podLink(ns, name),
+		})
+	}
+	return entries, rows
+}
+
+func podSeverityAndStatus(ph PodHealth) (string, string) {
+	if len(ph.Issues) > 0 {
+		// Pick the first issue as the human-readable reason.
+		return "bad", ph.Issues[0]
+	}
+	if ph.Phase == "Running" && ph.Ready < ph.Total {
+		return "warn", "NotReady"
+	}
+	if ph.Phase == "Pending" {
+		return "warn", "Pending"
+	}
+	return "good", ph.Phase
+}
+
+func podSeverityRank(sev string) int {
+	switch sev {
+	case "bad":
+		return 0
+	case "warn":
+		return 1
+	default:
+		return 2
+	}
+}
+
+// loadWorkloadRowsForNS walks the workload resource paths for this ns and
+// builds a compact row per item.
+func (h *Handler) loadWorkloadRowsForNS(ns string, at time.Time) []ResourceRow {
+	groups := []struct {
+		path  string
+		kind  string
+		short string // short label shown in the row
+	}{
+		{"/apis/apps/v1/namespaces/" + ns + "/deployments", "Deployment", "Deploy"},
+		{"/apis/apps/v1/namespaces/" + ns + "/statefulsets", "StatefulSet", "SS"},
+		{"/apis/apps/v1/namespaces/" + ns + "/daemonsets", "DaemonSet", "DS"},
+		{"/apis/apps/v1/namespaces/" + ns + "/replicasets", "ReplicaSet", "RS"},
+		{"/apis/batch/v1/namespaces/" + ns + "/jobs", "Job", "Job"},
+		{"/apis/batch/v1/namespaces/" + ns + "/cronjobs", "CronJob", "CronJob"},
+	}
+	var out []ResourceRow
+	for _, g := range groups {
+		out = append(out, h.loadWorkloadGroup(g.path, g.kind, g.short, at)...)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Severity != out[j].Severity {
+			return podSeverityRank(out[i].Severity) < podSeverityRank(out[j].Severity)
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func (h *Handler) loadWorkloadGroup(path, kind, short string, at time.Time) []ResourceRow {
+	body, code, err := h.Store.ReconstructAt(path, at)
+	if err != nil || code != http.StatusOK || len(body) == 0 {
+		return nil
+	}
+	var list struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(body, &list); err != nil {
+		return nil
+	}
+	out := make([]ResourceRow, 0, len(list.Items))
+	for _, raw := range list.Items {
+		out = append(out, classifyWorkload(short, kind, raw, at))
+	}
+	return out
+}
+
+// classifyWorkload reads spec.replicas + status.{readyReplicas,…} and turns
+// the result into a single human-readable row.
+func classifyWorkload(short, kind string, raw json.RawMessage, at time.Time) ResourceRow {
+	var w struct {
+		Metadata struct {
+			Name              string    `json:"name"`
+			CreationTimestamp time.Time `json:"creationTimestamp"`
+		} `json:"metadata"`
+		Spec struct {
+			Replicas *int `json:"replicas"`
+		} `json:"spec"`
+		Status struct {
+			Replicas               int `json:"replicas"`
+			ReadyReplicas          int `json:"readyReplicas"`
+			AvailableReplicas      int `json:"availableReplicas"`
+			NumberReady            int `json:"numberReady"`
+			DesiredNumberScheduled int `json:"desiredNumberScheduled"`
+			Succeeded              int `json:"succeeded"`
+			Active                 int `json:"active"`
+			Failed                 int `json:"failed"`
+		} `json:"status"`
+	}
+	_ = json.Unmarshal(raw, &w)
+
+	row := ResourceRow{
+		Kind:     short,
+		Name:     w.Metadata.Name,
+		Age:      humanAge(w.Metadata.CreationTimestamp, at),
+		Severity: "good",
+	}
+	switch kind {
+	case "Deployment", "StatefulSet", "ReplicaSet":
+		desired := 0
+		if w.Spec.Replicas != nil {
+			desired = *w.Spec.Replicas
+		}
+		row.Status = fmt.Sprintf("%d/%d Ready", w.Status.ReadyReplicas, desired)
+		row.Severity = readinessSeverity(w.Status.ReadyReplicas, desired)
+	case "DaemonSet":
+		row.Status = fmt.Sprintf("%d/%d Ready", w.Status.NumberReady, w.Status.DesiredNumberScheduled)
+		row.Severity = readinessSeverity(w.Status.NumberReady, w.Status.DesiredNumberScheduled)
+	case "Job":
+		if w.Status.Failed > 0 {
+			row.Status = fmt.Sprintf("Failed: %d", w.Status.Failed)
+			row.Severity = "bad"
+		} else if w.Status.Active > 0 {
+			row.Status = fmt.Sprintf("Active: %d", w.Status.Active)
+			row.Severity = "warn"
+		} else {
+			row.Status = fmt.Sprintf("Succeeded: %d", w.Status.Succeeded)
+		}
+	case "CronJob":
+		row.Status = "Scheduled"
+	}
+	return row
+}
+
+func readinessSeverity(ready, desired int) string {
+	if desired == 0 {
+		return "neutral"
+	}
+	if ready == 0 {
+		return "bad"
+	}
+	if ready < desired {
+		return "warn"
+	}
+	return "good"
+}
+
+// loadVMRowsForNS reads kubevirt VirtualMachine + VirtualMachineInstance
+// lists when present.
+func (h *Handler) loadVMRowsForNS(ns string, at time.Time) []ResourceRow {
+	groups := []struct {
+		path, kind, short string
+	}{
+		{"/apis/kubevirt.io/v1/namespaces/" + ns + "/virtualmachines", "VirtualMachine", "VM"},
+		{"/apis/kubevirt.io/v1/namespaces/" + ns + "/virtualmachineinstances", "VirtualMachineInstance", "VMI"},
+	}
+	var out []ResourceRow
+	for _, g := range groups {
+		body, code, err := h.Store.ReconstructAt(g.path, at)
+		if err != nil || code != http.StatusOK || len(body) == 0 {
+			continue
+		}
+		var list struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		if err := json.Unmarshal(body, &list); err != nil {
+			continue
+		}
+		for _, raw := range list.Items {
+			var v struct {
+				Metadata struct {
+					Name              string    `json:"name"`
+					CreationTimestamp time.Time `json:"creationTimestamp"`
+				} `json:"metadata"`
+				Status struct {
+					PrintableStatus string `json:"printableStatus"`
+					Phase           string `json:"phase"`
+				} `json:"status"`
+			}
+			_ = json.Unmarshal(raw, &v)
+			status := v.Status.PrintableStatus
+			if status == "" {
+				status = v.Status.Phase
+			}
+			sev := "good"
+			if status != "" && status != "Running" {
+				sev = "warn"
+			}
+			out = append(out, ResourceRow{
+				Kind:     g.short,
+				Name:     v.Metadata.Name,
+				Status:   status,
+				Severity: sev,
+				Age:      humanAge(v.Metadata.CreationTimestamp, at),
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// loadNamespaceMetadata reads the namespace object from /api/v1/namespaces
+// (the cluster-wide list) and surfaces labels/annotations/age/phase.
+func (h *Handler) loadNamespaceMetadata(ns string, at time.Time) NamespaceMetadata {
+	body, code, err := h.Store.ReconstructAt("/api/v1/namespaces", at)
+	if err != nil || code != http.StatusOK || len(body) == 0 {
+		return NamespaceMetadata{}
+	}
+	var list struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(body, &list); err != nil {
+		return NamespaceMetadata{}
+	}
+	for _, raw := range list.Items {
+		var n struct {
+			Metadata struct {
+				Name              string            `json:"name"`
+				CreationTimestamp time.Time         `json:"creationTimestamp"`
+				Labels            map[string]string `json:"labels"`
+				Annotations       map[string]string `json:"annotations"`
+			} `json:"metadata"`
+			Status struct {
+				Phase string `json:"phase"`
+			} `json:"status"`
+		}
+		if err := json.Unmarshal(raw, &n); err != nil {
+			continue
+		}
+		if n.Metadata.Name != ns {
+			continue
+		}
+		return NamespaceMetadata{
+			CreatedAt:   n.Metadata.CreationTimestamp.UTC().Format(time.RFC3339),
+			AgeHuman:    humanAge(n.Metadata.CreationTimestamp, at),
+			Phase:       n.Status.Phase,
+			Labels:      n.Metadata.Labels,
+			Annotations: n.Metadata.Annotations,
+		}
+	}
+	return NamespaceMetadata{}
+}
+
+// buildNamespaceTiles drops the workload/pod/vm resources (rendered as
+// separate cards) and turns the rest of the per-ns counts into tiles.
+func buildNamespaceTiles(byRes map[string]int) []ResourceTile {
+	out := make([]ResourceTile, 0, len(byRes))
+	for res, n := range byRes {
+		if n <= 0 {
+			continue
+		}
+		if workloadResources[res] || vmResources[res] || res == "pods" {
+			continue
+		}
+		out = append(out, ResourceTile{
+			Kind:  kindFromResource(res),
+			Count: n,
+			Link:  "#/namespaces",
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Count > out[j].Count })
+	return out
+}
+
+// humanAge converts a creationTimestamp + reference time into a short human
+// duration string like "14d" or "3h12m". Returns "" for zero timestamps.
+func humanAge(created, ref time.Time) string {
+	if created.IsZero() {
+		return ""
+	}
+	if ref.IsZero() {
+		ref = time.Now().UTC()
+	}
+	d := ref.Sub(created)
+	if d < 0 {
+		return "0s"
+	}
+	switch {
+	case d > 48*time.Hour:
+		return fmt.Sprintf("%dd", int(d/(24*time.Hour)))
+	case d > 1*time.Hour:
+		return fmt.Sprintf("%dh%dm", int(d/time.Hour), int(d%time.Hour/time.Minute))
+	case d > 1*time.Minute:
+		return fmt.Sprintf("%dm", int(d/time.Minute))
+	default:
+		return fmt.Sprintf("%ds", int(d/time.Second))
+	}
+}
+
+// getCreationTimestamp parses metadata.creationTimestamp from a raw object.
+func getCreationTimestamp(raw json.RawMessage) time.Time {
+	var m struct {
+		Metadata struct {
+			CreationTimestamp time.Time `json:"creationTimestamp"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return time.Time{}
+	}
+	return m.Metadata.CreationTimestamp
+}
+
+// buildSparklineForNS gets the real implementation now that the file
+// compiles with a placeholder. Replace inline above to keep imports tidy.
+//
+// We need access to the store to walk its WatchIndex. Hoist the func to
+// Handler so we can do that.
+func (h *Handler) sparklineForNS(ns string, buckets int) SparklineData {
+	store := h.Store
+	start := store.Metadata.CapturedAt.UTC()
+	end := store.Metadata.CapturedUntil.UTC()
+	if !end.After(start) || buckets <= 0 {
+		return SparklineData{StartTime: start, EndTime: end}
+	}
+	step := end.Sub(start) / time.Duration(buckets)
+	if step <= 0 {
+		step = time.Second
+	}
+	cells := make([]SparkBucket, buckets)
+	for i := range cells {
+		cells[i].Time = start.Add(time.Duration(i) * step)
+	}
+	prefix := "/api/v1/namespaces/" + ns + "/"
+	apisPrefix := "/apis/"
+	apisNsSegment := "/namespaces/" + ns + "/"
+	total := 0
+	for path, wi := range store.WatchIndex {
+		if wi == nil {
+			continue
+		}
+		isThisNS := strings.HasPrefix(path, prefix) ||
+			(strings.HasPrefix(path, apisPrefix) && strings.Contains(path, apisNsSegment))
+		if !isThisNS {
+			continue
+		}
+		isPodPath := strings.Contains(path, "/pods")
+		for i, t := range wi.Times {
+			total++
+			idx := int(t.Sub(start) / step)
+			if idx < 0 {
+				idx = 0
+			} else if idx >= buckets {
+				idx = buckets - 1
+			}
+			cells[idx].Total++
+			if !isPodPath || i >= len(wi.EventTypes) {
+				continue
+			}
+			switch wi.EventTypes[i] {
+			case "DELETED":
+				cells[idx].Bad++
+			case "MODIFIED":
+				cells[idx].Warn++
+			}
+		}
+	}
+	return SparklineData{Buckets: cells, TotalEvents: total, StartTime: start, EndTime: end}
+}

--- a/internal/ui/v2/namespace.go
+++ b/internal/ui/v2/namespace.go
@@ -38,6 +38,7 @@ type NamespaceKPIs struct {
 // ResourceRow is a compact row in the workloads / VMs lists.
 type ResourceRow struct {
 	Kind     string `json:"kind"`
+	Resource string `json:"resource,omitempty"`
 	Name     string `json:"name"`
 	Status   string `json:"status"`
 	Severity string `json:"severity"`
@@ -261,9 +262,12 @@ func (h *Handler) loadWorkloadGroup(path, kind, short string, at time.Time) []Re
 	if err := json.Unmarshal(body, &list); err != nil {
 		return nil
 	}
+	_, _, resource, _ := parseAPIPath(path)
 	out := make([]ResourceRow, 0, len(list.Items))
 	for _, raw := range list.Items {
-		out = append(out, classifyWorkload(short, kind, raw, at))
+		row := classifyWorkload(short, kind, raw, at)
+		row.Resource = resource
+		out = append(out, row)
 	}
 	return out
 }
@@ -379,8 +383,10 @@ func (h *Handler) loadVMRowsForNS(ns string, at time.Time) []ResourceRow {
 			if status != "" && status != "Running" {
 				sev = "warn"
 			}
+			_, _, vmResource, _ := parseAPIPath(g.path)
 			out = append(out, ResourceRow{
 				Kind:     g.short,
+				Resource: vmResource,
 				Name:     v.Metadata.Name,
 				Status:   status,
 				Severity: sev,

--- a/internal/ui/v2/objects.go
+++ b/internal/ui/v2/objects.go
@@ -1,0 +1,199 @@
+package v2
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ObjectDetail is the response from /v2/api/object — a single captured object
+// rendered as both pretty JSON and YAML, for the generic object view.
+type ObjectDetail struct {
+	Path      string `json:"path"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+	Kind      string `json:"kind,omitempty"`
+	At        string `json:"at,omitempty"`
+	Found     bool   `json:"found"`
+	JSON      string `json:"json"`
+	YAML      string `json:"yaml"`
+}
+
+// serveObject returns one captured object (by list path + name) as JSON+YAML.
+// When name is empty the whole list body is returned, which lets the view show
+// cluster/list-scoped resources too.
+func (h *Handler) serveObject(w http.ResponseWriter, r *http.Request) {
+	if h.Store == nil {
+		writeError(w, http.StatusInternalServerError, "store not initialized")
+		return
+	}
+	path := r.URL.Query().Get("path")
+	name := r.URL.Query().Get("name")
+	if path == "" {
+		writeError(w, http.StatusBadRequest, "missing path query parameter")
+		return
+	}
+	at := h.resolveAt(r)
+	body, code, err := h.Store.ReconstructAt(path, at)
+	resp := ObjectDetail{Path: path, Name: name}
+	if !at.IsZero() {
+		resp.At = at.UTC().Format(time.RFC3339)
+	}
+	if err != nil || code != http.StatusOK || len(body) == 0 {
+		writeJSON(w, http.StatusOK, resp) // Found=false
+		return
+	}
+
+	raw := body
+	if name != "" {
+		var list struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		found := false
+		if err := json.Unmarshal(body, &list); err == nil {
+			for _, it := range list.Items {
+				if getName(it) == name {
+					raw = it
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			writeJSON(w, http.StatusOK, resp) // Found=false
+			return
+		}
+	}
+
+	resp.Found = true
+	resp.Kind, resp.Namespace = kindAndNamespace(raw)
+	resp.JSON = prettyJSON(raw)
+	resp.YAML = toYAML(raw)
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// ResourceObjectRow is a single object in a generic resource-type list.
+type ResourceObjectRow struct {
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+	Age       string `json:"age,omitempty"`
+	Link      string `json:"link"`
+}
+
+// ResourceList is the response from /v2/api/resource — every object of a given
+// resource type (optionally scoped to a namespace) at the resolved snapshot.
+type ResourceList struct {
+	Resource string              `json:"resource"`
+	Kind     string              `json:"kind"`
+	Namespace string             `json:"namespace,omitempty"`
+	At       string              `json:"at,omitempty"`
+	Total    int                 `json:"total"`
+	Items    []ResourceObjectRow `json:"items"`
+}
+
+// serveResourceList lists every object of a resource type across the capture.
+// The resource is identified by its plural name (e.g. "configmaps"); the
+// handler discovers the matching API paths from the index, so the caller does
+// not need to know the group/version. Optional ns scopes to one namespace.
+func (h *Handler) serveResourceList(w http.ResponseWriter, r *http.Request) {
+	if h.Store == nil {
+		writeError(w, http.StatusInternalServerError, "store not initialized")
+		return
+	}
+	resource := r.URL.Query().Get("resource")
+	nsFilter := r.URL.Query().Get("ns")
+	if resource == "" {
+		writeError(w, http.StatusBadRequest, "missing resource query parameter")
+		return
+	}
+	at := h.resolveAt(r)
+
+	out := ResourceList{Resource: resource, Kind: kindFromResource(resource), Namespace: nsFilter}
+	if !at.IsZero() {
+		out.At = at.UTC().Format(time.RFC3339)
+	}
+
+	for path, entry := range h.Store.Index {
+		if entry == nil || len(entry.Seqs) == 0 {
+			continue
+		}
+		if strings.Contains(path, "?") {
+			continue
+		}
+		_, _, res, ns := parseAPIPath(path)
+		if res != resource {
+			continue
+		}
+		if nsFilter != "" && ns != nsFilter {
+			continue
+		}
+		body, code, err := h.Store.ReconstructAt(path, at)
+		if err != nil || code != http.StatusOK || len(body) == 0 {
+			continue
+		}
+		var list struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		if err := json.Unmarshal(body, &list); err != nil {
+			continue
+		}
+		for _, it := range list.Items {
+			name := getName(it)
+			if name == "" {
+				continue
+			}
+			out.Items = append(out.Items, ResourceObjectRow{
+				Namespace: ns,
+				Name:      name,
+				Age:       humanAge(getCreationTimestamp(it), at),
+				Link:      objectLink(path, name),
+			})
+		}
+	}
+	sort.SliceStable(out.Items, func(i, j int) bool {
+		if out.Items[i].Namespace != out.Items[j].Namespace {
+			return out.Items[i].Namespace < out.Items[j].Namespace
+		}
+		return out.Items[i].Name < out.Items[j].Name
+	})
+	out.Total = len(out.Items)
+	writeJSON(w, http.StatusOK, out)
+}
+
+// objectLink builds a hash link to the generic object view for a list path +
+// object name. Both are URL-query-encoded by the frontend; here we only need a
+// stable, parseable string.
+func objectLink(path, name string) string {
+	q := url.Values{}
+	q.Set("path", path)
+	q.Set("name", name)
+	return "#/object?" + q.Encode()
+}
+
+// kindAndNamespace pulls apiVersion/kind and metadata.namespace from a raw
+// object so the object view can show a readable header.
+func kindAndNamespace(raw json.RawMessage) (kind, namespace string) {
+	var m struct {
+		Kind     string `json:"kind"`
+		Metadata struct {
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return "", ""
+	}
+	return m.Kind, m.Metadata.Namespace
+}
+
+// prettyJSON re-indents a raw JSON body. Returns the original string on error.
+func prettyJSON(raw json.RawMessage) string {
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, raw, "", "  "); err != nil {
+		return string(raw)
+	}
+	return buf.String()
+}

--- a/internal/ui/v2/objects.go
+++ b/internal/ui/v2/objects.go
@@ -78,21 +78,22 @@ func (h *Handler) serveObject(w http.ResponseWriter, r *http.Request) {
 
 // ResourceObjectRow is a single object in a generic resource-type list.
 type ResourceObjectRow struct {
-	Namespace string `json:"namespace,omitempty"`
-	Name      string `json:"name"`
-	Age       string `json:"age,omitempty"`
-	Link      string `json:"link"`
+	Namespace string            `json:"namespace,omitempty"`
+	Name      string            `json:"name"`
+	Age       string            `json:"age,omitempty"`
+	Link      string            `json:"link"`
+	Labels    map[string]string `json:"labels,omitempty"`
 }
 
 // ResourceList is the response from /v2/api/resource — every object of a given
 // resource type (optionally scoped to a namespace) at the resolved snapshot.
 type ResourceList struct {
-	Resource string              `json:"resource"`
-	Kind     string              `json:"kind"`
-	Namespace string             `json:"namespace,omitempty"`
-	At       string              `json:"at,omitempty"`
-	Total    int                 `json:"total"`
-	Items    []ResourceObjectRow `json:"items"`
+	Resource  string              `json:"resource"`
+	Kind      string              `json:"kind"`
+	Namespace string              `json:"namespace,omitempty"`
+	At        string              `json:"at,omitempty"`
+	Total     int                 `json:"total"`
+	Items     []ResourceObjectRow `json:"items"`
 }
 
 // serveResourceList lists every object of a resource type across the capture.
@@ -151,6 +152,7 @@ func (h *Handler) serveResourceList(w http.ResponseWriter, r *http.Request) {
 				Name:      name,
 				Age:       humanAge(getCreationTimestamp(it), at),
 				Link:      objectLink(path, name),
+				Labels:    getLabels(it),
 			})
 		}
 	}
@@ -166,7 +168,7 @@ func (h *Handler) serveResourceList(w http.ResponseWriter, r *http.Request) {
 
 // ResourceCatalogRow describes one captured resource type (API kind).
 type ResourceCatalogRow struct {
-	Group      string `json:"group"`
+	Group      string   `json:"group"`
 	Version    string   `json:"version"`
 	Resource   string   `json:"resource"`
 	Kind       string   `json:"kind"`
@@ -344,6 +346,19 @@ func objectLink(path, name string) string {
 	q.Set("path", path)
 	q.Set("name", name)
 	return "#/object?" + q.Encode()
+}
+
+// getLabels reads metadata.labels from a raw object.
+func getLabels(raw json.RawMessage) map[string]string {
+	var m struct {
+		Metadata struct {
+			Labels map[string]string `json:"labels"`
+		} `json:"metadata"`
+	}
+	if json.Unmarshal(raw, &m) != nil {
+		return nil
+	}
+	return m.Metadata.Labels
 }
 
 // kindAndNamespace pulls apiVersion/kind and metadata.namespace from a raw

--- a/internal/ui/v2/objects.go
+++ b/internal/ui/v2/objects.go
@@ -164,6 +164,81 @@ func (h *Handler) serveResourceList(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
+// ResourceCatalogRow describes one captured resource type (API kind).
+type ResourceCatalogRow struct {
+	Group      string `json:"group"`
+	Version    string `json:"version"`
+	Resource   string `json:"resource"`
+	Kind       string `json:"kind"`
+	Namespaced bool   `json:"namespaced"`
+	Count      int    `json:"count"`
+	Link       string `json:"link"`
+}
+
+// ResourceCatalog is the response from /v2/api/resources — every resource type
+// seen in the capture, with item counts, for the Resources catalog page.
+type ResourceCatalog struct {
+	At        string               `json:"at,omitempty"`
+	Capture   CaptureMeta          `json:"capture"`
+	Total     int                  `json:"total"`
+	Resources []ResourceCatalogRow `json:"resources"`
+}
+
+// serveResourceCatalog enumerates every resource type captured (one row per
+// group/version/resource) with a summed item count at the resolved snapshot.
+// Counts come straight from the index (no body reads).
+func (h *Handler) serveResourceCatalog(w http.ResponseWriter, r *http.Request) {
+	if h.Store == nil {
+		writeError(w, http.StatusInternalServerError, "store not initialized")
+		return
+	}
+	at := h.resolveAt(r)
+
+	type key struct{ g, v, res string }
+	agg := map[key]*ResourceCatalogRow{}
+	for path, entry := range h.Store.Index {
+		if entry == nil || len(entry.Seqs) == 0 {
+			continue
+		}
+		if strings.Contains(path, "?") {
+			continue
+		}
+		g, v, res, ns := parseAPIPath(path)
+		if res == "" {
+			continue
+		}
+		k := key{g, v, res}
+		row := agg[k]
+		if row == nil {
+			row = &ResourceCatalogRow{Group: g, Version: v, Resource: res, Kind: kindFromResource(res), Link: resourceLink(res, "")}
+			agg[k] = row
+		}
+		if ns != "" {
+			row.Namespaced = true
+		}
+		if i := latestIndex(entry, at); i >= 0 && i < len(entry.Counts) && entry.Counts[i] > 0 {
+			row.Count += entry.Counts[i]
+		}
+	}
+
+	out := ResourceCatalog{Capture: h.captureMeta()}
+	if !at.IsZero() {
+		out.At = at.UTC().Format(time.RFC3339)
+	}
+	for _, row := range agg {
+		out.Resources = append(out.Resources, *row)
+	}
+	sort.SliceStable(out.Resources, func(i, j int) bool {
+		a, b := out.Resources[i], out.Resources[j]
+		if a.Group != b.Group {
+			return a.Group < b.Group // core ("") group sorts first
+		}
+		return a.Resource < b.Resource
+	})
+	out.Total = len(out.Resources)
+	writeJSON(w, http.StatusOK, out)
+}
+
 // objectLink builds a hash link to the generic object view for a list path +
 // object name. Both are URL-query-encoded by the frontend; here we only need a
 // stable, parseable string.

--- a/internal/ui/v2/objects.go
+++ b/internal/ui/v2/objects.go
@@ -167,12 +167,14 @@ func (h *Handler) serveResourceList(w http.ResponseWriter, r *http.Request) {
 // ResourceCatalogRow describes one captured resource type (API kind).
 type ResourceCatalogRow struct {
 	Group      string `json:"group"`
-	Version    string `json:"version"`
-	Resource   string `json:"resource"`
-	Kind       string `json:"kind"`
-	Namespaced bool   `json:"namespaced"`
-	Count      int    `json:"count"`
-	Link       string `json:"link"`
+	Version    string   `json:"version"`
+	Resource   string   `json:"resource"`
+	Kind       string   `json:"kind"`
+	Singular   string   `json:"singular,omitempty"`
+	ShortNames []string `json:"short_names,omitempty"`
+	Namespaced bool     `json:"namespaced"`
+	Count      int      `json:"count"`
+	Link       string   `json:"link"`
 }
 
 // ResourceCatalog is the response from /v2/api/resources — every resource type
@@ -194,7 +196,7 @@ func (h *Handler) serveResourceCatalog(w http.ResponseWriter, r *http.Request) {
 	}
 	at := h.resolveAt(r)
 
-	kinds := h.discoveryKindMap()
+	meta := h.discoveryResourceMeta()
 	type key struct{ g, v, res string }
 	agg := map[key]*ResourceCatalogRow{}
 	for path, entry := range h.Store.Index {
@@ -211,14 +213,15 @@ func (h *Handler) serveResourceCatalog(w http.ResponseWriter, r *http.Request) {
 		k := key{g, v, res}
 		row := agg[k]
 		if row == nil {
-			kind := kinds[g+"/"+v+"/"+res]
-			if kind == "" {
-				kind = kinds[res]
+			dm, ok := meta[g+"/"+v+"/"+res]
+			if !ok {
+				dm = meta[res]
 			}
+			kind := dm.Kind
 			if kind == "" {
 				kind = kindFromResource(res)
 			}
-			row = &ResourceCatalogRow{Group: g, Version: v, Resource: res, Kind: kind, Link: resourceLink(res, "")}
+			row = &ResourceCatalogRow{Group: g, Version: v, Resource: res, Kind: kind, Singular: dm.Singular, ShortNames: dm.Short, Link: resourceLink(res, "")}
 			agg[k] = row
 		}
 		if ns != "" {
@@ -247,13 +250,20 @@ func (h *Handler) serveResourceCatalog(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
-// discoveryKindMap builds an authoritative resource→kind map from the captured
-// API discovery documents (/api/v1 and /apis/<group>/<version>), which carry
-// the real Kind for every resource — including CRDs and irregular plurals that
-// kindFromResource can only guess at. Keyed by "group/version/resource" and,
-// as a fallback, by bare "resource".
-func (h *Handler) discoveryKindMap() map[string]string {
-	m := map[string]string{}
+// discMeta is the per-resource discovery info used by the Resources catalog.
+type discMeta struct {
+	Kind     string
+	Singular string
+	Short    []string
+}
+
+// discoveryResourceMeta builds an authoritative resource→{kind, singular,
+// short names} map from the captured API discovery documents (/api/v1 and
+// /apis/<group>/<version>). This gives correct kinds (incl. CRDs / irregular
+// plurals) and the kubectl short names for searching. Keyed by
+// "group/version/resource" and, as a fallback, by bare "resource".
+func (h *Handler) discoveryResourceMeta() map[string]discMeta {
+	m := map[string]discMeta{}
 	for path, entry := range h.Store.Index {
 		if entry == nil || len(entry.Seqs) == 0 {
 			continue
@@ -272,8 +282,10 @@ func (h *Handler) discoveryKindMap() map[string]string {
 		var rl struct {
 			GroupVersion string `json:"groupVersion"`
 			Resources    []struct {
-				Name string `json:"name"`
-				Kind string `json:"kind"`
+				Name         string   `json:"name"`
+				SingularName string   `json:"singularName"`
+				Kind         string   `json:"kind"`
+				ShortNames   []string `json:"shortNames"`
 			} `json:"resources"`
 		}
 		if json.Unmarshal(body, &rl) != nil {
@@ -287,13 +299,41 @@ func (h *Handler) discoveryKindMap() map[string]string {
 			if res.Kind == "" || strings.Contains(res.Name, "/") { // skip subresources
 				continue
 			}
-			m[group+"/"+version+"/"+res.Name] = res.Kind
+			dm := discMeta{Kind: res.Kind, Singular: res.SingularName, Short: res.ShortNames}
+			m[group+"/"+version+"/"+res.Name] = dm
 			if _, ok := m[res.Name]; !ok {
-				m[res.Name] = res.Kind
+				m[res.Name] = dm
 			}
 		}
 	}
 	return m
+}
+
+// apiListPath builds the Kubernetes list path for a group/version/resource,
+// scoped to a namespace when ns is non-empty.
+func apiListPath(group, version, resource, ns string) string {
+	base := "/api/" + version
+	if group != "" {
+		base = "/apis/" + group + "/" + version
+	}
+	if ns == "" {
+		return base + "/" + resource
+	}
+	return base + "/namespaces/" + ns + "/" + resource
+}
+
+// ownerLink builds an object-view link for an ownerReference, guessing the
+// resource as lowercase(kind)+"s" (correct for the common workload kinds).
+func ownerLink(o ownerRef, ns string) string {
+	group, version := "", o.APIVersion
+	if i := strings.Index(o.APIVersion, "/"); i >= 0 {
+		group, version = o.APIVersion[:i], o.APIVersion[i+1:]
+	}
+	if version == "" {
+		version = "v1"
+	}
+	resource := strings.ToLower(o.Kind) + "s"
+	return objectLink(apiListPath(group, version, resource, ns), o.Name)
 }
 
 // objectLink builds a hash link to the generic object view for a list path +

--- a/internal/ui/v2/objects.go
+++ b/internal/ui/v2/objects.go
@@ -194,6 +194,7 @@ func (h *Handler) serveResourceCatalog(w http.ResponseWriter, r *http.Request) {
 	}
 	at := h.resolveAt(r)
 
+	kinds := h.discoveryKindMap()
 	type key struct{ g, v, res string }
 	agg := map[key]*ResourceCatalogRow{}
 	for path, entry := range h.Store.Index {
@@ -210,7 +211,14 @@ func (h *Handler) serveResourceCatalog(w http.ResponseWriter, r *http.Request) {
 		k := key{g, v, res}
 		row := agg[k]
 		if row == nil {
-			row = &ResourceCatalogRow{Group: g, Version: v, Resource: res, Kind: kindFromResource(res), Link: resourceLink(res, "")}
+			kind := kinds[g+"/"+v+"/"+res]
+			if kind == "" {
+				kind = kinds[res]
+			}
+			if kind == "" {
+				kind = kindFromResource(res)
+			}
+			row = &ResourceCatalogRow{Group: g, Version: v, Resource: res, Kind: kind, Link: resourceLink(res, "")}
 			agg[k] = row
 		}
 		if ns != "" {
@@ -237,6 +245,55 @@ func (h *Handler) serveResourceCatalog(w http.ResponseWriter, r *http.Request) {
 	})
 	out.Total = len(out.Resources)
 	writeJSON(w, http.StatusOK, out)
+}
+
+// discoveryKindMap builds an authoritative resource→kind map from the captured
+// API discovery documents (/api/v1 and /apis/<group>/<version>), which carry
+// the real Kind for every resource — including CRDs and irregular plurals that
+// kindFromResource can only guess at. Keyed by "group/version/resource" and,
+// as a fallback, by bare "resource".
+func (h *Handler) discoveryKindMap() map[string]string {
+	m := map[string]string{}
+	for path, entry := range h.Store.Index {
+		if entry == nil || len(entry.Seqs) == 0 {
+			continue
+		}
+		if strings.Contains(path, "?") {
+			continue
+		}
+		// Discovery docs are /api/v1 (core) or /apis/<group>/<version>.
+		if path != "/api/v1" && !(strings.HasPrefix(path, "/apis/") && strings.Count(path, "/") == 3) {
+			continue
+		}
+		body, code, err := h.Store.Latest(path, time.Time{})
+		if err != nil || code != http.StatusOK || len(body) == 0 {
+			continue
+		}
+		var rl struct {
+			GroupVersion string `json:"groupVersion"`
+			Resources    []struct {
+				Name string `json:"name"`
+				Kind string `json:"kind"`
+			} `json:"resources"`
+		}
+		if json.Unmarshal(body, &rl) != nil {
+			continue
+		}
+		group, version := "", rl.GroupVersion
+		if i := strings.Index(rl.GroupVersion, "/"); i >= 0 {
+			group, version = rl.GroupVersion[:i], rl.GroupVersion[i+1:]
+		}
+		for _, res := range rl.Resources {
+			if res.Kind == "" || strings.Contains(res.Name, "/") { // skip subresources
+				continue
+			}
+			m[group+"/"+version+"/"+res.Name] = res.Kind
+			if _, ok := m[res.Name]; !ok {
+				m[res.Name] = res.Kind
+			}
+		}
+	}
+	return m
 }
 
 // objectLink builds a hash link to the generic object view for a list path +

--- a/internal/ui/v2/overview.go
+++ b/internal/ui/v2/overview.go
@@ -483,7 +483,7 @@ func buildResourceTiles(resourceTotals map[string]int) []ResourceTile {
 		out = append(out, ResourceTile{Kind: r.kind, Resource: r.res, Count: r.count, Link: resourceLink(r.res, "")})
 	}
 	if len(rest) > showRest {
-		out = append(out, ResourceTile{Kind: fmt.Sprintf("+ %d more…", len(rest)-showRest), Count: 0, Link: "#/namespaces"})
+		out = append(out, ResourceTile{Kind: fmt.Sprintf("+ %d more…", len(rest)-showRest), Count: 0, Link: "#/resources"})
 	}
 	return out
 }

--- a/internal/ui/v2/overview.go
+++ b/internal/ui/v2/overview.go
@@ -1,0 +1,487 @@
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/server"
+)
+
+const (
+	sparkBucketCount = 30
+	topNamespacesN   = 8
+	recentEventsN    = 8
+	maxIssuesShown   = 8
+)
+
+// workloadResources is the set of resource types categorised as "workloads"
+// for KPI counting. Mirrors the existing /api/ui drill-down classifier.
+var workloadResources = map[string]bool{
+	"deployments":  true,
+	"statefulsets": true,
+	"daemonsets":   true,
+	"jobs":         true,
+	"replicasets":  true,
+}
+
+// vmResources counts as VirtualMachines on the dashboard.
+var vmResources = map[string]bool{
+	"virtualmachines":         true,
+	"virtualmachineinstances": true,
+}
+
+func (h *Handler) serveOverview(w http.ResponseWriter, r *http.Request) {
+	at := h.resolveAt(r)
+	ov, err := h.buildOverview(at)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if !at.IsZero() {
+		ov.At = at.UTC().Format(time.RFC3339)
+	}
+	writeJSON(w, http.StatusOK, ov)
+}
+
+// resolveAt reads ?at= from the request, falling back to h.At.
+func (h *Handler) resolveAt(r *http.Request) time.Time {
+	q := r.URL.Query().Get("at")
+	if q == "" {
+		return h.At
+	}
+	t, err := time.Parse(time.RFC3339, q)
+	if err != nil {
+		return h.At
+	}
+	return t.UTC()
+}
+
+// buildOverview walks the index + reads pod bodies to compute everything the
+// dashboard landing page needs. Designed to be called per request — first
+// hit on a large archive takes ~1-3s (pod body reads dominate); subsequent
+// hits ride the store's record LRU.
+func (h *Handler) buildOverview(at time.Time) (*Overview, error) {
+	store := h.Store
+	if store == nil {
+		return nil, fmt.Errorf("store not initialized")
+	}
+
+	ov := &Overview{
+		Capture: CaptureMeta{
+			CaptureID:         store.Metadata.CaptureID,
+			CapturedAt:        store.Metadata.CapturedAt,
+			CapturedUntil:     store.Metadata.CapturedUntil,
+			KubernetesVersion: store.Metadata.KubernetesVersion,
+			ServerAddress:     store.Metadata.ServerAddress,
+			RecordCount:       store.Metadata.RecordCount,
+		},
+	}
+
+	// Per-(ns, resource) counts from the index — no body reads.
+	counts := store.NamespaceItemCountsAt(at)
+
+	// Cluster-scoped resource totals from the index — at the latest record per path.
+	clusterCounts := clusterScopedResourceCounts(store.Index, at)
+
+	// Aggregate KPIs + per-resource totals.
+	resourceTotals := map[string]int{}
+	hasPerNS := map[string]bool{}
+	for _, byRes := range counts {
+		for res, n := range byRes {
+			resourceTotals[res] += n
+			hasPerNS[res] = true
+			switch {
+			case workloadResources[res]:
+				ov.KPIs.Workloads += n
+			case res == "pods":
+				ov.KPIs.Pods += n
+			case vmResources[res]:
+				ov.KPIs.VirtualMachines += n
+			}
+		}
+	}
+	// Only add cluster-scoped totals for resources that don't already have
+	// per-namespace records — otherwise we double-count when the engine
+	// captured both the cluster-wide list (allNotFound fallback) AND the
+	// per-namespace lists.
+	for res, n := range clusterCounts {
+		if hasPerNS[res] {
+			continue
+		}
+		resourceTotals[res] += n
+	}
+
+	// Read pod bodies → classify health → fill UnhealthyPods + Issues.
+	podHealths := h.readAllPodHealths(at)
+	for _, ph := range podHealths {
+		if ph.health.IsHealthy() {
+			continue
+		}
+		ov.KPIs.UnhealthyPods++
+		for _, reason := range ph.health.Issues {
+			switch reason {
+			case "CrashLoopBackOff":
+				ov.KPIs.CrashLoopBackOff++
+			case "Failed":
+				ov.KPIs.Failed++
+			case "OOMKilled":
+				ov.KPIs.OOMKilled++
+			}
+		}
+		if ph.health.Phase == "Pending" && !ph.health.IsHealthy() {
+			ov.KPIs.Pending++
+		}
+	}
+	ov.Issues = buildIssues(podHealths, maxIssuesShown)
+
+	// Watch event totals + sparkline (per time bucket).
+	ov.Sparkline = buildSparkline(store, at, sparkBucketCount)
+	ov.KPIs.WatchEvents = ov.Sparkline.TotalEvents
+
+	// Per-namespace summaries with health rollup.
+	nsByName := map[string]*NamespaceSummary{}
+	for ns, byRes := range counts {
+		s := &NamespaceSummary{Name: ns}
+		for res, n := range byRes {
+			s.Resources += n
+			if workloadResources[res] {
+				s.Workloads += n
+			}
+			if res == "pods" {
+				s.Pods += n
+			}
+		}
+		nsByName[ns] = s
+	}
+	for _, ph := range podHealths {
+		if ns := nsByName[ph.namespace]; ns != nil && !ph.health.IsHealthy() {
+			ns.Unhealthy++
+		}
+	}
+	ov.Namespaces = make([]NamespaceSummary, 0, len(nsByName))
+	for _, s := range nsByName {
+		ov.Namespaces = append(ov.Namespaces, *s)
+	}
+	sort.Slice(ov.Namespaces, func(i, j int) bool { return ov.Namespaces[i].Name < ov.Namespaces[j].Name })
+
+	// Top namespaces by total resource count, capped.
+	top := append([]NamespaceSummary(nil), ov.Namespaces...)
+	sort.Slice(top, func(i, j int) bool { return top[i].Resources > top[j].Resources })
+	if len(top) > topNamespacesN {
+		top = top[:topNamespacesN]
+	}
+	ov.TopNamespaces = top
+
+	// Resource tiles — sorted by count desc, but keep "Pods" / "Deployments"
+	// up front when present for familiarity.
+	ov.Resources = buildResourceTiles(resourceTotals)
+
+	// Recent transitions from the watch index.
+	ov.Recent = recentTransitions(store, at, recentEventsN)
+
+	ov.KPIs.Namespaces = len(ov.Namespaces)
+	return ov, nil
+}
+
+// podHealthEntry is the internal tuple used during overview aggregation.
+type podHealthEntry struct {
+	namespace string
+	name      string
+	prefix    string // for grouping similar pods
+	health    PodHealth
+}
+
+// readAllPodHealths walks every per-namespace pod LIST in the index, reads
+// the latest record at or before `at`, and classifies each pod's health.
+func (h *Handler) readAllPodHealths(at time.Time) []podHealthEntry {
+	store := h.Store
+	var out []podHealthEntry
+
+	for path, entry := range store.Index {
+		if entry == nil || len(entry.Seqs) == 0 {
+			continue
+		}
+		if strings.Contains(path, "?") {
+			continue // skip Table records and other query-suffix variants
+		}
+		_, _, resource, ns := parseAPIPath(path)
+		if resource != "pods" || ns == "" {
+			continue
+		}
+
+		body, code, err := store.ReconstructAt(path, at)
+		if err != nil || code != http.StatusOK || len(body) == 0 {
+			continue
+		}
+		var list struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		if err := json.Unmarshal(body, &list); err != nil {
+			continue
+		}
+		for _, raw := range list.Items {
+			name := getName(raw)
+			if name == "" {
+				continue
+			}
+			ph := ClassifyPod(raw)
+			out = append(out, podHealthEntry{
+				namespace: ns,
+				name:      name,
+				prefix:    PodNamePrefix(name),
+				health:    ph,
+			})
+		}
+	}
+	return out
+}
+
+// getName reads metadata.name from a raw Kubernetes object body.
+func getName(raw json.RawMessage) string {
+	var m struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return ""
+	}
+	return m.Metadata.Name
+}
+
+// parseAPIPath is a local mirror of server.parseAPIPath (unexported there).
+// Returns (group, version, resource, namespace).
+func parseAPIPath(path string) (group, version, resource, namespace string) {
+	// Strip any query suffix.
+	if i := strings.Index(path, "?"); i >= 0 {
+		path = path[:i]
+	}
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	switch {
+	case len(parts) >= 3 && parts[0] == "api":
+		version = parts[1]
+		if len(parts) == 3 {
+			resource = parts[2]
+		} else if len(parts) == 5 && parts[2] == "namespaces" {
+			namespace = parts[3]
+			resource = parts[4]
+		}
+	case len(parts) >= 4 && parts[0] == "apis":
+		group = parts[1]
+		version = parts[2]
+		if len(parts) == 4 {
+			resource = parts[3]
+		} else if len(parts) == 6 && parts[3] == "namespaces" {
+			namespace = parts[4]
+			resource = parts[5]
+		}
+	}
+	return
+}
+
+// clusterScopedResourceCounts walks paths with no namespace segment.
+func clusterScopedResourceCounts(idx capture.Index, at time.Time) map[string]int {
+	out := map[string]int{}
+	for path, entry := range idx {
+		if entry == nil || len(entry.Seqs) == 0 {
+			continue
+		}
+		if strings.Contains(path, "?") {
+			continue
+		}
+		_, _, resource, ns := parseAPIPath(path)
+		if resource == "" || ns != "" {
+			continue
+		}
+		// Pick the latest Counts entry at or before `at`.
+		i := latestIndex(entry, at)
+		if i < 0 || i >= len(entry.Counts) {
+			continue
+		}
+		if entry.Counts[i] > 0 {
+			out[resource] += entry.Counts[i]
+		}
+	}
+	return out
+}
+
+// latestIndex returns the slice index into entry.Seqs that corresponds to
+// the most recent record at or before `at`. Returns -1 if `at` precedes the
+// first record. When at is zero the last index is returned.
+func latestIndex(entry *capture.IndexEntry, at time.Time) int {
+	if entry == nil || len(entry.Seqs) == 0 {
+		return -1
+	}
+	if at.IsZero() || len(entry.Times) != len(entry.Seqs) {
+		return len(entry.Seqs) - 1
+	}
+	pos := sort.Search(len(entry.Times), func(i int) bool {
+		return entry.Times[i].After(at)
+	})
+	if pos == 0 {
+		return -1
+	}
+	return pos - 1
+}
+
+// buildSparkline groups watch-event timestamps into sparkBucketCount equal
+// buckets across the capture window.
+func buildSparkline(store *server.CaptureStore, _ time.Time, buckets int) SparklineData {
+	start := store.Metadata.CapturedAt.UTC()
+	end := store.Metadata.CapturedUntil.UTC()
+	if !end.After(start) || buckets <= 0 {
+		return SparklineData{StartTime: start, EndTime: end}
+	}
+
+	step := end.Sub(start) / time.Duration(buckets)
+	if step <= 0 {
+		step = time.Second
+	}
+
+	cells := make([]SparkBucket, buckets)
+	for i := range cells {
+		cells[i].Time = start.Add(time.Duration(i) * step)
+	}
+
+	total := 0
+	for path, wi := range store.WatchIndex {
+		if wi == nil {
+			continue
+		}
+		isPodPath := strings.Contains(path, "/pods")
+		for i, t := range wi.Times {
+			total++
+			if !t.After(start) {
+				cells[0].Total++
+				if isPodPath && i < len(wi.EventTypes) && wi.EventTypes[i] == "DELETED" {
+					cells[0].Bad++
+				}
+				continue
+			}
+			idx := int(t.Sub(start) / step)
+			if idx < 0 {
+				idx = 0
+			} else if idx >= buckets {
+				idx = buckets - 1
+			}
+			cells[idx].Total++
+			if !isPodPath || i >= len(wi.EventTypes) {
+				continue
+			}
+			switch wi.EventTypes[i] {
+			case "DELETED":
+				cells[idx].Bad++
+			case "MODIFIED":
+				// Heuristic: a fast burst of MODIFIED events on the same pod is
+				// often a restart loop. We just lift the WARN bar a notch.
+				cells[idx].Warn++
+			}
+		}
+	}
+	return SparklineData{Buckets: cells, TotalEvents: total, StartTime: start, EndTime: end}
+}
+
+// recentTransitions returns the last `n` watch events captured anywhere in
+// the archive (across all paths), most recent first.
+func recentTransitions(store *server.CaptureStore, at time.Time, n int) []Transition {
+	type entry struct {
+		t         time.Time
+		eventType string
+		path      string
+		seq       int
+	}
+	var all []entry
+	for path, wi := range store.WatchIndex {
+		if wi == nil {
+			continue
+		}
+		for i, t := range wi.Times {
+			if !at.IsZero() && t.After(at) {
+				continue
+			}
+			et := ""
+			if i < len(wi.EventTypes) {
+				et = wi.EventTypes[i]
+			}
+			seq := i
+			if i < len(wi.Seqs) {
+				seq = wi.Seqs[i]
+			}
+			all = append(all, entry{t: t, eventType: et, path: path, seq: seq})
+		}
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].t.After(all[j].t) })
+	if len(all) > n {
+		all = all[:n]
+	}
+	out := make([]Transition, 0, len(all))
+	for _, e := range all {
+		_, _, resource, ns := parseAPIPath(e.path)
+		t := Transition{
+			Time:      e.t.UTC().Format(time.RFC3339),
+			EventType: e.eventType,
+			Kind:      kindFromResource(resource),
+			Namespace: ns,
+		}
+		// Cheap read of the event body to pull the object name.
+		rec, err := store.ReadRecord(e.path, e.seq)
+		if err == nil {
+			t.Name = getName(rec.ResponseBody)
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+// buildResourceTiles converts the resource→count map into a sorted slice of
+// tiles for the dashboard's "Resources captured" card. Pods/Deployments/
+// Services/ConfigMaps appear in a familiar order when present; the remainder
+// is sorted by count desc, with a "+N more" tail-tile if necessary.
+func buildResourceTiles(resourceTotals map[string]int) []ResourceTile {
+	if len(resourceTotals) == 0 {
+		return nil
+	}
+	type kv struct {
+		res, kind string
+		count     int
+	}
+	var rest []kv
+	preferred := []string{"deployments", "pods", "services", "configmaps", "secrets", "persistentvolumeclaims", "customresourcedefinitions", "virtualmachines"}
+	seen := map[string]bool{}
+	out := make([]ResourceTile, 0, len(resourceTotals))
+	for _, res := range preferred {
+		if c, ok := resourceTotals[res]; ok && c > 0 {
+			out = append(out, ResourceTile{Kind: kindFromResource(res), Count: c, Link: "#/namespaces"})
+			seen[res] = true
+		}
+	}
+	for res, c := range resourceTotals {
+		if seen[res] || c <= 0 {
+			continue
+		}
+		rest = append(rest, kv{res, kindFromResource(res), c})
+	}
+	sort.Slice(rest, func(i, j int) bool {
+		if rest[i].count != rest[j].count {
+			return rest[i].count > rest[j].count
+		}
+		return rest[i].res < rest[j].res
+	})
+	// Show the next 4 explicitly then collapse the rest into a "+N more" tile.
+	const showRest = 4
+	for i, r := range rest {
+		if i >= showRest {
+			break
+		}
+		out = append(out, ResourceTile{Kind: r.kind, Count: r.count, Link: "#/namespaces"})
+	}
+	if len(rest) > showRest {
+		out = append(out, ResourceTile{Kind: fmt.Sprintf("+ %d more…", len(rest)-showRest), Count: 0, Link: "#/namespaces"})
+	}
+	return out
+}

--- a/internal/ui/v2/overview.go
+++ b/internal/ui/v2/overview.go
@@ -163,6 +163,19 @@ func (h *Handler) buildOverview(at time.Time) (*Overview, error) {
 			ns.Unhealthy++
 		}
 	}
+	// Attach namespace labels from the captured namespaces list (one read).
+	if body, code, err := store.ReconstructAt("/api/v1/namespaces", at); err == nil && code == http.StatusOK && len(body) > 0 {
+		var list struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		if json.Unmarshal(body, &list) == nil {
+			for _, raw := range list.Items {
+				if s := nsByName[getName(raw)]; s != nil {
+					s.Labels = getLabels(raw)
+				}
+			}
+		}
+	}
 	ov.Namespaces = make([]NamespaceSummary, 0, len(nsByName))
 	for _, s := range nsByName {
 		ov.Namespaces = append(ov.Namespaces, *s)

--- a/internal/ui/v2/overview.go
+++ b/internal/ui/v2/overview.go
@@ -427,6 +427,8 @@ func recentTransitions(store *server.CaptureStore, at time.Time, n int) []Transi
 			EventType: e.eventType,
 			Kind:      kindFromResource(resource),
 			Namespace: ns,
+			Path:      e.path,
+			Resource:  resource,
 		}
 		// Cheap read of the event body to pull the object name.
 		rec, err := store.ReadRecord(e.path, e.seq)
@@ -456,7 +458,7 @@ func buildResourceTiles(resourceTotals map[string]int) []ResourceTile {
 	out := make([]ResourceTile, 0, len(resourceTotals))
 	for _, res := range preferred {
 		if c, ok := resourceTotals[res]; ok && c > 0 {
-			out = append(out, ResourceTile{Kind: kindFromResource(res), Count: c, Link: "#/namespaces"})
+			out = append(out, ResourceTile{Kind: kindFromResource(res), Resource: res, Count: c, Link: resourceLink(res, "")})
 			seen[res] = true
 		}
 	}
@@ -478,10 +480,20 @@ func buildResourceTiles(resourceTotals map[string]int) []ResourceTile {
 		if i >= showRest {
 			break
 		}
-		out = append(out, ResourceTile{Kind: r.kind, Count: r.count, Link: "#/namespaces"})
+		out = append(out, ResourceTile{Kind: r.kind, Resource: r.res, Count: r.count, Link: resourceLink(r.res, "")})
 	}
 	if len(rest) > showRest {
 		out = append(out, ResourceTile{Kind: fmt.Sprintf("+ %d more…", len(rest)-showRest), Count: 0, Link: "#/namespaces"})
 	}
 	return out
+}
+
+// resourceLink builds a hash link to the generic resource list for a resource
+// plural name, optionally scoped to a namespace.
+func resourceLink(resource, ns string) string {
+	link := "#/resource?resource=" + resource
+	if ns != "" {
+		link += "&ns=" + ns
+	}
+	return link
 }

--- a/internal/ui/v2/pod.go
+++ b/internal/ui/v2/pod.go
@@ -1,0 +1,733 @@
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// PodDetail is what /v2/api/pod?ns=…&name=… returns — everything the pod
+// drill-down view shows.
+type PodDetail struct {
+	Name             string             `json:"name"`
+	Namespace        string             `json:"namespace"`
+	At               string             `json:"at,omitempty"`
+	Capture          CaptureMeta        `json:"capture"`
+	Hero             PodHero            `json:"hero"`
+	KPIs             PodKPIs            `json:"kpis"`
+	Containers       []PodContainerCard `json:"containers"`
+	Events           []PodEvent         `json:"events"`
+	History          []PodTransition    `json:"history"`
+	Related          PodRelated         `json:"related"`
+	Metadata         PodMetadata        `json:"metadata"`
+	RestartSparkline []SparkBucket      `json:"restart_sparkline"`
+}
+
+type PodHero struct {
+	Phase    string `json:"phase"`
+	Severity string `json:"severity"`
+	Reason   string `json:"reason,omitempty"`
+	Subtitle string `json:"subtitle"`
+}
+
+type PodKPIs struct {
+	Phase        string `json:"phase"`
+	Restarts     int    `json:"restarts"`
+	AgeHuman     string `json:"age"`
+	Ready        string `json:"ready"`
+	Node         string `json:"node,omitempty"`
+	PodIP        string `json:"pod_ip,omitempty"`
+	QoSClass     string `json:"qos_class,omitempty"`
+	UnreadyCause string `json:"unready_cause,omitempty"`
+}
+
+type PodContainerCard struct {
+	Name           string             `json:"name"`
+	Role           string             `json:"role"` // "main" | "init" | "side"
+	Image          string             `json:"image,omitempty"`
+	State          string             `json:"state"`
+	StateBadge     string             `json:"state_badge"`
+	Severity       string             `json:"severity"`
+	RestartCount   int                `json:"restart_count"`
+	StartedAt      string             `json:"started_at,omitempty"`
+	LastTerminated string             `json:"last_terminated,omitempty"`
+	LastExitCode   int                `json:"last_exit_code,omitempty"`
+	Resources      ContainerResources `json:"resources"`
+	Probes         []string           `json:"probes,omitempty"`
+	Ports          []string           `json:"ports,omitempty"`
+	LogPreview     []string           `json:"log_preview,omitempty"`
+	LogPath        string             `json:"log_path,omitempty"`
+	HasPreviousLog bool               `json:"has_previous_log,omitempty"`
+}
+
+type ContainerResources struct {
+	CPURequest    string `json:"cpu_request,omitempty"`
+	CPULimit      string `json:"cpu_limit,omitempty"`
+	MemoryRequest string `json:"memory_request,omitempty"`
+	MemoryLimit   string `json:"memory_limit,omitempty"`
+}
+
+type PodEvent struct {
+	Severity string `json:"severity"`
+	Reason   string `json:"reason"`
+	Message  string `json:"message"`
+	Source   string `json:"source,omitempty"`
+	Time     string `json:"time"`
+	Count    int    `json:"count,omitempty"`
+}
+
+type PodTransition struct {
+	Time      string `json:"time"`
+	EventType string `json:"event_type"`
+	Detail    string `json:"detail,omitempty"`
+}
+
+type PodRelated struct {
+	Owner       *RelatedItem  `json:"owner,omitempty"`
+	Workload    *RelatedItem  `json:"workload,omitempty"`
+	SiblingPods int           `json:"sibling_pods"`
+	ConfigMaps  []RelatedItem `json:"config_maps,omitempty"`
+	Secrets     []RelatedItem `json:"secrets,omitempty"`
+	PVCs        []RelatedItem `json:"pvcs,omitempty"`
+}
+
+type RelatedItem struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+	Link string `json:"link,omitempty"`
+}
+
+type PodMetadata struct {
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Conditions  []PodCondition    `json:"conditions,omitempty"`
+	CreatedAt   string            `json:"created_at,omitempty"`
+}
+
+type PodCondition struct {
+	Type     string `json:"type"`
+	Status   string `json:"status"`
+	Reason   string `json:"reason,omitempty"`
+	Severity string `json:"severity"`
+}
+
+func (h *Handler) servePod(w http.ResponseWriter, r *http.Request) {
+	ns := r.URL.Query().Get("ns")
+	name := r.URL.Query().Get("name")
+	if ns == "" || name == "" {
+		writeError(w, http.StatusBadRequest, "missing ns or name query parameter")
+		return
+	}
+	at := h.resolveAt(r)
+	d, err := h.buildPodDetail(ns, name, at)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if d == nil {
+		writeError(w, http.StatusNotFound, "pod not found in capture")
+		return
+	}
+	if !at.IsZero() {
+		d.At = at.UTC().Format(time.RFC3339)
+	}
+	writeJSON(w, http.StatusOK, d)
+}
+
+// buildPodDetail reads the pod object + per-container logs + events + watch
+// history and assembles them into a single PodDetail blob.
+func (h *Handler) buildPodDetail(ns, name string, at time.Time) (*PodDetail, error) {
+	store := h.Store
+	if store == nil {
+		return nil, fmt.Errorf("store not initialized")
+	}
+
+	// Find the pod's raw body inside the captured pods list.
+	listPath := "/api/v1/namespaces/" + ns + "/pods"
+	body, code, err := store.ReconstructAt(listPath, at)
+	if err != nil || code != http.StatusOK || len(body) == 0 {
+		return nil, nil
+	}
+	var list struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(body, &list); err != nil {
+		return nil, nil
+	}
+	var raw json.RawMessage
+	for _, it := range list.Items {
+		if getName(it) == name {
+			raw = it
+			break
+		}
+	}
+	if raw == nil {
+		return nil, nil
+	}
+
+	d := &PodDetail{
+		Name:      name,
+		Namespace: ns,
+		Capture: CaptureMeta{
+			CaptureID:         store.Metadata.CaptureID,
+			CapturedAt:        store.Metadata.CapturedAt,
+			CapturedUntil:     store.Metadata.CapturedUntil,
+			KubernetesVersion: store.Metadata.KubernetesVersion,
+			ServerAddress:     store.Metadata.ServerAddress,
+			RecordCount:       store.Metadata.RecordCount,
+		},
+	}
+
+	var pod podObject
+	_ = json.Unmarshal(raw, &pod)
+
+	ph := ClassifyPod(raw)
+	d.Hero = buildPodHero(ph)
+
+	// KPIs
+	d.KPIs = PodKPIs{
+		Phase:    ph.Phase,
+		Restarts: ph.Restarts,
+		AgeHuman: humanAge(pod.Metadata.CreationTimestamp, at),
+		Ready:    fmt.Sprintf("%d / %d", ph.Ready, ph.Total),
+		Node:     pod.Spec.NodeName,
+		PodIP:    pod.Status.PodIP,
+		QoSClass: pod.Status.QoSClass,
+	}
+
+	// Container cards (init first, main next).
+	d.Containers = buildContainerCards(pod, ph, ns, name, h)
+
+	// Events for this pod.
+	d.Events = h.loadPodEvents(ns, name, at, 10)
+
+	// Watch-event history for this pod (filtered by name).
+	d.History = h.loadPodHistory(ns, name, at, 20)
+
+	// Related resources.
+	d.Related = buildRelated(pod, ns, name, h.Store, at)
+
+	// Metadata + conditions.
+	d.Metadata = buildPodMetadata(pod)
+
+	// Restart sparkline: bucket the pod's MODIFIED watch events.
+	d.RestartSparkline = h.podRestartSparkline(ns, name, sparkBucketCount)
+
+	return d, nil
+}
+
+func buildPodHero(ph PodHealth) PodHero {
+	hero := PodHero{Phase: ph.Phase, Severity: "good"}
+	if !ph.IsHealthy() {
+		hero.Severity = "bad"
+		hero.Reason = ph.Issues[0]
+	} else if ph.Ready < ph.Total {
+		hero.Severity = "warn"
+		hero.Reason = "Some containers not ready"
+	}
+	if hero.Reason == "" {
+		hero.Subtitle = fmt.Sprintf("%d/%d containers ready · %d restarts", ph.Ready, ph.Total, ph.Restarts)
+	} else {
+		hero.Subtitle = fmt.Sprintf("%s · %d restarts", hero.Reason, ph.Restarts)
+	}
+	return hero
+}
+
+// containerSpecByName maps a container name to its spec, used to enrich the
+// PodContainerCard with image / resources / probes / ports.
+type containerSpecByName map[string]containerSpec
+
+func buildContainerCards(pod podObject, ph PodHealth, ns, name string, h *Handler) []PodContainerCard {
+	specs := make(containerSpecByName)
+	for _, c := range pod.Spec.InitContainers {
+		specs[c.Name] = c
+	}
+	for _, c := range pod.Spec.Containers {
+		specs[c.Name] = c
+	}
+
+	cards := make([]PodContainerCard, 0, len(ph.Containers))
+	for _, c := range ph.Containers {
+		card := PodContainerCard{
+			Name:           c.Name,
+			Role:           containerRole(c),
+			Image:          c.Image,
+			State:          c.State,
+			Severity:       containerSeverity(c),
+			RestartCount:   c.RestartCount,
+			LastTerminated: c.LastTerminated,
+			LastExitCode:   c.LastExitCode,
+		}
+		card.StateBadge = containerStateBadge(c)
+		if spec, ok := specs[c.Name]; ok {
+			card.Image = firstNonEmpty(card.Image, spec.Image)
+			card.Resources = ContainerResources{
+				CPURequest:    spec.Resources.Requests["cpu"],
+				CPULimit:      spec.Resources.Limits["cpu"],
+				MemoryRequest: spec.Resources.Requests["memory"],
+				MemoryLimit:   spec.Resources.Limits["memory"],
+			}
+			card.Probes = describeProbes(spec)
+			card.Ports = describePorts(spec)
+		}
+
+		// Captured logs: read the per-container log records if present.
+		logPath := "/api/v1/namespaces/" + ns + "/pods/" + name + "/log?container=" + c.Name
+		previousPath := logPath + "&previous=true"
+		card.LogPreview, _ = h.readLogTail(logPath, 8)
+		_, card.HasPreviousLog = h.Store.Index[previousPath]
+		card.LogPath = "#/logs?ns=" + ns + "&pod=" + name + "&container=" + c.Name
+
+		cards = append(cards, card)
+	}
+	return cards
+}
+
+func containerRole(c ContainerHealth) string {
+	if c.IsInit {
+		return "init"
+	}
+	if isSidecarName(c.Name) {
+		return "side"
+	}
+	return "main"
+}
+
+func isSidecarName(name string) bool {
+	low := strings.ToLower(name)
+	for _, hint := range []string{"istio-proxy", "linkerd-proxy", "sidecar", "envoy", "fluent", "vector", "log-router"} {
+		if strings.Contains(low, hint) {
+			return true
+		}
+	}
+	return false
+}
+
+func containerSeverity(c ContainerHealth) string {
+	if c.State == "Waiting" {
+		switch c.StateReason {
+		case "CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull", "CreateContainerError", "CreateContainerConfigError":
+			return "bad"
+		}
+		return "warn"
+	}
+	if c.State == "Terminated" && !c.Ready {
+		if c.IsInit && c.LastExitCode == 0 {
+			return "good"
+		}
+		return "bad"
+	}
+	if c.RestartCount > 0 {
+		return "warn"
+	}
+	return "good"
+}
+
+func containerStateBadge(c ContainerHealth) string {
+	switch c.State {
+	case "Running":
+		if c.RestartCount > 0 {
+			return fmt.Sprintf("Running · %d restarts", c.RestartCount)
+		}
+		return "Running · 0 restarts"
+	case "Waiting":
+		if c.StateReason != "" {
+			return fmt.Sprintf("%s · %d restarts", c.StateReason, c.RestartCount)
+		}
+		return fmt.Sprintf("Waiting · %d restarts", c.RestartCount)
+	case "Terminated":
+		if c.StateReason != "" {
+			return fmt.Sprintf("Terminated · %s · exit %d", c.StateReason, c.LastExitCode)
+		}
+		return fmt.Sprintf("Terminated · exit %d", c.LastExitCode)
+	}
+	return "Unknown"
+}
+
+func describeProbes(spec containerSpec) []string {
+	var out []string
+	if spec.LivenessProbe != nil {
+		out = append(out, "liveness "+probeDescription(*spec.LivenessProbe))
+	}
+	if spec.ReadinessProbe != nil {
+		out = append(out, "readiness "+probeDescription(*spec.ReadinessProbe))
+	}
+	if spec.StartupProbe != nil {
+		out = append(out, "startup "+probeDescription(*spec.StartupProbe))
+	}
+	return out
+}
+
+func probeDescription(p probe) string {
+	switch {
+	case p.HTTPGet != nil:
+		return fmt.Sprintf("HTTP %s :%v%s", strings.ToUpper(firstNonEmpty(p.HTTPGet.Scheme, "GET")), p.HTTPGet.Port, p.HTTPGet.Path)
+	case p.TCPSocket != nil:
+		return fmt.Sprintf("TCP :%v", p.TCPSocket.Port)
+	case p.Exec != nil:
+		return "exec " + strings.Join(p.Exec.Command, " ")
+	}
+	return "configured"
+}
+
+func describePorts(spec containerSpec) []string {
+	var out []string
+	for _, p := range spec.Ports {
+		if p.Name != "" {
+			out = append(out, fmt.Sprintf("%d/%s (%s)", p.ContainerPort, firstNonEmpty(p.Protocol, "TCP"), p.Name))
+		} else {
+			out = append(out, fmt.Sprintf("%d/%s", p.ContainerPort, firstNonEmpty(p.Protocol, "TCP")))
+		}
+	}
+	return out
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+
+// readLogTail reads the captured log record (a JSON-encoded string) and
+// returns the last `n` lines. Returns false when no log was captured.
+func (h *Handler) readLogTail(indexKey string, n int) ([]string, bool) {
+	body, code, err := h.Store.Latest(indexKey, h.At)
+	if err != nil || code != http.StatusOK || len(body) == 0 {
+		return nil, false
+	}
+	var text string
+	if err := json.Unmarshal(body, &text); err != nil {
+		// older archives stored raw text
+		text = string(body)
+	}
+	if text == "" {
+		return nil, false
+	}
+	lines := strings.Split(strings.TrimRight(text, "\n"), "\n")
+	if n > 0 && len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return lines, true
+}
+
+// loadPodEvents scans captured Event resources for ones whose involvedObject
+// matches this pod.
+func (h *Handler) loadPodEvents(ns, name string, at time.Time, limit int) []PodEvent {
+	listPath := "/api/v1/namespaces/" + ns + "/events"
+	body, code, err := h.Store.ReconstructAt(listPath, at)
+	if err != nil || code != http.StatusOK || len(body) == 0 {
+		return nil
+	}
+	var list struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(body, &list); err != nil {
+		return nil
+	}
+	var out []PodEvent
+	for _, raw := range list.Items {
+		var ev eventObject
+		if err := json.Unmarshal(raw, &ev); err != nil {
+			continue
+		}
+		if ev.InvolvedObject.Kind != "Pod" || ev.InvolvedObject.Namespace != ns || ev.InvolvedObject.Name != name {
+			continue
+		}
+		t := ev.LastTimestamp
+		if t.IsZero() {
+			t = ev.EventTime
+		}
+		if t.IsZero() {
+			t = ev.FirstTimestamp
+		}
+		sev := "normal"
+		if strings.EqualFold(ev.Type, "Warning") {
+			sev = "warn"
+		}
+		if isBadEventReason(ev.Reason) {
+			sev = "bad"
+		}
+		out = append(out, PodEvent{
+			Severity: sev,
+			Reason:   ev.Reason,
+			Message:  ev.Message,
+			Source:   firstNonEmpty(ev.Source.Component, ev.ReportingController),
+			Time:     t.UTC().Format(time.RFC3339),
+			Count:    ev.Count,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Time > out[j].Time })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+func isBadEventReason(reason string) bool {
+	switch reason {
+	case "BackOff", "Killing", "Killed", "Failed", "FailedScheduling", "FailedMount", "FailedCreate", "OOMKilled", "Evicted":
+		return true
+	}
+	return false
+}
+
+// loadPodHistory walks WatchIndex entries for the pod list path and returns
+// the watch events whose embedded object matches this pod.
+func (h *Handler) loadPodHistory(ns, name string, at time.Time, limit int) []PodTransition {
+	listPath := "/api/v1/namespaces/" + ns + "/pods"
+	wi := h.Store.WatchIndex[listPath]
+	if wi == nil {
+		return nil
+	}
+
+	var out []PodTransition
+	for i := range wi.Seqs {
+		t := wi.Times[i]
+		if !at.IsZero() && t.After(at) {
+			continue
+		}
+		rec, err := h.Store.ReadRecord(listPath, wi.Seqs[i])
+		if err != nil {
+			continue
+		}
+		if getName(rec.ResponseBody) != name {
+			continue
+		}
+		evType := ""
+		if i < len(wi.EventTypes) {
+			evType = wi.EventTypes[i]
+		}
+		ph := ClassifyPod(rec.ResponseBody)
+		detail := ph.Phase
+		if !ph.IsHealthy() {
+			detail = ph.Issues[0]
+		}
+		out = append(out, PodTransition{
+			Time:      t.UTC().Format(time.RFC3339),
+			EventType: evType,
+			Detail:    detail,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Time > out[j].Time })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// podRestartSparkline bins MODIFIED watch events for this pod into a small
+// time-bucketed sparkline.
+func (h *Handler) podRestartSparkline(ns, name string, buckets int) []SparkBucket {
+	store := h.Store
+	start := store.Metadata.CapturedAt.UTC()
+	end := store.Metadata.CapturedUntil.UTC()
+	if !end.After(start) || buckets <= 0 {
+		return nil
+	}
+	step := end.Sub(start) / time.Duration(buckets)
+	if step <= 0 {
+		step = time.Second
+	}
+	cells := make([]SparkBucket, buckets)
+	for i := range cells {
+		cells[i].Time = start.Add(time.Duration(i) * step)
+	}
+
+	listPath := "/api/v1/namespaces/" + ns + "/pods"
+	wi := store.WatchIndex[listPath]
+	if wi == nil {
+		return cells
+	}
+	for i, t := range wi.Times {
+		rec, err := store.ReadRecord(listPath, wi.Seqs[i])
+		if err != nil {
+			continue
+		}
+		if getName(rec.ResponseBody) != name {
+			continue
+		}
+		idx := int(t.Sub(start) / step)
+		if idx < 0 {
+			idx = 0
+		} else if idx >= buckets {
+			idx = buckets - 1
+		}
+		cells[idx].Total++
+		et := ""
+		if i < len(wi.EventTypes) {
+			et = wi.EventTypes[i]
+		}
+		if et == "DELETED" {
+			cells[idx].Bad++
+		} else if et == "MODIFIED" {
+			cells[idx].Warn++
+		}
+	}
+	return cells
+}
+
+// buildRelated walks the pod's ownerReferences + volumes to surface related
+// objects that the user might want to click into next.
+func buildRelated(pod podObject, ns, name string, store interface{}, _ time.Time) PodRelated {
+	rel := PodRelated{}
+	for _, o := range pod.Metadata.OwnerReferences {
+		rel.Owner = &RelatedItem{Kind: o.Kind, Name: o.Name}
+		break
+	}
+	for _, v := range pod.Spec.Volumes {
+		if v.ConfigMap != nil && v.ConfigMap.Name != "" {
+			rel.ConfigMaps = append(rel.ConfigMaps, RelatedItem{Kind: "ConfigMap", Name: v.ConfigMap.Name})
+		}
+		if v.Secret != nil && v.Secret.SecretName != "" {
+			rel.Secrets = append(rel.Secrets, RelatedItem{Kind: "Secret", Name: v.Secret.SecretName})
+		}
+		if v.PersistentVolumeClaim != nil && v.PersistentVolumeClaim.ClaimName != "" {
+			rel.PVCs = append(rel.PVCs, RelatedItem{Kind: "PersistentVolumeClaim", Name: v.PersistentVolumeClaim.ClaimName})
+		}
+	}
+	// SiblingPods placeholder — would need to count pods with the same owner.
+	return rel
+}
+
+func buildPodMetadata(pod podObject) PodMetadata {
+	out := PodMetadata{
+		Labels:      pod.Metadata.Labels,
+		Annotations: pod.Metadata.Annotations,
+		CreatedAt:   pod.Metadata.CreationTimestamp.UTC().Format(time.RFC3339),
+	}
+	for _, c := range pod.Status.Conditions {
+		sev := "neutral"
+		if c.Status == "True" {
+			sev = "good"
+		} else if c.Status == "False" {
+			sev = "bad"
+		}
+		out.Conditions = append(out.Conditions, PodCondition{
+			Type:     c.Type,
+			Status:   c.Status,
+			Reason:   c.Reason,
+			Severity: sev,
+		})
+	}
+	return out
+}
+
+// ── Pod object subset ───────────────────────────────────────────────────────
+
+type podObject struct {
+	Metadata podMetadataObj `json:"metadata"`
+	Spec     struct {
+		NodeName       string          `json:"nodeName"`
+		Containers     []containerSpec `json:"containers"`
+		InitContainers []containerSpec `json:"initContainers"`
+		Volumes        []volume        `json:"volumes"`
+	} `json:"spec"`
+	Status struct {
+		Phase      string         `json:"phase"`
+		PodIP      string         `json:"podIP"`
+		QoSClass   string         `json:"qosClass"`
+		Conditions []podCondition `json:"conditions"`
+	} `json:"status"`
+}
+
+type podMetadataObj struct {
+	Name              string            `json:"name"`
+	Namespace         string            `json:"namespace"`
+	Labels            map[string]string `json:"labels"`
+	Annotations       map[string]string `json:"annotations"`
+	CreationTimestamp time.Time         `json:"creationTimestamp"`
+	OwnerReferences   []ownerRef        `json:"ownerReferences"`
+}
+
+type ownerRef struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}
+
+type containerSpec struct {
+	Name           string               `json:"name"`
+	Image          string               `json:"image"`
+	Ports          []containerPort      `json:"ports"`
+	Resources      resourceRequirements `json:"resources"`
+	LivenessProbe  *probe               `json:"livenessProbe,omitempty"`
+	ReadinessProbe *probe               `json:"readinessProbe,omitempty"`
+	StartupProbe   *probe               `json:"startupProbe,omitempty"`
+}
+
+type containerPort struct {
+	Name          string `json:"name"`
+	ContainerPort int    `json:"containerPort"`
+	Protocol      string `json:"protocol"`
+}
+
+type resourceRequirements struct {
+	Requests map[string]string `json:"requests"`
+	Limits   map[string]string `json:"limits"`
+}
+
+type probe struct {
+	HTTPGet   *probeHTTPGet   `json:"httpGet,omitempty"`
+	TCPSocket *probeTCPSocket `json:"tcpSocket,omitempty"`
+	Exec      *probeExec      `json:"exec,omitempty"`
+}
+
+type probeHTTPGet struct {
+	Path   string `json:"path"`
+	Port   any    `json:"port"`
+	Scheme string `json:"scheme"`
+}
+
+type probeTCPSocket struct {
+	Port any `json:"port"`
+}
+
+type probeExec struct {
+	Command []string `json:"command"`
+}
+
+type volume struct {
+	Name                  string              `json:"name"`
+	ConfigMap             *volumeConfigMap    `json:"configMap,omitempty"`
+	Secret                *volumeSecret       `json:"secret,omitempty"`
+	PersistentVolumeClaim *volumePersistentVC `json:"persistentVolumeClaim,omitempty"`
+}
+
+type volumeConfigMap struct {
+	Name string `json:"name"`
+}
+type volumeSecret struct {
+	SecretName string `json:"secretName"`
+}
+type volumePersistentVC struct {
+	ClaimName string `json:"claimName"`
+}
+
+type podCondition struct {
+	Type   string `json:"type"`
+	Status string `json:"status"`
+	Reason string `json:"reason"`
+}
+
+type eventObject struct {
+	Reason         string    `json:"reason"`
+	Message        string    `json:"message"`
+	Type           string    `json:"type"`
+	FirstTimestamp time.Time `json:"firstTimestamp"`
+	LastTimestamp  time.Time `json:"lastTimestamp"`
+	EventTime      time.Time `json:"eventTime"`
+	Count          int       `json:"count"`
+	Source         struct {
+		Component string `json:"component"`
+	} `json:"source"`
+	ReportingController string `json:"reportingController"`
+	InvolvedObject      struct {
+		Kind      string `json:"kind"`
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+		FieldPath string `json:"fieldPath"`
+	} `json:"involvedObject"`
+}

--- a/internal/ui/v2/pod.go
+++ b/internal/ui/v2/pod.go
@@ -575,18 +575,18 @@ func (h *Handler) podRestartSparkline(ns, name string, buckets int) []SparkBucke
 func buildRelated(pod podObject, ns, name string, store interface{}, _ time.Time) PodRelated {
 	rel := PodRelated{}
 	for _, o := range pod.Metadata.OwnerReferences {
-		rel.Owner = &RelatedItem{Kind: o.Kind, Name: o.Name}
+		rel.Owner = &RelatedItem{Kind: o.Kind, Name: o.Name, Link: ownerLink(o, ns)}
 		break
 	}
 	for _, v := range pod.Spec.Volumes {
 		if v.ConfigMap != nil && v.ConfigMap.Name != "" {
-			rel.ConfigMaps = append(rel.ConfigMaps, RelatedItem{Kind: "ConfigMap", Name: v.ConfigMap.Name})
+			rel.ConfigMaps = append(rel.ConfigMaps, RelatedItem{Kind: "ConfigMap", Name: v.ConfigMap.Name, Link: objectLink(apiListPath("", "v1", "configmaps", ns), v.ConfigMap.Name)})
 		}
 		if v.Secret != nil && v.Secret.SecretName != "" {
-			rel.Secrets = append(rel.Secrets, RelatedItem{Kind: "Secret", Name: v.Secret.SecretName})
+			rel.Secrets = append(rel.Secrets, RelatedItem{Kind: "Secret", Name: v.Secret.SecretName, Link: objectLink(apiListPath("", "v1", "secrets", ns), v.Secret.SecretName)})
 		}
 		if v.PersistentVolumeClaim != nil && v.PersistentVolumeClaim.ClaimName != "" {
-			rel.PVCs = append(rel.PVCs, RelatedItem{Kind: "PersistentVolumeClaim", Name: v.PersistentVolumeClaim.ClaimName})
+			rel.PVCs = append(rel.PVCs, RelatedItem{Kind: "PersistentVolumeClaim", Name: v.PersistentVolumeClaim.ClaimName, Link: objectLink(apiListPath("", "v1", "persistentvolumeclaims", ns), v.PersistentVolumeClaim.ClaimName)})
 		}
 	}
 	// SiblingPods placeholder — would need to count pods with the same owner.
@@ -644,8 +644,9 @@ type podMetadataObj struct {
 }
 
 type ownerRef struct {
-	Kind string `json:"kind"`
-	Name string `json:"name"`
+	Kind       string `json:"kind"`
+	Name       string `json:"name"`
+	APIVersion string `json:"apiVersion"`
 }
 
 type containerSpec struct {

--- a/internal/ui/v2/relationships.go
+++ b/internal/ui/v2/relationships.go
@@ -1,0 +1,395 @@
+package v2
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"time"
+)
+
+// RelatedGroup is a titled list of related objects for the object view.
+type RelatedGroup struct {
+	Title string        `json:"title"`
+	Items []RelatedItem `json:"items"`
+}
+
+// ObjectRelationships is the response from /v2/api/object-relationships.
+type ObjectRelationships struct {
+	Path   string         `json:"path"`
+	Name   string         `json:"name"`
+	Groups []RelatedGroup `json:"groups"`
+}
+
+func (h *Handler) serveObjectRelationships(w http.ResponseWriter, r *http.Request) {
+	if h.Store == nil {
+		writeError(w, http.StatusInternalServerError, "store not initialized")
+		return
+	}
+	path := r.URL.Query().Get("path")
+	name := r.URL.Query().Get("name")
+	if path == "" || name == "" {
+		writeError(w, http.StatusBadRequest, "missing path or name query parameter")
+		return
+	}
+	at := h.resolveAt(r)
+	g, _, res, ns := parseAPIPath(path)
+	_ = g
+	out := ObjectRelationships{Path: path, Name: name}
+
+	raw, ok := h.readObjectRaw(path, name, at)
+	if ok {
+		if items := ownerItems(raw, ns); len(items) > 0 {
+			out.Groups = append(out.Groups, RelatedGroup{Title: "Owned by", Items: items})
+		}
+	}
+
+	switch res {
+	case "pods":
+		if ok {
+			out.Groups = append(out.Groups, podMountGroups(raw, ns)...)
+		}
+	case "persistentvolumeclaims":
+		out.Groups = append(out.Groups, h.pvcGroups(raw, name, ns, at)...)
+	case "persistentvolumes":
+		out.Groups = append(out.Groups, h.pvGroups(raw, at)...)
+	case "configmaps":
+		out.Groups = append(out.Groups, h.usedByPods(ns, name, "configmap", at)...)
+	case "secrets":
+		out.Groups = append(out.Groups, h.usedByPods(ns, name, "secret", at)...)
+	case "deployments", "replicasets", "statefulsets", "daemonsets", "jobs":
+		out.Groups = append(out.Groups, h.ownedChildren(res, name, ns, at)...)
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+// readObjectRaw returns the raw JSON of one object inside a captured list.
+func (h *Handler) readObjectRaw(path, name string, at time.Time) (json.RawMessage, bool) {
+	body, code, err := h.Store.ReconstructAt(path, at)
+	if err != nil || code != http.StatusOK || len(body) == 0 {
+		return nil, false
+	}
+	var list struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(body, &list); err != nil {
+		return nil, false
+	}
+	for _, it := range list.Items {
+		if getName(it) == name {
+			return it, true
+		}
+	}
+	return nil, false
+}
+
+func (h *Handler) podsInNS(ns string, at time.Time) []json.RawMessage {
+	body, code, err := h.Store.ReconstructAt("/api/v1/namespaces/"+ns+"/pods", at)
+	if err != nil || code != http.StatusOK || len(body) == 0 {
+		return nil
+	}
+	var list struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(body, &list); err != nil {
+		return nil
+	}
+	return list.Items
+}
+
+// ownerItems parses metadata.ownerReferences into linked RelatedItems.
+func ownerItems(raw json.RawMessage, ns string) []RelatedItem {
+	var m struct {
+		Metadata struct {
+			OwnerReferences []ownerRef `json:"ownerReferences"`
+		} `json:"metadata"`
+	}
+	if json.Unmarshal(raw, &m) != nil {
+		return nil
+	}
+	var out []RelatedItem
+	for _, o := range m.Metadata.OwnerReferences {
+		out = append(out, RelatedItem{Kind: o.Kind, Name: o.Name, Link: ownerLink(o, ns)})
+	}
+	return out
+}
+
+// podMountGroups extracts the ConfigMaps / Secrets / PVCs a pod mounts.
+func podMountGroups(raw json.RawMessage, ns string) []RelatedGroup {
+	var p podScan
+	if json.Unmarshal(raw, &p) != nil {
+		return nil
+	}
+	cms, secs, pvcs := p.references()
+	var groups []RelatedGroup
+	add := func(title, resource string, names []string) {
+		if len(names) == 0 {
+			return
+		}
+		var items []RelatedItem
+		for _, n := range names {
+			items = append(items, RelatedItem{Kind: kindFromResource(resource), Name: n, Link: objectLink(apiListPath("", "v1", resource, ns), n)})
+		}
+		groups = append(groups, RelatedGroup{Title: title, Items: items})
+	}
+	add("Mounts ConfigMaps", "configmaps", cms)
+	add("Mounts Secrets", "secrets", secs)
+	add("Mounts PVCs", "persistentvolumeclaims", pvcs)
+	return groups
+}
+
+// pvcGroups: the PV this PVC is bound to + pods that mount it.
+func (h *Handler) pvcGroups(raw json.RawMessage, name, ns string, at time.Time) []RelatedGroup {
+	var groups []RelatedGroup
+	var pvc struct {
+		Spec struct {
+			VolumeName string `json:"volumeName"`
+		} `json:"spec"`
+	}
+	if raw != nil && json.Unmarshal(raw, &pvc) == nil && pvc.Spec.VolumeName != "" {
+		groups = append(groups, RelatedGroup{Title: "Bound volume", Items: []RelatedItem{{
+			Kind: "PersistentVolume", Name: pvc.Spec.VolumeName,
+			Link: objectLink(apiListPath("", "v1", "persistentvolumes", ""), pvc.Spec.VolumeName),
+		}}})
+	}
+	// Pods in this namespace that mount this PVC.
+	var items []RelatedItem
+	for _, praw := range h.podsInNS(ns, at) {
+		var p podScan
+		if json.Unmarshal(praw, &p) != nil {
+			continue
+		}
+		_, _, pvcs := p.references()
+		if containsStr(pvcs, name) {
+			items = append(items, RelatedItem{Kind: "Pod", Name: p.Metadata.Name, Link: podLink(ns, p.Metadata.Name)})
+		}
+	}
+	if len(items) > 0 {
+		groups = append(groups, RelatedGroup{Title: "Used by pods", Items: items})
+	}
+	return groups
+}
+
+// pvGroups: the PVC a PV is bound to.
+func (h *Handler) pvGroups(raw json.RawMessage, at time.Time) []RelatedGroup {
+	var pv struct {
+		Spec struct {
+			ClaimRef struct {
+				Namespace string `json:"namespace"`
+				Name      string `json:"name"`
+			} `json:"claimRef"`
+		} `json:"spec"`
+	}
+	if raw == nil || json.Unmarshal(raw, &pv) != nil || pv.Spec.ClaimRef.Name == "" {
+		return nil
+	}
+	cr := pv.Spec.ClaimRef
+	return []RelatedGroup{{Title: "Bound claim", Items: []RelatedItem{{
+		Kind: "PersistentVolumeClaim", Name: cr.Name,
+		Link: objectLink(apiListPath("", "v1", "persistentvolumeclaims", cr.Namespace), cr.Name),
+	}}}}
+}
+
+// usedByPods: pods in ns that reference a configmap/secret (volumes/env).
+func (h *Handler) usedByPods(ns, name, kind string, at time.Time) []RelatedGroup {
+	var items []RelatedItem
+	for _, praw := range h.podsInNS(ns, at) {
+		var p podScan
+		if json.Unmarshal(praw, &p) != nil {
+			continue
+		}
+		cms, secs, _ := p.references()
+		hit := (kind == "configmap" && containsStr(cms, name)) || (kind == "secret" && containsStr(secs, name))
+		if hit {
+			items = append(items, RelatedItem{Kind: "Pod", Name: p.Metadata.Name, Link: podLink(ns, p.Metadata.Name)})
+		}
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	return []RelatedGroup{{Title: "Used by pods", Items: items}}
+}
+
+// ownedChildren: pods (and, for Deployments, ReplicaSets) owned by this object.
+func (h *Handler) ownedChildren(res, name, ns string, at time.Time) []RelatedGroup {
+	var groups []RelatedGroup
+	// Direct child pods.
+	var pods []RelatedItem
+	for _, praw := range h.podsInNS(ns, at) {
+		var p podScan
+		if json.Unmarshal(praw, &p) != nil {
+			continue
+		}
+		for _, o := range p.Metadata.OwnerReferences {
+			if o.Name == name {
+				pods = append(pods, RelatedItem{Kind: "Pod", Name: p.Metadata.Name, Link: podLink(ns, p.Metadata.Name)})
+				break
+			}
+		}
+	}
+	if len(pods) > 0 {
+		groups = append(groups, RelatedGroup{Title: "Pods", Items: pods})
+	}
+	// Deployments own ReplicaSets (which in turn own the pods).
+	if res == "deployments" {
+		body, code, err := h.Store.ReconstructAt("/apis/apps/v1/namespaces/"+ns+"/replicasets", at)
+		if err == nil && code == http.StatusOK && len(body) > 0 {
+			var list struct {
+				Items []json.RawMessage `json:"items"`
+			}
+			if json.Unmarshal(body, &list) == nil {
+				var rss []RelatedItem
+				for _, rraw := range list.Items {
+					var rs struct {
+						Metadata struct {
+							Name            string     `json:"name"`
+							OwnerReferences []ownerRef `json:"ownerReferences"`
+						} `json:"metadata"`
+					}
+					if json.Unmarshal(rraw, &rs) != nil {
+						continue
+					}
+					for _, o := range rs.Metadata.OwnerReferences {
+						if o.Name == name {
+							rss = append(rss, RelatedItem{Kind: "ReplicaSet", Name: rs.Metadata.Name, Link: objectLink(apiListPath("apps", "v1", "replicasets", ns), rs.Metadata.Name)})
+							break
+						}
+					}
+				}
+				if len(rss) > 0 {
+					groups = append(groups, RelatedGroup{Title: "ReplicaSets", Items: rss})
+				}
+			}
+		}
+	}
+	for i := range groups {
+		sort.SliceStable(groups[i].Items, func(a, b int) bool { return groups[i].Items[a].Name < groups[i].Items[b].Name })
+	}
+	return groups
+}
+
+func containsStr(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// podScan is a minimal pod shape for extracting ConfigMap/Secret/PVC references
+// from volumes and container env.
+type podScan struct {
+	Metadata struct {
+		Name            string     `json:"name"`
+		OwnerReferences []ownerRef `json:"ownerReferences"`
+	} `json:"metadata"`
+	Spec struct {
+		Volumes []struct {
+			ConfigMap *struct {
+				Name string `json:"name"`
+			} `json:"configMap"`
+			Secret *struct {
+				SecretName string `json:"secretName"`
+			} `json:"secret"`
+			PersistentVolumeClaim *struct {
+				ClaimName string `json:"claimName"`
+			} `json:"persistentVolumeClaim"`
+			Projected *struct {
+				Sources []struct {
+					ConfigMap *struct {
+						Name string `json:"name"`
+					} `json:"configMap"`
+					Secret *struct {
+						Name string `json:"name"`
+					} `json:"secret"`
+				} `json:"sources"`
+			} `json:"projected"`
+		} `json:"volumes"`
+		Containers     []containerRefs `json:"containers"`
+		InitContainers []containerRefs `json:"initContainers"`
+	} `json:"spec"`
+}
+
+type containerRefs struct {
+	EnvFrom []struct {
+		ConfigMapRef *struct {
+			Name string `json:"name"`
+		} `json:"configMapRef"`
+		SecretRef *struct {
+			Name string `json:"name"`
+		} `json:"secretRef"`
+	} `json:"envFrom"`
+	Env []struct {
+		ValueFrom *struct {
+			ConfigMapKeyRef *struct {
+				Name string `json:"name"`
+			} `json:"configMapKeyRef"`
+			SecretKeyRef *struct {
+				Name string `json:"name"`
+			} `json:"secretKeyRef"`
+		} `json:"valueFrom"`
+	} `json:"env"`
+}
+
+// references returns the distinct ConfigMap, Secret, and PVC names a pod uses
+// via volumes and container env.
+func (p podScan) references() (configMaps, secrets, pvcs []string) {
+	cmSet, secSet, pvcSet := map[string]bool{}, map[string]bool{}, map[string]bool{}
+	for _, v := range p.Spec.Volumes {
+		if v.ConfigMap != nil && v.ConfigMap.Name != "" {
+			cmSet[v.ConfigMap.Name] = true
+		}
+		if v.Secret != nil && v.Secret.SecretName != "" {
+			secSet[v.Secret.SecretName] = true
+		}
+		if v.PersistentVolumeClaim != nil && v.PersistentVolumeClaim.ClaimName != "" {
+			pvcSet[v.PersistentVolumeClaim.ClaimName] = true
+		}
+		if v.Projected != nil {
+			for _, src := range v.Projected.Sources {
+				if src.ConfigMap != nil && src.ConfigMap.Name != "" {
+					cmSet[src.ConfigMap.Name] = true
+				}
+				if src.Secret != nil && src.Secret.Name != "" {
+					secSet[src.Secret.Name] = true
+				}
+			}
+		}
+	}
+	scan := func(cs []containerRefs) {
+		for _, c := range cs {
+			for _, ef := range c.EnvFrom {
+				if ef.ConfigMapRef != nil && ef.ConfigMapRef.Name != "" {
+					cmSet[ef.ConfigMapRef.Name] = true
+				}
+				if ef.SecretRef != nil && ef.SecretRef.Name != "" {
+					secSet[ef.SecretRef.Name] = true
+				}
+			}
+			for _, e := range c.Env {
+				if e.ValueFrom == nil {
+					continue
+				}
+				if e.ValueFrom.ConfigMapKeyRef != nil && e.ValueFrom.ConfigMapKeyRef.Name != "" {
+					cmSet[e.ValueFrom.ConfigMapKeyRef.Name] = true
+				}
+				if e.ValueFrom.SecretKeyRef != nil && e.ValueFrom.SecretKeyRef.Name != "" {
+					secSet[e.ValueFrom.SecretKeyRef.Name] = true
+				}
+			}
+		}
+	}
+	scan(p.Spec.Containers)
+	scan(p.Spec.InitContainers)
+	return keysOf(cmSet), keysOf(secSet), keysOf(pvcSet)
+}
+
+func keysOf(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/ui/v2/static/app.css
+++ b/internal/ui/v2/static/app.css
@@ -48,6 +48,11 @@
   border-radius: 6px; padding: 5px 9px; font-size: 12px; cursor: pointer;
 }
 .theme-toggle:hover { color: var(--fg); }
+.legacy-link {
+  font-size: 11px; color: var(--fg-faint); text-decoration: none;
+  border: 1px solid var(--border-strong); border-radius: 6px; padding: 5px 9px; white-space: nowrap;
+}
+.legacy-link:hover { color: var(--fg); border-color: var(--accent); }
 * { box-sizing: border-box; }
 html, body { margin: 0; padding: 0; height: 100%; background: var(--bg); color: var(--fg); font: 13px var(--font); }
 a { color: inherit; }

--- a/internal/ui/v2/static/app.css
+++ b/internal/ui/v2/static/app.css
@@ -187,6 +187,35 @@ a { color: inherit; }
 .resrow.static:hover { background: transparent; }
 .resrow:last-child { border-bottom: none; }
 
+/* Chip / token filter bar with type-ahead. */
+.filterbar {
+  position: relative; display: flex; flex-wrap: wrap; align-items: center; gap: 6px;
+  background: var(--bg-row); border: 1px solid var(--border-strong); border-radius: 6px;
+  padding: 5px 8px; min-width: 320px; flex: 1; max-width: 720px;
+}
+.filterbar .fb-chips { display: contents; }
+.filterbar .fb-input {
+  flex: 1; min-width: 140px; background: transparent; border: none; outline: none;
+  color: var(--fg); font-size: 12.5px;
+}
+.fb-chip {
+  display: inline-flex; align-items: center; gap: 6px; background: var(--tag-bg);
+  border: 1px solid var(--border-strong); color: var(--fg); border-radius: 4px;
+  padding: 2px 6px; font: 11px var(--mono);
+}
+.fb-chip .fb-x { color: var(--fg-faint); cursor: pointer; visibility: hidden; }
+.fb-chip:hover .fb-x { visibility: visible; }
+.fb-chip .fb-x:hover { color: var(--bad); }
+.fb-suggest {
+  position: absolute; top: 100%; left: 0; margin-top: 4px; min-width: 260px;
+  max-height: 280px; overflow: auto; background: var(--bg-panel);
+  border: 1px solid var(--border-strong); border-radius: 6px; z-index: 50;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, .35);
+}
+.fb-opt { display: flex; justify-content: space-between; gap: 14px; padding: 6px 10px; cursor: pointer; font-size: 12.5px; }
+.fb-opt:hover, .fb-opt.active { background: var(--bg-row-hover); }
+.fb-opt .fb-hint { color: var(--fg-faint); font: 11px var(--mono); }
+
 /* Cluster-wide object lists (pods / workloads) with a namespace column. */
 .objhead, .objrow {
   display: grid; grid-template-columns: 14px 70px 190px 1fr 160px 64px 56px; gap: 10px;

--- a/internal/ui/v2/static/app.css
+++ b/internal/ui/v2/static/app.css
@@ -344,23 +344,33 @@ a { color: inherit; }
   display: flex; align-items: center; gap: 8px; padding: 12px 6px 4px; margin-top: 6px;
   border-bottom: 1px solid var(--border-strong);
 }
-.cat-group .g { font: 600 11px var(--mono); color: var(--accent); letter-spacing: .03em; }
+.cat-group input[type=checkbox] { margin: 0; cursor: pointer; }
+.cat-group .g { font: 600 11px var(--mono); color: var(--accent); letter-spacing: .03em; cursor: pointer; }
 .cat-group .gc { color: var(--fg-faint); font-size: 11px; }
 .cat-row {
-  display: grid; grid-template-columns: 18px 150px 1fr 150px 88px 64px 18px; gap: 10px;
-  align-items: center; padding: 6px; border-bottom: 1px solid var(--border); font-size: 12.5px;
+  display: grid; grid-template-columns: 22px minmax(0, 230px) minmax(0, 1fr) minmax(0, 220px) 96px 64px 18px;
+  gap: 10px; align-items: center; padding: 6px; border-bottom: 1px solid var(--border); font-size: 12.5px;
 }
 .cat-row:hover { background: var(--bg-row-hover); }
 .cat-row.off { opacity: 0.42; }
+.cat-row input[type=checkbox] { margin: 0; }
 .cat-row .kind {
+  display: inline-block; max-width: 100%; box-sizing: border-box;
   font: 10px var(--mono); padding: 1px 6px; background: var(--tag-bg); color: var(--fg-dim);
-  border-radius: 3px; text-align: center; border: 1px solid var(--border-strong);
+  border-radius: 3px; border: 1px solid var(--border-strong);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; vertical-align: middle;
 }
-.cat-row .nm { font: 12px var(--mono); color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.cat-row .meta { color: var(--fg-faint); font: 11px var(--mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cat-row .nm { min-width: 0; font: 12px var(--mono); color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cat-row .meta { min-width: 0; color: var(--fg-faint); font: 11px var(--mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cat-row .badge { font: 10px var(--mono); color: var(--fg-dim); }
 .cat-row .num { text-align: right; font: 11px var(--mono); color: var(--fg-faint); }
 .cat-row .go { text-align: center; color: var(--fg-faint); }
+
+/* Capture details card (overview). */
+.capmeta { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 10px 24px; padding: 14px 16px; }
+.capmeta .row { display: flex; flex-direction: column; gap: 2px; }
+.capmeta .k { font-size: 10.5px; color: var(--fg-faint); text-transform: uppercase; letter-spacing: .05em; }
+.capmeta .v { font: 12.5px var(--mono); color: var(--fg); overflow: hidden; text-overflow: ellipsis; }
 
 .diff { font: 12px var(--mono); white-space: pre; background: #07090f; border: 1px solid var(--border); border-radius: 6px; overflow: auto; }
 .diff .add { background: rgba(34,197,94,0.12); color: var(--good); }

--- a/internal/ui/v2/static/app.css
+++ b/internal/ui/v2/static/app.css
@@ -327,6 +327,41 @@ a { color: inherit; }
 .json-view .c { color: var(--fg-faint); font-style: italic; }
 
 /* Diff view */
+/* Syntax-highlighted code (object YAML/JSON view). */
+.code {
+  font: 12px var(--mono); white-space: pre; background: #07090f; border: 1px solid var(--border);
+  border-radius: 6px; overflow: auto; color: var(--fg);
+}
+.code .k-key { color: var(--accent); }
+.code .k-str { color: var(--good); }
+.code .k-num { color: var(--warn); }
+.code .k-lit { color: var(--accent-2); }
+.code .k-com { color: var(--fg-faint); font-style: italic; }
+.code .k-punc { color: var(--fg-faint); }
+
+/* Resources catalog page. */
+.cat-group {
+  display: flex; align-items: center; gap: 8px; padding: 12px 6px 4px; margin-top: 6px;
+  border-bottom: 1px solid var(--border-strong);
+}
+.cat-group .g { font: 600 11px var(--mono); color: var(--accent); letter-spacing: .03em; }
+.cat-group .gc { color: var(--fg-faint); font-size: 11px; }
+.cat-row {
+  display: grid; grid-template-columns: 18px 150px 1fr 150px 88px 64px 18px; gap: 10px;
+  align-items: center; padding: 6px; border-bottom: 1px solid var(--border); font-size: 12.5px;
+}
+.cat-row:hover { background: var(--bg-row-hover); }
+.cat-row.off { opacity: 0.42; }
+.cat-row .kind {
+  font: 10px var(--mono); padding: 1px 6px; background: var(--tag-bg); color: var(--fg-dim);
+  border-radius: 3px; text-align: center; border: 1px solid var(--border-strong);
+}
+.cat-row .nm { font: 12px var(--mono); color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cat-row .meta { color: var(--fg-faint); font: 11px var(--mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cat-row .badge { font: 10px var(--mono); color: var(--fg-dim); }
+.cat-row .num { text-align: right; font: 11px var(--mono); color: var(--fg-faint); }
+.cat-row .go { text-align: center; color: var(--fg-faint); }
+
 .diff { font: 12px var(--mono); white-space: pre; background: #07090f; border: 1px solid var(--border); border-radius: 6px; overflow: auto; }
 .diff .add { background: rgba(34,197,94,0.12); color: var(--good); }
 .diff .del { background: rgba(239,68,68,0.12); color: var(--bad); }

--- a/internal/ui/v2/static/app.css
+++ b/internal/ui/v2/static/app.css
@@ -1,0 +1,312 @@
+/* Base tokens — match the Design C mockup */
+:root {
+  --bg: #0b0f17;
+  --bg-panel: #111827;
+  --bg-card: #0f1726;
+  --bg-row: #0d1422;
+  --bg-row-hover: #18243a;
+  --border: #1f2937;
+  --border-strong: #2d3748;
+  --fg: #e5e7eb;
+  --fg-dim: #9ca3af;
+  --fg-faint: #6b7280;
+  --accent: #38bdf8;
+  --accent-2: #818cf8;
+  --good: #22c55e;
+  --warn: #eab308;
+  --bad: #ef4444;
+  --tag-bg: #1e293b;
+  --workload: #a78bfa;
+  --pod: #38bdf8;
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif;
+  --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; height: 100%; background: var(--bg); color: var(--fg); font: 13px var(--font); }
+a { color: inherit; }
+
+/* Shell layout */
+#app { display: flex; flex-direction: column; height: 100vh; }
+
+#topbar {
+  display: flex; align-items: center; gap: 16px; padding: 8px 16px;
+  background: var(--bg-panel); border-bottom: 1px solid var(--border);
+}
+#topbar .brand {
+  font-weight: 600; display: flex; gap: 8px; align-items: center;
+}
+#topbar .brand .logo {
+  width: 22px; height: 22px; border-radius: 6px;
+  background: linear-gradient(135deg, var(--accent), var(--workload));
+}
+#nav { display: flex; gap: 4px; }
+#nav .tab {
+  padding: 6px 12px; font-size: 12.5px; color: var(--fg-dim); cursor: pointer;
+  border-radius: 5px; user-select: none;
+}
+#nav .tab:hover { background: var(--bg-row); color: var(--fg); }
+#nav .tab.active { color: var(--fg); background: var(--bg-row); }
+.grow { flex: 1; }
+#capture-meta { font-size: 11px; color: var(--fg-faint); }
+
+/* Scrubber */
+.scrubber {
+  display: flex; align-items: center; gap: 8px; padding: 4px 10px;
+  background: var(--bg-row); border: 1px solid var(--border); border-radius: 6px;
+}
+.scrubber input[type=range] { width: 200px; accent-color: var(--accent); }
+.scrubber .ts { font: 11px var(--mono); color: var(--fg-dim); min-width: 150px; text-align: right; }
+
+.btn {
+  background: var(--bg-row); color: var(--fg); border: 1px solid var(--border-strong);
+  padding: 4px 10px; border-radius: 5px; font-size: 12px; cursor: pointer;
+}
+.btn:hover { border-color: var(--accent); }
+.btn.primary { background: var(--accent); color: #0b0f17; border-color: var(--accent); font-weight: 600; }
+
+#content { flex: 1; overflow: auto; padding: 18px 20px 28px; }
+
+.section-title {
+  font-size: 12px; color: var(--fg-faint); letter-spacing: .08em;
+  text-transform: uppercase; font-weight: 600; margin: 6px 0 10px;
+}
+
+/* Loading / empty states */
+.state {
+  padding: 40px 24px; border: 1px dashed var(--border-strong); border-radius: 8px;
+  text-align: center; color: var(--fg-dim); font-size: 13px;
+}
+
+/* KPI cards */
+.kpis { display: grid; grid-template-columns: repeat(5, 1fr); gap: 14px; margin-bottom: 22px; }
+.kpis.k6 { grid-template-columns: repeat(6, 1fr); }
+.kpi {
+  background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px;
+  padding: 14px 16px; display: flex; flex-direction: column; gap: 6px;
+}
+.kpi .label { font-size: 11px; color: var(--fg-faint); text-transform: uppercase; letter-spacing: .06em; }
+.kpi .value { font: 600 22px var(--font); color: var(--fg); }
+.kpi .delta { font: 11px var(--mono); }
+.kpi .delta.up { color: var(--good); }
+.kpi .delta.down { color: var(--bad); }
+.kpi .delta.neutral { color: var(--fg-faint); }
+.kpi.alert { border-color: var(--bad); }
+.kpi.alert .value { color: var(--bad); }
+.kpi.warn { border-color: var(--warn); }
+.kpi.warn .value { color: var(--warn); }
+.kpi.good .value { color: var(--good); }
+
+/* Grids */
+.grid-2 { display: grid; grid-template-columns: 2fr 1fr; gap: 18px; }
+.grid-3 { display: grid; grid-template-columns: 2fr 1fr 1fr; gap: 16px; }
+
+.card {
+  background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px;
+  padding: 16px 18px; display: flex; flex-direction: column; gap: 12px;
+}
+.card .hdr { display: flex; align-items: center; gap: 10px; }
+.card .hdr .title { font-weight: 600; font-size: 14px; }
+.card .hdr .ct { font: 11.5px var(--mono); color: var(--fg-faint); margin-left: auto; }
+.card .hdr a { color: var(--accent); font-size: 12px; text-decoration: none; cursor: pointer; }
+
+/* Sparkline */
+.spark { display: flex; align-items: flex-end; gap: 2px; height: 50px; padding-top: 4px; }
+.spark > div { flex: 1; background: var(--accent); opacity: .6; border-radius: 1px; min-height: 1px; }
+.spark > div.warn { background: var(--warn); opacity: .8; }
+.spark > div.bad  { background: var(--bad); opacity: .9; }
+.spark-axis { display: flex; justify-content: space-between; font: 11px var(--mono); color: var(--fg-faint); }
+
+/* Issue rows */
+.issues { display: flex; flex-direction: column; gap: 8px; }
+.issue {
+  display: grid; grid-template-columns: 90px 1fr auto; gap: 10px; align-items: center;
+  padding: 9px 10px; background: var(--bg-row); border-radius: 6px; cursor: pointer;
+  border-left: 3px solid transparent;
+}
+.issue.bad { border-left-color: var(--bad); }
+.issue.warn { border-left-color: var(--warn); }
+.issue:hover { background: var(--bg-panel); }
+.issue .kind {
+  font: 11px var(--mono); padding: 2px 6px; border-radius: 3px;
+  background: var(--tag-bg); color: var(--fg-dim); text-align: center; border: 1px solid var(--border-strong);
+}
+.issue .body { font-size: 12.5px; line-height: 1.4; min-width: 0; }
+.issue .body b { color: var(--fg); }
+.issue .body .ns { color: var(--fg-dim); font-size: 11.5px; display: block; }
+.issue .age { font: 11px var(--mono); color: var(--fg-faint); }
+
+/* Resource tile grid */
+.resource-grid {
+  display: grid; grid-template-columns: repeat(6, 1fr); gap: 8px;
+}
+.res-chip {
+  background: var(--bg-row); border: 1px solid var(--border); border-radius: 6px;
+  padding: 10px 12px; cursor: pointer;
+}
+.res-chip:hover { border-color: var(--accent); }
+.res-chip .nm { font-size: 12px; color: var(--fg); }
+.res-chip .ct { font: 600 16px var(--mono); color: var(--accent); }
+
+/* Compact resource rows for ns/pod views */
+.resrow {
+  display: grid; grid-template-columns: 14px 60px 1fr 110px 60px 60px; gap: 10px;
+  align-items: center; padding: 6px 4px; cursor: pointer; border-bottom: 1px solid var(--border);
+  font-size: 12.5px;
+}
+.resrow:hover { background: var(--bg-row-hover); }
+.resrow:last-child { border-bottom: none; }
+.resrow .dot { width: 8px; height: 8px; border-radius: 50%; }
+.resrow .dot.good { background: var(--good); }
+.resrow .dot.warn { background: var(--warn); }
+.resrow .dot.bad  { background: var(--bad); }
+.resrow .dot.neutral { background: var(--fg-faint); }
+.resrow .kind {
+  font: 10px var(--mono); padding: 1px 6px; background: var(--tag-bg); color: var(--fg-dim);
+  border-radius: 3px; text-align: center; border: 1px solid var(--border-strong);
+}
+.resrow .nm { color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.resrow .status { font: 11px var(--mono); color: var(--fg-dim); text-align: right; }
+.resrow .status.bad { color: var(--bad); }
+.resrow .status.warn { color: var(--warn); }
+.resrow .status.good { color: var(--good); }
+.resrow .num { font: 11px var(--mono); color: var(--fg-faint); text-align: right; }
+
+/* Status pills */
+.pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 11.5px; padding: 2px 8px; border-radius: 999px;
+}
+.pill.good { background: rgba(34,197,94,0.15); color: var(--good); }
+.pill.warn { background: rgba(234,179,8,0.15); color: var(--warn); }
+.pill.bad { background: rgba(239,68,68,0.18); color: var(--bad); }
+.pill.neutral { background: var(--tag-bg); color: var(--fg-dim); }
+
+/* Hero block (ns / pod drilldown) */
+.hero { padding: 16px 20px 14px; background: var(--bg-panel); border-bottom: 1px solid var(--border); }
+.crumbs { color: var(--fg-dim); font-size: 12.5px; display: flex; gap: 8px; align-items: center; }
+.crumbs a { color: var(--accent); text-decoration: none; cursor: pointer; }
+.crumbs b { color: var(--fg); font-weight: 500; }
+.crumbs .sep { color: var(--fg-faint); }
+.hero-row { display: grid; grid-template-columns: 1fr auto; gap: 16px; align-items: end; margin-top: 8px; }
+.hero .title-row { display: flex; align-items: center; gap: 12px; }
+.hero .title { font-size: 20px; font-weight: 600; }
+.hero .sub { font-size: 12px; color: var(--fg-dim); margin-top: 4px; font-family: var(--mono); }
+.hero-actions { display: flex; gap: 8px; }
+
+/* Sub-tabs */
+.subtabs {
+  display: flex; gap: 0; padding: 0 20px; background: var(--bg-panel);
+  border-bottom: 1px solid var(--border);
+}
+.subtabs .tab {
+  padding: 9px 14px; font-size: 12.5px; color: var(--fg-dim); cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+.subtabs .tab:hover { color: var(--fg); }
+.subtabs .tab.active { color: var(--fg); border-bottom-color: var(--accent); }
+.subtabs .tab .ct { color: var(--fg-faint); font-size: 11px; margin-left: 4px; }
+
+/* Labels */
+.labels { display: flex; flex-wrap: wrap; gap: 4px; }
+.labels .lab {
+  font: 11px var(--mono); padding: 2px 7px; background: var(--bg-row);
+  border: 1px solid var(--border-strong); border-radius: 3px; color: var(--fg-dim);
+}
+
+/* Container card (pod drilldown) */
+.container-card { background: var(--bg-row); border: 1px solid var(--border); border-radius: 6px; padding: 12px 14px; }
+.container-card.bad { border-color: rgba(239,68,68,0.45); background: rgba(239,68,68,0.04); }
+.container-card.warn { border-color: rgba(234,179,8,0.45); background: rgba(234,179,8,0.03); }
+.container-card + .container-card { margin-top: 8px; }
+.container-head { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
+.container-head .nm { font-weight: 600; font-size: 13.5px; }
+.container-head .role {
+  font: 10px var(--mono); padding: 1px 6px; border-radius: 3px;
+  background: var(--tag-bg); color: var(--fg-dim); border: 1px solid var(--border-strong);
+}
+.container-head .role.init { color: #c4b5fd; border-color: #4c1d95; }
+.container-head .role.side { color: #6ee7b7; border-color: #064e3b; }
+.container-head .state { font-size: 11.5px; padding: 2px 8px; border-radius: 999px; margin-left: auto; }
+.container-head .state.good { background: rgba(34,197,94,0.15); color: var(--good); }
+.container-head .state.bad { background: rgba(239,68,68,0.18); color: var(--bad); }
+.container-head .state.warn { background: rgba(234,179,8,0.15); color: var(--warn); }
+.container-meta {
+  display: grid; grid-template-columns: max-content 1fr max-content 1fr; gap: 4px 14px;
+  font-size: 12px; margin-bottom: 8px;
+}
+.container-meta .k { color: var(--fg-faint); }
+.container-meta .v { color: var(--fg); font: 12px var(--mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.container-meta .v.bad { color: var(--bad); }
+.container-meta .v.warn { color: var(--warn); }
+.container-meta .v.good { color: var(--good); }
+.log-preview {
+  background: #07090f; border: 1px solid var(--border); border-radius: 5px;
+  padding: 8px 10px; font: 11px var(--mono); color: var(--fg-dim);
+  white-space: pre-wrap; max-height: 110px; overflow: auto;
+}
+.log-preview .err { color: var(--bad); }
+.log-preview .ts { color: var(--fg-faint); }
+
+/* Events */
+.events { display: flex; flex-direction: column; gap: 6px; }
+.event {
+  display: grid; grid-template-columns: 80px 1fr 60px; gap: 8px; align-items: center;
+  padding: 7px 10px; background: var(--bg-row); border-radius: 5px;
+  border-left: 3px solid transparent; font-size: 12px;
+}
+.event.bad { border-left-color: var(--bad); }
+.event.warn { border-left-color: var(--warn); }
+.event.normal { border-left-color: var(--fg-faint); }
+.event .kind {
+  font: 10px var(--mono); padding: 1px 5px; border-radius: 3px;
+  background: var(--tag-bg); color: var(--fg-dim); text-align: center;
+}
+.event .kind.bad { color: var(--bad); }
+.event .kind.warn { color: var(--warn); }
+.event .body b { color: var(--fg); }
+.event .body .small { color: var(--fg-dim); font-size: 11px; }
+.event .age { font: 11px var(--mono); color: var(--fg-faint); text-align: right; }
+
+/* Timeline rows (history sidebar) */
+.timeline-row { display: flex; align-items: center; gap: 8px; padding: 4px 0; font-size: 12px; }
+.timeline-row .dot { width: 8px; height: 8px; border-radius: 50%; }
+.timeline-row .dot.added { background: var(--good); }
+.timeline-row .dot.modified { background: var(--warn); }
+.timeline-row .dot.deleted { background: var(--bad); }
+.timeline-row .ts { font: 11px var(--mono); color: var(--fg-faint); min-width: 90px; }
+.timeline-row .ev { color: var(--fg-dim); }
+
+/* Bar list */
+.barlist .row { display: grid; grid-template-columns: 1fr 60px; gap: 10px; align-items: center; padding: 4px 0; cursor: pointer; }
+.barlist .row:hover .lbl { color: var(--accent); }
+.barlist .lbl { font-size: 13px; }
+.barlist .bar { height: 6px; background: var(--bg-row); border-radius: 3px; overflow: hidden; grid-column: 1 / 3; margin-top: 2px; }
+.barlist .bar > div { height: 100%; background: linear-gradient(90deg, var(--accent), var(--accent-2)); }
+.barlist .ct { font: 11.5px var(--mono); color: var(--fg-dim); text-align: right; }
+
+/* JSON / YAML viewers */
+.json-view, .yaml-view {
+  background: #07090f; border: 1px solid var(--border); border-radius: 6px;
+  padding: 14px; font: 12px var(--mono); white-space: pre-wrap; word-break: break-word;
+  color: var(--fg); overflow: auto; max-height: 70vh;
+}
+.json-view .k { color: #93c5fd; }
+.json-view .s { color: #fcd34d; }
+.json-view .n { color: #c4b5fd; }
+.json-view .b { color: #6ee7b7; }
+.json-view .c { color: var(--fg-faint); font-style: italic; }
+
+/* Diff view */
+.diff { font: 12px var(--mono); white-space: pre; background: #07090f; border: 1px solid var(--border); border-radius: 6px; overflow: auto; }
+.diff .add { background: rgba(34,197,94,0.12); color: var(--good); }
+.diff .del { background: rgba(239,68,68,0.12); color: var(--bad); }
+.diff .ctx { color: var(--fg-dim); }
+
+/* Toasts */
+#toasts { position: fixed; right: 18px; bottom: 18px; display: flex; flex-direction: column; gap: 8px; z-index: 10; }
+.toast {
+  padding: 10px 14px; background: var(--bg-panel); border: 1px solid var(--border-strong);
+  border-radius: 6px; font-size: 12.5px; color: var(--fg); max-width: 360px;
+}
+.toast.error { border-color: var(--bad); }
+.toast.success { border-color: var(--good); }

--- a/internal/ui/v2/static/app.css
+++ b/internal/ui/v2/static/app.css
@@ -156,7 +156,35 @@ a { color: inherit; }
   font-size: 12.5px;
 }
 .resrow:hover { background: var(--bg-row-hover); }
+.resrow.static { cursor: default; }
+.resrow.static:hover { background: transparent; }
 .resrow:last-child { border-bottom: none; }
+
+/* Cluster-wide object lists (pods / workloads) with a namespace column. */
+.objhead, .objrow {
+  display: grid; grid-template-columns: 14px 70px 190px 1fr 160px 64px 56px; gap: 10px;
+  align-items: center; padding: 7px 6px; border-bottom: 1px solid var(--border); font-size: 12.5px;
+}
+.objhead { color: var(--fg-faint); font: 10px var(--mono); text-transform: uppercase; letter-spacing: .05em; }
+.objrow.click { cursor: pointer; }
+.objrow.click:hover { background: var(--bg-row-hover); }
+.objrow:last-child { border-bottom: none; }
+.objrow .dot { width: 8px; height: 8px; border-radius: 50%; }
+.objrow .dot.good { background: var(--good); }
+.objrow .dot.warn { background: var(--warn); }
+.objrow .dot.bad { background: var(--bad); }
+.objrow .dot.neutral { background: var(--fg-faint); }
+.objrow .kind {
+  font: 10px var(--mono); padding: 1px 6px; background: var(--tag-bg); color: var(--fg-dim);
+  border-radius: 3px; text-align: center; border: 1px solid var(--border-strong);
+}
+.objrow .ns { color: var(--fg-dim); font: 11px var(--mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.objrow .nm { color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.objrow .status { font: 11px var(--mono); color: var(--fg-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.objrow .status.bad { color: var(--bad); }
+.objrow .status.warn { color: var(--warn); }
+.objrow .status.good { color: var(--good); }
+.objrow .num { font: 11px var(--mono); color: var(--fg-faint); text-align: right; }
 .resrow .dot { width: 8px; height: 8px; border-radius: 50%; }
 .resrow .dot.good { background: var(--good); }
 .resrow .dot.warn { background: var(--warn); }

--- a/internal/ui/v2/static/app.css
+++ b/internal/ui/v2/static/app.css
@@ -84,6 +84,8 @@ a { color: inherit; }
   background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px;
   padding: 14px 16px; display: flex; flex-direction: column; gap: 6px;
 }
+.kpi.clickable { cursor: pointer; transition: border-color .12s, background .12s; }
+.kpi.clickable:hover { border-color: var(--border-strong); background: var(--bg-row); }
 .kpi .label { font-size: 11px; color: var(--fg-faint); text-transform: uppercase; letter-spacing: .06em; }
 .kpi .value { font: 600 22px var(--font); color: var(--fg); }
 .kpi .delta { font: 11px var(--mono); }

--- a/internal/ui/v2/static/app.css
+++ b/internal/ui/v2/static/app.css
@@ -20,7 +20,34 @@
   --pod: #38bdf8;
   --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif;
   --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+  --code-bg: #07090f;
 }
+:root[data-theme="light"] {
+  --bg: #f6f7f9;
+  --bg-panel: #ffffff;
+  --bg-card: #ffffff;
+  --bg-row: #f1f3f5;
+  --bg-row-hover: #e7ebf0;
+  --border: #e3e7eb;
+  --border-strong: #cfd6dd;
+  --fg: #1b2733;
+  --fg-dim: #51606e;
+  --fg-faint: #8a97a5;
+  --accent: #0b76d0;
+  --accent-2: #5b4bd6;
+  --good: #15803d;
+  --warn: #b45309;
+  --bad: #dc2626;
+  --tag-bg: #eef1f4;
+  --workload: #7c5cff;
+  --pod: #0b76d0;
+  --code-bg: #0f1726;
+}
+.theme-toggle {
+  background: var(--bg-row); border: 1px solid var(--border-strong); color: var(--fg-dim);
+  border-radius: 6px; padding: 5px 9px; font-size: 12px; cursor: pointer;
+}
+.theme-toggle:hover { color: var(--fg); }
 * { box-sizing: border-box; }
 html, body { margin: 0; padding: 0; height: 100%; background: var(--bg); color: var(--fg); font: 13px var(--font); }
 a { color: inherit; }
@@ -270,7 +297,7 @@ a { color: inherit; }
 .container-meta .v.warn { color: var(--warn); }
 .container-meta .v.good { color: var(--good); }
 .log-preview {
-  background: #07090f; border: 1px solid var(--border); border-radius: 5px;
+  background: var(--code-bg); border: 1px solid var(--border); border-radius: 5px;
   padding: 8px 10px; font: 11px var(--mono); color: var(--fg-dim);
   white-space: pre-wrap; max-height: 110px; overflow: auto;
 }
@@ -316,7 +343,7 @@ a { color: inherit; }
 
 /* JSON / YAML viewers */
 .json-view, .yaml-view {
-  background: #07090f; border: 1px solid var(--border); border-radius: 6px;
+  background: var(--code-bg); border: 1px solid var(--border); border-radius: 6px;
   padding: 14px; font: 12px var(--mono); white-space: pre-wrap; word-break: break-word;
   color: var(--fg); overflow: auto; max-height: 70vh;
 }
@@ -329,7 +356,7 @@ a { color: inherit; }
 /* Diff view */
 /* Syntax-highlighted code (object YAML/JSON view). */
 .code {
-  font: 12px var(--mono); white-space: pre; background: #07090f; border: 1px solid var(--border);
+  font: 12px var(--mono); white-space: pre; background: var(--code-bg); border: 1px solid var(--border);
   border-radius: 6px; overflow: auto; color: var(--fg);
 }
 .code .k-key { color: var(--accent); }
@@ -372,7 +399,7 @@ a { color: inherit; }
 .capmeta .k { font-size: 10.5px; color: var(--fg-faint); text-transform: uppercase; letter-spacing: .05em; }
 .capmeta .v { font: 12.5px var(--mono); color: var(--fg); overflow: hidden; text-overflow: ellipsis; }
 
-.diff { font: 12px var(--mono); white-space: pre; background: #07090f; border: 1px solid var(--border); border-radius: 6px; overflow: auto; }
+.diff { font: 12px var(--mono); white-space: pre; background: var(--code-bg); border: 1px solid var(--border); border-radius: 6px; overflow: auto; }
 .diff .add { background: rgba(34,197,94,0.12); color: var(--good); }
 .diff .del { background: rgba(239,68,68,0.12); color: var(--bad); }
 .diff .ctx { color: var(--fg-dim); }

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -159,27 +159,262 @@
     return el('div', { class: 'state' }, 'Error: ' + msg);
   }
 
-  // ─ Views (placeholders to be filled in subsequent commits) ──────────────
-  async function renderOverview() {
-    setContent(loadingState('Loading cluster overview…'));
-    try {
-      const data = await getJSON('/v2/api/overview');
-      // Real rendering lands in the next commit.
-      setContent(el('div', { class: 'state' }, 'Overview data loaded (' + Object.keys(data || {}).length + ' fields). Real layout in next commit.'));
-    } catch (e) {
-      setContent(errorState(e.message));
-    }
+  // ── Shared bits ──────────────────────────────────────────────────────────
+  function kpi(label, value, opts = {}) {
+    return el('div', { class: 'kpi' + (opts.severity ? ' ' + opts.severity : '') },
+      el('span', { class: 'label' }, label),
+      el('span', { class: 'value' }, formatNumber(value)),
+      opts.delta ? el('span', { class: 'delta ' + (opts.deltaKind || 'neutral') }, opts.delta) : null);
   }
 
-  async function renderNamespacesIndex() {
-    setContent(loadingState('Loading namespaces…'));
+  function formatNumber(n) {
+    if (typeof n !== 'number') return n;
+    return n.toLocaleString('en-US');
+  }
+
+  function sparkChart(sparkline) {
+    const wrap = el('div', { class: 'spark' });
+    const buckets = (sparkline && sparkline.buckets) || [];
+    const totals = buckets.map((b) => b.total || 0);
+    const max = totals.reduce((a, b) => Math.max(a, b), 0) || 1;
+    for (const b of buckets) {
+      const v = (b.total || 0) / max;
+      const h = Math.max(2, Math.round(v * 100));
+      const cls = b.bad > 0 ? 'bad' : (b.warn > 0 ? 'warn' : '');
+      wrap.appendChild(el('div', { class: cls, style: `height: ${h}%` }));
+    }
+    const axis = el('div', { class: 'spark-axis' });
+    if (buckets.length) {
+      const s = buckets[0].time;
+      const e = buckets[buckets.length - 1].time;
+      axis.appendChild(el('span', {}, formatShortTS(s)));
+      axis.appendChild(el('span', {}, formatShortTS(e)));
+    }
+    return el('div', {},
+      wrap,
+      axis,
+    );
+  }
+
+  function formatShortTS(s) {
+    if (!s) return '';
+    // 2026-06-17T05:06:31Z → 05:06:31
+    const m = String(s).match(/T(\d{2}:\d{2}:\d{2})/);
+    return m ? m[1] : s;
+  }
+
+  function issueRow(issue) {
+    const kindLabel = issue.count && issue.count > 1
+      ? `${issue.kind} ×${issue.count}`
+      : issue.kind;
+    return el('div', {
+      class: 'issue ' + (issue.severity || 'warn'),
+      onclick: () => issue.link && go(issue.link),
+    },
+      el('span', { class: 'kind' }, kindLabel),
+      el('span', { class: 'body' },
+        el('b', {}, issue.title),
+        issue.namespace ? el('span', { class: 'ns' }, issue.namespace) : null,
+        issue.subtitle ? el('span', { class: 'ns' }, issue.subtitle) : null,
+      ),
+      el('span', { class: 'age' }, issue.age || ''),
+    );
+  }
+
+  function resourceTile(t) {
+    return el('div', {
+      class: 'res-chip',
+      onclick: () => t.link && go(t.link),
+    },
+      el('div', { class: 'ct' }, formatNumber(t.count) || ''),
+      el('div', { class: 'nm' }, t.kind),
+    );
+  }
+
+  function topNamespaceRow(ns) {
+    const maxRefVal = topNsMax;
+    const pct = maxRefVal > 0 ? Math.round((ns.resources / maxRefVal) * 100) : 0;
+    return el('div', {
+      onclick: () => go('#/ns/' + encodeURIComponent(ns.name)),
+      style: 'cursor:pointer; padding: 4px 0;',
+    },
+      el('div', { class: 'barlist' },
+        el('div', { class: 'row' },
+          el('span', { class: 'lbl' }, ns.name),
+          el('span', { class: 'ct' }, formatNumber(ns.resources)),
+        ),
+        el('div', { class: 'bar' }, el('div', { style: `width: ${pct}%` })),
+      ),
+    );
+  }
+  let topNsMax = 1;
+
+  function recentRow(t) {
+    const sevByEvent = { ADDED: 'normal', MODIFIED: 'warn', DELETED: 'bad' };
+    const cls = sevByEvent[t.event_type] || 'normal';
+    return el('div', { class: 'event ' + cls },
+      el('span', { class: 'kind ' + (cls === 'bad' ? 'bad' : (cls === 'warn' ? 'warn' : '')) }, t.event_type || ''),
+      el('span', { class: 'body' },
+        el('b', {}, t.name || ''),
+        el('span', { class: 'small' }, (t.kind || '') + (t.namespace ? ' · ' + t.namespace : '')),
+      ),
+      el('span', { class: 'age' }, formatShortTS(t.time)),
+    );
+  }
+
+  // ── Overview view ────────────────────────────────────────────────────────
+  async function renderOverview() {
+    setContent(loadingState('Loading cluster overview…'));
+    let data;
     try {
-      const data = await getJSON('/v2/api/overview');
-      const list = (data && data.namespaces) || [];
-      setContent(el('div', { class: 'state' }, list.length + ' namespaces. Card grid lands in next commit.'));
+      data = await getJSON('/v2/api/overview');
     } catch (e) {
       setContent(errorState(e.message));
+      return;
     }
+
+    const kpis = data.kpis || {};
+    topNsMax = (data.top_namespaces || []).reduce((m, n) => Math.max(m, n.resources || 0), 1);
+
+    const root = el('div', {});
+
+    // KPI strip
+    const kpiStrip = el('div', { class: 'kpis' });
+    kpiStrip.appendChild(kpi('Namespaces', kpis.namespaces || 0));
+    kpiStrip.appendChild(kpi('Workloads', kpis.workloads || 0));
+    kpiStrip.appendChild(kpi('Pods', kpis.pods || 0));
+    const unhealthyDelta = unhealthyDeltaText(kpis);
+    kpiStrip.appendChild(kpi('Unhealthy pods', kpis.unhealthy_pods || 0, {
+      severity: (kpis.unhealthy_pods || 0) > 0 ? 'alert' : '',
+      delta: unhealthyDelta,
+      deltaKind: 'down',
+    }));
+    kpiStrip.appendChild(kpi('Watch events', kpis.watch_events || 0, {
+      delta: data.sparkline && data.sparkline.buckets ? 'over ' + data.sparkline.buckets.length + ' buckets' : '',
+      deltaKind: 'neutral',
+    }));
+    root.appendChild(kpiStrip);
+
+    // Spark + issues row
+    const sparkCard = el('div', { class: 'card' },
+      cardHeader('Pod-state transitions (capture window)',
+        ((data.sparkline && data.sparkline.total_events) || 0) + ' events',
+        { hash: '#/timeline', label: 'View timeline →' }),
+      sparkChart(data.sparkline || {}));
+
+    const issuesCard = el('div', { class: 'card' },
+      cardHeader('Issues to investigate', String((data.issues || []).length)),
+      issuesList(data.issues));
+
+    const row1 = el('div', { class: 'grid-2', style: 'margin-bottom:18px;' });
+    row1.appendChild(sparkCard);
+    row1.appendChild(issuesCard);
+    root.appendChild(row1);
+
+    // Resource tiles
+    root.appendChild(el('div', { class: 'section-title' }, 'Resources captured'));
+    const resourceCard = el('div', { class: 'card', style: 'margin-bottom:18px;' });
+    const tileGrid = el('div', { class: 'resource-grid' });
+    for (const t of (data.resources || [])) {
+      tileGrid.appendChild(resourceTile(t));
+    }
+    resourceCard.appendChild(tileGrid);
+    root.appendChild(resourceCard);
+
+    // Top namespaces + recent row
+    const topCard = el('div', { class: 'card' },
+      cardHeader('Top namespaces by resource count', '', { hash: '#/namespaces', label: 'Browse all →' }));
+    for (const ns of (data.top_namespaces || [])) {
+      topCard.appendChild(topNamespaceRow(ns));
+    }
+
+    const recentCard = el('div', { class: 'card' },
+      cardHeader('Recent transitions', 'last events'));
+    if (!data.recent || data.recent.length === 0) {
+      recentCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No watch events captured.'));
+    } else {
+      const evWrap = el('div', { class: 'events' });
+      for (const t of data.recent) evWrap.appendChild(recentRow(t));
+      recentCard.appendChild(evWrap);
+    }
+
+    const row2 = el('div', { class: 'grid-2' });
+    row2.appendChild(topCard);
+    row2.appendChild(recentCard);
+    root.appendChild(row2);
+
+    setContent(root);
+  }
+
+  function cardHeader(title, ct, link) {
+    return el('div', { class: 'hdr' },
+      el('div', { class: 'title' }, title),
+      ct ? el('span', { class: 'ct' }, ct) : null,
+      link ? el('a', { onclick: () => go(link.hash) }, link.label || '→') : null,
+    );
+  }
+
+  function issuesList(issues) {
+    if (!issues || issues.length === 0) {
+      return el('div', { class: 'state', style: 'padding:18px;' }, 'No unhealthy resources at this snapshot.');
+    }
+    const wrap = el('div', { class: 'issues' });
+    for (const i of issues) wrap.appendChild(issueRow(i));
+    return wrap;
+  }
+
+  function unhealthyDeltaText(kpis) {
+    const parts = [];
+    if (kpis.crash_loop_back_off) parts.push('CrashLoop ' + kpis.crash_loop_back_off);
+    if (kpis.oom_killed) parts.push('OOMKilled ' + kpis.oom_killed);
+    if (kpis.failed) parts.push('Failed ' + kpis.failed);
+    if (kpis.pending) parts.push('Pending ' + kpis.pending);
+    return parts.join(' · ');
+  }
+
+  // ── Namespaces index (full grid view) ────────────────────────────────────
+  async function renderNamespacesIndex() {
+    setContent(loadingState('Loading namespaces…'));
+    let data;
+    try {
+      data = await getJSON('/v2/api/overview');
+    } catch (e) {
+      setContent(errorState(e.message));
+      return;
+    }
+    const list = data.namespaces || [];
+    const filter = el('input', {
+      placeholder: 'Filter namespaces…',
+      style: 'width:100%; max-width:380px; background:var(--bg-row); border:1px solid var(--border-strong); color:var(--fg); padding:7px 10px; border-radius:6px; outline:none; margin-bottom:14px;',
+    });
+    const grid = el('div', { class: 'resource-grid', style: 'grid-template-columns:repeat(4, minmax(0,1fr));' });
+    function build(q) {
+      grid.innerHTML = '';
+      let shown = 0;
+      for (const ns of list) {
+        if (q && !ns.name.toLowerCase().includes(q)) continue;
+        const card = el('div', {
+          class: 'res-chip',
+          style: 'cursor:pointer; padding:12px 14px;',
+          onclick: () => go('#/ns/' + encodeURIComponent(ns.name)),
+        });
+        card.appendChild(el('div', { class: 'nm', style: 'font-size:13px;color:var(--fg);font-weight:500;margin-bottom:4px;' }, ns.name));
+        const chips = el('div', { style: 'display:flex;gap:6px;flex-wrap:wrap;' });
+        if (ns.workloads) chips.appendChild(el('span', { class: 'pill neutral' }, ns.workloads + ' workload' + (ns.workloads !== 1 ? 's' : '')));
+        if (ns.pods) chips.appendChild(el('span', { class: 'pill neutral' }, ns.pods + ' pod' + (ns.pods !== 1 ? 's' : '')));
+        if (ns.resources) chips.appendChild(el('span', { class: 'pill neutral' }, ns.resources + ' resource' + (ns.resources !== 1 ? 's' : '')));
+        if (ns.unhealthy) chips.appendChild(el('span', { class: 'pill bad' }, ns.unhealthy + ' unhealthy'));
+        card.appendChild(chips);
+        grid.appendChild(card);
+        shown++;
+      }
+      if (shown === 0) {
+        grid.appendChild(el('div', { class: 'state', style: 'grid-column:1/-1;' }, 'No namespaces match.'));
+      }
+    }
+    filter.addEventListener('input', () => build(filter.value.trim().toLowerCase()));
+    build('');
+    setContent(filter, grid);
   }
 
   async function renderNamespace(ns) {

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -577,21 +577,25 @@
     const list = data.namespaces || [];
     const hq = new URLSearchParams((location.hash.split('?')[1]) || '');
     const unhealthyOnly = hq.get('health') === 'unhealthy';
-    const filter = el('input', {
-      placeholder: 'Filter namespaces…',
-      style: 'width:100%; max-width:380px; background:var(--bg-row); border:1px solid var(--border-strong); color:var(--fg); padding:7px 10px; border-radius:6px; outline:none; margin-bottom:14px;',
+    const nameList = [...new Set(list.map((n) => n.name).filter(Boolean))].sort();
+    const fb = filterBar({
+      placeholder: 'Filter namespaces… (name=, /regex/)',
+      facets: [{ key: 'name', label: 'name', field: (n) => n.name, suggest: () => nameList }],
+      bareFields: (n) => [n.name],
+      onChange: () => build(),
     });
+    const barWrap = el('div', { style: 'margin-bottom:14px; max-width:680px;' }, fb.el);
     const banner = unhealthyOnly ? el('div', { class: 'state', style: 'padding:10px 14px; margin-bottom:14px; display:flex; gap:12px; align-items:center;' },
       el('span', {}, 'Showing namespaces with unhealthy pods'),
       el('a', { onclick: () => go('#/namespaces'), style: 'cursor:pointer;' }, 'Show all →'),
     ) : null;
     const grid = el('div', { class: 'resource-grid', style: 'grid-template-columns:repeat(4, minmax(0,1fr));' });
-    function build(q) {
+    function build() {
       grid.innerHTML = '';
       let shown = 0;
       for (const ns of list) {
         if (unhealthyOnly && !(ns.unhealthy > 0)) continue;
-        if (q && !ns.name.toLowerCase().includes(q)) continue;
+        if (!fb.matches(ns)) continue;
         const card = el('div', {
           class: 'res-chip',
           style: 'cursor:pointer; padding:12px 14px;',
@@ -612,9 +616,8 @@
           unhealthyOnly ? 'No namespaces with unhealthy pods at this snapshot.' : 'No namespaces match.'));
       }
     }
-    filter.addEventListener('input', () => build(filter.value.trim().toLowerCase()));
-    build('');
-    setContent(filter, banner, grid);
+    build();
+    setContent(barWrap, banner, grid);
   }
 
   async function renderNamespace(ns) {
@@ -1039,17 +1042,24 @@
     const sub = el('div', { style: 'color:var(--fg-dim); font-size:12px; margin-bottom:14px;' });
     root.appendChild(sub);
 
-    const filter = el('input', { placeholder: 'Filter by name, kind or namespace…', style: listFilterStyle });
-    root.appendChild(el('div', { style: 'display:flex; gap:10px; align-items:center; margin-bottom:12px;' }, filter));
+    const nsList = [...new Set(all.map((w) => w.namespace).filter(Boolean))].sort();
+    const nameList = [...new Set(all.map((w) => w.name).filter(Boolean))].sort();
+    const kindList = [...new Set(all.map((w) => w.kind).filter(Boolean))].sort();
+    const fb = filterBar({
+      placeholder: 'Filter workloads… (ns=, kind=, name=, /regex/)',
+      facets: [
+        { key: 'ns', aliases: ['namespace'], label: 'namespace', field: (w) => w.namespace, suggest: () => nsList },
+        { key: 'kind', label: 'kind', field: (w) => w.kind, suggest: () => kindList },
+        { key: 'name', label: 'name', field: (w) => w.name, suggest: () => nameList },
+      ],
+      bareFields: (w) => [w.name, w.namespace, w.kind, w.status],
+      initial: nsExact ? [{ key: 'ns', value: nsExact }] : [],
+      onChange: () => build(),
+    });
+    root.appendChild(el('div', { style: 'display:flex; gap:10px; align-items:center; margin-bottom:12px;' }, fb.el));
 
     const wlBanner = resourceFilterBanner();
     if (wlBanner) root.appendChild(wlBanner);
-
-    if (nsExact) {
-      root.appendChild(el('div', { class: 'state', style: 'padding:10px 14px; margin-bottom:12px; display:flex; gap:12px; align-items:center;' },
-        el('span', {}, 'Showing namespace ' + nsExact),
-        el('a', { onclick: () => go('#/workloads'), style: 'cursor:pointer;' }, 'Show all →')));
-    }
 
     const card = el('div', { class: 'card' });
     card.appendChild(el('div', { class: 'objhead' },
@@ -1060,20 +1070,17 @@
     root.appendChild(card);
 
     function build() {
-      const term = filter.value.trim().toLowerCase();
       listWrap.innerHTML = '';
       let shown = 0;
       for (const w of all) {
         if (!resourceEnabled(w.resource)) continue;
-        if (nsExact && w.namespace !== nsExact) continue;
-        if (term && !(w.name.toLowerCase().includes(term) || w.namespace.toLowerCase().includes(term) || (w.kind || '').toLowerCase().includes(term))) continue;
+        if (!fb.matches(w)) continue;
         listWrap.appendChild(objRow({ severity: w.severity, kind: w.kind, namespace: w.namespace, name: w.name, status: w.status, num1: w.restarts ? String(w.restarts) : '', num2: w.age || '', link: w.link }));
         shown++;
       }
       if (!shown) listWrap.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No workloads match.'));
       sub.textContent = data.total + ' workloads · ' + shown + ' shown';
     }
-    filter.addEventListener('input', build);
     build();
     setContent(root);
   }
@@ -1319,13 +1326,19 @@
       setContent(root);
       return;
     }
-    const filter = el('input', { placeholder: 'Filter by name or namespace…', style: listFilterStyle });
-    root.appendChild(el('div', { style: 'display:flex; gap:10px; margin-bottom:12px;' }, filter));
-    if (nsParam) {
-      root.appendChild(el('div', { class: 'state', style: 'padding:10px 14px; margin-bottom:12px; display:flex; gap:12px; align-items:center;' },
-        el('span', {}, 'Showing namespace ' + nsParam),
-        el('a', { onclick: () => go('#/resource?resource=' + encodeURIComponent(resource)), style: 'cursor:pointer;' }, 'Show all →')));
-    }
+    const nsList = [...new Set(all.map((it) => it.namespace).filter(Boolean))].sort();
+    const nameList = [...new Set(all.map((it) => it.name).filter(Boolean))].sort();
+    const fb = filterBar({
+      placeholder: 'Filter ' + resource + '… (ns=, name=, /regex/)',
+      facets: [
+        { key: 'ns', aliases: ['namespace'], label: 'namespace', field: (it) => it.namespace, suggest: () => nsList },
+        { key: 'name', label: 'name', field: (it) => it.name, suggest: () => nameList },
+      ],
+      bareFields: (it) => [it.name, it.namespace],
+      initial: nsParam ? [{ key: 'ns', value: nsParam }] : [],
+      onChange: () => build(),
+    });
+    root.appendChild(el('div', { style: 'display:flex; gap:10px; margin-bottom:12px;' }, fb.el));
     const gridCols = 'grid-template-columns:200px 1fr 60px;';
     const card = el('div', { class: 'card' });
     card.appendChild(el('div', { class: 'objhead', style: gridCols }, el('span', {}, 'Namespace'), el('span', {}, 'Name'), el('span', { style: 'text-align:right;' }, 'Age')));
@@ -1333,11 +1346,10 @@
     card.appendChild(listWrap);
     root.appendChild(card);
     function build() {
-      const term = filter.value.trim().toLowerCase();
       listWrap.innerHTML = '';
       let shown = 0;
       for (const it of all) {
-        if (term && !((it.name || '').toLowerCase().includes(term) || (it.namespace || '').toLowerCase().includes(term))) continue;
+        if (!fb.matches(it)) continue;
         listWrap.appendChild(el('div', { class: 'objrow click', style: gridCols, onclick: () => go(it.link) },
           el('span', { class: 'ns' }, it.namespace || '—'),
           el('span', { class: 'nm' }, it.name || ''),
@@ -1347,7 +1359,6 @@
       if (!shown) listWrap.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No objects match.'));
       sub.textContent = d.total + ' ' + resource + ' · ' + shown + ' shown';
     }
-    filter.addEventListener('input', build);
     build();
     setContent(root);
   }

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -595,34 +595,43 @@
     row1.appendChild(issuesCard);
     root.appendChild(row1);
 
-    // Workloads + VMs row
-    const wlCard = el('div', { class: 'card' }, cardHeader('Workloads', String((d.workloads || []).length)));
-    if (!d.workloads || d.workloads.length === 0) {
-      wlCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No workloads.'));
+    // Hint when the Resources filter hides some types from this namespace.
+    const nsBanner = resourceFilterBanner();
+    if (nsBanner) root.appendChild(nsBanner);
+
+    // Workloads + VMs row (honor the global Resources filter, by each row's
+    // resource type).
+    const wls = (d.workloads || []).filter((w) => resourceEnabled(w.resource));
+    const wlCard = el('div', { class: 'card' }, cardHeader('Workloads', String(wls.length)));
+    if (wls.length === 0) {
+      wlCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, (d.workloads || []).length ? 'No workloads for the enabled resource types.' : 'No workloads.'));
     } else {
-      for (const w of d.workloads.slice(0, 12)) wlCard.appendChild(resourceRowEl(w));
-      if (d.workloads.length > 12) wlCard.appendChild(el('div', { style: 'padding:6px 4px; font-size:11px; color:var(--fg-faint);' }, `+ ${d.workloads.length - 12} more`));
+      for (const w of wls.slice(0, 12)) wlCard.appendChild(resourceRowEl(w));
+      if (wls.length > 12) wlCard.appendChild(el('div', { style: 'padding:6px 4px; font-size:11px; color:var(--fg-faint);' }, `+ ${wls.length - 12} more`));
     }
-    const vmCard = el('div', { class: 'card' }, cardHeader('VirtualMachines', String((d.vms || []).length)));
-    if (!d.vms || d.vms.length === 0) {
-      vmCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No VirtualMachines captured.'));
+    const vms = (d.vms || []).filter((v) => resourceEnabled(v.resource));
+    const vmCard = el('div', { class: 'card' }, cardHeader('VirtualMachines', String(vms.length)));
+    if (vms.length === 0) {
+      vmCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, (d.vms || []).length ? 'No VirtualMachines for the enabled resource types.' : 'No VirtualMachines captured.'));
     } else {
-      for (const v of d.vms.slice(0, 12)) vmCard.appendChild(resourceRowEl(v));
-      if (d.vms.length > 12) vmCard.appendChild(el('div', { style: 'padding:6px 4px; font-size:11px; color:var(--fg-faint);' }, `+ ${d.vms.length - 12} more`));
+      for (const v of vms.slice(0, 12)) vmCard.appendChild(resourceRowEl(v));
+      if (vms.length > 12) vmCard.appendChild(el('div', { style: 'padding:6px 4px; font-size:11px; color:var(--fg-faint);' }, `+ ${vms.length - 12} more`));
     }
     const row2 = el('div', { class: 'grid-2', style: 'margin-bottom:18px;' });
     row2.appendChild(wlCard);
     row2.appendChild(vmCard);
     root.appendChild(row2);
 
-    // Pods table
-    const podHeader = cardHeader('Pods', `${d.pods?.length || 0} total · ${kpis.unhealthy_pods || 0} unhealthy`);
+    // Pods table (hidden when "pods" is toggled off in the Resources filter).
+    const podsOn = resourceEnabled('pods');
+    const podRows = podsOn ? (d.pods || []) : [];
+    const podHeader = cardHeader('Pods', `${podRows.length} total · ${kpis.unhealthy_pods || 0} unhealthy`);
     const podCard = el('div', { class: 'card', style: 'margin-bottom:18px;' }, podHeader);
-    if (!d.pods || d.pods.length === 0) {
-      podCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No pods captured.'));
+    if (podRows.length === 0) {
+      podCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, !podsOn ? 'Pods are hidden by your Resources filter.' : 'No pods captured.'));
     } else {
-      for (const p of d.pods.slice(0, 40)) podCard.appendChild(podRowEl(p));
-      if (d.pods.length > 40) podCard.appendChild(el('div', { style: 'padding:6px 4px; font-size:11px; color:var(--fg-faint);' }, `+ ${d.pods.length - 40} more (filtering UI coming)`));
+      for (const p of podRows.slice(0, 40)) podCard.appendChild(podRowEl(p));
+      if (podRows.length > 40) podCard.appendChild(el('div', { style: 'padding:6px 4px; font-size:11px; color:var(--fg-faint);' }, `+ ${podRows.length - 40} more`));
     }
     root.appendChild(podCard);
 
@@ -745,6 +754,9 @@
     const toggle = el('button', { class: 'btn' });
     root.appendChild(el('div', { style: 'display:flex; gap:10px; align-items:center; margin-bottom:12px;' }, filter, toggle));
 
+    const podsBanner = resourceFilterBanner();
+    if (podsBanner) root.appendChild(podsBanner);
+
     if (nsExact) {
       root.appendChild(el('div', { class: 'state', style: 'padding:10px 14px; margin-bottom:12px; display:flex; gap:12px; align-items:center;' },
         el('span', {}, 'Showing namespace ' + nsExact),
@@ -767,7 +779,9 @@
       const term = filter.value.trim().toLowerCase();
       listWrap.innerHTML = '';
       let shown = 0;
+      const podsOn = resourceEnabled('pods');
       for (const p of all) {
+        if (!podsOn) break;
         if (nsExact && p.namespace !== nsExact) continue;
         if (unhealthyOnly && !p.unhealthy) continue;
         if (term && !(p.name.toLowerCase().includes(term) || p.namespace.toLowerCase().includes(term))) continue;
@@ -775,7 +789,7 @@
         listWrap.appendChild(objRow({ severity: p.severity, kind: 'Pod', namespace: p.namespace, name: p.name, status, num1: p.restarts ? String(p.restarts) : '', num2: p.age || '', link: p.link }));
         shown++;
       }
-      if (!shown) listWrap.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, unhealthyOnly ? 'No unhealthy pods match.' : 'No pods match.'));
+      if (!shown) listWrap.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, !podsOn ? 'Pods are hidden by your Resources filter.' : (unhealthyOnly ? 'No unhealthy pods match.' : 'No pods match.')));
       sub.textContent = data.total + ' pods · ' + data.unhealthy + ' unhealthy · ' + shown + ' shown';
     }
     toggle.addEventListener('click', () => { unhealthyOnly = !unhealthyOnly; refreshToggle(); build(); });
@@ -806,6 +820,9 @@
     const filter = el('input', { placeholder: 'Filter by name, kind or namespace…', style: listFilterStyle });
     root.appendChild(el('div', { style: 'display:flex; gap:10px; align-items:center; margin-bottom:12px;' }, filter));
 
+    const wlBanner = resourceFilterBanner();
+    if (wlBanner) root.appendChild(wlBanner);
+
     if (nsExact) {
       root.appendChild(el('div', { class: 'state', style: 'padding:10px 14px; margin-bottom:12px; display:flex; gap:12px; align-items:center;' },
         el('span', {}, 'Showing namespace ' + nsExact),
@@ -825,6 +842,7 @@
       listWrap.innerHTML = '';
       let shown = 0;
       for (const w of all) {
+        if (!resourceEnabled(w.resource)) continue;
         if (nsExact && w.namespace !== nsExact) continue;
         if (term && !(w.name.toLowerCase().includes(term) || w.namespace.toLowerCase().includes(term) || (w.kind || '').toLowerCase().includes(term))) continue;
         listWrap.appendChild(objRow({ severity: w.severity, kind: w.kind, namespace: w.namespace, name: w.name, status: w.status, num1: w.restarts ? String(w.restarts) : '', num2: w.age || '', link: w.link }));
@@ -1034,6 +1052,14 @@
     root.appendChild(el('div', { class: 'section-title', style: 'font-size:15px; margin-bottom:2px;' }, d.kind || resource));
     const sub = el('div', { style: 'color:var(--fg-dim); font-size:12px; margin-bottom:14px;' });
     root.appendChild(sub);
+    if (!resourceEnabled(resource)) {
+      sub.textContent = d.total + ' ' + resource + ' · hidden';
+      root.appendChild(el('div', { class: 'state', style: 'padding:24px; display:flex; gap:12px; align-items:center;' },
+        el('span', {}, (d.kind || resource) + ' is hidden by your Resources filter.'),
+        el('a', { onclick: () => go('#/resources'), style: 'cursor:pointer;' }, 'Manage resources →')));
+      setContent(root);
+      return;
+    }
     const filter = el('input', { placeholder: 'Filter by name or namespace…', style: listFilterStyle });
     root.appendChild(el('div', { style: 'display:flex; gap:10px; margin-bottom:12px;' }, filter));
     if (nsParam) {

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -419,12 +419,169 @@
 
   async function renderNamespace(ns) {
     setContent(loadingState('Loading namespace ' + ns + '…'));
+    let d;
     try {
-      const data = await getJSON('/v2/api/namespace?ns=' + encodeURIComponent(ns));
-      setContent(el('div', { class: 'state' }, 'Namespace ' + ns + ' data loaded. Real layout in next commit.'));
+      d = await getJSON('/v2/api/namespace?ns=' + encodeURIComponent(ns));
     } catch (e) {
       setContent(errorState(e.message));
+      return;
     }
+
+    const kpis = d.kpis || {};
+    const root = el('div', {});
+
+    // Hero — breadcrumb + title + action row
+    const hero = el('div', { class: 'hero', style: 'margin:-18px -20px 18px; padding:14px 20px 14px;' },
+      el('div', { class: 'crumbs' },
+        el('a', { onclick: () => go('#/overview') }, '← Cluster'),
+        el('span', { class: 'sep' }, '/'),
+        el('a', { onclick: () => go('#/namespaces') }, 'Namespaces'),
+        el('span', { class: 'sep' }, '/'),
+        el('b', {}, d.name),
+      ),
+      el('div', { class: 'hero-row' },
+        el('div', {},
+          el('div', { class: 'title-row' },
+            el('div', { class: 'title' }, d.name),
+            (d.metadata && d.metadata.phase) ? el('span', { class: 'pill ' + (d.metadata.phase === 'Active' ? 'good' : 'warn') }, d.metadata.phase) : null,
+            kpis.unhealthy_pods > 0 ? el('span', { class: 'pill bad' }, kpis.unhealthy_pods + ' unhealthy') : null,
+          ),
+          el('div', { class: 'sub' },
+            (kpis.resources || 0) + ' resources · created ' + (d.metadata?.age || '?') + ' ago',
+          ),
+        ),
+        el('div', { class: 'hero-actions' },
+          el('button', { class: 'btn', onclick: () => go('#/logs') }, '▶ Open in Logs'),
+          el('button', { class: 'btn' }, '⏷ Compare snapshots'),
+        ),
+      ),
+    );
+    root.appendChild(hero);
+
+    // KPIs
+    const kpiStrip = el('div', { class: 'kpis k6' });
+    kpiStrip.appendChild(kpi('Workloads', kpis.workloads || 0));
+    kpiStrip.appendChild(kpi('Pods', kpis.pods || 0));
+    kpiStrip.appendChild(kpi('Unhealthy pods', kpis.unhealthy_pods || 0, { severity: (kpis.unhealthy_pods || 0) > 0 ? 'alert' : '' }));
+    kpiStrip.appendChild(kpi('VirtualMachines', kpis.virtual_machines || 0));
+    kpiStrip.appendChild(kpi('ConfigMaps', kpis.configmaps || 0));
+    kpiStrip.appendChild(kpi('Secrets', kpis.secrets || 0));
+    root.appendChild(kpiStrip);
+
+    // Spark + issues row
+    const sparkCard = el('div', { class: 'card' },
+      cardHeader('Pod-state transitions (this namespace)',
+        ((d.sparkline && d.sparkline.total_events) || 0) + ' events'),
+      sparkChart(d.sparkline || {}));
+    const issuesCard = el('div', { class: 'card' },
+      cardHeader('Issues in this namespace', String((d.issues || []).length)),
+      issuesList(d.issues));
+    const row1 = el('div', { class: 'grid-2', style: 'margin-bottom:18px;' });
+    row1.appendChild(sparkCard);
+    row1.appendChild(issuesCard);
+    root.appendChild(row1);
+
+    // Workloads + VMs row
+    const wlCard = el('div', { class: 'card' }, cardHeader('Workloads', String((d.workloads || []).length)));
+    if (!d.workloads || d.workloads.length === 0) {
+      wlCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No workloads.'));
+    } else {
+      for (const w of d.workloads.slice(0, 12)) wlCard.appendChild(resourceRowEl(w));
+      if (d.workloads.length > 12) wlCard.appendChild(el('div', { style: 'padding:6px 4px; font-size:11px; color:var(--fg-faint);' }, `+ ${d.workloads.length - 12} more`));
+    }
+    const vmCard = el('div', { class: 'card' }, cardHeader('VirtualMachines', String((d.vms || []).length)));
+    if (!d.vms || d.vms.length === 0) {
+      vmCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No VirtualMachines captured.'));
+    } else {
+      for (const v of d.vms.slice(0, 12)) vmCard.appendChild(resourceRowEl(v));
+      if (d.vms.length > 12) vmCard.appendChild(el('div', { style: 'padding:6px 4px; font-size:11px; color:var(--fg-faint);' }, `+ ${d.vms.length - 12} more`));
+    }
+    const row2 = el('div', { class: 'grid-2', style: 'margin-bottom:18px;' });
+    row2.appendChild(wlCard);
+    row2.appendChild(vmCard);
+    root.appendChild(row2);
+
+    // Pods table
+    const podHeader = cardHeader('Pods', `${d.pods?.length || 0} total · ${kpis.unhealthy_pods || 0} unhealthy`);
+    const podCard = el('div', { class: 'card', style: 'margin-bottom:18px;' }, podHeader);
+    if (!d.pods || d.pods.length === 0) {
+      podCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No pods captured.'));
+    } else {
+      for (const p of d.pods.slice(0, 40)) podCard.appendChild(podRowEl(p));
+      if (d.pods.length > 40) podCard.appendChild(el('div', { style: 'padding:6px 4px; font-size:11px; color:var(--fg-faint);' }, `+ ${d.pods.length - 40} more (filtering UI coming)`));
+    }
+    root.appendChild(podCard);
+
+    // Other resources tile grid
+    if (d.resources && d.resources.length > 0) {
+      root.appendChild(el('div', { class: 'section-title' }, 'Other resources'));
+      const tileCard = el('div', { class: 'card', style: 'margin-bottom:18px;' });
+      const tileGrid = el('div', { class: 'resource-grid', style: 'grid-template-columns:repeat(6, minmax(0,1fr));' });
+      for (const t of d.resources) tileGrid.appendChild(resourceTile(t));
+      tileCard.appendChild(tileGrid);
+      root.appendChild(tileCard);
+    }
+
+    // Namespace metadata
+    if (d.metadata && (d.metadata.labels || d.metadata.annotations)) {
+      root.appendChild(el('div', { class: 'section-title' }, 'Namespace metadata'));
+      const grid = el('div', { class: 'grid-2' });
+
+      const labCard = el('div', { class: 'card' }, cardHeader('Labels & annotations', ''));
+      const labels = d.metadata.labels || {};
+      if (Object.keys(labels).length === 0) {
+        labCard.appendChild(el('div', { class: 'state', style: 'padding:14px;' }, 'No labels.'));
+      } else {
+        const wrap = el('div', { class: 'labels' });
+        for (const k of Object.keys(labels)) {
+          wrap.appendChild(el('span', { class: 'lab' }, `${k}=${labels[k]}`));
+        }
+        labCard.appendChild(wrap);
+      }
+      grid.appendChild(labCard);
+
+      const ownersCard = el('div', { class: 'card' }, cardHeader('Status', ''));
+      ownersCard.appendChild(el('div', { style: 'font-size:12.5px; color:var(--fg-dim); display:flex; flex-direction:column; gap:6px;' },
+        el('div', {}, 'Phase: ', el('span', { style: 'color:var(--fg);' }, d.metadata.phase || '?')),
+        el('div', {}, 'Created: ', el('span', { style: 'color:var(--fg); font-family:var(--mono);' }, d.metadata.created_at || '?')),
+        el('div', {}, 'Age: ', el('span', { style: 'color:var(--fg); font-family:var(--mono);' }, d.metadata.age || '?')),
+      ));
+      grid.appendChild(ownersCard);
+
+      root.appendChild(grid);
+    }
+
+    setContent(root);
+  }
+
+  // Render a workload/VM ResourceRow into a .resrow element.
+  function resourceRowEl(r) {
+    return el('div', {
+      class: 'resrow',
+      onclick: () => { /* TODO: link to detail */ },
+    },
+      el('span', { class: 'dot ' + (r.severity || 'neutral') }),
+      el('span', { class: 'kind' }, r.kind || ''),
+      el('span', { class: 'nm' }, r.name || ''),
+      el('span', { class: 'status ' + (r.severity || '') }, r.status || ''),
+      el('span', { class: 'num' }, r.restarts ? String(r.restarts) : ''),
+      el('span', { class: 'num' }, r.age || ''),
+    );
+  }
+
+  // Render a PodRow into a .resrow with a click-handler to the pod drill-down.
+  function podRowEl(p) {
+    return el('div', {
+      class: 'resrow',
+      onclick: () => p.link && go(p.link),
+    },
+      el('span', { class: 'dot ' + (p.severity || 'neutral') }),
+      el('span', { class: 'kind' }, 'Pod'),
+      el('span', { class: 'nm' }, p.name || ''),
+      el('span', { class: 'status ' + (p.severity || '') }, p.status || p.phase || ''),
+      el('span', { class: 'num' }, p.restarts ? String(p.restarts) : ''),
+      el('span', { class: 'num' }, p.age || ''),
+    );
   }
 
   async function renderPod(ns, name) {

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -80,8 +80,6 @@
       { key: 'pods',       label: 'Pods',       hash: '#/pods' },
       { key: 'resources',  label: 'Resources',  hash: '#/resources' },
       { key: 'timeline',   label: 'Timeline',   hash: '#/timeline' },
-      { key: 'logs',       label: 'Logs',       hash: '#/logs' },
-      { key: 'diff',       label: 'Diff',       hash: '#/diff' },
     ];
     const activeKey = state.route.name === 'namespace' ? 'namespaces'
       : state.route.name === 'pod' ? 'pods'
@@ -997,6 +995,38 @@
     return wrap;
   }
 
+  // relatedRow renders a "<label>: <kind/name>" timeline row, linking the
+  // value to the object/pod view when the item carries a link.
+  function relatedRow(label, item) {
+    const text = (item.kind ? item.kind + '/' : '') + (item.name || '');
+    const val = item.link
+      ? el('a', { style: 'cursor:pointer; color:var(--accent);', onclick: () => go(item.link) }, text)
+      : el('span', {}, text);
+    return el('div', { class: 'timeline-row' },
+      el('span', { class: 'ts' }, label),
+      el('span', { class: 'ev' }, val));
+  }
+
+  // objectRelationshipsPanel fetches and renders the related-objects groups for
+  // an arbitrary captured object (PV↔PVC↔Pod, ConfigMap/Secret→Pod, owners…).
+  function objectRelationshipsPanel(path, name) {
+    const card = el('div', { class: 'card' }, cardHeader('Relationships', ''));
+    const body = el('div', {}, loadingState('Loading relationships…'));
+    card.appendChild(body);
+    getJSON('/v2/api/object-relationships?path=' + encodeURIComponent(path) + (name ? '&name=' + encodeURIComponent(name) : ''))
+      .then((d) => {
+        body.innerHTML = '';
+        const groups = (d && d.groups) || [];
+        if (!groups.length) { body.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No related objects found.')); return; }
+        for (const g of groups) {
+          body.appendChild(el('div', { class: 'section-title', style: 'margin-top:10px;' }, g.title + ' (' + (g.items || []).length + ')'));
+          for (const it of (g.items || [])) body.appendChild(relatedRow(it.kind || '', it));
+        }
+      })
+      .catch((e) => { body.innerHTML = ''; body.appendChild(errorState(e.message)); });
+    return card;
+  }
+
   function objectHistoryPanel(path, name) {
     const card = el('div', { class: 'card' }, cardHeader('Watch event history', ''));
     const body = el('div', {}, loadingState('Loading history…'));
@@ -1097,6 +1127,7 @@
     const panelDefs = [
       { key: 'yaml', label: 'YAML', build: () => codePanel(d.yaml || '', 'yaml', baseName) },
       { key: 'json', label: 'JSON', build: () => codePanel(d.json || '', 'json', baseName) },
+      { key: 'relationships', label: 'Relationships', build: () => objectRelationshipsPanel(path, name) },
       { key: 'history', label: 'History', build: () => objectHistoryPanel(path, name) },
       { key: 'diff', label: 'Diff', build: () => objectDiffPanel(path, name) },
     ];
@@ -1221,6 +1252,17 @@
       el('a', { onclick: () => go('#/resources'), style: 'cursor:pointer;' }, 'Manage →'));
   }
 
+  // resourceMatches does a partial (substring) match of a search term against a
+  // resource's plural name, full kind, singular name, short names, and group.
+  function resourceMatches(r, term) {
+    if ((r.resource || '').toLowerCase().includes(term)) return true;
+    if ((r.kind || '').toLowerCase().includes(term)) return true;
+    if ((r.singular || '').toLowerCase().includes(term)) return true;
+    if ((r.group || 'core').toLowerCase().includes(term)) return true;
+    for (const s of (r.short_names || [])) { if (s.toLowerCase().includes(term)) return true; }
+    return false;
+  }
+
   async function renderResourceCatalog() {
     setContent(loadingState('Loading resources…'));
     let d;
@@ -1252,7 +1294,7 @@
       body.innerHTML = '';
       const groups = {};
       for (const r of all) {
-        if (term && !(r.resource.toLowerCase().includes(term) || r.kind.toLowerCase().includes(term) || (r.group || 'core').toLowerCase().includes(term))) continue;
+        if (term && !resourceMatches(r, term)) continue;
         const g = r.group || 'core';
         (groups[g] = groups[g] || []).push(r);
       }
@@ -1289,7 +1331,9 @@
           body.appendChild(el('div', { class: 'cat-row' + (isOn(r.resource) ? '' : ' off') },
             cb,
             el('span', { class: 'kind' }, r.kind),
-            el('span', { class: 'nm', style: 'cursor:pointer;', onclick: () => go(r.link) }, r.resource),
+            el('span', { class: 'nm', style: 'cursor:pointer;', onclick: () => go(r.link) },
+              r.resource,
+              (r.short_names && r.short_names.length) ? el('span', { style: 'color:var(--fg-faint); margin-left:6px;' }, '(' + r.short_names.join(', ') + ')') : null),
             el('span', { class: 'meta' }, (r.group ? r.group + '/' : '') + r.version),
             el('span', { class: 'badge' }, r.namespaced ? 'namespaced' : 'cluster'),
             el('span', { class: 'num' }, r.count ? formatNumber(r.count) : ''),
@@ -1455,19 +1499,14 @@
     function buildRelationships() {
       const r = d.related || {};
       const rows = [];
-      if (r.owner) rows.push(['Owner', r.owner.kind + '/' + r.owner.name]);
-      if (r.workload) rows.push(['Workload', r.workload.kind + '/' + r.workload.name]);
-      if (typeof r.sibling_pods === 'number' && r.sibling_pods > 0) rows.push(['Sibling pods', String(r.sibling_pods)]);
-      for (const cm of (r.config_maps || [])) rows.push(['Mounts ConfigMap', cm.name]);
-      for (const s of (r.secrets || [])) rows.push(['Mounts Secret', s.name]);
-      for (const p of (r.pvcs || [])) rows.push(['Mounts PVC', p.name]);
+      if (r.owner) rows.push(['Owner', r.owner]);
+      if (r.workload) rows.push(['Workload', r.workload]);
+      for (const cm of (r.config_maps || [])) rows.push(['Mounts ConfigMap', cm]);
+      for (const s of (r.secrets || [])) rows.push(['Mounts Secret', s]);
+      for (const p of (r.pvcs || [])) rows.push(['Mounts PVC', p]);
       if (!rows.length) return emptyState('No related objects found for this pod.');
       const card = el('div', { class: 'card' }, cardHeader('Relationships', String(rows.length)));
-      for (const [k, v] of rows) {
-        card.appendChild(el('div', { class: 'timeline-row' },
-          el('span', { class: 'ts' }, k),
-          el('span', { class: 'ev' }, v)));
-      }
+      for (const [label, item] of rows) card.appendChild(relatedRow(label, item));
       return card;
     }
 
@@ -1789,7 +1828,34 @@
   }
 
   // ── Bootstrap ────────────────────────────────────────────────────────────
+  // ── Theme (light/dark) ─────────────────────────────────────────────────────
+  const THEME_KEY = 'kshrk.v2.theme';
+  function currentTheme() {
+    try { return localStorage.getItem(THEME_KEY) === 'light' ? 'light' : 'dark'; } catch (_) { return 'dark'; }
+  }
+  function applyTheme(t) {
+    if (t === 'light') document.documentElement.setAttribute('data-theme', 'light');
+    else document.documentElement.removeAttribute('data-theme');
+  }
+  function setupThemeToggle() {
+    const btn = el('button', { class: 'theme-toggle', title: 'Toggle light / dark theme' });
+    const paint = () => { btn.textContent = currentTheme() === 'light' ? '☾ Dark' : '☀ Light'; };
+    btn.addEventListener('click', () => {
+      const next = currentTheme() === 'light' ? 'dark' : 'light';
+      try { localStorage.setItem(THEME_KEY, next); } catch (_) {}
+      applyTheme(next);
+      paint();
+    });
+    paint();
+    const bar = $('topbar');
+    const meta = $('capture-meta');
+    if (bar && meta) bar.insertBefore(btn, meta);
+    else if (bar) bar.appendChild(btn);
+  }
+
   async function init() {
+    applyTheme(currentTheme());
+    setupThemeToggle();
     state.route = parseRoute();
     try {
       const ts = await getJSON('/v2/api/timestamps');

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -45,7 +45,7 @@
     if (qIdx >= 0) h = h.slice(0, qIdx);
     const parts = h.split('/').filter(Boolean);
     if (parts.length === 0) return { name: 'overview' };
-    if (parts[0] === 'overview' || parts[0] === 'namespaces' || parts[0] === 'pods' || parts[0] === 'workloads' || parts[0] === 'timeline' || parts[0] === 'logs' || parts[0] === 'diff') {
+    if (parts[0] === 'overview' || parts[0] === 'namespaces' || parts[0] === 'pods' || parts[0] === 'workloads' || parts[0] === 'resource' || parts[0] === 'object' || parts[0] === 'timeline' || parts[0] === 'logs' || parts[0] === 'diff') {
       return { name: parts[0] };
     }
     if (parts[0] === 'ns' && parts[1]) {
@@ -263,7 +263,10 @@
   function recentRow(t) {
     const sevByEvent = { ADDED: 'normal', MODIFIED: 'warn', DELETED: 'bad' };
     const cls = sevByEvent[t.event_type] || 'normal';
-    return el('div', { class: 'event ' + cls },
+    const link = transitionLink(t);
+    const attrs = { class: 'event ' + cls };
+    if (link) { attrs.onclick = () => go(link); attrs.style = 'cursor:pointer;'; }
+    return el('div', attrs,
       el('span', { class: 'kind ' + (cls === 'bad' ? 'bad' : (cls === 'warn' ? 'warn' : '')) }, t.event_type || ''),
       el('span', { class: 'body' },
         el('b', {}, t.name || ''),
@@ -310,7 +313,7 @@
 
     // Spark + issues row
     const sparkCard = el('div', { class: 'card' },
-      cardHeader('Pod-state transitions (capture window)',
+      cardHeader('Resource transitions (capture window)',
         ((data.sparkline && data.sparkline.total_events) || 0) + ' events',
         { hash: '#/timeline', label: 'View timeline →' }),
       sparkChart(data.sparkline || {}));
@@ -489,9 +492,9 @@
       severity: (kpis.unhealthy_pods || 0) > 0 ? 'alert' : '',
       link: '#/pods?ns=' + nsq + '&health=unhealthy',
     }));
-    kpiStrip.appendChild(kpi('VirtualMachines', kpis.virtual_machines || 0));
-    kpiStrip.appendChild(kpi('ConfigMaps', kpis.configmaps || 0));
-    kpiStrip.appendChild(kpi('Secrets', kpis.secrets || 0));
+    kpiStrip.appendChild(kpi('VirtualMachines', kpis.virtual_machines || 0, { link: '#/resource?resource=virtualmachines&ns=' + nsq }));
+    kpiStrip.appendChild(kpi('ConfigMaps', kpis.configmaps || 0, { link: '#/resource?resource=configmaps&ns=' + nsq }));
+    kpiStrip.appendChild(kpi('Secrets', kpis.secrets || 0, { link: '#/resource?resource=secrets&ns=' + nsq }));
     root.appendChild(kpiStrip);
 
     // Spark + issues row
@@ -749,6 +752,232 @@
     setContent(root);
   }
 
+  // parseListPath extracts {ns, resource} from an API list path so the object
+  // view can show a breadcrumb.
+  function parseListPath(p) {
+    const parts = (p || '').replace(/^\//, '').split('/').filter(Boolean);
+    const i = parts.indexOf('namespaces');
+    if (i >= 0 && parts.length > i + 2) return { ns: parts[i + 1], resource: parts[i + 2] };
+    return { ns: '', resource: parts[parts.length - 1] || '' };
+  }
+
+  // transitionLink maps a watch-event/transition to its best destination:
+  // the pod detail for pods, otherwise the generic object view.
+  function transitionLink(t) {
+    if (t.resource === 'pods' && t.namespace && t.name) {
+      return '#/ns/' + encodeURIComponent(t.namespace) + '/pod/' + encodeURIComponent(t.name);
+    }
+    if (t.path && t.name) {
+      return '#/object?path=' + encodeURIComponent(t.path) + '&name=' + encodeURIComponent(t.name);
+    }
+    return '';
+  }
+
+  // rawObjectPanel fetches one object and shows it as YAML/JSON with a toggle.
+  function rawObjectPanel(path, name) {
+    const wrap = el('div', {});
+    const pre = el('pre', { class: 'log-preview', style: 'max-height:calc(100vh - 360px); padding:14px;' }, 'Loading…');
+    let data = null, mode = 'yaml';
+    const ybtn = el('button', { class: 'btn primary', onclick: () => { mode = 'yaml'; paint(); } }, 'YAML');
+    const jbtn = el('button', { class: 'btn', onclick: () => { mode = 'json'; paint(); } }, 'JSON');
+    function paint() {
+      if (!data) return;
+      pre.textContent = mode === 'yaml' ? (data.yaml || '') : (data.json || '');
+      ybtn.className = 'btn' + (mode === 'yaml' ? ' primary' : '');
+      jbtn.className = 'btn' + (mode === 'json' ? ' primary' : '');
+    }
+    wrap.appendChild(el('div', { style: 'display:flex; gap:8px; margin-bottom:10px;' }, ybtn, jbtn));
+    wrap.appendChild(pre);
+    getJSON('/v2/api/object?path=' + encodeURIComponent(path) + (name ? '&name=' + encodeURIComponent(name) : ''))
+      .then((d) => { data = d; if (!d.found) { pre.textContent = 'Object not present at this snapshot.'; return; } paint(); })
+      .catch((e) => { pre.textContent = 'Error: ' + e.message; });
+    return wrap;
+  }
+
+  function objectHistoryPanel(path, name) {
+    const card = el('div', { class: 'card' }, cardHeader('Watch event history', ''));
+    const body = el('div', {}, loadingState('Loading history…'));
+    card.appendChild(body);
+    getJSON('/v2/api/object-history?path=' + encodeURIComponent(path) + (name ? '&name=' + encodeURIComponent(name) : ''))
+      .then((h) => {
+        body.innerHTML = '';
+        const events = (h && h.events) || [];
+        if (!events.length) { body.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No watch events recorded for this object. (Enable watch on its resource to capture transitions.)')); return; }
+        for (const e of events) {
+          const cls = e.event_type === 'ADDED' ? 'added' : (e.event_type === 'DELETED' ? 'deleted' : 'modified');
+          body.appendChild(el('div', { class: 'timeline-row' },
+            el('span', { class: 'ts' }, formatShortTS(e.time)),
+            el('span', { class: 'dot ' + cls }),
+            el('span', { class: 'ev' }, e.event_type + (e.detail ? ' · ' + e.detail : ''))));
+        }
+      })
+      .catch((e) => { body.innerHTML = ''; body.appendChild(errorState(e.message)); });
+    return card;
+  }
+
+  function objectDiffPanel(path, name) {
+    const card = el('div', { class: 'card' }, cardHeader('Compare snapshots', ''));
+    if (state.snapshots.length < 2) {
+      card.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'Need at least two snapshots to diff.'));
+      return card;
+    }
+    const mkSel = (val) => {
+      const s = el('select', { style: listFilterStyle });
+      for (const ts of state.snapshots) s.appendChild(el('option', { value: ts, selected: ts === val ? 'selected' : null }, ts));
+      return s;
+    };
+    const before = mkSel(state.snapshots[0]);
+    const after = mkSel(state.snapshots[state.snapshots.length - 1]);
+    const out = el('div', { style: 'margin-top:12px;' });
+    const run = async () => {
+      out.innerHTML = '';
+      out.appendChild(loadingState('Diffing…'));
+      try {
+        const data = await getJSON('/v2/api/diff?path=' + encodeURIComponent(path) + (name ? '&name=' + encodeURIComponent(name) : '') + '&before=' + encodeURIComponent(before.value) + '&after=' + encodeURIComponent(after.value));
+        out.innerHTML = '';
+        if (data.before_missing || data.after_missing) {
+          out.appendChild(el('div', { class: 'state' }, data.before_missing && data.after_missing ? 'Object not present at either snapshot.' : (data.before_missing ? 'Did not exist at the "before" snapshot — full add.' : 'Did not exist at the "after" snapshot — full delete.')));
+        }
+        if (!data.has_diff && !data.before_missing && !data.after_missing) {
+          out.appendChild(el('div', { class: 'state' }, 'No changes between these snapshots.'));
+        }
+        const diff = el('div', { class: 'diff', style: 'padding:14px;' });
+        for (const hk of (data.hunks || [])) diff.appendChild(el('div', { class: hk.type === 'add' ? 'add' : (hk.type === 'del' ? 'del' : 'ctx') }, hk.text));
+        out.appendChild(diff);
+      } catch (e) {
+        out.innerHTML = '';
+        out.appendChild(errorState(e.message));
+      }
+    };
+    card.appendChild(el('div', { style: 'display:flex; gap:8px; align-items:center; flex-wrap:wrap;' },
+      el('span', { style: 'font-size:12px; color:var(--fg-dim);' }, 'Before'), before,
+      el('span', { style: 'font-size:12px; color:var(--fg-dim);' }, 'After'), after,
+      el('button', { class: 'btn primary', onclick: run }, 'Compare')));
+    card.appendChild(out);
+    return card;
+  }
+
+  // Generic object view: YAML / JSON / History / Diff for any captured object.
+  async function renderObject() {
+    const q = hashQuery();
+    const path = q.get('path') || '';
+    const name = q.get('name') || '';
+    if (!path) { setContent(errorState('Missing object path.')); return; }
+    setContent(loadingState('Loading ' + (name || path) + '…'));
+    let d;
+    try {
+      d = await getJSON('/v2/api/object?path=' + encodeURIComponent(path) + (name ? '&name=' + encodeURIComponent(name) : ''));
+    } catch (e) {
+      setContent(errorState(e.message));
+      return;
+    }
+    const parsed = parseListPath(path);
+    const kind = d.kind || kindLabelFor(parsed.resource);
+    const root = el('div', {});
+    root.appendChild(el('div', { class: 'hero', style: 'margin:-18px -20px 18px; padding:14px 20px;' },
+      el('div', { class: 'crumbs' },
+        el('a', { onclick: () => go('#/overview') }, '← Cluster'),
+        el('span', { class: 'sep' }, '/'),
+        parsed.ns ? el('a', { onclick: () => go('#/ns/' + encodeURIComponent(parsed.ns)) }, parsed.ns) : null,
+        parsed.ns ? el('span', { class: 'sep' }, '/') : null,
+        el('a', { onclick: () => go('#/resource?resource=' + encodeURIComponent(parsed.resource) + (parsed.ns ? '&ns=' + encodeURIComponent(parsed.ns) : '')) }, kind),
+        el('span', { class: 'sep' }, '/'),
+        el('b', {}, name || parsed.resource),
+      ),
+      el('div', { class: 'hero-row' }, el('div', {},
+        el('div', { class: 'title' }, name || parsed.resource),
+        el('div', { class: 'sub' }, kind + (parsed.ns ? ' · ' + parsed.ns : '') + (d.found ? '' : ' · not present at this snapshot')))),
+    ));
+    if (!d.found) { root.appendChild(el('div', { class: 'state', style: 'padding:24px;' }, 'Object not present at this snapshot.')); setContent(root); return; }
+
+    const panelDefs = [
+      { key: 'yaml', label: 'YAML', build: () => el('pre', { class: 'log-preview', style: 'max-height:calc(100vh - 320px); padding:14px;' }, d.yaml || '') },
+      { key: 'json', label: 'JSON', build: () => el('pre', { class: 'log-preview', style: 'max-height:calc(100vh - 320px); padding:14px;' }, d.json || '') },
+      { key: 'history', label: 'History', build: () => objectHistoryPanel(path, name) },
+      { key: 'diff', label: 'Diff', build: () => objectDiffPanel(path, name) },
+    ];
+    const subtabs = el('div', { class: 'subtabs', style: 'margin:0 -20px 18px;' });
+    const host = el('div', {});
+    const tabEls = {}, panelEls = {};
+    const select = (k) => {
+      for (const def of panelDefs) {
+        const a = def.key === k;
+        tabEls[def.key].classList.toggle('active', a);
+        if (a && !panelEls[def.key]) { panelEls[def.key] = def.build(); host.appendChild(panelEls[def.key]); }
+        if (panelEls[def.key]) panelEls[def.key].style.display = a ? '' : 'none';
+      }
+    };
+    for (const def of panelDefs) {
+      const t = el('div', { class: 'tab', onclick: () => select(def.key) }, def.label);
+      tabEls[def.key] = t;
+      subtabs.appendChild(t);
+    }
+    root.appendChild(subtabs);
+    root.appendChild(host);
+    select('yaml');
+    setContent(root);
+  }
+
+  // Small JS-side mirror of kindFromResource for headers when the captured
+  // object has no top-level kind (List items often omit it).
+  function kindLabelFor(resource) {
+    const m = { pods: 'Pod', configmaps: 'ConfigMap', secrets: 'Secret', services: 'Service', deployments: 'Deployment', statefulsets: 'StatefulSet', daemonsets: 'DaemonSet', replicasets: 'ReplicaSet', jobs: 'Job', cronjobs: 'CronJob', persistentvolumeclaims: 'PersistentVolumeClaim', virtualmachines: 'VirtualMachine', virtualmachineinstances: 'VirtualMachineInstance', namespaces: 'Namespace', nodes: 'Node', events: 'Event' };
+    return m[resource] || resource;
+  }
+
+  // Generic resource-type list: every object of a resource kind, optionally
+  // scoped to a namespace. Rows open the object view.
+  async function renderResourceList() {
+    const q = hashQuery();
+    const resource = q.get('resource') || '';
+    const nsParam = q.get('ns') || '';
+    if (!resource) { setContent(errorState('Missing resource.')); return; }
+    setContent(loadingState('Loading ' + resource + '…'));
+    let d;
+    try {
+      d = await getJSON('/v2/api/resource?resource=' + encodeURIComponent(resource) + (nsParam ? '&ns=' + encodeURIComponent(nsParam) : ''));
+    } catch (e) {
+      setContent(errorState(e.message));
+      return;
+    }
+    const all = d.items || [];
+    const root = el('div', {});
+    root.appendChild(el('div', { class: 'section-title', style: 'font-size:15px; margin-bottom:2px;' }, d.kind || resource));
+    const sub = el('div', { style: 'color:var(--fg-dim); font-size:12px; margin-bottom:14px;' });
+    root.appendChild(sub);
+    const filter = el('input', { placeholder: 'Filter by name or namespace…', style: listFilterStyle });
+    root.appendChild(el('div', { style: 'display:flex; gap:10px; margin-bottom:12px;' }, filter));
+    if (nsParam) {
+      root.appendChild(el('div', { class: 'state', style: 'padding:10px 14px; margin-bottom:12px; display:flex; gap:12px; align-items:center;' },
+        el('span', {}, 'Showing namespace ' + nsParam),
+        el('a', { onclick: () => go('#/resource?resource=' + encodeURIComponent(resource)), style: 'cursor:pointer;' }, 'Show all →')));
+    }
+    const gridCols = 'grid-template-columns:200px 1fr 60px;';
+    const card = el('div', { class: 'card' });
+    card.appendChild(el('div', { class: 'objhead', style: gridCols }, el('span', {}, 'Namespace'), el('span', {}, 'Name'), el('span', { style: 'text-align:right;' }, 'Age')));
+    const listWrap = el('div', {});
+    card.appendChild(listWrap);
+    root.appendChild(card);
+    function build() {
+      const term = filter.value.trim().toLowerCase();
+      listWrap.innerHTML = '';
+      let shown = 0;
+      for (const it of all) {
+        if (term && !((it.name || '').toLowerCase().includes(term) || (it.namespace || '').toLowerCase().includes(term))) continue;
+        listWrap.appendChild(el('div', { class: 'objrow click', style: gridCols, onclick: () => go(it.link) },
+          el('span', { class: 'ns' }, it.namespace || '—'),
+          el('span', { class: 'nm' }, it.name || ''),
+          el('span', { class: 'num' }, it.age || '')));
+        shown++;
+      }
+      if (!shown) listWrap.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No objects match.'));
+      sub.textContent = d.total + ' ' + resource + ' · ' + shown + ' shown';
+    }
+    filter.addEventListener('input', build);
+    build();
+    setContent(root);
+  }
+
   async function renderPod(ns, name) {
     setContent(loadingState('Loading pod ' + ns + '/' + name + '…'));
     let d;
@@ -871,27 +1100,6 @@
       return card;
     }
 
-    function buildLogs() {
-      const withLogs = (d.containers || []).filter((c) => (c.log_preview || []).length > 0 || c.log_path);
-      if (!withLogs.length) return emptyState('No logs captured for this pod. Set "logs: <N>" on the pods resource in the capture config to capture container logs.');
-      const wrap = el('div', {});
-      for (const c of withLogs) {
-        const card = el('div', { class: 'card', style: 'margin-bottom:14px;' },
-          cardHeader('Logs · ' + c.name, (c.role && c.role !== 'main') ? c.role : ''));
-        if ((c.log_preview || []).length) {
-          card.appendChild(el('pre', { class: 'log-preview', style: 'max-height:340px; padding:12px;' }, c.log_preview.join('\n')));
-        } else {
-          card.appendChild(el('div', { class: 'state', style: 'padding:12px;' }, 'No preview captured.'));
-        }
-        const actions = el('div', { style: 'display:flex; gap:8px; margin-top:10px;' });
-        if (c.log_path) actions.appendChild(el('button', { class: 'btn', onclick: () => go(c.log_path) }, 'Open full logs'));
-        if (c.has_previous_log && c.log_path) actions.appendChild(el('button', { class: 'btn', onclick: () => go(c.log_path + '&previous=true') }, 'Previous logs'));
-        if (actions.childNodes.length) card.appendChild(actions);
-        wrap.appendChild(card);
-      }
-      return wrap;
-    }
-
     function buildEvents() {
       if (!d.events || d.events.length === 0) return emptyState('No events captured for this pod. (Did the capture include /api/v1/events?)');
       const card = el('div', { class: 'card' }, cardHeader('Events', String(d.events.length)));
@@ -935,15 +1143,14 @@
     }
 
     function buildYaml() {
-      return emptyState('Raw YAML view isn\'t available here yet — the captured object lives in the archive. Use the Compare snapshots (Diff) view or "kshrk inspect" to view it.');
+      // Render the pod's captured object as YAML/JSON via the generic endpoint.
+      return rawObjectPanel('/api/v1/namespaces/' + d.namespace + '/pods', d.name);
     }
 
-    const logsCount = (d.containers || []).filter((c) => (c.log_preview || []).length > 0).length;
     const relCount = (d.related?.owner ? 1 : 0) + (d.related?.config_maps || []).length + (d.related?.secrets || []).length + (d.related?.pvcs || []).length;
     const panelDefs = [
       { key: 'summary', label: 'Summary', count: null, build: buildSummary },
-      { key: 'containers', label: 'Containers', count: (d.containers || []).length, build: buildContainers },
-      { key: 'logs', label: 'Logs', count: logsCount, build: buildLogs },
+      { key: 'containers', label: 'Containers & Logs', count: (d.containers || []).length, build: buildContainers },
       { key: 'events', label: 'Events', count: (d.events || []).length, build: buildEvents },
       { key: 'history', label: 'History', count: (d.history || []).length, build: buildHistory },
       { key: 'relationships', label: 'Relationships', count: relCount, build: buildRelationships },
@@ -1237,6 +1444,8 @@
     if (r.name === 'namespaces') return renderNamespacesIndex();
     if (r.name === 'pods') return renderPodsList();
     if (r.name === 'workloads') return renderWorkloadsList();
+    if (r.name === 'resource') return renderResourceList();
+    if (r.name === 'object') return renderObject();
     if (r.name === 'namespace') return renderNamespace(r.ns);
     if (r.name === 'pod') return renderPod(r.ns, r.pod);
     if (r.name === 'timeline') return renderTimeline();

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -45,7 +45,7 @@
     if (qIdx >= 0) h = h.slice(0, qIdx);
     const parts = h.split('/').filter(Boolean);
     if (parts.length === 0) return { name: 'overview' };
-    if (parts[0] === 'overview' || parts[0] === 'namespaces' || parts[0] === 'timeline' || parts[0] === 'logs' || parts[0] === 'diff') {
+    if (parts[0] === 'overview' || parts[0] === 'namespaces' || parts[0] === 'pods' || parts[0] === 'workloads' || parts[0] === 'timeline' || parts[0] === 'logs' || parts[0] === 'diff') {
       return { name: parts[0] };
     }
     if (parts[0] === 'ns' && parts[1]) {
@@ -76,11 +76,15 @@
     const items = [
       { key: 'overview',   label: 'Overview',   hash: '#/overview' },
       { key: 'namespaces', label: 'Namespaces', hash: '#/namespaces' },
+      { key: 'workloads',  label: 'Workloads',  hash: '#/workloads' },
+      { key: 'pods',       label: 'Pods',       hash: '#/pods' },
       { key: 'timeline',   label: 'Timeline',   hash: '#/timeline' },
       { key: 'logs',       label: 'Logs',       hash: '#/logs' },
       { key: 'diff',       label: 'Diff',       hash: '#/diff' },
     ];
-    const activeKey = state.route.name === 'namespace' || state.route.name === 'pod' ? 'namespaces' : state.route.name;
+    const activeKey = state.route.name === 'namespace' ? 'namespaces'
+      : state.route.name === 'pod' ? 'pods'
+      : state.route.name;
     for (const it of items) {
       nav.appendChild(el('div', {
         class: 'tab' + (it.key === activeKey ? ' active' : ''),
@@ -288,14 +292,14 @@
     // KPI strip — each tile drills into the relevant view.
     const kpiStrip = el('div', { class: 'kpis' });
     kpiStrip.appendChild(kpi('Namespaces', kpis.namespaces || 0, { link: '#/namespaces' }));
-    kpiStrip.appendChild(kpi('Workloads', kpis.workloads || 0, { link: '#/namespaces' }));
-    kpiStrip.appendChild(kpi('Pods', kpis.pods || 0, { link: '#/namespaces' }));
+    kpiStrip.appendChild(kpi('Workloads', kpis.workloads || 0, { link: '#/workloads' }));
+    kpiStrip.appendChild(kpi('Pods', kpis.pods || 0, { link: '#/pods' }));
     const unhealthyDelta = unhealthyDeltaText(kpis);
     kpiStrip.appendChild(kpi('Unhealthy pods', kpis.unhealthy_pods || 0, {
       severity: (kpis.unhealthy_pods || 0) > 0 ? 'alert' : '',
       delta: unhealthyDelta,
       deltaKind: 'down',
-      link: '#/namespaces?health=unhealthy',
+      link: '#/pods?health=unhealthy',
     }));
     kpiStrip.appendChild(kpi('Watch events', kpis.watch_events || 0, {
       delta: data.sparkline && data.sparkline.buckets ? 'over ' + data.sparkline.buckets.length + ' buckets' : '',
@@ -475,11 +479,16 @@
     );
     root.appendChild(hero);
 
-    // KPIs
+    // KPIs — Workloads/Pods/Unhealthy drill into the cluster lists scoped to
+    // this namespace. VMs/ConfigMaps/Secrets have no list view yet.
+    const nsq = encodeURIComponent(d.name);
     const kpiStrip = el('div', { class: 'kpis k6' });
-    kpiStrip.appendChild(kpi('Workloads', kpis.workloads || 0));
-    kpiStrip.appendChild(kpi('Pods', kpis.pods || 0));
-    kpiStrip.appendChild(kpi('Unhealthy pods', kpis.unhealthy_pods || 0, { severity: (kpis.unhealthy_pods || 0) > 0 ? 'alert' : '' }));
+    kpiStrip.appendChild(kpi('Workloads', kpis.workloads || 0, { link: '#/workloads?ns=' + nsq }));
+    kpiStrip.appendChild(kpi('Pods', kpis.pods || 0, { link: '#/pods?ns=' + nsq }));
+    kpiStrip.appendChild(kpi('Unhealthy pods', kpis.unhealthy_pods || 0, {
+      severity: (kpis.unhealthy_pods || 0) > 0 ? 'alert' : '',
+      link: '#/pods?ns=' + nsq + '&health=unhealthy',
+    }));
     kpiStrip.appendChild(kpi('VirtualMachines', kpis.virtual_machines || 0));
     kpiStrip.appendChild(kpi('ConfigMaps', kpis.configmaps || 0));
     kpiStrip.appendChild(kpi('Secrets', kpis.secrets || 0));
@@ -571,12 +580,13 @@
     setContent(root);
   }
 
-  // Render a workload/VM ResourceRow into a .resrow element.
+  // Render a workload/VM ResourceRow into a .resrow element. These have no
+  // dedicated detail page, so the row is non-interactive unless it carries a
+  // link.
   function resourceRowEl(r) {
-    return el('div', {
-      class: 'resrow',
-      onclick: () => { /* TODO: link to detail */ },
-    },
+    const attrs = { class: 'resrow' + (r.link ? '' : ' static') };
+    if (r.link) attrs.onclick = () => go(r.link);
+    return el('div', attrs,
       el('span', { class: 'dot ' + (r.severity || 'neutral') }),
       el('span', { class: 'kind' }, r.kind || ''),
       el('span', { class: 'nm' }, r.name || ''),
@@ -599,6 +609,144 @@
       el('span', { class: 'num' }, p.restarts ? String(p.restarts) : ''),
       el('span', { class: 'num' }, p.age || ''),
     );
+  }
+
+  // One row in a cluster-wide object list (pods / workloads).
+  function objRow(o) {
+    const attrs = { class: 'objrow' + (o.link ? ' click' : '') };
+    if (o.link) attrs.onclick = () => go(o.link);
+    return el('div', attrs,
+      el('span', { class: 'dot ' + (o.severity || 'neutral') }),
+      el('span', { class: 'kind' }, o.kind || ''),
+      el('span', { class: 'ns' }, o.namespace || ''),
+      el('span', { class: 'nm' }, o.name || ''),
+      el('span', { class: 'status ' + (o.severity || '') }, o.status || ''),
+      el('span', { class: 'num' }, o.num1 || ''),
+      el('span', { class: 'num' }, o.num2 || ''),
+    );
+  }
+
+  const listFilterStyle = 'background:var(--bg-row); border:1px solid var(--border-strong); color:var(--fg); padding:7px 10px; border-radius:6px; outline:none; min-width:280px;';
+
+  function hashQuery() {
+    const i = (location.hash || '').indexOf('?');
+    return new URLSearchParams(i < 0 ? '' : location.hash.slice(i + 1));
+  }
+
+  async function renderPodsList() {
+    setContent(loadingState('Loading pods…'));
+    let data;
+    try {
+      data = await getJSON('/v2/api/pods');
+    } catch (e) {
+      setContent(errorState(e.message));
+      return;
+    }
+    const all = data.pods || [];
+    const q = hashQuery();
+    const nsExact = q.get('ns') || '';
+    let unhealthyOnly = q.get('health') === 'unhealthy';
+
+    const root = el('div', {});
+    root.appendChild(el('div', { class: 'section-title', style: 'font-size:15px; margin-bottom:2px;' }, 'Pods'));
+    const sub = el('div', { style: 'color:var(--fg-dim); font-size:12px; margin-bottom:14px;' });
+    root.appendChild(sub);
+
+    const filter = el('input', { placeholder: 'Filter by name or namespace…', style: listFilterStyle });
+    const toggle = el('button', { class: 'btn' });
+    root.appendChild(el('div', { style: 'display:flex; gap:10px; align-items:center; margin-bottom:12px;' }, filter, toggle));
+
+    if (nsExact) {
+      root.appendChild(el('div', { class: 'state', style: 'padding:10px 14px; margin-bottom:12px; display:flex; gap:12px; align-items:center;' },
+        el('span', {}, 'Showing namespace ' + nsExact),
+        el('a', { onclick: () => go('#/pods' + (unhealthyOnly ? '?health=unhealthy' : '')), style: 'cursor:pointer;' }, 'Show all →')));
+    }
+
+    const card = el('div', { class: 'card' });
+    card.appendChild(el('div', { class: 'objhead' },
+      el('span', {}, ''), el('span', {}, 'Kind'), el('span', {}, 'Namespace'), el('span', {}, 'Name'),
+      el('span', {}, 'Status'), el('span', { style: 'text-align:right;' }, 'Restarts'), el('span', { style: 'text-align:right;' }, 'Age')));
+    const listWrap = el('div', {});
+    card.appendChild(listWrap);
+    root.appendChild(card);
+
+    function refreshToggle() {
+      toggle.className = 'btn' + (unhealthyOnly ? ' primary' : '');
+      toggle.textContent = (unhealthyOnly ? '✓ ' : '') + 'Unhealthy only';
+    }
+    function build() {
+      const term = filter.value.trim().toLowerCase();
+      listWrap.innerHTML = '';
+      let shown = 0;
+      for (const p of all) {
+        if (nsExact && p.namespace !== nsExact) continue;
+        if (unhealthyOnly && !p.unhealthy) continue;
+        if (term && !(p.name.toLowerCase().includes(term) || p.namespace.toLowerCase().includes(term))) continue;
+        const status = (p.status || p.phase || '') + (p.ready ? ' · ' + p.ready : '');
+        listWrap.appendChild(objRow({ severity: p.severity, kind: 'Pod', namespace: p.namespace, name: p.name, status, num1: p.restarts ? String(p.restarts) : '', num2: p.age || '', link: p.link }));
+        shown++;
+      }
+      if (!shown) listWrap.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, unhealthyOnly ? 'No unhealthy pods match.' : 'No pods match.'));
+      sub.textContent = data.total + ' pods · ' + data.unhealthy + ' unhealthy · ' + shown + ' shown';
+    }
+    toggle.addEventListener('click', () => { unhealthyOnly = !unhealthyOnly; refreshToggle(); build(); });
+    filter.addEventListener('input', build);
+    refreshToggle();
+    build();
+    setContent(root);
+  }
+
+  async function renderWorkloadsList() {
+    setContent(loadingState('Loading workloads…'));
+    let data;
+    try {
+      data = await getJSON('/v2/api/workloads');
+    } catch (e) {
+      setContent(errorState(e.message));
+      return;
+    }
+    const all = data.workloads || [];
+    const q = hashQuery();
+    const nsExact = q.get('ns') || '';
+
+    const root = el('div', {});
+    root.appendChild(el('div', { class: 'section-title', style: 'font-size:15px; margin-bottom:2px;' }, 'Workloads'));
+    const sub = el('div', { style: 'color:var(--fg-dim); font-size:12px; margin-bottom:14px;' });
+    root.appendChild(sub);
+
+    const filter = el('input', { placeholder: 'Filter by name, kind or namespace…', style: listFilterStyle });
+    root.appendChild(el('div', { style: 'display:flex; gap:10px; align-items:center; margin-bottom:12px;' }, filter));
+
+    if (nsExact) {
+      root.appendChild(el('div', { class: 'state', style: 'padding:10px 14px; margin-bottom:12px; display:flex; gap:12px; align-items:center;' },
+        el('span', {}, 'Showing namespace ' + nsExact),
+        el('a', { onclick: () => go('#/workloads'), style: 'cursor:pointer;' }, 'Show all →')));
+    }
+
+    const card = el('div', { class: 'card' });
+    card.appendChild(el('div', { class: 'objhead' },
+      el('span', {}, ''), el('span', {}, 'Kind'), el('span', {}, 'Namespace'), el('span', {}, 'Name'),
+      el('span', {}, 'Status'), el('span', { style: 'text-align:right;' }, ''), el('span', { style: 'text-align:right;' }, 'Age')));
+    const listWrap = el('div', {});
+    card.appendChild(listWrap);
+    root.appendChild(card);
+
+    function build() {
+      const term = filter.value.trim().toLowerCase();
+      listWrap.innerHTML = '';
+      let shown = 0;
+      for (const w of all) {
+        if (nsExact && w.namespace !== nsExact) continue;
+        if (term && !(w.name.toLowerCase().includes(term) || w.namespace.toLowerCase().includes(term) || (w.kind || '').toLowerCase().includes(term))) continue;
+        listWrap.appendChild(objRow({ severity: w.severity, kind: w.kind, namespace: w.namespace, name: w.name, status: w.status, num1: w.restarts ? String(w.restarts) : '', num2: w.age || '', link: w.link }));
+        shown++;
+      }
+      if (!shown) listWrap.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No workloads match.'));
+      sub.textContent = data.total + ' workloads · ' + shown + ' shown';
+    }
+    filter.addEventListener('input', build);
+    build();
+    setContent(root);
   }
 
   async function renderPod(ns, name) {
@@ -1087,6 +1235,8 @@
     const r = state.route;
     if (r.name === 'overview') return renderOverview();
     if (r.name === 'namespaces') return renderNamespacesIndex();
+    if (r.name === 'pods') return renderPodsList();
+    if (r.name === 'workloads') return renderWorkloadsList();
     if (r.name === 'namespace') return renderNamespace(r.ns);
     if (r.name === 'pod') return renderPod(r.ns, r.pod);
     if (r.name === 'timeline') return renderTimeline();

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -822,6 +822,133 @@
     return new URLSearchParams(i < 0 ? '' : location.hash.slice(i + 1));
   }
 
+  // ── Chip / token filter bar ────────────────────────────────────────────────
+  // opts: {
+  //   facets: [{ key, aliases?, label, field(row)->string, suggest()->[string] }],
+  //   bareFields(row)->[string],   // fields a bare term matches against
+  //   placeholder?, initial?: [{key,value}], onChange(),
+  // }
+  // Semantics: AND across chips. A value wrapped in /.../ is a (case-insensitive)
+  // regex; otherwise it's a case-insensitive substring. Bare terms match any of
+  // bareFields. Returns { el, matches(row), chips() }.
+  function filterBar(opts) {
+    const facets = opts.facets || [];
+    const byKey = {};
+    for (const f of facets) { byKey[f.key] = f; for (const a of (f.aliases || [])) byKey[a] = f; }
+    const normKey = (k) => { const f = byKey[k.toLowerCase()]; return f ? f.key : k.toLowerCase(); };
+
+    let chips = [];
+    let suggestions = [];
+    let sel = -1;
+
+    const chipHost = el('span', { class: 'fb-chips' });
+    const input = el('input', { class: 'fb-input', placeholder: opts.placeholder || 'Filter… (try ns=, name=, k=v, /regex/)' });
+    const drop = el('div', { class: 'fb-suggest', style: 'display:none;' });
+    const wrap = el('div', { class: 'filterbar', onclick: () => input.focus() }, chipHost, input, drop);
+
+    function makeChip(key, value) {
+      let regex = false, v = value;
+      if (v.length >= 2 && v[0] === '/' && v[v.length - 1] === '/') { regex = true; v = v.slice(1, -1); }
+      return { key, value: v, regex, label: (key ? key + '=' : '') + value };
+    }
+    function renderChips() {
+      chipHost.innerHTML = '';
+      chips.forEach((c, i) => {
+        chipHost.appendChild(el('span', { class: 'fb-chip' }, c.label,
+          el('span', { class: 'fb-x', title: 'Remove', onclick: (e) => { e.stopPropagation(); chips.splice(i, 1); renderChips(); fire(); } }, '✕')));
+      });
+    }
+    function fire() { if (opts.onChange) opts.onChange(); }
+    function addChip(key, value) {
+      if (value === '') return;
+      chips.push(makeChip(key, value));
+      renderChips(); input.value = ''; closeDrop(); fire();
+    }
+
+    function updateSuggestions() {
+      const tok = input.value;
+      suggestions = [];
+      const eq = tok.indexOf('=');
+      if (eq < 0) {
+        const p = tok.toLowerCase();
+        const keyMatch = [], labelMatch = [];
+        for (const f of facets) {
+          if (!p || f.key.startsWith(p)) keyMatch.push(f);
+          else if ((f.label || '').toLowerCase().startsWith(p)) labelMatch.push(f);
+        }
+        for (const f of keyMatch.concat(labelMatch)) suggestions.push({ type: 'key', label: f.key + '=', hint: f.label, key: f.key });
+      } else {
+        const key = normKey(tok.slice(0, eq));
+        const partial = tok.slice(eq + 1).toLowerCase().replace(/^\/|\/$/g, '');
+        const f = byKey[key];
+        if (f && f.suggest) {
+          for (const v of (f.suggest() || [])) {
+            if (!partial || v.toLowerCase().includes(partial)) suggestions.push({ type: 'value', label: v, key, value: v });
+            if (suggestions.length >= 12) break;
+          }
+        }
+      }
+      sel = -1; // no auto-highlight: Enter commits typed text unless a suggestion is chosen
+      renderDrop();
+    }
+    function renderDrop() {
+      drop.innerHTML = '';
+      if (!suggestions.length) { drop.style.display = 'none'; return; }
+      suggestions.forEach((sg, i) => {
+        drop.appendChild(el('div', { class: 'fb-opt' + (i === sel ? ' active' : ''), onmousedown: (e) => { e.preventDefault(); choose(i); } },
+          el('span', {}, sg.label), sg.hint ? el('span', { class: 'fb-hint' }, sg.hint) : null));
+      });
+      drop.style.display = '';
+    }
+    function closeDrop() { suggestions = []; sel = -1; drop.style.display = 'none'; }
+    function choose(i) {
+      const sg = suggestions[i];
+      if (!sg) return;
+      if (sg.type === 'key') { input.value = sg.key + '='; updateSuggestions(); input.focus(); }
+      else addChip(sg.key, sg.value);
+    }
+    function commitInput() {
+      const tok = input.value.trim();
+      if (!tok) return;
+      const eq = tok.indexOf('=');
+      if (eq > 0) addChip(normKey(tok.slice(0, eq)), tok.slice(eq + 1));
+      else addChip('', tok);
+    }
+
+    input.addEventListener('input', updateSuggestions);
+    input.addEventListener('focus', updateSuggestions);
+    input.addEventListener('blur', () => setTimeout(closeDrop, 120));
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowDown' && suggestions.length) { sel = (sel + 1) % suggestions.length; renderDrop(); e.preventDefault(); }
+      else if (e.key === 'ArrowUp' && suggestions.length) { sel = (sel - 1 + suggestions.length) % suggestions.length; renderDrop(); e.preventDefault(); }
+      else if (e.key === 'Tab' && suggestions.length) { e.preventDefault(); choose(sel >= 0 ? sel : 0); }
+      else if (e.key === 'Enter') {
+        if (sel >= 0 && suggestions.length && suggestions[sel].type === 'value') { e.preventDefault(); choose(sel); }
+        else { e.preventDefault(); commitInput(); }
+      } else if (e.key === 'Escape') { closeDrop(); }
+      else if (e.key === 'Backspace' && input.value === '' && chips.length) { chips.pop(); renderChips(); fire(); }
+    });
+
+    for (const c of (opts.initial || [])) { if (c && c.value) chips.push(makeChip(normKey(c.key || ''), c.value)); }
+    renderChips();
+
+    const test = (c, str) => {
+      str = String(str == null ? '' : str);
+      if (c.regex) { try { return new RegExp(c.value, 'i').test(str); } catch (_) { return false; } }
+      return str.toLowerCase().includes(c.value.toLowerCase());
+    };
+    function chipMatches(c, row) {
+      if (c.key && byKey[c.key]) return test(c, byKey[c.key].field(row));
+      for (const fv of (opts.bareFields ? opts.bareFields(row) : [])) if (test(c, fv)) return true;
+      return false;
+    }
+    return {
+      el: wrap,
+      chips: () => chips,
+      matches: (row) => { for (const c of chips) if (!chipMatches(c, row)) return false; return true; },
+    };
+  }
+
   async function renderPodsList() {
     setContent(loadingState('Loading pods…'));
     let data;
@@ -841,18 +968,25 @@
     const sub = el('div', { style: 'color:var(--fg-dim); font-size:12px; margin-bottom:14px;' });
     root.appendChild(sub);
 
-    const filter = el('input', { placeholder: 'Filter by name or namespace…', style: listFilterStyle });
+    const nsList = [...new Set(all.map((p) => p.namespace).filter(Boolean))].sort();
+    const nameList = [...new Set(all.map((p) => p.name).filter(Boolean))].sort();
+    const statusList = [...new Set(all.map((p) => p.status || p.phase).filter(Boolean))].sort();
     const toggle = el('button', { class: 'btn' });
-    root.appendChild(el('div', { style: 'display:flex; gap:10px; align-items:center; margin-bottom:12px;' }, filter, toggle));
+    const fb = filterBar({
+      placeholder: 'Filter pods… (ns=, name=, status=, /regex/)',
+      facets: [
+        { key: 'ns', aliases: ['namespace'], label: 'namespace', field: (p) => p.namespace, suggest: () => nsList },
+        { key: 'name', label: 'name', field: (p) => p.name, suggest: () => nameList },
+        { key: 'status', label: 'status', field: (p) => p.status || p.phase, suggest: () => statusList },
+      ],
+      bareFields: (p) => [p.name, p.namespace, p.status, p.phase],
+      initial: nsExact ? [{ key: 'ns', value: nsExact }] : [],
+      onChange: () => build(),
+    });
+    root.appendChild(el('div', { style: 'display:flex; gap:10px; align-items:center; margin-bottom:12px;' }, fb.el, toggle));
 
     const podsBanner = resourceFilterBanner();
     if (podsBanner) root.appendChild(podsBanner);
-
-    if (nsExact) {
-      root.appendChild(el('div', { class: 'state', style: 'padding:10px 14px; margin-bottom:12px; display:flex; gap:12px; align-items:center;' },
-        el('span', {}, 'Showing namespace ' + nsExact),
-        el('a', { onclick: () => go('#/pods' + (unhealthyOnly ? '?health=unhealthy' : '')), style: 'cursor:pointer;' }, 'Show all →')));
-    }
 
     const card = el('div', { class: 'card' });
     card.appendChild(el('div', { class: 'objhead' },
@@ -867,15 +1001,13 @@
       toggle.textContent = (unhealthyOnly ? '✓ ' : '') + 'Unhealthy only';
     }
     function build() {
-      const term = filter.value.trim().toLowerCase();
       listWrap.innerHTML = '';
       let shown = 0;
       const podsOn = resourceEnabled('pods');
       for (const p of all) {
         if (!podsOn) break;
-        if (nsExact && p.namespace !== nsExact) continue;
         if (unhealthyOnly && !p.unhealthy) continue;
-        if (term && !(p.name.toLowerCase().includes(term) || p.namespace.toLowerCase().includes(term))) continue;
+        if (!fb.matches(p)) continue;
         const status = (p.status || p.phase || '') + (p.ready ? ' · ' + p.ready : '');
         listWrap.appendChild(objRow({ severity: p.severity, kind: 'Pod', namespace: p.namespace, name: p.name, status, num1: p.restarts ? String(p.restarts) : '', num2: p.age || '', link: p.link }));
         shown++;
@@ -884,7 +1016,6 @@
       sub.textContent = data.total + ' pods · ' + data.unhealthy + ' unhealthy · ' + shown + ' shown';
     }
     toggle.addEventListener('click', () => { unhealthyOnly = !unhealthyOnly; refreshToggle(); build(); });
-    filter.addEventListener('input', build);
     refreshToggle();
     build();
     setContent(root);

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -405,11 +405,16 @@
     row1.appendChild(issuesCard);
     root.appendChild(row1);
 
-    // Resource tiles
+    // Hint when the Resources filter is hiding some types from this page.
+    const banner = resourceFilterBanner();
+    if (banner) root.appendChild(banner);
+
+    // Resource tiles (honor the global Resources filter; keep the "+N more" tile).
     root.appendChild(el('div', { class: 'section-title' }, 'Resources captured'));
     const resourceCard = el('div', { class: 'card', style: 'margin-bottom:18px;' });
     const tileGrid = el('div', { class: 'resource-grid' });
     for (const t of (data.resources || [])) {
+      if (t.resource && !resourceEnabled(t.resource)) continue;
       tileGrid.appendChild(resourceTile(t));
     }
     resourceCard.appendChild(tileGrid);
@@ -424,11 +429,13 @@
 
     const recentCard = el('div', { class: 'card' },
       cardHeader('Recent transitions', 'last events'));
-    if (!data.recent || data.recent.length === 0) {
-      recentCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No watch events captured.'));
+    const recent = (data.recent || []).filter((t) => resourceEnabled(t.resource));
+    if (recent.length === 0) {
+      recentCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' },
+        (data.recent && data.recent.length) ? 'No transitions for the enabled resource types.' : 'No watch events captured.'));
     } else {
       const evWrap = el('div', { class: 'events' });
-      for (const t of data.recent) evWrap.appendChild(recentRow(t));
+      for (const t of recent) evWrap.appendChild(recentRow(t));
       recentCard.appendChild(evWrap);
     }
 
@@ -619,12 +626,13 @@
     }
     root.appendChild(podCard);
 
-    // Other resources tile grid
-    if (d.resources && d.resources.length > 0) {
+    // Other resources tile grid (honors the global Resources filter).
+    const nsTiles = (d.resources || []).filter((t) => !t.resource || resourceEnabled(t.resource));
+    if (nsTiles.length > 0) {
       root.appendChild(el('div', { class: 'section-title' }, 'Other resources'));
       const tileCard = el('div', { class: 'card', style: 'margin-bottom:18px;' });
       const tileGrid = el('div', { class: 'resource-grid', style: 'grid-template-columns:repeat(6, minmax(0,1fr));' });
-      for (const t of d.resources) tileGrid.appendChild(resourceTile(t));
+      for (const t of nsTiles) tileGrid.appendChild(resourceTile(t));
       tileCard.appendChild(tileGrid);
       root.appendChild(tileCard);
     }
@@ -1070,6 +1078,25 @@
   function saveEnabledResources(set) {
     try { if (set) localStorage.setItem(RES_ENABLED_KEY, JSON.stringify(Array.from(set))); else localStorage.removeItem(RES_ENABLED_KEY); } catch (_) {}
   }
+  // resourceEnabled reports whether a resource type is currently toggled on in
+  // the Resources catalog (used to globally filter other views). A null set
+  // (no customization, or "All") means everything is enabled.
+  function resourceEnabled(resource) {
+    if (!resource) return true;
+    const set = loadEnabledResources();
+    return !set || set.has(resource);
+  }
+  function resourceFilterActive() {
+    return loadEnabledResources() !== null;
+  }
+  // A small banner linking to the catalog, shown on views that honor the
+  // resource filter when it's active, so hidden data is discoverable.
+  function resourceFilterBanner() {
+    if (!resourceFilterActive()) return null;
+    return el('div', { class: 'state', style: 'padding:9px 14px; margin-bottom:14px; display:flex; gap:12px; align-items:center; font-size:12px;' },
+      el('span', {}, 'Some resource types are hidden by your Resources filter.'),
+      el('a', { onclick: () => go('#/resources'), style: 'cursor:pointer;' }, 'Manage →'));
+  }
 
   async function renderResourceCatalog() {
     setContent(loadingState('Loading resources…'));
@@ -1412,13 +1439,17 @@
       sparkChart(sparkData),
     );
     root.appendChild(sparkCard);
+    const tlBanner = resourceFilterBanner();
+    if (tlBanner) root.appendChild(tlBanner);
     root.appendChild(el('div', { class: 'section-title' }, 'All recent transitions'));
     const recentCard = el('div', { class: 'card' });
-    if (!data.recent || data.recent.length === 0) {
-      recentCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No watch events were captured. Enable `watch: true` on your config’s resource entries to see live transitions.'));
+    const tlRecent = (data.recent || []).filter((t) => resourceEnabled(t.resource));
+    if (tlRecent.length === 0) {
+      recentCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' },
+        (data.recent && data.recent.length) ? 'No transitions for the enabled resource types.' : 'No watch events were captured. Enable `watch: true` on your config’s resource entries to see live transitions.'));
     } else {
       const wrap = el('div', { class: 'events' });
-      for (const t of data.recent) wrap.appendChild(recentRow(t));
+      for (const t of tlRecent) wrap.appendChild(recentRow(t));
       recentCard.appendChild(wrap);
     }
     root.appendChild(recentCard);

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -185,6 +185,63 @@
     return n.toLocaleString('en-US');
   }
 
+  function humanBytes(n) {
+    if (!n || n < 0) return '0 B';
+    const u = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+    let i = 0, v = n;
+    while (v >= 1024 && i < u.length - 1) { v /= 1024; i++; }
+    return (i === 0 ? v : v.toFixed(1)) + ' ' + u[i];
+  }
+
+  function formatDuration(secs) {
+    secs = Math.max(0, Math.round(secs || 0));
+    const h = Math.floor(secs / 3600), m = Math.floor((secs % 3600) / 60), s = secs % 60;
+    if (h) return h + 'h' + (m ? m + 'm' : '');
+    if (m) return m + 'm' + (s ? s + 's' : '');
+    return s + 's';
+  }
+
+  // Capture details card for the overview, fed by /v2/api/capture.
+  function captureDetailsCard() {
+    const card = el('div', { class: 'card', style: 'margin-bottom:18px;' }, cardHeader('Capture details', ''));
+    const body = el('div', {}, loadingState('Loading…'));
+    card.appendChild(body);
+    getJSON('/v2/api/capture')
+      .then((c) => { body.innerHTML = ''; body.appendChild(captureMetaGrid(c)); })
+      .catch(() => { body.innerHTML = ''; body.appendChild(el('div', { class: 'state', style: 'padding:14px;' }, 'Capture details unavailable.')); });
+    return card;
+  }
+
+  function captureMetaGrid(c) {
+    const grid = el('div', { class: 'capmeta' });
+    const row = (k, v) => {
+      if (v === null || v === undefined || v === '') return;
+      grid.appendChild(el('div', { class: 'row' }, el('span', { class: 'k' }, k), el('span', { class: 'v' }, String(v))));
+    };
+    row('Captured', c.captured_at ? new Date(c.captured_at).toLocaleString() : '');
+    row('Until', c.captured_until ? new Date(c.captured_until).toLocaleString() : '');
+    row('Length', formatDuration(c.duration_seconds));
+    row('Kubernetes', c.kubernetes_version);
+    row('Server', c.server_address);
+    row('Archive size', c.compressed_bytes ? humanBytes(c.compressed_bytes) + ' compressed' : '');
+    row('Uncompressed', c.uncompressed_bytes ? humanBytes(c.uncompressed_bytes) : (c.has_config_meta ? '' : 'not recorded'));
+    row('Records', formatNumber(c.record_count || 0) + (c.deduplicated_count ? ' · ' + formatNumber(c.deduplicated_count) + ' deduplicated' : ''));
+    row('Resource paths', formatNumber(c.resource_paths || 0));
+    row('Resource types', formatNumber(c.resource_types || 0));
+    row('Namespaces', formatNumber(c.namespaces || 0));
+    row('Watch events', formatNumber(c.watch_events || 0));
+    if (c.has_config_meta) {
+      row('Dynamic discovery', c.auto_discovered ? 'yes' : 'no');
+      row('Watch enabled', c.watch_enabled ? 'yes' : 'no');
+      if (c.intervals && c.intervals.length) row('Poll interval(s)', c.intervals.join(', '));
+      row('Redaction', c.redacted ? ('yes' + ((c.secrets_redacted || c.fields_redacted) ? ' (' + (c.secrets_redacted || 0) + ' secrets, ' + (c.fields_redacted || 0) + ' fields)' : '')) : 'no');
+    } else {
+      row('Capture config', 'not recorded (captured before this was tracked)');
+    }
+    row('Archive', c.archive_path);
+    return grid;
+  }
+
   // ── Syntax highlighting (dependency-free, builds DOM nodes via textContent
   //    so captured content can never inject markup) ──────────────────────────
   function tok(cls, text) {
@@ -254,11 +311,44 @@
   // codeBlock renders text as a highlighted <pre>. Highlighting is skipped for
   // very large bodies to keep rendering snappy.
   function codeBlock(text, lang) {
-    const pre = el('pre', { class: 'code', style: 'max-height:calc(100vh - 320px); padding:14px;' });
+    const pre = el('pre', { class: 'code', style: 'max-height:calc(100vh - 360px); padding:14px;' });
     text = text || '';
     if (text.length > 300000) { pre.textContent = text; return pre; }
     pre.appendChild(lang === 'json' ? highlightJSON(text) : highlightYAML(text));
     return pre;
+  }
+
+  function copyToClipboard(text, btn) {
+    const flash = () => { const old = btn.textContent; btn.textContent = '✓ Copied'; setTimeout(() => { btn.textContent = old; }, 1200); };
+    const fallback = () => {
+      const ta = document.createElement('textarea');
+      ta.value = text; ta.style.position = 'fixed'; ta.style.opacity = '0';
+      document.body.appendChild(ta); ta.select();
+      try { document.execCommand('copy'); flash(); } catch (_) {}
+      document.body.removeChild(ta);
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(flash).catch(fallback);
+    } else { fallback(); }
+  }
+
+  function downloadText(text, filename, mime) {
+    const blob = new Blob([text], { type: mime || 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = el('a', { href: url, download: filename });
+    document.body.appendChild(a); a.click(); document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
+  // codePanel wraps a codeBlock with Copy / Download actions.
+  function codePanel(text, lang, baseName) {
+    text = text || '';
+    const wrap = el('div', {});
+    const copyBtn = el('button', { class: 'btn', onclick: () => copyToClipboard(text, copyBtn) }, 'Copy');
+    const dlBtn = el('button', { class: 'btn', onclick: () => downloadText(text, (baseName || 'object') + '.' + lang, lang === 'json' ? 'application/json' : 'application/yaml') }, 'Download');
+    wrap.appendChild(el('div', { style: 'display:flex; gap:8px; margin-bottom:10px;' }, copyBtn, dlBtn));
+    wrap.appendChild(codeBlock(text, lang));
+    return wrap;
   }
 
   function sparkChart(sparkline) {
@@ -388,6 +478,9 @@
       link: '#/timeline',
     }));
     root.appendChild(kpiStrip);
+
+    // Capture details (file size, timing, config facts).
+    root.appendChild(captureDetailsCard());
 
     // Spark + issues row
     const sparkCard = el('div', { class: 'card' },
@@ -885,6 +978,9 @@
     let data = null, mode = 'yaml';
     const ybtn = el('button', { class: 'btn primary', onclick: () => { mode = 'yaml'; paint(); } }, 'YAML');
     const jbtn = el('button', { class: 'btn', onclick: () => { mode = 'json'; paint(); } }, 'JSON');
+    const curText = () => data ? (mode === 'yaml' ? data.yaml : data.json) || '' : '';
+    const copyBtn = el('button', { class: 'btn', onclick: () => copyToClipboard(curText(), copyBtn) }, 'Copy');
+    const dlBtn = el('button', { class: 'btn', onclick: () => downloadText(curText(), (name || 'object') + '.' + mode, mode === 'json' ? 'application/json' : 'application/yaml') }, 'Download');
     function paint() {
       host.innerHTML = '';
       if (!data) return;
@@ -893,7 +989,7 @@
       ybtn.className = 'btn' + (mode === 'yaml' ? ' primary' : '');
       jbtn.className = 'btn' + (mode === 'json' ? ' primary' : '');
     }
-    wrap.appendChild(el('div', { style: 'display:flex; gap:8px; margin-bottom:10px;' }, ybtn, jbtn));
+    wrap.appendChild(el('div', { style: 'display:flex; gap:8px; margin-bottom:10px;' }, ybtn, jbtn, copyBtn, dlBtn));
     wrap.appendChild(host);
     getJSON('/v2/api/object?path=' + encodeURIComponent(path) + (name ? '&name=' + encodeURIComponent(name) : ''))
       .then((d) => { data = d; paint(); })
@@ -997,9 +1093,10 @@
     ));
     if (!d.found) { root.appendChild(el('div', { class: 'state', style: 'padding:24px;' }, 'Object not present at this snapshot.')); setContent(root); return; }
 
+    const baseName = name || parsed.resource;
     const panelDefs = [
-      { key: 'yaml', label: 'YAML', build: () => codeBlock(d.yaml || '', 'yaml') },
-      { key: 'json', label: 'JSON', build: () => codeBlock(d.json || '', 'json') },
+      { key: 'yaml', label: 'YAML', build: () => codePanel(d.yaml || '', 'yaml', baseName) },
+      { key: 'json', label: 'JSON', build: () => codePanel(d.json || '', 'json', baseName) },
       { key: 'history', label: 'History', build: () => objectHistoryPanel(path, name) },
       { key: 'diff', label: 'Diff', build: () => objectDiffPanel(path, name) },
     ];
@@ -1161,9 +1258,23 @@
       }
       const gnames = Object.keys(groups).sort();
       let shown = 0, enabledCount = 0;
+      const setGroup = (rows, on) => {
+        if (!enabled) enabled = new Set(all.map((x) => x.resource));
+        for (const r of rows) { if (on) enabled.add(r.resource); else enabled.delete(r.resource); }
+        saveEnabledResources(enabled);
+        build();
+      };
       for (const g of gnames) {
         const rows = groups[g];
-        body.appendChild(el('div', { class: 'cat-group' }, el('span', { class: 'g' }, g), el('span', { class: 'gc' }, rows.length + ' kind' + (rows.length !== 1 ? 's' : ''))));
+        const onInGroup = rows.filter((r) => isOn(r.resource)).length;
+        const gcb = el('input', { type: 'checkbox' });
+        gcb.checked = onInGroup === rows.length;
+        gcb.indeterminate = onInGroup > 0 && onInGroup < rows.length;
+        gcb.addEventListener('change', () => setGroup(rows, gcb.checked));
+        body.appendChild(el('div', { class: 'cat-group' },
+          gcb,
+          el('span', { class: 'g', onclick: () => setGroup(rows, onInGroup !== rows.length) }, g),
+          el('span', { class: 'gc' }, onInGroup + '/' + rows.length + ' enabled')));
         for (const r of rows) {
           shown++;
           if (isOn(r.resource)) enabledCount++;

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -45,7 +45,7 @@
     if (qIdx >= 0) h = h.slice(0, qIdx);
     const parts = h.split('/').filter(Boolean);
     if (parts.length === 0) return { name: 'overview' };
-    if (parts[0] === 'overview' || parts[0] === 'namespaces' || parts[0] === 'pods' || parts[0] === 'workloads' || parts[0] === 'resource' || parts[0] === 'object' || parts[0] === 'timeline' || parts[0] === 'logs' || parts[0] === 'diff') {
+    if (parts[0] === 'overview' || parts[0] === 'namespaces' || parts[0] === 'pods' || parts[0] === 'workloads' || parts[0] === 'resources' || parts[0] === 'resource' || parts[0] === 'object' || parts[0] === 'timeline' || parts[0] === 'logs' || parts[0] === 'diff') {
       return { name: parts[0] };
     }
     if (parts[0] === 'ns' && parts[1]) {
@@ -78,12 +78,14 @@
       { key: 'namespaces', label: 'Namespaces', hash: '#/namespaces' },
       { key: 'workloads',  label: 'Workloads',  hash: '#/workloads' },
       { key: 'pods',       label: 'Pods',       hash: '#/pods' },
+      { key: 'resources',  label: 'Resources',  hash: '#/resources' },
       { key: 'timeline',   label: 'Timeline',   hash: '#/timeline' },
       { key: 'logs',       label: 'Logs',       hash: '#/logs' },
       { key: 'diff',       label: 'Diff',       hash: '#/diff' },
     ];
     const activeKey = state.route.name === 'namespace' ? 'namespaces'
       : state.route.name === 'pod' ? 'pods'
+      : (state.route.name === 'resource' || state.route.name === 'object') ? 'resources'
       : state.route.name;
     for (const it of items) {
       nav.appendChild(el('div', {
@@ -181,6 +183,82 @@
   function formatNumber(n) {
     if (typeof n !== 'number') return n;
     return n.toLocaleString('en-US');
+  }
+
+  // ── Syntax highlighting (dependency-free, builds DOM nodes via textContent
+  //    so captured content can never inject markup) ──────────────────────────
+  function tok(cls, text) {
+    const s = document.createElement('span');
+    s.className = cls;
+    s.textContent = text;
+    return s;
+  }
+
+  function highlightJSON(text) {
+    const frag = document.createDocumentFragment();
+    const re = /("(?:\\.|[^"\\])*")(\s*:)?|\b(true|false|null)\b|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g;
+    let last = 0, m;
+    while ((m = re.exec(text)) !== null) {
+      if (m.index > last) frag.appendChild(document.createTextNode(text.slice(last, m.index)));
+      if (m[1] !== undefined) {
+        const isKey = m[2] !== undefined;
+        frag.appendChild(tok(isKey ? 'k-key' : 'k-str', m[1]));
+        if (isKey) frag.appendChild(document.createTextNode(m[2]));
+      } else if (m[3] !== undefined) {
+        frag.appendChild(tok('k-lit', m[3]));
+      } else if (m[4] !== undefined) {
+        frag.appendChild(tok('k-num', m[4]));
+      }
+      last = re.lastIndex;
+    }
+    if (last < text.length) frag.appendChild(document.createTextNode(text.slice(last)));
+    return frag;
+  }
+
+  function yamlScalar(frag, s) {
+    if (s === '') return;
+    const t = s.trim();
+    if (/^(true|false|null|~)$/i.test(t)) frag.appendChild(tok('k-lit', s));
+    else if (/^-?\d+(\.\d+)?$/.test(t)) frag.appendChild(tok('k-num', s));
+    else frag.appendChild(tok('k-str', s));
+  }
+
+  function highlightYAML(text) {
+    const frag = document.createDocumentFragment();
+    const lines = text.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      let m;
+      if ((m = line.match(/^(\s*)(#.*)$/))) {
+        frag.appendChild(document.createTextNode(m[1]));
+        frag.appendChild(tok('k-com', m[2]));
+      } else if ((m = line.match(/^(\s*)(- )?([^:\s][^:]*?):(\s*)(.*)$/))) {
+        frag.appendChild(document.createTextNode(m[1]));
+        if (m[2]) frag.appendChild(tok('k-punc', m[2]));
+        frag.appendChild(tok('k-key', m[3]));
+        frag.appendChild(tok('k-punc', ':'));
+        frag.appendChild(document.createTextNode(m[4]));
+        yamlScalar(frag, m[5]);
+      } else if ((m = line.match(/^(\s*)(- )(.*)$/))) {
+        frag.appendChild(document.createTextNode(m[1]));
+        frag.appendChild(tok('k-punc', m[2]));
+        yamlScalar(frag, m[3]);
+      } else {
+        yamlScalar(frag, line);
+      }
+      if (i < lines.length - 1) frag.appendChild(document.createTextNode('\n'));
+    }
+    return frag;
+  }
+
+  // codeBlock renders text as a highlighted <pre>. Highlighting is skipped for
+  // very large bodies to keep rendering snappy.
+  function codeBlock(text, lang) {
+    const pre = el('pre', { class: 'code', style: 'max-height:calc(100vh - 320px); padding:14px;' });
+    text = text || '';
+    if (text.length > 300000) { pre.textContent = text; return pre; }
+    pre.appendChild(lang === 'json' ? highlightJSON(text) : highlightYAML(text));
+    return pre;
   }
 
   function sparkChart(sparkline) {
@@ -773,24 +851,27 @@
     return '';
   }
 
-  // rawObjectPanel fetches one object and shows it as YAML/JSON with a toggle.
+  // rawObjectPanel fetches one object and shows it as highlighted YAML/JSON
+  // with a toggle.
   function rawObjectPanel(path, name) {
     const wrap = el('div', {});
-    const pre = el('pre', { class: 'log-preview', style: 'max-height:calc(100vh - 360px); padding:14px;' }, 'Loading…');
+    const host = el('div', {}, loadingState('Loading…'));
     let data = null, mode = 'yaml';
     const ybtn = el('button', { class: 'btn primary', onclick: () => { mode = 'yaml'; paint(); } }, 'YAML');
     const jbtn = el('button', { class: 'btn', onclick: () => { mode = 'json'; paint(); } }, 'JSON');
     function paint() {
+      host.innerHTML = '';
       if (!data) return;
-      pre.textContent = mode === 'yaml' ? (data.yaml || '') : (data.json || '');
+      if (!data.found) { host.appendChild(el('div', { class: 'state', style: 'padding:14px;' }, 'Object not present at this snapshot.')); return; }
+      host.appendChild(codeBlock(mode === 'yaml' ? data.yaml : data.json, mode));
       ybtn.className = 'btn' + (mode === 'yaml' ? ' primary' : '');
       jbtn.className = 'btn' + (mode === 'json' ? ' primary' : '');
     }
     wrap.appendChild(el('div', { style: 'display:flex; gap:8px; margin-bottom:10px;' }, ybtn, jbtn));
-    wrap.appendChild(pre);
+    wrap.appendChild(host);
     getJSON('/v2/api/object?path=' + encodeURIComponent(path) + (name ? '&name=' + encodeURIComponent(name) : ''))
-      .then((d) => { data = d; if (!d.found) { pre.textContent = 'Object not present at this snapshot.'; return; } paint(); })
-      .catch((e) => { pre.textContent = 'Error: ' + e.message; });
+      .then((d) => { data = d; paint(); })
+      .catch((e) => { host.innerHTML = ''; host.appendChild(errorState(e.message)); });
     return wrap;
   }
 
@@ -891,8 +972,8 @@
     if (!d.found) { root.appendChild(el('div', { class: 'state', style: 'padding:24px;' }, 'Object not present at this snapshot.')); setContent(root); return; }
 
     const panelDefs = [
-      { key: 'yaml', label: 'YAML', build: () => el('pre', { class: 'log-preview', style: 'max-height:calc(100vh - 320px); padding:14px;' }, d.yaml || '') },
-      { key: 'json', label: 'JSON', build: () => el('pre', { class: 'log-preview', style: 'max-height:calc(100vh - 320px); padding:14px;' }, d.json || '') },
+      { key: 'yaml', label: 'YAML', build: () => codeBlock(d.yaml || '', 'yaml') },
+      { key: 'json', label: 'JSON', build: () => codeBlock(d.json || '', 'json') },
       { key: 'history', label: 'History', build: () => objectHistoryPanel(path, name) },
       { key: 'diff', label: 'Diff', build: () => objectDiffPanel(path, name) },
     ];
@@ -974,6 +1055,90 @@
       sub.textContent = d.total + ' ' + resource + ' · ' + shown + ' shown';
     }
     filter.addEventListener('input', build);
+    build();
+    setContent(root);
+  }
+
+  // Resources catalog: every captured API resource type, grouped by API group,
+  // with per-resource toggles (persisted, v1-sidebar style) and links to the
+  // resource list.
+  const RES_ENABLED_KEY = 'kshrk.v2.resources.enabled';
+  function loadEnabledResources() {
+    try { const s = localStorage.getItem(RES_ENABLED_KEY); if (s) return new Set(JSON.parse(s)); } catch (_) {}
+    return null; // null means "all enabled"
+  }
+  function saveEnabledResources(set) {
+    try { if (set) localStorage.setItem(RES_ENABLED_KEY, JSON.stringify(Array.from(set))); else localStorage.removeItem(RES_ENABLED_KEY); } catch (_) {}
+  }
+
+  async function renderResourceCatalog() {
+    setContent(loadingState('Loading resources…'));
+    let d;
+    try {
+      d = await getJSON('/v2/api/resources');
+    } catch (e) {
+      setContent(errorState(e.message));
+      return;
+    }
+    const all = d.resources || [];
+    let enabled = loadEnabledResources();
+    const isOn = (res) => !enabled || enabled.has(res);
+
+    const root = el('div', {});
+    root.appendChild(el('div', { class: 'section-title', style: 'font-size:15px; margin-bottom:2px;' }, 'API resources'));
+    const sub = el('div', { style: 'color:var(--fg-dim); font-size:12px; margin-bottom:14px;' });
+    root.appendChild(sub);
+
+    const filter = el('input', { placeholder: 'Filter by kind, resource or group…', style: listFilterStyle });
+    const allBtn = el('button', { class: 'btn' }, 'All');
+    const noneBtn = el('button', { class: 'btn' }, 'None');
+    root.appendChild(el('div', { style: 'display:flex; gap:10px; align-items:center; margin-bottom:8px;' }, filter, allBtn, noneBtn));
+
+    const body = el('div', {});
+    root.appendChild(body);
+
+    function build() {
+      const term = filter.value.trim().toLowerCase();
+      body.innerHTML = '';
+      const groups = {};
+      for (const r of all) {
+        if (term && !(r.resource.toLowerCase().includes(term) || r.kind.toLowerCase().includes(term) || (r.group || 'core').toLowerCase().includes(term))) continue;
+        const g = r.group || 'core';
+        (groups[g] = groups[g] || []).push(r);
+      }
+      const gnames = Object.keys(groups).sort();
+      let shown = 0, enabledCount = 0;
+      for (const g of gnames) {
+        const rows = groups[g];
+        body.appendChild(el('div', { class: 'cat-group' }, el('span', { class: 'g' }, g), el('span', { class: 'gc' }, rows.length + ' kind' + (rows.length !== 1 ? 's' : ''))));
+        for (const r of rows) {
+          shown++;
+          if (isOn(r.resource)) enabledCount++;
+          const cb = el('input', { type: 'checkbox' });
+          cb.checked = isOn(r.resource);
+          cb.addEventListener('change', () => {
+            if (!enabled) enabled = new Set(all.map((x) => x.resource));
+            if (cb.checked) enabled.add(r.resource); else enabled.delete(r.resource);
+            saveEnabledResources(enabled);
+            build();
+          });
+          body.appendChild(el('div', { class: 'cat-row' + (isOn(r.resource) ? '' : ' off') },
+            cb,
+            el('span', { class: 'kind' }, r.kind),
+            el('span', { class: 'nm', style: 'cursor:pointer;', onclick: () => go(r.link) }, r.resource),
+            el('span', { class: 'meta' }, (r.group ? r.group + '/' : '') + r.version),
+            el('span', { class: 'badge' }, r.namespaced ? 'namespaced' : 'cluster'),
+            el('span', { class: 'num' }, r.count ? formatNumber(r.count) : ''),
+            el('a', { class: 'go', style: 'cursor:pointer;', onclick: () => go(r.link) }, '→'),
+          ));
+        }
+      }
+      if (!shown) body.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No resources match.'));
+      sub.textContent = d.total + ' resource types · ' + enabledCount + ' enabled';
+    }
+    filter.addEventListener('input', build);
+    allBtn.addEventListener('click', () => { enabled = null; saveEnabledResources(enabled); build(); });
+    noneBtn.addEventListener('click', () => { enabled = new Set(); saveEnabledResources(enabled); build(); });
     build();
     setContent(root);
   }
@@ -1444,6 +1609,7 @@
     if (r.name === 'namespaces') return renderNamespacesIndex();
     if (r.name === 'pods') return renderPodsList();
     if (r.name === 'workloads') return renderWorkloadsList();
+    if (r.name === 'resources') return renderResourceCatalog();
     if (r.name === 'resource') return renderResourceList();
     if (r.name === 'object') return renderObject();
     if (r.name === 'namespace') return renderNamespace(r.ns);

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -600,6 +600,8 @@
     }
 
     const root = el('div', {});
+    // Assigned once the tab bar is built below; hero action buttons jump to a tab.
+    let selectTab = () => {};
 
     // Hero
     const sevToBadge = { good: 'good', warn: 'warn', bad: 'bad' };
@@ -623,31 +625,14 @@
         ),
         el('div', { class: 'hero-actions' },
           el('button', { class: 'btn', onclick: () => go('#/logs?ns=' + encodeURIComponent(d.namespace) + '&pod=' + encodeURIComponent(d.name)) }, '▶ Logs'),
-          el('button', { class: 'btn' }, 'Events · ' + ((d.events || []).length)),
-          el('button', { class: 'btn' }, '⏷ Compare snapshots'),
-          el('button', { class: 'btn' }, 'YAML'),
+          el('button', { class: 'btn', onclick: () => selectTab('events') }, 'Events · ' + ((d.events || []).length)),
+          el('button', { class: 'btn', onclick: () => go('#/diff?path=' + encodeURIComponent('/api/v1/namespaces/' + d.namespace + '/pods') + '&name=' + encodeURIComponent(d.name)) }, '⏷ Compare snapshots'),
+          el('button', { class: 'btn', onclick: () => selectTab('yaml') }, 'YAML'),
         ),
       ),
     ));
 
-    // Sub-tabs (visual only — content scrolled-to vertically since this is a single page for now)
-    const subtabs = el('div', { class: 'subtabs', style: 'margin:0 -20px 18px;' });
-    for (const [label, ct] of [
-      ['Summary', null],
-      ['Containers', (d.containers || []).length],
-      ['Logs', (d.containers || []).filter((c) => (c.log_preview || []).length > 0).length + ' captured'],
-      ['Events', (d.events || []).length],
-      ['History', (d.history || []).length],
-      ['YAML', null],
-      ['Relationships', null],
-    ]) {
-      const t = el('div', { class: 'tab' + (label === 'Summary' ? ' active' : '') }, label);
-      if (ct !== null) t.appendChild(el('span', { class: 'ct' }, ' · ' + ct));
-      subtabs.appendChild(t);
-    }
-    root.appendChild(subtabs);
-
-    // KPIs
+    // KPIs (persistent — shown under the tab bar on every tab).
     const kpis = d.kpis || {};
     const kpiStrip = el('div', { class: 'kpis k6' });
     kpiStrip.appendChild(kpi('Phase', kpis.phase || '?', {
@@ -661,113 +646,176 @@
     kpiStrip.appendChild(kpi('Ready', kpis.ready || '0/0'));
     kpiStrip.appendChild(kpi('Node', kpis.node || '—', { delta: kpis.pod_ip || '' }));
     kpiStrip.appendChild(kpi('QoS', kpis.qos_class || '—'));
-    root.appendChild(kpiStrip);
 
-    // Restart sparkline + recent events
-    const sparkData = { buckets: d.restart_sparkline || [], total_events: (d.restart_sparkline || []).reduce((s, b) => s + (b.total || 0), 0), start_time: d.capture?.captured_at, end_time: d.capture?.captured_until };
-    const sparkCard = el('div', { class: 'card' },
-      cardHeader('Container restarts over capture window', sparkData.total_events + ' events'),
-      sparkChart(sparkData),
+    // ── Tab panels ───────────────────────────────────────────────────────────
+    const emptyState = (msg) => el('div', { class: 'state', style: 'padding:24px;' }, msg);
+
+    const eventRow = (ev) => el('div', { class: 'event ' + (ev.severity || 'normal') },
+      el('span', { class: 'kind ' + (ev.severity === 'bad' ? 'bad' : (ev.severity === 'warn' ? 'warn' : '')) }, ev.reason || ''),
+      el('span', { class: 'body' },
+        el('b', {}, ev.message || ev.reason || ''),
+        ev.source || ev.count ? el('span', { class: 'small' }, (ev.source ? ev.source : '') + (ev.count ? ' · ' + ev.count + 'x' : '')) : null,
+      ),
+      el('span', { class: 'age' }, formatShortTS(ev.time)),
     );
-    const evCard = el('div', { class: 'card' }, cardHeader('Recent events', String((d.events || []).length)));
-    if (!d.events || d.events.length === 0) {
-      evCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No events captured for this pod. (Did the capture include /api/v1/events?)'));
-    } else {
-      const wrap = el('div', { class: 'events' });
-      for (const ev of d.events.slice(0, 6)) {
-        wrap.appendChild(el('div', { class: 'event ' + (ev.severity || 'normal') },
-          el('span', { class: 'kind ' + (ev.severity === 'bad' ? 'bad' : (ev.severity === 'warn' ? 'warn' : '')) }, ev.reason || ''),
-          el('span', { class: 'body' },
-            el('b', {}, ev.message || ev.reason || ''),
-            ev.source || ev.count ? el('span', { class: 'small' },
-              (ev.source ? ev.source : '') + (ev.count ? ' · ' + ev.count + 'x' : ''),
-            ) : null,
-          ),
-          el('span', { class: 'age' }, formatShortTS(ev.time)),
-        ));
-      }
-      evCard.appendChild(wrap);
-    }
-    const row1 = el('div', { class: 'grid-2', style: 'margin-bottom:18px;' });
-    row1.appendChild(sparkCard);
-    row1.appendChild(evCard);
-    root.appendChild(row1);
 
-    // Containers
-    root.appendChild(el('div', { class: 'section-title' }, 'Containers (' + (d.containers || []).length + ')'));
-    const containersCard = el('div', { class: 'card', style: 'margin-bottom:18px;' });
-    for (const c of (d.containers || [])) {
-      containersCard.appendChild(containerCardEl(c));
-    }
-    root.appendChild(containersCard);
-
-    // Metadata + history
-    const grid = el('div', { class: 'grid-2' });
-
-    // Metadata card
-    const metaCard = el('div', { class: 'card' }, cardHeader('Metadata', ''));
     const metaRow = (k, v, color) => el('div', { style: 'display:grid; grid-template-columns:140px 1fr; gap:8px; font-size:12.5px;' },
       el('span', { style: 'color:var(--fg-faint);' }, k),
       el('span', { style: 'font-family:var(--mono); color:' + (color || 'var(--fg)') + ';' }, v));
-    if (d.related?.owner) metaCard.appendChild(metaRow('Owner', (d.related.owner.kind || '') + '/' + (d.related.owner.name || '')));
-    if (d.kpis?.node) metaCard.appendChild(metaRow('Node', d.kpis.node));
-    if (d.kpis?.pod_ip) metaCard.appendChild(metaRow('Pod IP', d.kpis.pod_ip));
-    if (d.metadata?.created_at) metaCard.appendChild(metaRow('Created', d.metadata.created_at));
-    if (d.metadata?.labels && Object.keys(d.metadata.labels).length > 0) {
-      const labWrap = el('div', { class: 'labels', style: 'margin-top:10px;' });
-      for (const k of Object.keys(d.metadata.labels)) {
-        labWrap.appendChild(el('span', { class: 'lab' }, k + '=' + d.metadata.labels[k]));
-      }
-      metaCard.appendChild(el('div', { class: 'section-title', style: 'margin-top:10px;' }, 'Labels'));
-      metaCard.appendChild(labWrap);
-    }
-    if (d.metadata?.conditions && d.metadata.conditions.length > 0) {
-      metaCard.appendChild(el('div', { class: 'section-title', style: 'margin-top:10px;' }, 'Conditions'));
-      for (const c of d.metadata.conditions) {
-        const sevColor = c.severity === 'good' ? 'var(--good)' : c.severity === 'bad' ? 'var(--bad)' : 'var(--fg-dim)';
-        metaCard.appendChild(metaRow(c.type, c.status + (c.reason ? ' · ' + c.reason : ''), sevColor));
-      }
-    }
-    grid.appendChild(metaCard);
 
-    // History card
-    const histCard = el('div', { class: 'card' }, cardHeader('State history in capture', ''));
-    if (!d.history || d.history.length === 0) {
-      histCard.appendChild(el('div', { class: 'state', style: 'padding:14px;' }, 'No watch events captured for this pod.'));
-    } else {
-      for (const t of d.history.slice(0, 12)) {
+    function buildSummary() {
+      const wrap = el('div', {});
+      const sparkData = { buckets: d.restart_sparkline || [], total_events: (d.restart_sparkline || []).reduce((s, b) => s + (b.total || 0), 0), start_time: d.capture?.captured_at, end_time: d.capture?.captured_until };
+      const sparkCard = el('div', { class: 'card' },
+        cardHeader('Container restarts over capture window', sparkData.total_events + ' events'),
+        sparkChart(sparkData));
+      const evCard = el('div', { class: 'card' }, cardHeader('Recent events', String((d.events || []).length)));
+      if (!d.events || d.events.length === 0) {
+        evCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No events captured for this pod. (Did the capture include /api/v1/events?)'));
+      } else {
+        const w = el('div', { class: 'events' });
+        for (const ev of d.events.slice(0, 6)) w.appendChild(eventRow(ev));
+        evCard.appendChild(w);
+      }
+      const row1 = el('div', { class: 'grid-2', style: 'margin-bottom:18px;' });
+      row1.appendChild(sparkCard);
+      row1.appendChild(evCard);
+      wrap.appendChild(row1);
+
+      const metaCard = el('div', { class: 'card' }, cardHeader('Metadata', ''));
+      if (d.related?.owner) metaCard.appendChild(metaRow('Owner', (d.related.owner.kind || '') + '/' + (d.related.owner.name || '')));
+      if (d.kpis?.node) metaCard.appendChild(metaRow('Node', d.kpis.node));
+      if (d.kpis?.pod_ip) metaCard.appendChild(metaRow('Pod IP', d.kpis.pod_ip));
+      if (d.metadata?.created_at) metaCard.appendChild(metaRow('Created', d.metadata.created_at));
+      if (d.metadata?.labels && Object.keys(d.metadata.labels).length > 0) {
+        metaCard.appendChild(el('div', { class: 'section-title', style: 'margin-top:10px;' }, 'Labels'));
+        const labWrap = el('div', { class: 'labels', style: 'margin-top:10px;' });
+        for (const k of Object.keys(d.metadata.labels)) labWrap.appendChild(el('span', { class: 'lab' }, k + '=' + d.metadata.labels[k]));
+        metaCard.appendChild(labWrap);
+      }
+      if (d.metadata?.conditions && d.metadata.conditions.length > 0) {
+        metaCard.appendChild(el('div', { class: 'section-title', style: 'margin-top:10px;' }, 'Conditions'));
+        for (const c of d.metadata.conditions) {
+          const sevColor = c.severity === 'good' ? 'var(--good)' : c.severity === 'bad' ? 'var(--bad)' : 'var(--fg-dim)';
+          metaCard.appendChild(metaRow(c.type, c.status + (c.reason ? ' · ' + c.reason : ''), sevColor));
+        }
+      }
+      wrap.appendChild(metaCard);
+      return wrap;
+    }
+
+    function buildContainers() {
+      if (!(d.containers || []).length) return emptyState('No containers found for this pod.');
+      const card = el('div', { class: 'card' });
+      for (const c of d.containers) card.appendChild(containerCardEl(c));
+      return card;
+    }
+
+    function buildLogs() {
+      const withLogs = (d.containers || []).filter((c) => (c.log_preview || []).length > 0 || c.log_path);
+      if (!withLogs.length) return emptyState('No logs captured for this pod. Set "logs: <N>" on the pods resource in the capture config to capture container logs.');
+      const wrap = el('div', {});
+      for (const c of withLogs) {
+        const card = el('div', { class: 'card', style: 'margin-bottom:14px;' },
+          cardHeader('Logs · ' + c.name, (c.role && c.role !== 'main') ? c.role : ''));
+        if ((c.log_preview || []).length) {
+          card.appendChild(el('pre', { class: 'log-preview', style: 'max-height:340px; padding:12px;' }, c.log_preview.join('\n')));
+        } else {
+          card.appendChild(el('div', { class: 'state', style: 'padding:12px;' }, 'No preview captured.'));
+        }
+        const actions = el('div', { style: 'display:flex; gap:8px; margin-top:10px;' });
+        if (c.log_path) actions.appendChild(el('button', { class: 'btn', onclick: () => go(c.log_path) }, 'Open full logs'));
+        if (c.has_previous_log && c.log_path) actions.appendChild(el('button', { class: 'btn', onclick: () => go(c.log_path + '&previous=true') }, 'Previous logs'));
+        if (actions.childNodes.length) card.appendChild(actions);
+        wrap.appendChild(card);
+      }
+      return wrap;
+    }
+
+    function buildEvents() {
+      if (!d.events || d.events.length === 0) return emptyState('No events captured for this pod. (Did the capture include /api/v1/events?)');
+      const card = el('div', { class: 'card' }, cardHeader('Events', String(d.events.length)));
+      const w = el('div', { class: 'events' });
+      for (const ev of d.events) w.appendChild(eventRow(ev));
+      card.appendChild(w);
+      return card;
+    }
+
+    function buildHistory() {
+      if (!d.history || d.history.length === 0) return emptyState('No watch events captured for this pod. Enable "watch: true" on the pods resource to record transitions.');
+      const card = el('div', { class: 'card' }, cardHeader('State history in capture', String(d.history.length)));
+      for (const t of d.history) {
         const evCls = t.event_type === 'ADDED' ? 'added' : (t.event_type === 'DELETED' ? 'deleted' : 'modified');
-        histCard.appendChild(el('div', { class: 'timeline-row' },
+        card.appendChild(el('div', { class: 'timeline-row' },
           el('span', { class: 'ts' }, formatShortTS(t.time)),
           el('span', { class: 'dot ' + evCls }),
           el('span', { class: 'ev' }, t.event_type + (t.detail ? ' · ' + t.detail : '')),
         ));
       }
+      return card;
     }
-    if (d.related) {
-      histCard.appendChild(el('div', { class: 'section-title', style: 'margin-top:12px;' }, 'Related'));
-      if (d.related.owner) histCard.appendChild(el('div', { class: 'timeline-row' },
-        el('span', { class: 'ts' }, 'Owner'),
-        el('span', { class: 'ev' }, d.related.owner.kind + '/' + d.related.owner.name)));
-      for (const cm of (d.related.config_maps || [])) {
-        histCard.appendChild(el('div', { class: 'timeline-row' },
-          el('span', { class: 'ts' }, 'Mounts CM'),
-          el('span', { class: 'ev' }, cm.name)));
-      }
-      for (const s of (d.related.secrets || [])) {
-        histCard.appendChild(el('div', { class: 'timeline-row' },
-          el('span', { class: 'ts' }, 'Mounts Secret'),
-          el('span', { class: 'ev' }, s.name)));
-      }
-      for (const p of (d.related.pvcs || [])) {
-        histCard.appendChild(el('div', { class: 'timeline-row' },
-          el('span', { class: 'ts' }, 'Mounts PVC'),
-          el('span', { class: 'ev' }, p.name)));
-      }
-    }
-    grid.appendChild(histCard);
 
-    root.appendChild(grid);
+    function buildRelationships() {
+      const r = d.related || {};
+      const rows = [];
+      if (r.owner) rows.push(['Owner', r.owner.kind + '/' + r.owner.name]);
+      if (r.workload) rows.push(['Workload', r.workload.kind + '/' + r.workload.name]);
+      if (typeof r.sibling_pods === 'number' && r.sibling_pods > 0) rows.push(['Sibling pods', String(r.sibling_pods)]);
+      for (const cm of (r.config_maps || [])) rows.push(['Mounts ConfigMap', cm.name]);
+      for (const s of (r.secrets || [])) rows.push(['Mounts Secret', s.name]);
+      for (const p of (r.pvcs || [])) rows.push(['Mounts PVC', p.name]);
+      if (!rows.length) return emptyState('No related objects found for this pod.');
+      const card = el('div', { class: 'card' }, cardHeader('Relationships', String(rows.length)));
+      for (const [k, v] of rows) {
+        card.appendChild(el('div', { class: 'timeline-row' },
+          el('span', { class: 'ts' }, k),
+          el('span', { class: 'ev' }, v)));
+      }
+      return card;
+    }
+
+    function buildYaml() {
+      return emptyState('Raw YAML view isn\'t available here yet — the captured object lives in the archive. Use the Compare snapshots (Diff) view or "kshrk inspect" to view it.');
+    }
+
+    const logsCount = (d.containers || []).filter((c) => (c.log_preview || []).length > 0).length;
+    const relCount = (d.related?.owner ? 1 : 0) + (d.related?.config_maps || []).length + (d.related?.secrets || []).length + (d.related?.pvcs || []).length;
+    const panelDefs = [
+      { key: 'summary', label: 'Summary', count: null, build: buildSummary },
+      { key: 'containers', label: 'Containers', count: (d.containers || []).length, build: buildContainers },
+      { key: 'logs', label: 'Logs', count: logsCount, build: buildLogs },
+      { key: 'events', label: 'Events', count: (d.events || []).length, build: buildEvents },
+      { key: 'history', label: 'History', count: (d.history || []).length, build: buildHistory },
+      { key: 'relationships', label: 'Relationships', count: relCount, build: buildRelationships },
+      { key: 'yaml', label: 'YAML', count: null, build: buildYaml },
+    ];
+
+    // Tab bar: clicking a tab lazily builds its panel and shows it.
+    const subtabs = el('div', { class: 'subtabs', style: 'margin:0 -20px 18px;' });
+    const panelHost = el('div', {});
+    const tabEls = {};
+    const panelEls = {};
+    selectTab = (key) => {
+      for (const def of panelDefs) {
+        const active = def.key === key;
+        tabEls[def.key].classList.toggle('active', active);
+        if (active && !panelEls[def.key]) {
+          panelEls[def.key] = def.build();
+          panelHost.appendChild(panelEls[def.key]);
+        }
+        if (panelEls[def.key]) panelEls[def.key].style.display = active ? '' : 'none';
+      }
+    };
+    for (const def of panelDefs) {
+      const t = el('div', { class: 'tab', onclick: () => selectTab(def.key) }, def.label);
+      if (def.count !== null) t.appendChild(el('span', { class: 'ct' }, ' · ' + def.count));
+      tabEls[def.key] = t;
+      subtabs.appendChild(t);
+    }
+    root.appendChild(subtabs);
+    root.appendChild(kpiStrip);
+    root.appendChild(panelHost);
+    selectTab('summary');
     setContent(root);
   }
 
@@ -808,8 +856,8 @@
       card.appendChild(el('div', { class: 'state', style: 'padding:10px; font-size:11.5px;' }, 'No captured log lines for this container.'));
     }
     const actions = el('div', { style: 'display:flex; gap:8px; margin-top:8px;' },
-      c.log_preview && c.log_preview.length > 0 ? el('button', { class: 'btn', onclick: () => go(c.log_path) }, 'View logs') : null,
-      c.has_previous_log ? el('button', { class: 'btn' }, 'Previous logs') : null,
+      c.log_path ? el('button', { class: 'btn', onclick: () => go(c.log_path) }, 'View logs') : null,
+      c.has_previous_log && c.log_path ? el('button', { class: 'btn', onclick: () => go(c.log_path + '&previous=true') }, 'Previous logs') : null,
     );
     card.appendChild(actions);
     return card;

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -577,10 +577,11 @@
     const list = data.namespaces || [];
     const hq = new URLSearchParams((location.hash.split('?')[1]) || '');
     const unhealthyOnly = hq.get('health') === 'unhealthy';
-    const nameList = [...new Set(list.map((n) => n.name).filter(Boolean))].sort();
     const fb = filterBar({
-      placeholder: 'Filter namespaces… (name=, /regex/)',
-      facets: [{ key: 'name', label: 'name', field: (n) => n.name, suggest: () => nameList }],
+      placeholder: 'Filter namespaces… (name=, label=value, /regex/)',
+      rows: () => list,
+      facets: [{ key: 'name', label: 'name', field: (n) => n.name }],
+      labels: (n) => n.labels,
       bareFields: (n) => [n.name],
       onChange: () => build(),
     });
@@ -827,25 +828,32 @@
 
   // ── Chip / token filter bar ────────────────────────────────────────────────
   // opts: {
-  //   facets: [{ key, aliases?, label, field(row)->string, suggest()->[string] }],
-  //   bareFields(row)->[string],   // fields a bare term matches against
+  //   rows: () => [row],                         // full dataset (for suggestions)
+  //   facets: [{ key, aliases?, label, field(row)->string }],
+  //   labels: (row) => ({k:v}),                  // label map for label selectors
+  //   bareFields(row)->[string],                 // fields a bare term matches
   //   placeholder?, initial?: [{key,value}], onChange(),
   // }
-  // Semantics: AND across chips. A value wrapped in /.../ is a (case-insensitive)
-  // regex; otherwise it's a case-insensitive substring. Bare terms match any of
-  // bareFields. Returns { el, matches(row), chips() }.
+  // Semantics: chips AND together. A value wrapped in /.../ is a case-insensitive
+  // regex. Facet and bare terms are case-insensitive substrings; a label
+  // selector (any non-facet key=value, e.g. app.kubernetes.io/name=web) is an
+  // exact (case-insensitive) match on metadata.labels[key]. Suggestions are
+  // aggregated: each facet/label's value list is scoped by the other chips.
   function filterBar(opts) {
     const facets = opts.facets || [];
     const byKey = {};
     for (const f of facets) { byKey[f.key] = f; for (const a of (f.aliases || [])) byKey[a] = f; }
-    const normKey = (k) => { const f = byKey[k.toLowerCase()]; return f ? f.key : k.toLowerCase(); };
+    // Resolve a typed key to a facet key, else keep it verbatim (label keys are
+    // case-sensitive, so don't lowercase those).
+    const resolveKey = (k) => { const f = byKey[k.toLowerCase()]; return f ? f.key : k; };
+    const labelsOf = (row) => (opts.labels ? (opts.labels(row) || {}) : {});
 
     let chips = [];
     let suggestions = [];
     let sel = -1;
 
     const chipHost = el('span', { class: 'fb-chips' });
-    const input = el('input', { class: 'fb-input', placeholder: opts.placeholder || 'Filter… (try ns=, name=, k=v, /regex/)' });
+    const input = el('input', { class: 'fb-input', placeholder: opts.placeholder || 'Filter… (ns=, name=, label=value, /regex/)' });
     const drop = el('div', { class: 'fb-suggest', style: 'display:none;' });
     const wrap = el('div', { class: 'filterbar', onclick: () => input.focus() }, chipHost, input, drop);
 
@@ -868,10 +876,44 @@
       renderChips(); input.value = ''; closeDrop(); fire();
     }
 
+    const test = (c, str, exact) => {
+      str = String(str == null ? '' : str);
+      if (c.regex) { try { return new RegExp(c.value, 'i').test(str); } catch (_) { return false; } }
+      if (exact) return str.toLowerCase() === c.value.toLowerCase();
+      return str.toLowerCase().includes(c.value.toLowerCase());
+    };
+    function chipMatches(c, row) {
+      if (c.key && byKey[c.key]) return test(c, byKey[c.key].field(row), false);
+      if (c.key) { const lv = labelsOf(row)[c.key]; return lv !== undefined && test(c, lv, true); }
+      for (const fv of (opts.bareFields ? opts.bareFields(row) : [])) if (test(c, fv, false)) return true;
+      return false;
+    }
+    const matchesChips = (row) => { for (const c of chips) if (!chipMatches(c, row)) return false; return true; };
+    const scopedRows = () => (opts.rows ? opts.rows() : []).filter(matchesChips);
+
+    function distinct(values, partial, cap) {
+      const seen = new Set(), out = [];
+      for (let v of values) {
+        if (v == null || v === '') continue;
+        v = String(v);
+        if (partial && !v.toLowerCase().includes(partial)) continue;
+        if (seen.has(v)) continue;
+        seen.add(v); out.push(v);
+        if (out.length >= cap) break;
+      }
+      return out;
+    }
+    function labelKeys(rows) {
+      const set = new Set();
+      for (const r of rows) for (const k in labelsOf(r)) set.add(k);
+      return [...set].sort();
+    }
+
     function updateSuggestions() {
       const tok = input.value;
       suggestions = [];
       const eq = tok.indexOf('=');
+      const scope = scopedRows();
       if (eq < 0) {
         const p = tok.toLowerCase();
         const keyMatch = [], labelMatch = [];
@@ -880,16 +922,16 @@
           else if ((f.label || '').toLowerCase().startsWith(p)) labelMatch.push(f);
         }
         for (const f of keyMatch.concat(labelMatch)) suggestions.push({ type: 'key', label: f.key + '=', hint: f.label, key: f.key });
+        for (const lk of labelKeys(scope)) {
+          if (suggestions.length >= 16) break;
+          if (!p || lk.toLowerCase().includes(p)) suggestions.push({ type: 'key', label: lk + '=', hint: 'label', key: lk });
+        }
       } else {
-        const key = normKey(tok.slice(0, eq));
+        const key = resolveKey(tok.slice(0, eq));
         const partial = tok.slice(eq + 1).toLowerCase().replace(/^\/|\/$/g, '');
         const f = byKey[key];
-        if (f && f.suggest) {
-          for (const v of (f.suggest() || [])) {
-            if (!partial || v.toLowerCase().includes(partial)) suggestions.push({ type: 'value', label: v, key, value: v });
-            if (suggestions.length >= 12) break;
-          }
-        }
+        const vals = f ? scope.map(f.field) : scope.map((r) => labelsOf(r)[key]);
+        for (const v of distinct(vals, partial, 12)) suggestions.push({ type: 'value', label: v, key: f ? f.key : key, value: v });
       }
       sel = -1; // no auto-highlight: Enter commits typed text unless a suggestion is chosen
       renderDrop();
@@ -914,7 +956,7 @@
       const tok = input.value.trim();
       if (!tok) return;
       const eq = tok.indexOf('=');
-      if (eq > 0) addChip(normKey(tok.slice(0, eq)), tok.slice(eq + 1));
+      if (eq > 0) addChip(resolveKey(tok.slice(0, eq)), tok.slice(eq + 1));
       else addChip('', tok);
     }
 
@@ -932,23 +974,13 @@
       else if (e.key === 'Backspace' && input.value === '' && chips.length) { chips.pop(); renderChips(); fire(); }
     });
 
-    for (const c of (opts.initial || [])) { if (c && c.value) chips.push(makeChip(normKey(c.key || ''), c.value)); }
+    for (const c of (opts.initial || [])) { if (c && c.value) chips.push(makeChip(resolveKey(c.key || ''), c.value)); }
     renderChips();
 
-    const test = (c, str) => {
-      str = String(str == null ? '' : str);
-      if (c.regex) { try { return new RegExp(c.value, 'i').test(str); } catch (_) { return false; } }
-      return str.toLowerCase().includes(c.value.toLowerCase());
-    };
-    function chipMatches(c, row) {
-      if (c.key && byKey[c.key]) return test(c, byKey[c.key].field(row));
-      for (const fv of (opts.bareFields ? opts.bareFields(row) : [])) if (test(c, fv)) return true;
-      return false;
-    }
     return {
       el: wrap,
       chips: () => chips,
-      matches: (row) => { for (const c of chips) if (!chipMatches(c, row)) return false; return true; },
+      matches: matchesChips,
     };
   }
 
@@ -971,17 +1003,16 @@
     const sub = el('div', { style: 'color:var(--fg-dim); font-size:12px; margin-bottom:14px;' });
     root.appendChild(sub);
 
-    const nsList = [...new Set(all.map((p) => p.namespace).filter(Boolean))].sort();
-    const nameList = [...new Set(all.map((p) => p.name).filter(Boolean))].sort();
-    const statusList = [...new Set(all.map((p) => p.status || p.phase).filter(Boolean))].sort();
     const toggle = el('button', { class: 'btn' });
     const fb = filterBar({
-      placeholder: 'Filter pods… (ns=, name=, status=, /regex/)',
+      placeholder: 'Filter pods… (ns=, name=, status=, label=value, /regex/)',
+      rows: () => all,
       facets: [
-        { key: 'ns', aliases: ['namespace'], label: 'namespace', field: (p) => p.namespace, suggest: () => nsList },
-        { key: 'name', label: 'name', field: (p) => p.name, suggest: () => nameList },
-        { key: 'status', label: 'status', field: (p) => p.status || p.phase, suggest: () => statusList },
+        { key: 'ns', aliases: ['namespace'], label: 'namespace', field: (p) => p.namespace },
+        { key: 'name', label: 'name', field: (p) => p.name },
+        { key: 'status', label: 'status', field: (p) => p.status || p.phase },
       ],
+      labels: (p) => p.labels,
       bareFields: (p) => [p.name, p.namespace, p.status, p.phase],
       initial: nsExact ? [{ key: 'ns', value: nsExact }] : [],
       onChange: () => build(),
@@ -1042,16 +1073,15 @@
     const sub = el('div', { style: 'color:var(--fg-dim); font-size:12px; margin-bottom:14px;' });
     root.appendChild(sub);
 
-    const nsList = [...new Set(all.map((w) => w.namespace).filter(Boolean))].sort();
-    const nameList = [...new Set(all.map((w) => w.name).filter(Boolean))].sort();
-    const kindList = [...new Set(all.map((w) => w.kind).filter(Boolean))].sort();
     const fb = filterBar({
-      placeholder: 'Filter workloads… (ns=, kind=, name=, /regex/)',
+      placeholder: 'Filter workloads… (ns=, kind=, name=, label=value, /regex/)',
+      rows: () => all,
       facets: [
-        { key: 'ns', aliases: ['namespace'], label: 'namespace', field: (w) => w.namespace, suggest: () => nsList },
-        { key: 'kind', label: 'kind', field: (w) => w.kind, suggest: () => kindList },
-        { key: 'name', label: 'name', field: (w) => w.name, suggest: () => nameList },
+        { key: 'ns', aliases: ['namespace'], label: 'namespace', field: (w) => w.namespace },
+        { key: 'kind', label: 'kind', field: (w) => w.kind },
+        { key: 'name', label: 'name', field: (w) => w.name },
       ],
+      labels: (w) => w.labels,
       bareFields: (w) => [w.name, w.namespace, w.kind, w.status],
       initial: nsExact ? [{ key: 'ns', value: nsExact }] : [],
       onChange: () => build(),
@@ -1326,14 +1356,14 @@
       setContent(root);
       return;
     }
-    const nsList = [...new Set(all.map((it) => it.namespace).filter(Boolean))].sort();
-    const nameList = [...new Set(all.map((it) => it.name).filter(Boolean))].sort();
     const fb = filterBar({
-      placeholder: 'Filter ' + resource + '… (ns=, name=, /regex/)',
+      placeholder: 'Filter ' + resource + '… (ns=, name=, label=value, /regex/)',
+      rows: () => all,
       facets: [
-        { key: 'ns', aliases: ['namespace'], label: 'namespace', field: (it) => it.namespace, suggest: () => nsList },
-        { key: 'name', label: 'name', field: (it) => it.name, suggest: () => nameList },
+        { key: 'ns', aliases: ['namespace'], label: 'namespace', field: (it) => it.namespace },
+        { key: 'name', label: 'name', field: (it) => it.name },
       ],
+      labels: (it) => it.labels,
       bareFields: (it) => [it.name, it.namespace],
       initial: nsParam ? [{ key: 'ns', value: nsParam }] : [],
       onChange: () => build(),

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -586,12 +586,228 @@
 
   async function renderPod(ns, name) {
     setContent(loadingState('Loading pod ' + ns + '/' + name + '…'));
+    let d;
     try {
-      const data = await getJSON('/v2/api/pod?ns=' + encodeURIComponent(ns) + '&name=' + encodeURIComponent(name));
-      setContent(el('div', { class: 'state' }, 'Pod ' + ns + '/' + name + ' data loaded. Real layout in next commit.'));
+      d = await getJSON('/v2/api/pod?ns=' + encodeURIComponent(ns) + '&name=' + encodeURIComponent(name));
     } catch (e) {
       setContent(errorState(e.message));
+      return;
     }
+
+    const root = el('div', {});
+
+    // Hero
+    const sevToBadge = { good: 'good', warn: 'warn', bad: 'bad' };
+    root.appendChild(el('div', { class: 'hero', style: 'margin:-18px -20px 0; padding:14px 20px 14px;' },
+      el('div', { class: 'crumbs' },
+        el('a', { onclick: () => go('#/overview') }, '← Cluster'),
+        el('span', { class: 'sep' }, '/'),
+        el('a', { onclick: () => go('#/ns/' + encodeURIComponent(d.namespace)) }, d.namespace),
+        el('span', { class: 'sep' }, '/'),
+        d.related && d.related.owner ? el('span', {}, d.related.owner.kind + ' / ' + d.related.owner.name) : null,
+        d.related && d.related.owner ? el('span', { class: 'sep' }, '/') : null,
+        el('b', {}, 'Pod / ' + d.name),
+      ),
+      el('div', { class: 'hero-row' },
+        el('div', {},
+          el('div', { class: 'title-row' },
+            el('div', { class: 'title' }, d.name),
+            d.hero ? el('span', { class: 'pill ' + (sevToBadge[d.hero.severity] || 'neutral') }, d.hero.reason || d.hero.phase) : null,
+          ),
+          el('div', { class: 'sub' }, 'Pod · ' + d.namespace + (d.hero?.subtitle ? ' · ' + d.hero.subtitle : '')),
+        ),
+        el('div', { class: 'hero-actions' },
+          el('button', { class: 'btn', onclick: () => go('#/logs?ns=' + encodeURIComponent(d.namespace) + '&pod=' + encodeURIComponent(d.name)) }, '▶ Logs'),
+          el('button', { class: 'btn' }, 'Events · ' + ((d.events || []).length)),
+          el('button', { class: 'btn' }, '⏷ Compare snapshots'),
+          el('button', { class: 'btn' }, 'YAML'),
+        ),
+      ),
+    ));
+
+    // Sub-tabs (visual only — content scrolled-to vertically since this is a single page for now)
+    const subtabs = el('div', { class: 'subtabs', style: 'margin:0 -20px 18px;' });
+    for (const [label, ct] of [
+      ['Summary', null],
+      ['Containers', (d.containers || []).length],
+      ['Logs', (d.containers || []).filter((c) => (c.log_preview || []).length > 0).length + ' captured'],
+      ['Events', (d.events || []).length],
+      ['History', (d.history || []).length],
+      ['YAML', null],
+      ['Relationships', null],
+    ]) {
+      const t = el('div', { class: 'tab' + (label === 'Summary' ? ' active' : '') }, label);
+      if (ct !== null) t.appendChild(el('span', { class: 'ct' }, ' · ' + ct));
+      subtabs.appendChild(t);
+    }
+    root.appendChild(subtabs);
+
+    // KPIs
+    const kpis = d.kpis || {};
+    const kpiStrip = el('div', { class: 'kpis k6' });
+    kpiStrip.appendChild(kpi('Phase', kpis.phase || '?', {
+      severity: d.hero?.severity === 'bad' ? 'alert' : (d.hero?.severity === 'warn' ? 'warn' : ''),
+      delta: d.hero?.reason || '',
+    }));
+    kpiStrip.appendChild(kpi('Restarts', kpis.restarts || 0, {
+      severity: (kpis.restarts || 0) > 0 ? 'alert' : '',
+    }));
+    kpiStrip.appendChild(kpi('Age', kpis.age || '?'));
+    kpiStrip.appendChild(kpi('Ready', kpis.ready || '0/0'));
+    kpiStrip.appendChild(kpi('Node', kpis.node || '—', { delta: kpis.pod_ip || '' }));
+    kpiStrip.appendChild(kpi('QoS', kpis.qos_class || '—'));
+    root.appendChild(kpiStrip);
+
+    // Restart sparkline + recent events
+    const sparkData = { buckets: d.restart_sparkline || [], total_events: (d.restart_sparkline || []).reduce((s, b) => s + (b.total || 0), 0), start_time: d.capture?.captured_at, end_time: d.capture?.captured_until };
+    const sparkCard = el('div', { class: 'card' },
+      cardHeader('Container restarts over capture window', sparkData.total_events + ' events'),
+      sparkChart(sparkData),
+    );
+    const evCard = el('div', { class: 'card' }, cardHeader('Recent events', String((d.events || []).length)));
+    if (!d.events || d.events.length === 0) {
+      evCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No events captured for this pod. (Did the capture include /api/v1/events?)'));
+    } else {
+      const wrap = el('div', { class: 'events' });
+      for (const ev of d.events.slice(0, 6)) {
+        wrap.appendChild(el('div', { class: 'event ' + (ev.severity || 'normal') },
+          el('span', { class: 'kind ' + (ev.severity === 'bad' ? 'bad' : (ev.severity === 'warn' ? 'warn' : '')) }, ev.reason || ''),
+          el('span', { class: 'body' },
+            el('b', {}, ev.message || ev.reason || ''),
+            ev.source || ev.count ? el('span', { class: 'small' },
+              (ev.source ? ev.source : '') + (ev.count ? ' · ' + ev.count + 'x' : ''),
+            ) : null,
+          ),
+          el('span', { class: 'age' }, formatShortTS(ev.time)),
+        ));
+      }
+      evCard.appendChild(wrap);
+    }
+    const row1 = el('div', { class: 'grid-2', style: 'margin-bottom:18px;' });
+    row1.appendChild(sparkCard);
+    row1.appendChild(evCard);
+    root.appendChild(row1);
+
+    // Containers
+    root.appendChild(el('div', { class: 'section-title' }, 'Containers (' + (d.containers || []).length + ')'));
+    const containersCard = el('div', { class: 'card', style: 'margin-bottom:18px;' });
+    for (const c of (d.containers || [])) {
+      containersCard.appendChild(containerCardEl(c));
+    }
+    root.appendChild(containersCard);
+
+    // Metadata + history
+    const grid = el('div', { class: 'grid-2' });
+
+    // Metadata card
+    const metaCard = el('div', { class: 'card' }, cardHeader('Metadata', ''));
+    const metaRow = (k, v, color) => el('div', { style: 'display:grid; grid-template-columns:140px 1fr; gap:8px; font-size:12.5px;' },
+      el('span', { style: 'color:var(--fg-faint);' }, k),
+      el('span', { style: 'font-family:var(--mono); color:' + (color || 'var(--fg)') + ';' }, v));
+    if (d.related?.owner) metaCard.appendChild(metaRow('Owner', (d.related.owner.kind || '') + '/' + (d.related.owner.name || '')));
+    if (d.kpis?.node) metaCard.appendChild(metaRow('Node', d.kpis.node));
+    if (d.kpis?.pod_ip) metaCard.appendChild(metaRow('Pod IP', d.kpis.pod_ip));
+    if (d.metadata?.created_at) metaCard.appendChild(metaRow('Created', d.metadata.created_at));
+    if (d.metadata?.labels && Object.keys(d.metadata.labels).length > 0) {
+      const labWrap = el('div', { class: 'labels', style: 'margin-top:10px;' });
+      for (const k of Object.keys(d.metadata.labels)) {
+        labWrap.appendChild(el('span', { class: 'lab' }, k + '=' + d.metadata.labels[k]));
+      }
+      metaCard.appendChild(el('div', { class: 'section-title', style: 'margin-top:10px;' }, 'Labels'));
+      metaCard.appendChild(labWrap);
+    }
+    if (d.metadata?.conditions && d.metadata.conditions.length > 0) {
+      metaCard.appendChild(el('div', { class: 'section-title', style: 'margin-top:10px;' }, 'Conditions'));
+      for (const c of d.metadata.conditions) {
+        const sevColor = c.severity === 'good' ? 'var(--good)' : c.severity === 'bad' ? 'var(--bad)' : 'var(--fg-dim)';
+        metaCard.appendChild(metaRow(c.type, c.status + (c.reason ? ' · ' + c.reason : ''), sevColor));
+      }
+    }
+    grid.appendChild(metaCard);
+
+    // History card
+    const histCard = el('div', { class: 'card' }, cardHeader('State history in capture', ''));
+    if (!d.history || d.history.length === 0) {
+      histCard.appendChild(el('div', { class: 'state', style: 'padding:14px;' }, 'No watch events captured for this pod.'));
+    } else {
+      for (const t of d.history.slice(0, 12)) {
+        const evCls = t.event_type === 'ADDED' ? 'added' : (t.event_type === 'DELETED' ? 'deleted' : 'modified');
+        histCard.appendChild(el('div', { class: 'timeline-row' },
+          el('span', { class: 'ts' }, formatShortTS(t.time)),
+          el('span', { class: 'dot ' + evCls }),
+          el('span', { class: 'ev' }, t.event_type + (t.detail ? ' · ' + t.detail : '')),
+        ));
+      }
+    }
+    if (d.related) {
+      histCard.appendChild(el('div', { class: 'section-title', style: 'margin-top:12px;' }, 'Related'));
+      if (d.related.owner) histCard.appendChild(el('div', { class: 'timeline-row' },
+        el('span', { class: 'ts' }, 'Owner'),
+        el('span', { class: 'ev' }, d.related.owner.kind + '/' + d.related.owner.name)));
+      for (const cm of (d.related.config_maps || [])) {
+        histCard.appendChild(el('div', { class: 'timeline-row' },
+          el('span', { class: 'ts' }, 'Mounts CM'),
+          el('span', { class: 'ev' }, cm.name)));
+      }
+      for (const s of (d.related.secrets || [])) {
+        histCard.appendChild(el('div', { class: 'timeline-row' },
+          el('span', { class: 'ts' }, 'Mounts Secret'),
+          el('span', { class: 'ev' }, s.name)));
+      }
+      for (const p of (d.related.pvcs || [])) {
+        histCard.appendChild(el('div', { class: 'timeline-row' },
+          el('span', { class: 'ts' }, 'Mounts PVC'),
+          el('span', { class: 'ev' }, p.name)));
+      }
+    }
+    grid.appendChild(histCard);
+
+    root.appendChild(grid);
+    setContent(root);
+  }
+
+  function containerCardEl(c) {
+    const card = el('div', { class: 'container-card ' + (c.severity || '') });
+    card.appendChild(el('div', { class: 'container-head' },
+      el('span', { class: 'nm' }, c.name),
+      el('span', { class: 'role ' + (c.role === 'init' ? 'init' : (c.role === 'side' ? 'side' : '')) }, c.role || 'main'),
+      el('span', { class: 'state ' + (c.severity || 'good') }, c.state_badge || c.state || ''),
+    ));
+    const meta = el('div', { class: 'container-meta' });
+    const mkRow = (k, v, cls) => {
+      meta.appendChild(el('span', { class: 'k' }, k));
+      meta.appendChild(el('span', { class: 'v ' + (cls || '') }, v || ''));
+    };
+    if (c.image) mkRow('Image', c.image);
+    if (c.last_terminated) {
+      mkRow('Last state', `Terminated · ${c.last_terminated}${c.last_exit_code ? ' · exit ' + c.last_exit_code : ''}`, 'bad');
+    }
+    if (c.resources) {
+      if (c.resources.cpu_limit || c.resources.cpu_request) {
+        mkRow('CPU', (c.resources.cpu_request || '?') + ' req · ' + (c.resources.cpu_limit || 'no limit'));
+      }
+      if (c.resources.memory_limit || c.resources.memory_request) {
+        mkRow('Memory', (c.resources.memory_request || '?') + ' req · ' + (c.resources.memory_limit || 'no limit'));
+      }
+    }
+    if (c.probes && c.probes.length > 0) mkRow('Probes', c.probes.join(' · '));
+    if (c.ports && c.ports.length > 0) mkRow('Ports', c.ports.join(', '));
+    card.appendChild(meta);
+    if (c.log_preview && c.log_preview.length > 0) {
+      const pre = el('div', { class: 'log-preview' });
+      for (const line of c.log_preview) {
+        pre.appendChild(document.createTextNode(line + '\n'));
+      }
+      card.appendChild(pre);
+    } else {
+      card.appendChild(el('div', { class: 'state', style: 'padding:10px; font-size:11.5px;' }, 'No captured log lines for this container.'));
+    }
+    const actions = el('div', { style: 'display:flex; gap:8px; margin-top:8px;' },
+      c.log_preview && c.log_preview.length > 0 ? el('button', { class: 'btn', onclick: () => go(c.log_path) }, 'View logs') : null,
+      c.has_previous_log ? el('button', { class: 'btn' }, 'Previous logs') : null,
+    );
+    card.appendChild(actions);
+    return card;
   }
 
   function renderTimeline() {

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -1424,17 +1424,6 @@
       el('a', { onclick: () => go('#/resources'), style: 'cursor:pointer;' }, 'Manage →'));
   }
 
-  // resourceMatches does a partial (substring) match of a search term against a
-  // resource's plural name, full kind, singular name, short names, and group.
-  function resourceMatches(r, term) {
-    if ((r.resource || '').toLowerCase().includes(term)) return true;
-    if ((r.kind || '').toLowerCase().includes(term)) return true;
-    if ((r.singular || '').toLowerCase().includes(term)) return true;
-    if ((r.group || 'core').toLowerCase().includes(term)) return true;
-    for (const s of (r.short_names || [])) { if (s.toLowerCase().includes(term)) return true; }
-    return false;
-  }
-
   async function renderResourceCatalog() {
     setContent(loadingState('Loading resources…'));
     let d;
@@ -1453,20 +1442,30 @@
     const sub = el('div', { style: 'color:var(--fg-dim); font-size:12px; margin-bottom:14px;' });
     root.appendChild(sub);
 
-    const filter = el('input', { placeholder: 'Filter by kind, resource or group…', style: listFilterStyle });
     const allBtn = el('button', { class: 'btn' }, 'All');
     const noneBtn = el('button', { class: 'btn' }, 'None');
-    root.appendChild(el('div', { style: 'display:flex; gap:10px; align-items:center; margin-bottom:8px;' }, filter, allBtn, noneBtn));
+    const fb = filterBar({
+      placeholder: 'Filter resources… (kind=, group=, resource=, namespaced=, /regex/)',
+      rows: () => all,
+      facets: [
+        { key: 'kind', label: 'kind', field: (r) => r.kind },
+        { key: 'group', label: 'group', field: (r) => r.group || 'core' },
+        { key: 'resource', label: 'resource', field: (r) => r.resource },
+        { key: 'namespaced', label: 'namespaced', field: (r) => (r.namespaced ? 'true' : 'false') },
+      ],
+      bareFields: (r) => [r.resource, r.kind, r.singular, r.group || 'core', ...(r.short_names || [])],
+      onChange: () => build(),
+    });
+    root.appendChild(el('div', { style: 'display:flex; gap:10px; align-items:center; margin-bottom:8px;' }, fb.el, allBtn, noneBtn));
 
     const body = el('div', {});
     root.appendChild(body);
 
     function build() {
-      const term = filter.value.trim().toLowerCase();
       body.innerHTML = '';
       const groups = {};
       for (const r of all) {
-        if (term && !resourceMatches(r, term)) continue;
+        if (!fb.matches(r)) continue;
         const g = r.group || 'core';
         (groups[g] = groups[g] || []).push(r);
       }
@@ -1516,7 +1515,6 @@
       if (!shown) body.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No resources match.'));
       sub.textContent = d.total + ' resource types · ' + enabledCount + ' enabled';
     }
-    filter.addEventListener('input', build);
     allBtn.addEventListener('click', () => { enabled = null; saveEnabledResources(enabled); build(); });
     noneBtn.addEventListener('click', () => { enabled = new Set(); saveEnabledResources(enabled); build(); });
     build();
@@ -1790,17 +1788,32 @@
     const tlBanner = resourceFilterBanner();
     if (tlBanner) root.appendChild(tlBanner);
     root.appendChild(el('div', { class: 'section-title' }, 'All recent transitions'));
-    const recentCard = el('div', { class: 'card' });
     const tlRecent = (data.recent || []).filter((t) => resourceEnabled(t.resource));
-    if (tlRecent.length === 0) {
-      recentCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' },
-        (data.recent && data.recent.length) ? 'No transitions for the enabled resource types.' : 'No watch events were captured. Enable `watch: true` on your config’s resource entries to see live transitions.'));
-    } else {
-      const wrap = el('div', { class: 'events' });
-      for (const t of tlRecent) wrap.appendChild(recentRow(t));
-      recentCard.appendChild(wrap);
-    }
+    const fb = filterBar({
+      placeholder: 'Filter transitions… (kind=, ns=, name=, event=, /regex/)',
+      rows: () => tlRecent,
+      facets: [
+        { key: 'kind', label: 'kind', field: (t) => t.kind },
+        { key: 'ns', aliases: ['namespace'], label: 'namespace', field: (t) => t.namespace },
+        { key: 'name', label: 'name', field: (t) => t.name },
+        { key: 'event', aliases: ['type'], label: 'event type', field: (t) => t.event_type },
+      ],
+      bareFields: (t) => [t.name, t.kind, t.namespace, t.event_type],
+      onChange: () => build(),
+    });
+    root.appendChild(el('div', { style: 'margin-bottom:12px; max-width:720px;' }, fb.el));
+    const recentCard = el('div', { class: 'card' });
+    const listWrap = el('div', { class: 'events' });
+    recentCard.appendChild(listWrap);
     root.appendChild(recentCard);
+    function build() {
+      listWrap.innerHTML = '';
+      let shown = 0;
+      for (const t of tlRecent) { if (!fb.matches(t)) continue; listWrap.appendChild(recentRow(t)); shown++; }
+      if (!shown) listWrap.appendChild(el('div', { class: 'state', style: 'padding:18px;' },
+        (data.recent && data.recent.length) ? 'No transitions match.' : 'No watch events were captured. Enable `watch: true` on your config’s resource entries to see live transitions.'));
+    }
+    build();
     setContent(root);
   }
 

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -1847,10 +1847,10 @@
       paint();
     });
     paint();
+    // Append last so it sits at the far right of the topbar (after the
+    // capture-meta and scrubber).
     const bar = $('topbar');
-    const meta = $('capture-meta');
-    if (bar && meta) bar.insertBefore(btn, meta);
-    else if (bar) bar.appendChild(btn);
+    if (bar) bar.appendChild(btn);
   }
 
   async function init() {

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -1,0 +1,249 @@
+// k8shark v2 UI — dashboard-style explorer.
+// Single-file vanilla JS. Hash-based router so a refresh stays on the right view.
+// View functions render into #content; the topbar/nav/scrubber are shared.
+
+(() => {
+  'use strict';
+
+  const $ = (id) => document.getElementById(id);
+  const el = (tag, attrs = {}, ...children) => {
+    const n = document.createElement(tag);
+    for (const [k, v] of Object.entries(attrs)) {
+      if (k === 'class') n.className = v;
+      else if (k === 'html') n.innerHTML = v;
+      else if (k.startsWith('on') && typeof v === 'function') n.addEventListener(k.slice(2), v);
+      else if (v !== undefined && v !== null) n.setAttribute(k, v);
+    }
+    for (const c of children) {
+      if (c === null || c === undefined || c === false) continue;
+      n.appendChild(typeof c === 'string' ? document.createTextNode(c) : c);
+    }
+    return n;
+  };
+
+  // ── State ────────────────────────────────────────────────────────────────
+  const state = {
+    captureMeta: null,
+    snapshots: [],   // RFC3339 strings
+    at: '',          // selected snapshot timestamp ('' = latest)
+    route: { name: 'overview' },
+  };
+
+  // ── Router ───────────────────────────────────────────────────────────────
+  // Routes:
+  //   #/overview              dashboard landing
+  //   #/namespaces            namespace browser
+  //   #/ns/<name>             namespace drilldown
+  //   #/ns/<name>/pod/<pod>   pod drilldown
+  //   #/timeline              timeline
+  //   #/logs                  logs full-screen
+  function parseRoute() {
+    const h = (location.hash || '#/overview').replace(/^#/, '');
+    const parts = h.split('/').filter(Boolean);
+    if (parts.length === 0) return { name: 'overview' };
+    if (parts[0] === 'overview' || parts[0] === 'namespaces' || parts[0] === 'timeline' || parts[0] === 'logs') {
+      return { name: parts[0] };
+    }
+    if (parts[0] === 'ns' && parts[1]) {
+      if (parts[2] === 'pod' && parts[3]) {
+        return { name: 'pod', ns: decodeURIComponent(parts[1]), pod: decodeURIComponent(parts[3]) };
+      }
+      return { name: 'namespace', ns: decodeURIComponent(parts[1]) };
+    }
+    return { name: 'overview' };
+  }
+
+  function go(hash) {
+    if (location.hash === hash) {
+      render();
+    } else {
+      location.hash = hash;
+    }
+  }
+  window.addEventListener('hashchange', () => {
+    state.route = parseRoute();
+    render();
+  });
+
+  // ── Top nav / scrubber ───────────────────────────────────────────────────
+  function renderNav() {
+    const nav = $('nav');
+    nav.innerHTML = '';
+    const items = [
+      { key: 'overview',   label: 'Overview',   hash: '#/overview' },
+      { key: 'namespaces', label: 'Namespaces', hash: '#/namespaces' },
+      { key: 'timeline',   label: 'Timeline',   hash: '#/timeline' },
+      { key: 'logs',       label: 'Logs',       hash: '#/logs' },
+    ];
+    const activeKey = state.route.name === 'namespace' || state.route.name === 'pod' ? 'namespaces' : state.route.name;
+    for (const it of items) {
+      nav.appendChild(el('div', {
+        class: 'tab' + (it.key === activeKey ? ' active' : ''),
+        onclick: () => go(it.hash),
+      }, it.label));
+    }
+  }
+
+  function renderScrubber() {
+    const s = $('scrubber');
+    s.innerHTML = '';
+    const prev = el('button', { class: 'btn', onclick: stepSnapshot.bind(null, -1) }, '◀');
+    const next = el('button', { class: 'btn', onclick: stepSnapshot.bind(null, +1) }, '▶');
+    const range = el('input', { type: 'range', min: '0', max: String(Math.max(0, state.snapshots.length - 1)), value: String(currentSnapshotIndex()) });
+    range.addEventListener('input', () => {
+      const idx = Number(range.value);
+      state.at = state.snapshots[idx] || '';
+      ts.textContent = formatTS(state.at);
+    });
+    range.addEventListener('change', () => {
+      const idx = Number(range.value);
+      state.at = state.snapshots[idx] || '';
+      render();
+    });
+    const ts = el('span', { class: 'ts' }, formatTS(state.at));
+    s.appendChild(prev);
+    s.appendChild(range);
+    s.appendChild(next);
+    s.appendChild(ts);
+  }
+
+  function currentSnapshotIndex() {
+    if (!state.at) return state.snapshots.length - 1; // latest
+    const i = state.snapshots.indexOf(state.at);
+    return i >= 0 ? i : state.snapshots.length - 1;
+  }
+
+  function stepSnapshot(delta) {
+    const idx = Math.max(0, Math.min(state.snapshots.length - 1, currentSnapshotIndex() + delta));
+    state.at = state.snapshots[idx] || '';
+    render();
+  }
+
+  function formatTS(s) {
+    if (!s) return 'latest';
+    return s.replace('T', ' ').replace(/Z$/, ' UTC');
+  }
+
+  // ── HTTP ─────────────────────────────────────────────────────────────────
+  async function getJSON(path) {
+    const url = new URL(path, location.href);
+    if (state.at) url.searchParams.set('at', state.at);
+    const res = await fetch(url.toString());
+    let data = null;
+    try { data = await res.json(); } catch (_) { /* not JSON */ }
+    if (!res.ok) {
+      const msg = (data && data.error) || `${res.status} ${res.statusText}`;
+      throw new Error(msg);
+    }
+    return data;
+  }
+
+  // ── Toasts ───────────────────────────────────────────────────────────────
+  function toast(kind, message, ttl) {
+    const box = el('div', { class: 'toast ' + kind }, message);
+    $('toasts').appendChild(box);
+    setTimeout(() => box.remove(), ttl || (kind === 'error' ? 6000 : 3000));
+  }
+
+  // ── View rendering ───────────────────────────────────────────────────────
+  function setContent(...nodes) {
+    const c = $('content');
+    c.innerHTML = '';
+    for (const n of nodes) c.appendChild(n);
+  }
+
+  function loadingState(msg) {
+    return el('div', { class: 'state' }, msg || 'Loading…');
+  }
+  function errorState(msg) {
+    return el('div', { class: 'state' }, 'Error: ' + msg);
+  }
+
+  // ─ Views (placeholders to be filled in subsequent commits) ──────────────
+  async function renderOverview() {
+    setContent(loadingState('Loading cluster overview…'));
+    try {
+      const data = await getJSON('/v2/api/overview');
+      // Real rendering lands in the next commit.
+      setContent(el('div', { class: 'state' }, 'Overview data loaded (' + Object.keys(data || {}).length + ' fields). Real layout in next commit.'));
+    } catch (e) {
+      setContent(errorState(e.message));
+    }
+  }
+
+  async function renderNamespacesIndex() {
+    setContent(loadingState('Loading namespaces…'));
+    try {
+      const data = await getJSON('/v2/api/overview');
+      const list = (data && data.namespaces) || [];
+      setContent(el('div', { class: 'state' }, list.length + ' namespaces. Card grid lands in next commit.'));
+    } catch (e) {
+      setContent(errorState(e.message));
+    }
+  }
+
+  async function renderNamespace(ns) {
+    setContent(loadingState('Loading namespace ' + ns + '…'));
+    try {
+      const data = await getJSON('/v2/api/namespace?ns=' + encodeURIComponent(ns));
+      setContent(el('div', { class: 'state' }, 'Namespace ' + ns + ' data loaded. Real layout in next commit.'));
+    } catch (e) {
+      setContent(errorState(e.message));
+    }
+  }
+
+  async function renderPod(ns, name) {
+    setContent(loadingState('Loading pod ' + ns + '/' + name + '…'));
+    try {
+      const data = await getJSON('/v2/api/pod?ns=' + encodeURIComponent(ns) + '&name=' + encodeURIComponent(name));
+      setContent(el('div', { class: 'state' }, 'Pod ' + ns + '/' + name + ' data loaded. Real layout in next commit.'));
+    } catch (e) {
+      setContent(errorState(e.message));
+    }
+  }
+
+  function renderTimeline() {
+    setContent(el('div', { class: 'state' }, 'Timeline view — coming soon.'));
+  }
+  function renderLogs() {
+    setContent(el('div', { class: 'state' }, 'Logs view — coming soon.'));
+  }
+
+  function render() {
+    renderNav();
+    renderScrubber();
+    const r = state.route;
+    if (r.name === 'overview') return renderOverview();
+    if (r.name === 'namespaces') return renderNamespacesIndex();
+    if (r.name === 'namespace') return renderNamespace(r.ns);
+    if (r.name === 'pod') return renderPod(r.ns, r.pod);
+    if (r.name === 'timeline') return renderTimeline();
+    if (r.name === 'logs') return renderLogs();
+    return setContent(errorState('Unknown route'));
+  }
+
+  // ── Bootstrap ────────────────────────────────────────────────────────────
+  async function init() {
+    state.route = parseRoute();
+    try {
+      const ts = await getJSON('/v2/api/timestamps');
+      state.snapshots = (ts && ts.timestamps) || [];
+      state.captureMeta = ts && {
+        captured_at: ts.captured_at,
+        captured_until: ts.captured_until,
+        total_count: ts.total_count,
+      };
+      if (state.captureMeta) {
+        $('capture-meta').textContent =
+          `${state.captureMeta.captured_at?.slice(0, 19) ?? ''} → ${state.captureMeta.captured_until?.slice(0, 19) ?? ''} · ${state.captureMeta.total_count} records`;
+      }
+    } catch (e) {
+      // Timestamps endpoint not implemented yet — keep going with empty snapshots.
+      $('capture-meta').textContent = 'capture loaded';
+    }
+    render();
+  }
+  document.addEventListener('DOMContentLoaded', init);
+  // Expose for debugging in the browser console.
+  window.kshrk = { state, go, render };
+})();

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -154,7 +154,7 @@
   function setContent(...nodes) {
     const c = $('content');
     c.innerHTML = '';
-    for (const n of nodes) c.appendChild(n);
+    for (const n of nodes) if (n) c.appendChild(n);
   }
 
   function loadingState(msg) {
@@ -166,7 +166,9 @@
 
   // ── Shared bits ──────────────────────────────────────────────────────────
   function kpi(label, value, opts = {}) {
-    return el('div', { class: 'kpi' + (opts.severity ? ' ' + opts.severity : '') },
+    const attrs = { class: 'kpi' + (opts.severity ? ' ' + opts.severity : '') + (opts.link ? ' clickable' : '') };
+    if (opts.link) attrs.onclick = () => go(opts.link);
+    return el('div', attrs,
       el('span', { class: 'label' }, label),
       el('span', { class: 'value' }, formatNumber(value)),
       opts.delta ? el('span', { class: 'delta ' + (opts.deltaKind || 'neutral') }, opts.delta) : null);
@@ -283,20 +285,22 @@
 
     const root = el('div', {});
 
-    // KPI strip
+    // KPI strip — each tile drills into the relevant view.
     const kpiStrip = el('div', { class: 'kpis' });
-    kpiStrip.appendChild(kpi('Namespaces', kpis.namespaces || 0));
-    kpiStrip.appendChild(kpi('Workloads', kpis.workloads || 0));
-    kpiStrip.appendChild(kpi('Pods', kpis.pods || 0));
+    kpiStrip.appendChild(kpi('Namespaces', kpis.namespaces || 0, { link: '#/namespaces' }));
+    kpiStrip.appendChild(kpi('Workloads', kpis.workloads || 0, { link: '#/namespaces' }));
+    kpiStrip.appendChild(kpi('Pods', kpis.pods || 0, { link: '#/namespaces' }));
     const unhealthyDelta = unhealthyDeltaText(kpis);
     kpiStrip.appendChild(kpi('Unhealthy pods', kpis.unhealthy_pods || 0, {
       severity: (kpis.unhealthy_pods || 0) > 0 ? 'alert' : '',
       delta: unhealthyDelta,
       deltaKind: 'down',
+      link: '#/namespaces?health=unhealthy',
     }));
     kpiStrip.appendChild(kpi('Watch events', kpis.watch_events || 0, {
       delta: data.sparkline && data.sparkline.buckets ? 'over ' + data.sparkline.buckets.length + ' buckets' : '',
       deltaKind: 'neutral',
+      link: '#/timeline',
     }));
     root.appendChild(kpiStrip);
 
@@ -388,15 +392,22 @@
       return;
     }
     const list = data.namespaces || [];
+    const hq = new URLSearchParams((location.hash.split('?')[1]) || '');
+    const unhealthyOnly = hq.get('health') === 'unhealthy';
     const filter = el('input', {
       placeholder: 'Filter namespaces…',
       style: 'width:100%; max-width:380px; background:var(--bg-row); border:1px solid var(--border-strong); color:var(--fg); padding:7px 10px; border-radius:6px; outline:none; margin-bottom:14px;',
     });
+    const banner = unhealthyOnly ? el('div', { class: 'state', style: 'padding:10px 14px; margin-bottom:14px; display:flex; gap:12px; align-items:center;' },
+      el('span', {}, 'Showing namespaces with unhealthy pods'),
+      el('a', { onclick: () => go('#/namespaces'), style: 'cursor:pointer;' }, 'Show all →'),
+    ) : null;
     const grid = el('div', { class: 'resource-grid', style: 'grid-template-columns:repeat(4, minmax(0,1fr));' });
     function build(q) {
       grid.innerHTML = '';
       let shown = 0;
       for (const ns of list) {
+        if (unhealthyOnly && !(ns.unhealthy > 0)) continue;
         if (q && !ns.name.toLowerCase().includes(q)) continue;
         const card = el('div', {
           class: 'res-chip',
@@ -414,12 +425,13 @@
         shown++;
       }
       if (shown === 0) {
-        grid.appendChild(el('div', { class: 'state', style: 'grid-column:1/-1;' }, 'No namespaces match.'));
+        grid.appendChild(el('div', { class: 'state', style: 'grid-column:1/-1;' },
+          unhealthyOnly ? 'No namespaces with unhealthy pods at this snapshot.' : 'No namespaces match.'));
       }
     }
     filter.addEventListener('input', () => build(filter.value.trim().toLowerCase()));
     build('');
-    setContent(filter, grid);
+    setContent(filter, banner, grid);
   }
 
   async function renderNamespace(ns) {

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -38,10 +38,14 @@
   //   #/timeline              timeline
   //   #/logs                  logs full-screen
   function parseRoute() {
-    const h = (location.hash || '#/overview').replace(/^#/, '');
+    let h = (location.hash || '#/overview').replace(/^#/, '');
+    // Strip any ?query=... before splitting on slashes; route params live in
+    // the path segments, the query is parsed per-view.
+    const qIdx = h.indexOf('?');
+    if (qIdx >= 0) h = h.slice(0, qIdx);
     const parts = h.split('/').filter(Boolean);
     if (parts.length === 0) return { name: 'overview' };
-    if (parts[0] === 'overview' || parts[0] === 'namespaces' || parts[0] === 'timeline' || parts[0] === 'logs') {
+    if (parts[0] === 'overview' || parts[0] === 'namespaces' || parts[0] === 'timeline' || parts[0] === 'logs' || parts[0] === 'diff') {
       return { name: parts[0] };
     }
     if (parts[0] === 'ns' && parts[1]) {
@@ -74,6 +78,7 @@
       { key: 'namespaces', label: 'Namespaces', hash: '#/namespaces' },
       { key: 'timeline',   label: 'Timeline',   hash: '#/timeline' },
       { key: 'logs',       label: 'Logs',       hash: '#/logs' },
+      { key: 'diff',       label: 'Diff',       hash: '#/diff' },
     ];
     const activeKey = state.route.name === 'namespace' || state.route.name === 'pod' ? 'namespaces' : state.route.name;
     for (const it of items) {
@@ -810,11 +815,210 @@
     return card;
   }
 
-  function renderTimeline() {
-    setContent(el('div', { class: 'state' }, 'Timeline view — coming soon.'));
+  // ── Timeline ─────────────────────────────────────────────────────────────
+  async function renderTimeline() {
+    setContent(loadingState('Loading timeline…'));
+    let data;
+    try {
+      data = await getJSON('/v2/api/overview');
+    } catch (e) {
+      setContent(errorState(e.message));
+      return;
+    }
+    const root = el('div', {});
+    const sparkData = data.sparkline || {};
+    const sparkCard = el('div', { class: 'card', style: 'margin-bottom:18px;' },
+      cardHeader('Watch events across capture window', ((sparkData.total_events) || 0) + ' events'),
+      sparkChart(sparkData),
+    );
+    root.appendChild(sparkCard);
+    root.appendChild(el('div', { class: 'section-title' }, 'All recent transitions'));
+    const recentCard = el('div', { class: 'card' });
+    if (!data.recent || data.recent.length === 0) {
+      recentCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' }, 'No watch events were captured. Enable `watch: true` on your config’s resource entries to see live transitions.'));
+    } else {
+      const wrap = el('div', { class: 'events' });
+      for (const t of data.recent) wrap.appendChild(recentRow(t));
+      recentCard.appendChild(wrap);
+    }
+    root.appendChild(recentCard);
+    setContent(root);
   }
-  function renderLogs() {
-    setContent(el('div', { class: 'state' }, 'Logs view — coming soon.'));
+
+  // ── Logs ─────────────────────────────────────────────────────────────────
+  async function renderLogs() {
+    // Parse query params from the hash (e.g. #/logs?ns=X&pod=Y&container=Z)
+    const params = parseLogsParams();
+    if (!params.ns || !params.pod) {
+      setContent(el('div', { class: 'state' }, 'Open a pod first, then click "Logs" to view its captured logs here.'));
+      return;
+    }
+
+    setContent(loadingState('Loading logs for ' + params.pod + '…'));
+    let data;
+    try {
+      const q = new URLSearchParams();
+      q.set('ns', params.ns);
+      q.set('pod', params.pod);
+      if (params.container) q.set('container', params.container);
+      if (params.previous) q.set('previous', 'true');
+      data = await getJSON('/v2/api/logs?' + q.toString());
+    } catch (e) {
+      setContent(errorState(e.message));
+      return;
+    }
+
+    const root = el('div', {});
+
+    // Hero
+    root.appendChild(el('div', { class: 'hero', style: 'margin:-18px -20px 18px; padding:14px 20px 14px;' },
+      el('div', { class: 'crumbs' },
+        el('a', { onclick: () => go('#/overview') }, '← Cluster'),
+        el('span', { class: 'sep' }, '/'),
+        el('a', { onclick: () => go('#/ns/' + encodeURIComponent(data.namespace)) }, data.namespace),
+        el('span', { class: 'sep' }, '/'),
+        el('a', { onclick: () => go('#/ns/' + encodeURIComponent(data.namespace) + '/pod/' + encodeURIComponent(data.pod)) }, 'Pod / ' + data.pod),
+        el('span', { class: 'sep' }, '/'),
+        el('b', {}, 'Logs · ' + data.container + (data.previous ? ' (previous)' : '')),
+      ),
+      el('div', { class: 'hero-row' },
+        el('div', {},
+          el('div', { class: 'title-row' },
+            el('div', { class: 'title' }, data.container),
+            el('span', { class: 'pill neutral' }, data.line_count + ' lines'),
+          ),
+          el('div', { class: 'sub' }, data.pod + (data.previous ? ' · previous container' : ' · current container')),
+        ),
+      ),
+    ));
+
+    // Container picker + previous toggle
+    const picker = el('div', { class: 'card', style: 'margin-bottom:18px; padding:10px 14px; flex-direction:row; align-items:center; gap:10px;' });
+    picker.appendChild(el('span', { style: 'font-size:11px; color:var(--fg-faint); text-transform:uppercase; letter-spacing:.06em;' }, 'Container'));
+    for (const c of (data.containers || [])) {
+      const isActive = c.name === data.container;
+      const btn = el('button', {
+        class: 'btn' + (isActive ? ' primary' : ''),
+        onclick: () => go('#/logs?ns=' + encodeURIComponent(data.namespace) + '&pod=' + encodeURIComponent(data.pod) + '&container=' + encodeURIComponent(c.name) + (data.previous ? '&previous=true' : '')),
+      }, c.name);
+      picker.appendChild(btn);
+    }
+    picker.appendChild(el('span', { style: 'margin-left:auto; font-size:11px; color:var(--fg-faint);' }, data.has_previous_variant ? 'previous log captured for this container' : ''));
+    picker.appendChild(el('button', {
+      class: 'btn' + (data.previous ? ' primary' : ''),
+      disabled: data.has_previous_variant ? null : 'disabled',
+      onclick: () => go('#/logs?ns=' + encodeURIComponent(data.namespace) + '&pod=' + encodeURIComponent(data.pod) + '&container=' + encodeURIComponent(data.container) + (data.previous ? '' : '&previous=true')),
+    }, data.previous ? '← current logs' : 'previous logs →'));
+    root.appendChild(picker);
+
+    // Log text
+    const pre = el('pre', { class: 'log-preview', style: 'max-height: calc(100vh - 320px); padding:14px;' }, data.text || '');
+    root.appendChild(pre);
+
+    setContent(root);
+  }
+
+  // ── Diff ─────────────────────────────────────────────────────────────────
+  async function renderDiff() {
+    const params = parseDiffParams();
+    const root = el('div', {});
+
+    // Form card
+    const form = el('div', { class: 'card', style: 'margin-bottom:18px;' },
+      cardHeader('Compare an object at two snapshots', ''));
+
+    const inputStyle = 'background:var(--bg-row); border:1px solid var(--border-strong); color:var(--fg); padding:6px 10px; border-radius:5px; font-size:12.5px; outline:none; min-width:240px;';
+    const pathInput = el('input', { value: params.path || '', placeholder: '/api/v1/namespaces/<ns>/pods', style: inputStyle });
+    const nameInput = el('input', { value: params.name || '', placeholder: 'pod name (optional, filters list)', style: inputStyle });
+    const beforeSelect = el('select', { style: inputStyle });
+    const afterSelect = el('select', { style: inputStyle });
+    for (const ts of state.snapshots) {
+      beforeSelect.appendChild(el('option', { value: ts, selected: params.before === ts ? 'selected' : null }, ts));
+      afterSelect.appendChild(el('option', { value: ts, selected: params.after === ts ? 'selected' : null }, ts));
+    }
+    if (!params.before && state.snapshots.length > 0) {
+      beforeSelect.value = state.snapshots[0];
+    }
+    if (!params.after && state.snapshots.length > 0) {
+      afterSelect.value = state.snapshots[state.snapshots.length - 1];
+    }
+    const goBtn = el('button', { class: 'btn primary', onclick: () => runDiff() }, 'Compare');
+
+    const formRow = el('div', { style: 'display:grid; grid-template-columns:max-content 1fr; gap:8px 16px; align-items:center;' },
+      el('span', {}, 'Path'),
+      pathInput,
+      el('span', {}, 'Name (optional)'),
+      nameInput,
+      el('span', {}, 'Before'),
+      beforeSelect,
+      el('span', {}, 'After'),
+      afterSelect,
+    );
+    form.appendChild(formRow);
+    form.appendChild(el('div', { style: 'display:flex; gap:8px; justify-content:flex-end; margin-top:8px;' }, goBtn));
+    root.appendChild(form);
+
+    const out = el('div', {});
+    root.appendChild(out);
+    setContent(root);
+
+    async function runDiff() {
+      const q = new URLSearchParams();
+      q.set('path', pathInput.value.trim());
+      if (nameInput.value.trim()) q.set('name', nameInput.value.trim());
+      q.set('before', beforeSelect.value);
+      q.set('after', afterSelect.value);
+      out.innerHTML = '';
+      out.appendChild(loadingState('Diffing…'));
+      try {
+        const data = await getJSON('/v2/api/diff?' + q.toString());
+        out.innerHTML = '';
+        if (data.before_missing || data.after_missing) {
+          out.appendChild(el('div', { class: 'state' },
+            data.before_missing && data.after_missing
+              ? 'Object not present at either snapshot.'
+              : (data.before_missing ? 'Object did not exist at the "before" snapshot — full add.' : 'Object did not exist at the "after" snapshot — full delete.'),
+          ));
+        }
+        if (!data.has_diff && !data.before_missing && !data.after_missing) {
+          out.appendChild(el('div', { class: 'state' }, 'No changes between snapshots.'));
+        }
+        const diff = el('div', { class: 'diff', style: 'padding:14px;' });
+        for (const h of (data.hunks || [])) {
+          const cls = h.type === 'add' ? 'add' : (h.type === 'del' ? 'del' : 'ctx');
+          diff.appendChild(el('div', { class: cls }, h.text));
+        }
+        out.appendChild(diff);
+      } catch (e) {
+        out.innerHTML = '';
+        out.appendChild(errorState(e.message));
+      }
+    }
+    if (params.path && params.before && params.after) runDiff();
+  }
+
+  function parseDiffParams() {
+    const idx = (location.hash || '').indexOf('?');
+    if (idx < 0) return {};
+    const q = new URLSearchParams(location.hash.slice(idx + 1));
+    return {
+      path: q.get('path') || '',
+      name: q.get('name') || '',
+      before: q.get('before') || '',
+      after: q.get('after') || '',
+    };
+  }
+
+  function parseLogsParams() {
+    const idx = (location.hash || '').indexOf('?');
+    if (idx < 0) return {};
+    const q = new URLSearchParams(location.hash.slice(idx + 1));
+    return {
+      ns: q.get('ns') || '',
+      pod: q.get('pod') || '',
+      container: q.get('container') || '',
+      previous: q.get('previous') === 'true',
+    };
   }
 
   function render() {
@@ -827,6 +1031,7 @@
     if (r.name === 'pod') return renderPod(r.ns, r.pod);
     if (r.name === 'timeline') return renderTimeline();
     if (r.name === 'logs') return renderLogs();
+    if (r.name === 'diff') return renderDiff();
     return setContent(errorState('Unknown route'));
   }
 

--- a/internal/ui/v2/static/index.html
+++ b/internal/ui/v2/static/index.html
@@ -15,6 +15,7 @@
     <div class="grow"></div>
     <div class="meta" id="capture-meta">loading…</div>
     <div class="scrubber" id="scrubber"></div>
+    <a class="legacy-link" href="/v1/" title="Open the legacy v1 explorer">Legacy UI ↗</a>
   </div>
   <main id="content"></main>
   <div id="toasts"></div>

--- a/internal/ui/v2/static/index.html
+++ b/internal/ui/v2/static/index.html
@@ -5,6 +5,7 @@
 <title>k8shark</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="app.css">
+<script>try{if(localStorage.getItem('kshrk.v2.theme')==='light')document.documentElement.setAttribute('data-theme','light');}catch(e){}</script>
 </head>
 <body>
 <div id="app">

--- a/internal/ui/v2/static/index.html
+++ b/internal/ui/v2/static/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>k8shark</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="app.css">
+</head>
+<body>
+<div id="app">
+  <div id="topbar">
+    <div class="brand"><span class="logo"></span><span>kshrk</span></div>
+    <nav id="nav"></nav>
+    <div class="grow"></div>
+    <div class="meta" id="capture-meta">loading…</div>
+    <div class="scrubber" id="scrubber"></div>
+  </div>
+  <main id="content"></main>
+  <div id="toasts"></div>
+</div>
+<script src="app.js"></script>
+</body>
+</html>

--- a/internal/ui/v2/timestamps.go
+++ b/internal/ui/v2/timestamps.go
@@ -1,0 +1,91 @@
+package v2
+
+import (
+	"net/http"
+	"sort"
+	"time"
+)
+
+// TimestampsResponse is what /v2/api/timestamps returns. Sampled when the
+// capture has more than ~180 distinct event timestamps so the scrubber stays
+// usable on long captures.
+type TimestampsResponse struct {
+	CapturedAt    time.Time `json:"captured_at"`
+	CapturedUntil time.Time `json:"captured_until"`
+	DefaultAt     string    `json:"default_at,omitempty"`
+	TotalCount    int       `json:"total_count"`
+	Sampled       bool      `json:"sampled"`
+	Timestamps    []string  `json:"timestamps"`
+}
+
+const scrubberMaxStops = 180
+
+func (h *Handler) timestampsHandler(w http.ResponseWriter, _ *http.Request) {
+	resp := TimestampsResponse{
+		CapturedAt:    h.Store.Metadata.CapturedAt,
+		CapturedUntil: h.Store.Metadata.CapturedUntil,
+	}
+	if !h.At.IsZero() {
+		resp.DefaultAt = h.At.UTC().Format(time.RFC3339)
+	}
+
+	uniq := make(map[time.Time]struct{})
+	for _, entry := range h.Store.Index {
+		if entry == nil {
+			continue
+		}
+		for _, t := range entry.Times {
+			if t.IsZero() {
+				continue
+			}
+			uniq[t.UTC()] = struct{}{}
+		}
+	}
+	for _, wi := range h.Store.WatchIndex {
+		if wi == nil {
+			continue
+		}
+		for _, t := range wi.Times {
+			if t.IsZero() {
+				continue
+			}
+			uniq[t.UTC()] = struct{}{}
+		}
+	}
+
+	all := make([]time.Time, 0, len(uniq))
+	for t := range uniq {
+		all = append(all, t)
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].Before(all[j]) })
+	resp.TotalCount = len(all)
+
+	out := all
+	if len(out) > scrubberMaxStops {
+		resp.Sampled = true
+		out = sampleTimes(out, scrubberMaxStops)
+	}
+	resp.Timestamps = make([]string, 0, len(out))
+	for _, t := range out {
+		resp.Timestamps = append(resp.Timestamps, t.Format(time.RFC3339))
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// sampleTimes picks roughly-evenly-spaced timestamps so the scrubber doesn't
+// render a million ticks on long captures.
+func sampleTimes(all []time.Time, n int) []time.Time {
+	if len(all) <= n || n <= 1 {
+		return all
+	}
+	out := make([]time.Time, 0, n)
+	step := float64(len(all)-1) / float64(n-1)
+	for i := 0; i < n; i++ {
+		idx := int(float64(i) * step)
+		if idx >= len(all) {
+			idx = len(all) - 1
+		}
+		out = append(out, all[idx])
+	}
+	return out
+}

--- a/internal/ui/v2/types.go
+++ b/internal/ui/v2/types.go
@@ -72,9 +72,10 @@ type Issue struct {
 
 // ResourceTile is one of the small cards in the "Resources captured" grid.
 type ResourceTile struct {
-	Kind  string `json:"kind"`
-	Count int    `json:"count"`
-	Link  string `json:"link"`
+	Kind     string `json:"kind"`
+	Resource string `json:"resource,omitempty"`
+	Count    int    `json:"count"`
+	Link     string `json:"link"`
 }
 
 // NamespaceSummary is a single row in the top-namespaces list and also the
@@ -96,4 +97,9 @@ type Transition struct {
 	Namespace string `json:"namespace,omitempty"`
 	Name      string `json:"name"`
 	Detail    string `json:"detail,omitempty"`
+	// Path is the watch event's API list path (e.g. /api/v1/namespaces/x/pods)
+	// and Resource its plural name; the UI uses them to link a transition row
+	// to the pod detail or the generic object view.
+	Path     string `json:"path,omitempty"`
+	Resource string `json:"resource,omitempty"`
 }

--- a/internal/ui/v2/types.go
+++ b/internal/ui/v2/types.go
@@ -1,0 +1,99 @@
+package v2
+
+import "time"
+
+// CaptureMeta is the small slice of metadata the UI shows in the top bar.
+type CaptureMeta struct {
+	CaptureID         string    `json:"capture_id"`
+	CapturedAt        time.Time `json:"captured_at"`
+	CapturedUntil     time.Time `json:"captured_until"`
+	KubernetesVersion string    `json:"kubernetes_version,omitempty"`
+	ServerAddress     string    `json:"server_address,omitempty"`
+	RecordCount       int       `json:"record_count"`
+}
+
+// Overview is the response from /v2/api/overview — everything the dashboard
+// landing page needs.
+type Overview struct {
+	Capture       CaptureMeta        `json:"capture"`
+	At            string             `json:"at,omitempty"`
+	KPIs          KPIs               `json:"kpis"`
+	Sparkline     SparklineData      `json:"sparkline"`
+	Issues        []Issue            `json:"issues"`
+	Resources     []ResourceTile     `json:"resources"`
+	Namespaces    []NamespaceSummary `json:"namespaces"`
+	TopNamespaces []NamespaceSummary `json:"top_namespaces"`
+	Recent        []Transition       `json:"recent"`
+}
+
+// KPIs are the top-of-dashboard counters.
+type KPIs struct {
+	Namespaces       int `json:"namespaces"`
+	Workloads        int `json:"workloads"`
+	Pods             int `json:"pods"`
+	UnhealthyPods    int `json:"unhealthy_pods"`
+	WatchEvents      int `json:"watch_events"`
+	CrashLoopBackOff int `json:"crash_loop_back_off"`
+	Failed           int `json:"failed"`
+	Pending          int `json:"pending"`
+	OOMKilled        int `json:"oom_killed"`
+	VirtualMachines  int `json:"virtual_machines"`
+}
+
+// SparklineData powers the pod-state-transitions chart on the overview.
+type SparklineData struct {
+	Buckets     []SparkBucket `json:"buckets"`
+	TotalEvents int           `json:"total_events"`
+	StartTime   time.Time     `json:"start_time"`
+	EndTime     time.Time     `json:"end_time"`
+}
+
+// SparkBucket is one column in the sparkline — counts of watch events in
+// a fixed time window, split by severity.
+type SparkBucket struct {
+	Time  time.Time `json:"time"`
+	Total int       `json:"total"`
+	Warn  int       `json:"warn"`
+	Bad   int       `json:"bad"`
+}
+
+// Issue is one row in the "Issues to investigate" panel. Pods with the
+// same failure mode and the same name prefix are grouped (Count > 1).
+type Issue struct {
+	Severity  string `json:"severity"` // "bad" | "warn"
+	Kind      string `json:"kind"`     // short resource kind ("Pod", "Deploy", "DS", …)
+	Title     string `json:"title"`
+	Subtitle  string `json:"subtitle"`
+	Namespace string `json:"namespace,omitempty"`
+	Count     int    `json:"count,omitempty"` // ≥2 when grouped
+	AgeHuman  string `json:"age,omitempty"`
+	Link      string `json:"link,omitempty"` // hash route the UI navigates to on click
+}
+
+// ResourceTile is one of the small cards in the "Resources captured" grid.
+type ResourceTile struct {
+	Kind  string `json:"kind"`
+	Count int    `json:"count"`
+	Link  string `json:"link"`
+}
+
+// NamespaceSummary is a single row in the top-namespaces list and also the
+// shape returned from the Namespaces tab.
+type NamespaceSummary struct {
+	Name      string `json:"name"`
+	Resources int    `json:"resources"`
+	Workloads int    `json:"workloads"`
+	Pods      int    `json:"pods"`
+	Unhealthy int    `json:"unhealthy,omitempty"`
+}
+
+// Transition is a single recent watch event used by the "Recent transitions"
+// panel on the overview.
+type Transition struct {
+	Time      string `json:"time"`
+	EventType string `json:"event_type"`
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+	Detail    string `json:"detail,omitempty"`
+}

--- a/internal/ui/v2/types.go
+++ b/internal/ui/v2/types.go
@@ -81,11 +81,12 @@ type ResourceTile struct {
 // NamespaceSummary is a single row in the top-namespaces list and also the
 // shape returned from the Namespaces tab.
 type NamespaceSummary struct {
-	Name      string `json:"name"`
-	Resources int    `json:"resources"`
-	Workloads int    `json:"workloads"`
-	Pods      int    `json:"pods"`
-	Unhealthy int    `json:"unhealthy,omitempty"`
+	Name      string            `json:"name"`
+	Resources int               `json:"resources"`
+	Workloads int               `json:"workloads"`
+	Pods      int               `json:"pods"`
+	Unhealthy int               `json:"unhealthy,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
 }
 
 // Transition is a single recent watch event used by the "Recent transitions"

--- a/internal/ui/v2/v2.go
+++ b/internal/ui/v2/v2.go
@@ -41,6 +41,7 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("/v2/api/resources", h.serveResourceCatalog)
 	mux.HandleFunc("/v2/api/resource", h.serveResourceList)
 	mux.HandleFunc("/v2/api/object", h.serveObject)
+	mux.HandleFunc("/v2/api/object-relationships", h.serveObjectRelationships)
 	mux.HandleFunc("/v2/api/pod", h.servePod)
 	mux.HandleFunc("/v2/api/events", h.serveEvents)
 	mux.HandleFunc("/v2/api/logs", h.serveLogs)

--- a/internal/ui/v2/v2.go
+++ b/internal/ui/v2/v2.go
@@ -37,6 +37,7 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("/v2/api/namespace", h.serveNamespace)
 	mux.HandleFunc("/v2/api/pods", h.serveAllPods)
 	mux.HandleFunc("/v2/api/workloads", h.serveAllWorkloads)
+	mux.HandleFunc("/v2/api/resources", h.serveResourceCatalog)
 	mux.HandleFunc("/v2/api/resource", h.serveResourceList)
 	mux.HandleFunc("/v2/api/object", h.serveObject)
 	mux.HandleFunc("/v2/api/pod", h.servePod)

--- a/internal/ui/v2/v2.go
+++ b/internal/ui/v2/v2.go
@@ -1,0 +1,44 @@
+// Package v2 is the redesigned k8shark web UI. It mounts under /v2/ and
+// provides a dashboard-style overview plus drilldowns for namespaces, pods,
+// and other resources. Eventually intended to replace the original UI in
+// internal/ui — until then both live side by side.
+package v2
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/server"
+)
+
+//go:embed static
+var staticFS embed.FS
+
+// Handler holds the shared state for v2 endpoints.
+type Handler struct {
+	Store       *server.CaptureStore
+	At          time.Time
+	ArchivePath string
+	Verbose     bool
+}
+
+// Mount registers all /v2/* routes on mux. The /v2/ HTML shell is served
+// from the embedded static FS; /v2/api/* endpoints return JSON.
+func (h *Handler) Mount(mux *http.ServeMux) {
+	sub, err := fs.Sub(staticFS, "static")
+	if err != nil {
+		panic(err) // embed failure is a compile-time misconfiguration
+	}
+	mux.Handle("/v2/", http.StripPrefix("/v2/", http.FileServer(http.FS(sub))))
+
+	mux.HandleFunc("/v2/api/overview", h.serveOverview)
+	mux.HandleFunc("/v2/api/namespace", h.serveNamespace)
+	mux.HandleFunc("/v2/api/pod", h.servePod)
+	mux.HandleFunc("/v2/api/events", h.serveEvents)
+	mux.HandleFunc("/v2/api/logs", h.serveLogs)
+	mux.HandleFunc("/v2/api/diff", h.serveDiff)
+	mux.HandleFunc("/v2/api/object-history", h.serveObjectHistory)
+	mux.HandleFunc("/v2/api/timestamps", h.serveTimestamps)
+}

--- a/internal/ui/v2/v2.go
+++ b/internal/ui/v2/v2.go
@@ -37,6 +37,8 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("/v2/api/namespace", h.serveNamespace)
 	mux.HandleFunc("/v2/api/pods", h.serveAllPods)
 	mux.HandleFunc("/v2/api/workloads", h.serveAllWorkloads)
+	mux.HandleFunc("/v2/api/resource", h.serveResourceList)
+	mux.HandleFunc("/v2/api/object", h.serveObject)
 	mux.HandleFunc("/v2/api/pod", h.servePod)
 	mux.HandleFunc("/v2/api/events", h.serveEvents)
 	mux.HandleFunc("/v2/api/logs", h.serveLogs)

--- a/internal/ui/v2/v2.go
+++ b/internal/ui/v2/v2.go
@@ -34,6 +34,7 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	mux.Handle("/v2/", http.StripPrefix("/v2/", http.FileServer(http.FS(sub))))
 
 	mux.HandleFunc("/v2/api/overview", h.serveOverview)
+	mux.HandleFunc("/v2/api/capture", h.serveCaptureInfo)
 	mux.HandleFunc("/v2/api/namespace", h.serveNamespace)
 	mux.HandleFunc("/v2/api/pods", h.serveAllPods)
 	mux.HandleFunc("/v2/api/workloads", h.serveAllWorkloads)

--- a/internal/ui/v2/v2.go
+++ b/internal/ui/v2/v2.go
@@ -35,6 +35,8 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 
 	mux.HandleFunc("/v2/api/overview", h.serveOverview)
 	mux.HandleFunc("/v2/api/namespace", h.serveNamespace)
+	mux.HandleFunc("/v2/api/pods", h.serveAllPods)
+	mux.HandleFunc("/v2/api/workloads", h.serveAllWorkloads)
 	mux.HandleFunc("/v2/api/pod", h.servePod)
 	mux.HandleFunc("/v2/api/events", h.serveEvents)
 	mux.HandleFunc("/v2/api/logs", h.serveLogs)


### PR DESCRIPTION
## Summary

A redesigned, dashboard-style web UI for browsing k8shark captures. It is now the **default UI** — `/` redirects to `/v2/` — and the original explorer is preserved at **`/v1/`**. Built incrementally as many small, self-contained commits you can review in sequence.

## What's included

**Views**
- **Overview dashboard** — KPI tiles (namespaces / workloads / pods / unhealthy / watch events), a "Capture details" card, resource-transition sparkline + recent transitions, "Resources captured" tiles, top namespaces, and grouped Issues (CrashLoopBackOff / OOMKilled / …).
- **Namespaces** index + **namespace** drill-down (workloads, pods, VMs, resource tiles, metadata).
- **Pods** list and **Workloads** list (cluster-wide, sortable, unhealthy-first).
- **Resources catalog** — every captured API resource type, grouped by API group, with per-resource and per-group on/off toggles (v1-sidebar style, persisted).
- **Generic resource list** + **generic object view** with **YAML / JSON** (syntax-highlighted, Copy + Download), **History**, **Diff** (snapshot-to-snapshot), and **Relationships** (PV↔PVC↔Pod, ConfigMap/Secret→Pod, owner refs) tabs.
- **Pod** drill-down (Summary, Containers & Logs, Events, History, Relationships, YAML), plus **Timeline**, **Logs**, **Diff**.

**Search / filtering**
- A chip/token **filter bar** on every list surface (Pods, Workloads, Resource list, Namespaces, Timeline, Resources catalog): type-ahead + Tab completion, `k=v` facets, `/regex/` values, **label selectors** (`app.kubernetes.io/name=…`), suggestions **aggregated** across existing chips, and removable chips.
- A **global resource on/off filter** (the catalog toggles) honored across the overview, transitions, and all object lists, with a "some types hidden" banner.

**Navigation / UX**
- Clickable KPI tiles, resource tiles, and watch-event/transition rows; relationship links; breadcrumbs; snapshot scrubber.
- **Light / dark theme** toggle (persisted).
- Cross-links between the two UIs (v2 "Legacy UI ↗" → /v1/, v1 "Dashboard (v2) →" → /v2/).

**Config**
- A `ui:` config block (`port` / `api_port`) to pin consistent web-UI / mock-API ports; `--port` / `--api-port` flags override it.

## Capture-engine fixes (found while building the UI)

- **Watch events were never recorded.** The hand-rolled HTTP/2 watch connected (200) but received no frames, leaving an empty watch-index (and an empty v2 timeline). Rewrote watch streaming through client-go's dynamic client (List + Watch). *(04e337b)*
- **Slow startup / flaky fetches on large clusters.** Parallelized API discovery, fixed an `allNotFound` code-0 misclassification that triggered spurious cluster-scoped fallbacks, and added a per-fetch timeout so a stalled read can't pin a slot. *(ab4ce28)*

## Compatibility

- **v2 is now the default** (`/` → `/v2/`); the original explorer stays at **`/v1/`**; all existing `/api/ui/*` endpoints are unchanged.
- **Archive format is backward-compatible.** Capture metadata gained additive fields (`auto_discovered`, `watch_enabled`, `intervals`, `uncompressed_bytes`, `redacted`); older archives load fine and show "not recorded" for those.
- New v2 endpoints live under `/v2/api/*` (`overview`, `capture`, `namespace`, `pods`, `workloads`, `resource`, `resources`, `object`, `object-relationships`, `pod`, `logs`, `diff`, `object-history`, `timestamps`).

## Test plan

- [x] `go test ./...` and `go vet ./...` clean (incl. `-race` on the archive writer + capture engine)
- [x] Unit tests for pod classification, resource-kind derivation, and the per-fetch timeout
- [x] Extensive live verification against a real ~550 MiB / 153-namespace OpenShift capture, with UI flows driven and confirmed via headless Chrome (CDP): chip filtering (facets/regex/labels/aggregation), resource toggles, object YAML/JSON + relationships, capture-details card, theme toggle, v2-default routing and cross-links

## Try it locally

```sh
kshrk ui ./your-capture.khsrk
# Opens on the v2 dashboard by default. Legacy UI at /v1/.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #61 
closes #60 
closes #59 
closes #58 
closes #57 
closes #56 
closes #55 
closes #54
