### PR TITLE
feat: cluster demo scripts + pod view fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,6 @@ planning/
 
 # Test / local capture data
 *.tar.gz
+*.khsrk
 k8shark-capture/
+scale-manifests/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-race test-cover bench fmt lint lint-ci-install lint-ci e2e kind-up kind-down release-snapshot release-local clean help
+.PHONY: build test test-race test-cover bench fmt lint lint-ci-install lint-ci e2e kind-up kind-chaos kind-scale kind-down release-snapshot release-local clean help
 
 BINARY  := kshrk
 VERSION ?= dev
@@ -40,9 +40,16 @@ e2e: build ## Build binary and run end-to-end tests (requires kind + kubectl)
 kind-up: ## Create a dev KinD cluster with test resources (use --reset to recreate)
 	./scripts/kind-up.sh $(ARGS)
 
-kind-down: ## Delete the dev KinD cluster (k8shark-dev)
-	kind delete cluster --name k8shark-dev
-	rm -f $(HOME)/.kube/k8shark-dev.yaml
+kind-chaos: ## Create a KinD cluster of unhealthy workloads for event/capture demos (ARGS=--churn 180)
+	./scripts/kind-chaos.sh $(ARGS)
+
+kind-scale: ## Create a multi-node KinD cluster with 50+ namespaces and dozens of workloads (ARGS=--namespaces 80)
+	./scripts/kind-scale.sh $(ARGS)
+
+kind-down: ## Delete the dev KinD clusters (k8shark-dev and k8shark-scale)
+	-kind delete cluster --name k8shark-dev
+	-kind delete cluster --name k8shark-scale
+	rm -f $(HOME)/.kube/k8shark-dev.yaml $(HOME)/.kube/k8shark-scale.yaml
 
 clean: ## Remove build artifacts
 	rm -f $(BINARY) coverage.out coverage.html

