### PR TITLE
Potential fix for code scanning alert no. 6: Client-side cross-site scripting

### DIFF
--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -9,14 +9,11 @@
   const FORBIDDEN_CHILD_TAGS = ['script', 'iframe', 'object', 'embed', 'link', 'meta', 'style'];
   const FORBIDDEN_CHILD_TAGS_SET = new Set(FORBIDDEN_CHILD_TAGS.map((t) => t.toUpperCase()));
   const FORBIDDEN_CHILD_SELECTOR = FORBIDDEN_CHILD_TAGS.join(',');
-  const SAFE_CHILD_NODE_CACHE = new WeakMap();
   const isSafeChildNode = (node) => {
-    if (!(node instanceof Node)) return false;
-    const cached = SAFE_CHILD_NODE_CACHE.get(node);
-    if (cached !== undefined) return cached;
+    let ok = node instanceof Node;
 
-    let ok = true;
     if (
+      ok &&
       node.nodeType !== Node.ELEMENT_NODE &&
       node.nodeType !== Node.TEXT_NODE &&
       node.nodeType !== Node.DOCUMENT_FRAGMENT_NODE
@@ -30,10 +27,19 @@
         const tn = (node.tagName || '').toUpperCase();
         if (FORBIDDEN_CHILD_TAGS_SET.has(tn)) ok = false;
       }
-      if (ok && typeof node.querySelector === 'function' && node.querySelector(FORBIDDEN_CHILD_SELECTOR)) ok = false;
+      if (ok) {
+        try {
+          const qs =
+            node.nodeType === Node.ELEMENT_NODE
+              ? Element.prototype.querySelector
+              : DocumentFragment.prototype.querySelector;
+          if (typeof qs === 'function' && qs.call(node, FORBIDDEN_CHILD_SELECTOR)) ok = false;
+        } catch (_) {
+          ok = false; // fail closed
+        }
+      }
     }
 
-    SAFE_CHILD_NODE_CACHE.set(node, ok);
     return ok;
   };
   const el = (tag, attrs = {}, ...children) => {

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -16,9 +16,14 @@
     ) {
       return false;
     }
