### PR TITLE
Potential fix for code scanning alert no. 6: Client-side cross-site scripting

### DIFF
--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -10,7 +10,7 @@
     const n = document.createElement(tag);
     for (const [k, v] of Object.entries(attrs)) {
       if (k === 'class') n.className = v;
-      else if (k === 'html') n.textContent = String(v);
+      else if (k === 'text' || k === 'html') n.textContent = String(v); // 'html' kept as deprecated alias
       else if (k.startsWith('on') && typeof v === 'function') n.addEventListener(k.slice(2), v);
       else if (v !== undefined && v !== null) n.setAttribute(k, v);
     }

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -10,7 +10,7 @@
     const n = document.createElement(tag);
     for (const [k, v] of Object.entries(attrs)) {
       if (k === 'class') n.className = v;
-      else if (k === 'html') n.innerHTML = v;
+      else if (k === 'html') n.textContent = String(v);
       else if (k.startsWith('on') && typeof v === 'function') n.addEventListener(k.slice(2), v);
       else if (v !== undefined && v !== null) n.setAttribute(k, v);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/phenixblue/k8shark/security/code-scanning/6](https://github.com/phenixblue/k8shark/security/code-scanning/6)

Best fix: eliminate dynamic `innerHTML` writes in the shared `el()` helper and treat `html` attribute values as text content. This preserves current behavior for plain text while preventing script/markup execution if untrusted input reaches this path.

Concretely in `internal/ui/v2/static/app.js`:
- In `el()` (around lines 11–16), replace:
  - `else if (k === 'html') n.innerHTML = v;`
  with
  - `else if (k === 'html') n.textContent = String(v);`
  
This is the smallest, safest single change in the shown code that hardens rendering against DOM XSS and addresses the reported variants flowing from `location.hash`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