--- a/internal/ui/v2/objects.go
+++ b/internal/ui/v2/objects.go
@@ -49,12 +49,24 @@ func (h *Handler) serveObject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	raw := body
+	// The parent List envelope carries the correctly-cased kind
+	// (e.g. "MutatingWebhookConfigurationList") and the real apiVersion, which
+	// individual items inside the list omit. Capture them as hints so we can
+	// restore them on the item without guessing casing from the resource name.
+	var apiVersionHint, kindHint string
 	if name != "" {
 		var list struct {
-			Items []json.RawMessage `json:"items"`
+			Kind       string            `json:"kind"`
+			APIVersion string            `json:"apiVersion"`
+			Items      []json.RawMessage `json:"items"`
 		}
 		found := false
 		if err := json.Unmarshal(body, &list); err == nil {
+			apiVersionHint = list.APIVersion
+			kindHint = strings.TrimSuffix(list.Kind, "List")
+			if kindHint == list.Kind { // didn't end in "List" — not a usable hint
+				kindHint = ""
+			}
 			for _, it := range list.Items {
 				if getName(it) == name {
 					raw = it
@@ -70,7 +82,7 @@ func (h *Handler) serveObject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp.Found = true
-	raw = normalizeObjectBody(raw, path)
+	raw = normalizeObjectBody(raw, path, apiVersionHint, kindHint)
 	resp.Kind, resp.Namespace = kindAndNamespace(raw)
 	resp.JSON = prettyJSON(raw)
 	resp.YAML = toYAML(raw)
@@ -378,10 +390,12 @@ func kindAndNamespace(raw json.RawMessage) (kind, namespace string) {
 }
 
 // normalizeObjectBody restores the top-level apiVersion and kind fields that
-// Kubernetes omits from objects nested inside a List response. They're inferred
-// from the capture path's group/version/resource. List and Table envelopes are
-// left untouched. The fix mirrors the legacy v1 UI's normalizeDetailBody.
-func normalizeObjectBody(raw json.RawMessage, path string) json.RawMessage {
+// Kubernetes omits from objects nested inside a List response. It prefers the
+// hints derived from the parent List envelope (which preserve correct casing,
+// e.g. "MutatingWebhookConfiguration") and falls back to inferring them from
+// the capture path's group/version/resource. List and Table envelopes are left
+// untouched. The fix mirrors the legacy v1 UI's normalizeDetailBody.
+func normalizeObjectBody(raw json.RawMessage, path, apiVersionHint, kindHint string) json.RawMessage {
 	var obj map[string]any
 	if err := json.Unmarshal(raw, &obj); err != nil {
 		return raw
@@ -396,17 +410,28 @@ func normalizeObjectBody(raw json.RawMessage, path string) json.RawMessage {
 
 	group, version, resource, _ := parseAPIPath(path)
 	changed := false
-	if s, _ := obj["apiVersion"].(string); s == "" && version != "" {
-		if group == "" {
+	if s, _ := obj["apiVersion"].(string); s == "" {
+		switch {
+		case apiVersionHint != "":
+			obj["apiVersion"] = apiVersionHint
+			changed = true
+		case version != "" && group == "":
 			obj["apiVersion"] = version
-		} else {
+			changed = true
+		case version != "":
 			obj["apiVersion"] = group + "/" + version
+			changed = true
 		}
-		changed = true
 	}
-	if s, _ := obj["kind"].(string); s == "" && resource != "" {
-		obj["kind"] = kindFromResource(resource)
-		changed = true
+	if s, _ := obj["kind"].(string); s == "" {
+		switch {
+		case kindHint != "":
+			obj["kind"] = kindHint
+			changed = true
+		case resource != "":
+			obj["kind"] = kindFromResource(resource)
+			changed = true
+		}
 	}
 	if !changed {
 		return raw

--- a/internal/ui/v2/objects.go
+++ b/internal/ui/v2/objects.go
@@ -70,6 +70,7 @@ func (h *Handler) serveObject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp.Found = true
+	raw = normalizeObjectBody(raw, path)
 	resp.Kind, resp.Namespace = kindAndNamespace(raw)
 	resp.JSON = prettyJSON(raw)
 	resp.YAML = toYAML(raw)
@@ -374,6 +375,49 @@ func kindAndNamespace(raw json.RawMessage) (kind, namespace string) {
 		return "", ""
 	}
 	return m.Kind, m.Metadata.Namespace
+}
+
+// normalizeObjectBody restores the top-level apiVersion and kind fields that
+// Kubernetes omits from objects nested inside a List response. They're inferred
+// from the capture path's group/version/resource. List and Table envelopes are
+// left untouched. The fix mirrors the legacy v1 UI's normalizeDetailBody.
+func normalizeObjectBody(raw json.RawMessage, path string) json.RawMessage {
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return raw
+	}
+	// Leave list/table envelopes as-is — they carry their own kind.
+	if _, hasItems := obj["items"]; hasItems {
+		return raw
+	}
+	if k, _ := obj["kind"].(string); strings.HasSuffix(k, "Table") {
+		return raw
+	}
+
+	group, version, resource, _ := parseAPIPath(path)
+	changed := false
+	if s, _ := obj["apiVersion"].(string); s == "" && version != "" {
+		if group == "" {
+			obj["apiVersion"] = version
+		} else {
+			obj["apiVersion"] = group + "/" + version
+		}
+		changed = true
+	}
+	if s, _ := obj["kind"].(string); s == "" && resource != "" {
+		obj["kind"] = kindFromResource(resource)
+		changed = true
+	}
+	if !changed {
+		return raw
+	}
+	// Re-marshaling sorts keys alphabetically, which happens to match the
+	// canonical apiVersion/kind/metadata/spec/status ordering.
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return raw
+	}
+	return b
 }
 
 // prettyJSON re-indents a raw JSON body. Returns the original string on error.

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -1155,7 +1155,9 @@
       ybtn.className = 'btn' + (mode === 'yaml' ? ' primary' : '');
       jbtn.className = 'btn' + (mode === 'json' ? ' primary' : '');
     }
-    wrap.appendChild(el('div', { style: 'display:flex; gap:8px; margin-bottom:10px;' }, ybtn, jbtn, copyBtn, dlBtn));
+    wrap.appendChild(el('div', { style: 'display:flex; gap:8px; align-items:center; justify-content:space-between; margin-bottom:10px;' },
+      el('div', { style: 'display:flex; gap:8px;' }, ybtn, jbtn),
+      el('div', { style: 'display:flex; gap:8px;' }, copyBtn, dlBtn)));
     wrap.appendChild(host);
     getJSON('/v2/api/object?path=' + encodeURIComponent(path) + (name ? '&name=' + encodeURIComponent(name) : ''))
       .then((d) => { data = d; paint(); })

--- a/scripts/kind-chaos.sh
+++ b/scripts/kind-chaos.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# Spin up a KinD cluster full of deliberately *unhealthy* workloads so a
+# k8shark capture has rich pod events to show off: CrashLoopBackOff, OOMKilled,
+# ImagePullBackOff, FailedScheduling, probe flapping, unbound PVCs and Job
+# backoff. Use this when kind-up.sh's healthy workloads are too quiet to
+# demonstrate the Timeline / pod-detail Conditions & restart sparkline.
+#
+# Usage:
+#   ./scripts/kind-chaos.sh                 # create cluster + deploy chaos workloads
+#   ./scripts/kind-chaos.sh --reset         # delete existing cluster first, then recreate
+#   ./scripts/kind-chaos.sh --churn 180     # after deploying, bounce healthy pods for 180s
+#                                           #   to generate Scheduled/Created/Killing events
+#
+# Tear down with:  make kind-down  (or: kind delete cluster --name k8shark-dev)
+set -euo pipefail
+
+CLUSTER_NAME="k8shark-dev"
+KIND_KUBECONFIG="${HOME}/.kube/k8shark-dev.yaml"
+NS="k8shark-chaos"
+NS_JOBS="k8shark-chaos-jobs"
+RESET=false
+CHURN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --reset) RESET=true; shift ;;
+    --churn) CHURN="${2:?--churn needs a number of seconds}"; shift 2 ;;
+    -h|--help) sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+  esac
+done
+
+log()  { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+info() { printf '    %s\n' "$*"; }
+ok()   { printf '  \033[1;32m[OK]\033[0m  %s\n' "$*"; }
+die()  { printf '\n\033[1;31mFATAL: %s\033[0m\n' "$*" >&2; exit 1; }
+
+# ── Prerequisites ──────────────────────────────────────────────────────────────
+log "Checking prerequisites"
+for tool in kind kubectl; do
+  command -v "$tool" >/dev/null 2>&1 || die "'$tool' not found in PATH"
+  ok "$tool: $(command -v "$tool")"
+done
+
+# ── Optional reset ─────────────────────────────────────────────────────────────
+if $RESET && kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+  log "Deleting existing cluster '$CLUSTER_NAME'"
+  kind delete cluster --name "$CLUSTER_NAME"
+fi
+
+# ── Create KinD cluster ────────────────────────────────────────────────────────
+if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+  log "Cluster '$CLUSTER_NAME' already exists — skipping creation"
+  kind get kubeconfig --name "$CLUSTER_NAME" > "$KIND_KUBECONFIG"
+  chmod 0600 "$KIND_KUBECONFIG"
+else
+  log "Creating KinD cluster '$CLUSTER_NAME'"
+  kind create cluster \
+    --name "$CLUSTER_NAME" \
+    --kubeconfig "$KIND_KUBECONFIG" \
+    --wait 90s
+  ok "Cluster '$CLUSTER_NAME' ready"
+fi
+
+KC=(--kubeconfig "$KIND_KUBECONFIG")
+
+# ── Namespaces ───────────────────────────────────────────────────────────────
+log "Creating namespaces"
+for ns in "$NS" "$NS_JOBS"; do
+  kubectl "${KC[@]}" get namespace "$ns" &>/dev/null || kubectl "${KC[@]}" create namespace "$ns"
+done
+ok "Namespaces: $NS, $NS_JOBS"
+
+# ── Eventful workloads ─────────────────────────────────────────────────────────
+log "Deploying chaos workloads into '$NS'"
+
+# 1. Healthy baseline (also the churn target). Gives a "good" contrast row.
+kubectl "${KC[@]}" apply -n "$NS" -f - <<'YAML'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: healthy-web
+  labels: { app: healthy-web, k8shark.io/scenario: healthy }
+spec:
+  replicas: 2
+  selector: { matchLabels: { app: healthy-web } }
+  template:
+    metadata: { labels: { app: healthy-web } }
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          resources: { requests: { cpu: 10m, memory: 16Mi }, limits: { memory: 64Mi } }
+YAML
+ok "healthy-web        — 2 healthy replicas (baseline)"
+
+# 2. CrashLoopBackOff — container exits non-zero, restart count climbs forever.
+kubectl "${KC[@]}" apply -n "$NS" -f - <<'YAML'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crashloop
+  labels: { app: crashloop, k8shark.io/scenario: crashloop }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: crashloop } }
+  template:
+    metadata: { labels: { app: crashloop } }
+    spec:
+      containers:
+        - name: flaky
+          image: busybox:1.36
+          command: ["/bin/sh", "-c", "echo starting up; sleep 4; echo crashing; exit 1"]
+YAML
+ok "crashloop          — exits 1 on a loop -> CrashLoopBackOff, rising restarts"
+
+# 3. OOMKilled — balloons anonymous memory past its limit, gets OOM-killed, repeats.
+kubectl "${KC[@]}" apply -n "$NS" -f - <<'YAML'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oomkill
+  labels: { app: oomkill, k8shark.io/scenario: oomkill }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: oomkill } }
+  template:
+    metadata: { labels: { app: oomkill } }
+    spec:
+      containers:
+        - name: hog
+          image: busybox:1.36
+          # Buffer ~300MB into a shell variable; the 100Mi limit triggers an OOM kill.
+          command: ["/bin/sh", "-c", "echo eating memory; A=$(yes payload | head -c 314572800); echo done"]
+          resources: { requests: { memory: 32Mi }, limits: { memory: 100Mi } }
+YAML
+ok "oomkill            — allocates past memory limit -> OOMKilled, rising restarts"
+
+# 4. ImagePullBackOff — image that can never be pulled.
+kubectl "${KC[@]}" apply -n "$NS" -f - <<'YAML'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bad-image
+  labels: { app: bad-image, k8shark.io/scenario: imagepull }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: bad-image } }
+  template:
+    metadata: { labels: { app: bad-image } }
+    spec:
+      containers:
+        - name: missing
+          image: registry.invalid/k8shark/does-not-exist:v0
+YAML
+ok "bad-image          — bogus image -> ErrImagePull / ImagePullBackOff (Pending)"
+
+# 5. FailedScheduling — requests more CPU than any node can offer.
+kubectl "${KC[@]}" apply -n "$NS" -f - <<'YAML'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unschedulable
+  labels: { app: unschedulable, k8shark.io/scenario: unschedulable }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: unschedulable } }
+  template:
+    metadata: { labels: { app: unschedulable } }
+    spec:
+      containers:
+        - name: greedy
+          image: nginx:alpine
+          resources: { requests: { cpu: "64" } }   # no kind node has 64 cores
+YAML
+ok "unschedulable      — 64-core request -> FailedScheduling (Pending, Unschedulable)"
+
+# 6. Liveness probe flapping — kubelet keeps killing/restarting the container.
+kubectl "${KC[@]}" apply -n "$NS" -f - <<'YAML'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: liveness-flap
+  labels: { app: liveness-flap, k8shark.io/scenario: liveness }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: liveness-flap } }
+  template:
+    metadata: { labels: { app: liveness-flap } }
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          livenessProbe:
+            exec: { command: ["/bin/sh", "-c", "exit 1"] }   # always fails
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 2
+YAML
+ok "liveness-flap      — failing liveness probe -> Unhealthy/Killing events, restarts"
+
+# 7. Readiness never passes — Ready=False forever, but no restarts (clean Conditions demo).
+kubectl "${KC[@]}" apply -n "$NS" -f - <<'YAML'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notready
+  labels: { app: notready, k8shark.io/scenario: notready }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: notready } }
+  template:
+    metadata: { labels: { app: notready } }
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          readinessProbe:
+            exec: { command: ["/bin/sh", "-c", "exit 1"] }   # never ready
+            initialDelaySeconds: 3
+            periodSeconds: 5
+YAML
+ok "notready           — failing readiness probe -> Ready=False (no restarts)"
+
+# 8. Unbound PVC — references a storage class that does not exist; pod stays Pending.
+kubectl "${KC[@]}" apply -n "$NS" -f - <<'YAML'
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: missing-storage
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: does-not-exist
+  resources: { requests: { storage: 1Gi } }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pending-pvc
+  labels: { app: pending-pvc, k8shark.io/scenario: pending-pvc }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: pending-pvc } }
+  template:
+    metadata: { labels: { app: pending-pvc } }
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          volumeMounts: [{ name: data, mountPath: /data }]
+      volumes:
+        - name: data
+          persistentVolumeClaim: { claimName: missing-storage }
+YAML
+ok "pending-pvc        — PVC on a missing StorageClass -> Pending (unbound PVC)"
+
+# 9. Failing Job — retries until backoffLimit is hit, leaving several failed pods.
+kubectl "${KC[@]}" apply -n "$NS_JOBS" -f - <<'YAML'
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: failing-job
+  labels: { app: failing-job, k8shark.io/scenario: job-backoff }
+spec:
+  backoffLimit: 3
+  template:
+    metadata: { labels: { app: failing-job } }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: worker
+          image: busybox:1.36
+          command: ["/bin/sh", "-c", "echo working; sleep 3; echo failing; exit 1"]
+YAML
+ok "failing-job        — exits 1 -> Job backoff, BackoffLimitExceeded (in $NS_JOBS)"
+
+# ── Let events accumulate ────────────────────────────────────────────────────
+log "Waiting ~45s for failures to surface (restarts, backoffs, scheduling events)"
+kubectl "${KC[@]}" rollout status deployment/healthy-web -n "$NS" --timeout=90s || true
+sleep 45
+kubectl "${KC[@]}" get pods -A -o wide | grep -E "NAMESPACE|$NS" || true
+
+# ── Optional churn loop ──────────────────────────────────────────────────────
+if [[ "$CHURN" -gt 0 ]]; then
+  log "Churning healthy-web for ${CHURN}s to generate pod-lifecycle Timeline events"
+  info "(rolling restarts + pod deletions every ~12s; Ctrl-C to stop early)"
+  end=$((SECONDS + CHURN))
+  while [[ $SECONDS -lt $end ]]; do
+    kubectl "${KC[@]}" rollout restart deployment/healthy-web -n "$NS" >/dev/null 2>&1 || true
+    pod=$(kubectl "${KC[@]}" get pods -n "$NS" -l app=healthy-web -o name 2>/dev/null | head -1)
+    [[ -n "$pod" ]] && kubectl "${KC[@]}" delete -n "$NS" "$pod" --grace-period=0 --force >/dev/null 2>&1 || true
+    info "churned at +$((SECONDS))s"
+    sleep 12
+  done
+  ok "Churn complete"
+fi
+
+# ── Done ───────────────────────────────────────────────────────────────────────
+printf '\n\033[1;32mChaos cluster ready.\033[0m\n\n'
+info "Inspect the carnage:"
+printf '    export KUBECONFIG=%s\n' "$KIND_KUBECONFIG"
+printf '    kubectl get pods -n %s -o wide\n' "$NS"
+printf '    kubectl get events -n %s --sort-by=.lastTimestamp\n\n' "$NS"
+info "Capture it with k8shark (run for a few minutes so events keep flowing):"
+printf '    make build\n'
+printf '    ./kshrk capture --kubeconfig %s --auto-discover --duration 3m -o chaos.khsrk\n\n' "$KIND_KUBECONFIG"
+info "Then explore the capture (UI on 18080/18081):"
+printf '    ./kshrk ui chaos.khsrk --port 18080 --api-port 18081\n\n'
+info "Tear down when finished:"
+printf '    make kind-down\n\n'