-    if (node.nodeType === Node.ELEMENT_NODE) {
-      const tn = (node.tagName || '').toUpperCase();
-      if (FORBIDDEN_CHILD_TAGS.has(tn)) return false;
+    if (node.nodeType === Node.ELEMENT_NODE || node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+      // Block forbidden tags on the node itself (ELEMENT_NODE) and anywhere in its subtree.
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const tn = (node.tagName || '').toUpperCase();
+        if (FORBIDDEN_CHILD_TAGS.has(tn)) return false;
+      }
+      const sel = 'script,iframe,object,embed,link,meta,style';
+      if (typeof node.querySelector === 'function' && node.querySelector(sel)) return false;
     }
     return true;
   };

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -16,7 +16,13 @@
     }
     for (const c of children) {
       if (c === null || c === undefined || c === false) continue;
-      n.appendChild(typeof c === 'string' ? document.createTextNode(c) : c);
+      if (typeof c === 'string' || typeof c === 'number' || typeof c === 'boolean' || typeof c === 'bigint') {
+        n.appendChild(document.createTextNode(String(c)));
+      } else if (c instanceof Node) {
+        n.appendChild(c);
+      } else {
+        n.appendChild(document.createTextNode(String(c)));
+      }
     }
     return n;
   };

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -29,11 +29,14 @@
       }
       if (ok) {
         try {
-          const qs =
-            node.nodeType === Node.ELEMENT_NODE
-              ? Element.prototype.querySelector
-              : DocumentFragment.prototype.querySelector;
-          if (typeof qs === 'function' && qs.call(node, FORBIDDEN_CHILD_SELECTOR)) ok = false;
+          const walker = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT);
+          // For elements, include the element itself; for fragments, start at the first element child.
+          let cur = node.nodeType === Node.ELEMENT_NODE ? node : walker.nextNode();
+          while (cur) {
+            const tn = (cur.tagName || '').toUpperCase();
+            if (FORBIDDEN_CHILD_TAGS_SET.has(tn)) { ok = false; break; }
+            cur = walker.nextNode();
+          }
         } catch (_) {
           ok = false; // fail closed
         }

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -45,7 +45,7 @@
       else if (v !== undefined && v !== null) n.setAttribute(k, v);
     }
     for (const c of children) {
-      if (c === null || c === undefined || c === false) continue;
+      if (c === null || c === undefined) continue;
       if (typeof c === 'string' || typeof c === 'number' || typeof c === 'boolean' || typeof c === 'bigint') {
         n.appendChild(document.createTextNode(String(c)));
       } else if (isSafeChildNode(c)) {

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -6,6 +6,23 @@
   'use strict';
 
   const $ = (id) => document.getElementById(id);
+  const isSafeChildNode = (node) => {
+    if (!(node instanceof Node)) return false;
+    if (
+      node.nodeType !== Node.ELEMENT_NODE &&
+      node.nodeType !== Node.TEXT_NODE &&
+      node.nodeType !== Node.DOCUMENT_FRAGMENT_NODE
+    ) {
+      return false;
+    }
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      const tn = (node.tagName || '').toUpperCase();
+      if (tn === 'SCRIPT' || tn === 'IFRAME' || tn === 'OBJECT' || tn === 'EMBED' || tn === 'LINK' || tn === 'META' || tn === 'STYLE') {
+        return false;
+      }
+    }
+    return true;
+  };
   const el = (tag, attrs = {}, ...children) => {
     const n = document.createElement(tag);
     for (const [k, v] of Object.entries(attrs)) {
@@ -18,7 +35,7 @@
       if (c === null || c === undefined || c === false) continue;
       if (typeof c === 'string' || typeof c === 'number' || typeof c === 'boolean' || typeof c === 'bigint') {
         n.appendChild(document.createTextNode(String(c)));
-      } else if (c instanceof Node) {
+      } else if (isSafeChildNode(c)) {
         n.appendChild(c);
       } else {
         n.appendChild(document.createTextNode(String(c)));

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -6,7 +6,9 @@
   'use strict';
 
   const $ = (id) => document.getElementById(id);
-  const FORBIDDEN_CHILD_TAGS = new Set(['SCRIPT', 'IFRAME', 'OBJECT', 'EMBED', 'LINK', 'META', 'STYLE']);
+  const FORBIDDEN_CHILD_TAGS = ['script', 'iframe', 'object', 'embed', 'link', 'meta', 'style'];
+  const FORBIDDEN_CHILD_TAGS_SET = new Set(FORBIDDEN_CHILD_TAGS.map((t) => t.toUpperCase()));
+  const FORBIDDEN_CHILD_SELECTOR = FORBIDDEN_CHILD_TAGS.join(',');
   const isSafeChildNode = (node) => {
     if (!(node instanceof Node)) return false;
     if (
@@ -20,10 +22,9 @@
       // Block forbidden tags on the node itself (ELEMENT_NODE) and anywhere in its subtree.
       if (node.nodeType === Node.ELEMENT_NODE) {
         const tn = (node.tagName || '').toUpperCase();
-        if (FORBIDDEN_CHILD_TAGS.has(tn)) return false;
+        if (FORBIDDEN_CHILD_TAGS_SET.has(tn)) return false;
       }
-      const sel = 'script,iframe,object,embed,link,meta,style';
-      if (typeof node.querySelector === 'function' && node.querySelector(sel)) return false;
+      if (typeof node.querySelector === 'function' && node.querySelector(FORBIDDEN_CHILD_SELECTOR)) return false;
     }
     return true;
   };

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -6,6 +6,7 @@
   'use strict';
 
   const $ = (id) => document.getElementById(id);
+  const FORBIDDEN_CHILD_TAGS = new Set(['SCRIPT', 'IFRAME', 'OBJECT', 'EMBED', 'LINK', 'META', 'STYLE']);
   const isSafeChildNode = (node) => {
     if (!(node instanceof Node)) return false;
     if (
@@ -17,9 +18,7 @@
     }
     if (node.nodeType === Node.ELEMENT_NODE) {
       const tn = (node.tagName || '').toUpperCase();
-      if (tn === 'SCRIPT' || tn === 'IFRAME' || tn === 'OBJECT' || tn === 'EMBED' || tn === 'LINK' || tn === 'META' || tn === 'STYLE') {
-        return false;
-      }
+      if (FORBIDDEN_CHILD_TAGS.has(tn)) return false;
     }
     return true;
   };

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -54,8 +54,8 @@
       else if (v !== undefined && v !== null) n.setAttribute(k, v);
     }
     for (const c of children) {
-      if (c === null || c === undefined) continue;
-      if (typeof c === 'string' || typeof c === 'number' || typeof c === 'boolean' || typeof c === 'bigint') {
+      if (c === null || c === undefined || typeof c === 'boolean') continue;
+      if (typeof c === 'string' || typeof c === 'number' || typeof c === 'bigint') {
         n.appendChild(document.createTextNode(String(c)));
       } else if (isSafeChildNode(c)) {
         n.appendChild(c);

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -9,24 +9,32 @@
   const FORBIDDEN_CHILD_TAGS = ['script', 'iframe', 'object', 'embed', 'link', 'meta', 'style'];
   const FORBIDDEN_CHILD_TAGS_SET = new Set(FORBIDDEN_CHILD_TAGS.map((t) => t.toUpperCase()));
   const FORBIDDEN_CHILD_SELECTOR = FORBIDDEN_CHILD_TAGS.join(',');
+  const SAFE_CHILD_NODE_CACHE = new WeakMap();
   const isSafeChildNode = (node) => {
     if (!(node instanceof Node)) return false;
+    const cached = SAFE_CHILD_NODE_CACHE.get(node);
+    if (cached !== undefined) return cached;
+
+    let ok = true;
     if (
       node.nodeType !== Node.ELEMENT_NODE &&
       node.nodeType !== Node.TEXT_NODE &&
       node.nodeType !== Node.DOCUMENT_FRAGMENT_NODE
     ) {
-      return false;
+      ok = false;
     }
-    if (node.nodeType === Node.ELEMENT_NODE || node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+
+    if (ok && (node.nodeType === Node.ELEMENT_NODE || node.nodeType === Node.DOCUMENT_FRAGMENT_NODE)) {
       // Block forbidden tags on the node itself (ELEMENT_NODE) and anywhere in its subtree.
       if (node.nodeType === Node.ELEMENT_NODE) {
         const tn = (node.tagName || '').toUpperCase();
-        if (FORBIDDEN_CHILD_TAGS_SET.has(tn)) return false;
+        if (FORBIDDEN_CHILD_TAGS_SET.has(tn)) ok = false;
       }
-      if (typeof node.querySelector === 'function' && node.querySelector(FORBIDDEN_CHILD_SELECTOR)) return false;
+      if (ok && typeof node.querySelector === 'function' && node.querySelector(FORBIDDEN_CHILD_SELECTOR)) ok = false;
     }
-    return true;
+
+    SAFE_CHILD_NODE_CACHE.set(node, ok);
+    return ok;
   };
   const el = (tag, attrs = {}, ...children) => {
     const n = document.createElement(tag);

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -58,7 +58,7 @@
       else if (v !== undefined && v !== null) n.setAttribute(k, v);
     }
     for (const c of children) {
-      if (c === null || c === undefined || typeof c === 'boolean') continue;
+      if (c === null || c === undefined) continue;
       if (typeof c === 'string' || typeof c === 'number' || typeof c === 'bigint') {
         n.appendChild(document.createTextNode(String(c)));
       } else if (isSafeChildNode(c)) {

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -29,13 +29,17 @@
       }
       if (ok) {
         try {
-          const walker = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT);
-          // For elements, include the element itself; for fragments, start at the first element child.
-          let cur = node.nodeType === Node.ELEMENT_NODE ? node : walker.nextNode();
-          while (cur) {
-            const tn = (cur.tagName || '').toUpperCase();
-            if (FORBIDDEN_CHILD_TAGS_SET.has(tn)) { ok = false; break; }
-            cur = walker.nextNode();
+          if (typeof node.querySelector === 'function') {
+            if (node.querySelector(FORBIDDEN_CHILD_SELECTOR)) ok = false;
+          } else {
+            const walker = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT);
+            // For elements, include the element itself; for fragments, start at the first element child.
+            let cur = node.nodeType === Node.ELEMENT_NODE ? node : walker.nextNode();
+            while (cur) {
+              const tn = (cur.tagName || '').toUpperCase();
+              if (FORBIDDEN_CHILD_TAGS_SET.has(tn)) { ok = false; break; }
+              cur = walker.nextNode();
+            }
           }
         } catch (_) {
           ok = false; // fail closed


### PR DESCRIPTION
Potential fix for [https://github.com/phenixblue/k8shark/security/code-scanning/6](https://github.com/phenixblue/k8shark/security/code-scanning/6)

General fix: ensure all user-controlled data is rendered as text, not as executable/parsed DOM. For this file, the best single fix is to harden the `el` helper’s child-handling branch so only safe primitive text or trusted `Node` instances are appended; everything else is converted to text nodes.

Best concrete change (single file, targeted region):
- **File:** `internal/ui/v2/static/app.js`
- **Region:** `el` function, loop over `children` (around current lines 17–20).
- Replace the direct append expression with explicit safe handling:
  - strings/numbers/booleans/bigints -> `document.createTextNode(String(c))`
  - `Node` instances -> append directly
  - all other values -> `document.createTextNode(String(c))`

This preserves current functionality for normal text and legitimate DOM children while preventing risky direct insertion of arbitrary objects and satisfying all alert variants that end at line 19.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