--- a/scripts/kind-scale.sh
+++ b/scripts/kind-scale.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Spin up a multi-node KinD cluster populated at *scale*: 50+ namespaces and
+# dozens of workloads, so a k8shark capture exercises the namespace list,
+# search, and Timeline under realistic load. A handful of the workloads are
+# deliberately unhealthy (crashloop / unschedulable) so the capture still has
+# interesting events to show off — see kind-chaos.sh for an event-focused run.
+#
+# Usage:
+#   ./scripts/kind-scale.sh                 # 50 namespaces, ~2 workloads each
+#   ./scripts/kind-scale.sh --namespaces 80 # pick the namespace count
+#   ./scripts/kind-scale.sh --reset         # delete existing scale cluster first
+#
+# Uses its own cluster (k8shark-scale) so it won't collide with kind-chaos.sh.
+# Tear down with:  make kind-down  (removes both dev clusters)
+set -euo pipefail
+
+CLUSTER_NAME="k8shark-scale"
+KIND_KUBECONFIG="${HOME}/.kube/k8shark-scale.yaml"
+NS_COUNT=50
+RESET=false
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespaces) NS_COUNT="${2:?--namespaces needs a count}"; shift 2 ;;
+    --reset) RESET=true; shift ;;
+    --dry-run) DRY_RUN=true; shift ;;   # generate manifests only; no cluster, no apply
+    -h|--help) sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+  esac
+done
+[[ "$NS_COUNT" -ge 1 ]] 2>/dev/null || { printf '--namespaces must be a positive integer\n' >&2; exit 2; }
+
+log()  { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+info() { printf '    %s\n' "$*"; }
+ok()   { printf '  \033[1;32m[OK]\033[0m  %s\n' "$*"; }
+die()  { printf '\n\033[1;31mFATAL: %s\033[0m\n' "$*" >&2; exit 1; }
+
+# ── Prerequisites ──────────────────────────────────────────────────────────────
+log "Checking prerequisites"
+for tool in kind kubectl; do
+  command -v "$tool" >/dev/null 2>&1 || die "'$tool' not found in PATH"
+  ok "$tool: $(command -v "$tool")"
+done
+
+# ── Generate manifests ───────────────────────────────────────────────────────
+# Build the whole fleet as two manifests (namespaces first, then everything
+# else) and apply each in a single kubectl call — far faster than per-object
+# applies, and it avoids namespace-creation races. Generation needs no cluster,
+# so --dry-run can produce and inspect the manifests on their own.
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+NS_FILE="$TMP/namespaces.yaml"
+WL_FILE="$TMP/workloads.yaml"
+
+log "Generating $NS_COUNT namespaces and their workloads"
+
+# Resource block shared by every pod template — keep pods tiny so they pack in.
+RES='resources: { requests: { cpu: 5m, memory: 8Mi }, limits: { memory: 48Mi } }'
+
+emit_deploy() {  # ns name app image replicas [command-json]
+  local ns="$1" name="$2" app="$3" image="$4" replicas="$5" cmd="${6:-}"
+  {
+    printf -- '---\napiVersion: apps/v1\nkind: Deployment\n'
+    printf 'metadata: { name: %s, namespace: %s, labels: { app: %s, k8shark.io/suite: scale } }\n' "$name" "$ns" "$app"
+    printf 'spec:\n  replicas: %s\n  selector: { matchLabels: { app: %s } }\n' "$replicas" "$app"
+    printf '  template:\n    metadata: { labels: { app: %s, k8shark.io/suite: scale } }\n    spec:\n      containers:\n' "$app"
+    printf '        - name: main\n          image: %s\n          %s\n' "$image" "$RES"
+    if [[ -n "$cmd" ]]; then printf '          command: %s\n' "$cmd"; fi
+  } >>"$WL_FILE"
+}
+
+for i in $(seq 1 "$NS_COUNT"); do
+  ns=$(printf 'scale-%03d' "$i")
+
+  # Namespace (+ a tier label so there's something to group/filter on).
+  tier=$(( i % 3 ))
+  {
+    printf -- '---\napiVersion: v1\nkind: Namespace\n'
+    printf 'metadata: { name: %s, labels: { k8shark.io/suite: scale, k8shark.io/tier: "t%s" } }\n' "$ns" "$tier"
+  } >>"$NS_FILE"
+
+  # ConfigMap (a non-pod object in every namespace).
+  {
+    printf -- '---\napiVersion: v1\nkind: ConfigMap\n'
+    printf 'metadata: { name: app-config, namespace: %s }\ndata: { tier: "t%s", index: "%s" }\n' "$ns" "$tier" "$i"
+  } >>"$WL_FILE"
+
+  # Every namespace gets a web Deployment + Service.
+  emit_deploy "$ns" web nginx nginx:alpine 1
+  {
+    printf -- '---\napiVersion: v1\nkind: Service\n'
+    printf 'metadata: { name: web, namespace: %s }\n' "$ns"
+    printf 'spec: { selector: { app: nginx }, ports: [{ port: 80, targetPort: 80 }] }\n'
+  } >>"$WL_FILE"
+
+  # Rotate a second workload so the fleet is varied; sprinkle in eventful ones.
+  case $(( i % 6 )) in
+    0) emit_deploy "$ns" cache  redis  redis:7-alpine        1 ;;
+    1) emit_deploy "$ns" worker pause  registry.k8s.io/pause:3.9 3 ;;
+    2) emit_deploy "$ns" api    nginx  nginx:alpine          2 ;;
+    3) # crashloop — eventful
+       emit_deploy "$ns" crashloop crashloop busybox:1.36 1 '["/bin/sh","-c","echo up; sleep 4; exit 1"]' ;;
+    4) # unschedulable — stays Pending, no node resource used
+       {
+         printf -- '---\napiVersion: apps/v1\nkind: Deployment\n'
+         printf 'metadata: { name: greedy, namespace: %s, labels: { app: greedy, k8shark.io/suite: scale } }\n' "$ns"
+         printf 'spec:\n  replicas: 1\n  selector: { matchLabels: { app: greedy } }\n'
+         printf '  template:\n    metadata: { labels: { app: greedy, k8shark.io/suite: scale } }\n    spec:\n      containers:\n'
+         printf '        - name: main\n          image: nginx:alpine\n          resources: { requests: { cpu: "64" } }\n'
+       } >>"$WL_FILE" ;;
+    5) # short-lived Job
+       {
+         printf -- '---\napiVersion: batch/v1\nkind: Job\n'
+         printf 'metadata: { name: oneshot, namespace: %s, labels: { app: oneshot, k8shark.io/suite: scale } }\n' "$ns"
+         printf 'spec:\n  template:\n    metadata: { labels: { app: oneshot, k8shark.io/suite: scale } }\n    spec:\n      restartPolicy: Never\n      containers:\n'
+         printf '        - name: main\n          image: busybox:1.36\n          %s\n' "$RES"
+         printf '          command: ["/bin/sh","-c","echo working; sleep 8; echo done"]\n'
+       } >>"$WL_FILE" ;;
+  esac
+done
+
+ns_objs=$(grep -c '^kind: Namespace' "$NS_FILE" || true)
+wl_objs=$(grep -cE '^kind: (Deployment|Service|ConfigMap|Job)' "$WL_FILE" || true)
+ok "Generated $ns_objs namespaces and $wl_objs workload objects"
+
+if $DRY_RUN; then
+  out="./scale-manifests"
+  mkdir -p "$out"
+  cp "$NS_FILE" "$WL_FILE" "$out/"
+  ok "Dry run — wrote manifests to $out/ (no cluster created, nothing applied)"
+  exit 0
+fi
+
+# ── Optional reset ─────────────────────────────────────────────────────────────
+if $RESET && kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+  log "Deleting existing cluster '$CLUSTER_NAME'"
+  kind delete cluster --name "$CLUSTER_NAME"
+fi
+
+# ── Create multi-node KinD cluster ───────────────────────────────────────────
+# 1 control-plane + 2 workers, with maxPods raised so a few hundred tiny pods
+# fit comfortably (default is 110/node).
+if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+  log "Cluster '$CLUSTER_NAME' already exists — skipping creation"
+  kind get kubeconfig --name "$CLUSTER_NAME" > "$KIND_KUBECONFIG"
+  chmod 0600 "$KIND_KUBECONFIG"
+else
+  log "Creating multi-node KinD cluster '$CLUSTER_NAME' (1 control-plane + 2 workers)"
+  kind create cluster \
+    --name "$CLUSTER_NAME" \
+    --kubeconfig "$KIND_KUBECONFIG" \
+    --wait 120s \
+    --config - <<'YAML'
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+kubeadmConfigPatches:
+  - |
+    kind: KubeletConfiguration
+    maxPods: 250
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker
+YAML
+  ok "Cluster '$CLUSTER_NAME' ready"
+fi
+
+KC=(--kubeconfig "$KIND_KUBECONFIG")
+
+# ── Apply ────────────────────────────────────────────────────────────────────
+log "Creating namespaces"
+kubectl "${KC[@]}" apply -f "$NS_FILE" >/dev/null
+ok "Namespaces applied"
+
+log "Deploying workloads (single bulk apply)"
+kubectl "${KC[@]}" apply -f "$WL_FILE" >/dev/null
+ok "Workloads applied"
+
+# ── Settle ───────────────────────────────────────────────────────────────────
+log "Waiting ~60s for pods to schedule and events to flow"
+sleep 60
+printf '\n'
+info "Pods by phase:"
+kubectl "${KC[@]}" get pods -A -l k8shark.io/suite=scale \
+  --no-headers 2>/dev/null | awk '{print $4}' | sort | uniq -c | sort -rn | sed 's/^/      /'
+total_pods=$(kubectl "${KC[@]}" get pods -A -l k8shark.io/suite=scale --no-headers 2>/dev/null | wc -l | tr -d ' ')
+total_ns=$(kubectl "${KC[@]}" get ns -l k8shark.io/suite=scale --no-headers 2>/dev/null | wc -l | tr -d ' ')
+
+# ── Done ───────────────────────────────────────────────────────────────────────
+printf '\n\033[1;32mScale cluster ready: %s namespaces, %s pods.\033[0m\n\n' "$total_ns" "$total_pods"
+info "Inspect it:"
+printf '    export KUBECONFIG=%s\n' "$KIND_KUBECONFIG"
+printf '    kubectl get ns -l k8shark.io/suite=scale\n'
+printf '    kubectl get pods -A -l k8shark.io/suite=scale -o wide\n\n'
+info "Capture it with k8shark:"
+printf '    make build\n'
+printf '    ./kshrk capture --kubeconfig %s --auto-discover --duration 5m -o scale.khsrk\n\n' "$KIND_KUBECONFIG"
+info "Then explore the capture (UI on 18080/18081):"
+printf '    ./kshrk ui scale.khsrk --port 18080 --api-port 18081\n\n'
+info "Tear down when finished:"
+printf '    make kind-down\n\n'


### PR DESCRIPTION
## Summary

Bundles two KinD demo-data helper scripts with two fixes to the v2 web UI's object view.

### Scripts (`scripts/` + Makefile targets)
- **`kind-chaos.sh`** (`make kind-chaos`) — a cluster of deliberately *unhealthy* workloads (CrashLoopBackOff, OOMKilled, ImagePullBackOff, FailedScheduling, liveness-probe flapping, unbound PVC, Job backoff) so a capture has rich pod events to show off. Optional `--churn N` generates pod-lifecycle Timeline events.
- **`kind-scale.sh`** (`make kind-scale`) — a multi-node cluster (raised `maxPods`) with **50+ namespaces** and **dozens of light workloads** to exercise the namespace list / search / Timeline at scale. `--namespaces N` to size it; `--dry-run` emits the manifests without creating a cluster.
- **`kind-down`** now tears down both dev clusters (`k8shark-dev`, `k8shark-scale`).

### UI fixes (`internal/ui/v2`)
- **Object view — restore `apiVersion`/`kind`:** Kubernetes omits these top-level fields from objects nested inside a `List` response, so the YAML/JSON view was missing them. `normalizeObjectBody` now infers them from the capture path's group/version/resource (reusing the existing `parseAPIPath` + `kindFromResource`), leaving `List`/`Table` envelopes untouched. This mirrors the legacy v1 UI's `normalizeDetailBody`.
- **Pod YAML/JSON viewer — toolbar layout:** Copy/Download moved to the right of the toolbar (YAML/JSON toggles stay left) via `justify-content: space-between`, matching the legacy v1 pod view.

### Misc
- `.gitignore`: ignore `*.khsrk` capture files and `scale-manifests/` dry-run output.

## Testing
- `go build ./...`, `go vet`, and `go test ./internal/ui/v2/` all pass.
- Both scripts run end-to-end: chaos cluster produced the expected mix (Running/Pending/Error/OOMKilled), scale cluster came up with 50 namespaces / 140 pods.
- apiVersion/kind fix verified against a live capture: core resource → `apiVersion: v1`/`kind: Pod`; grouped resource → `apiVersion: apps/v1`/`kind: Deployment`.
- Toolbar change confirmed served by the rebuilt embedded binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)