### PR TITLE
test(cmd): cover redact/inspect/open subcommands and byte formatting

### DIFF
--- a/cmd/bytes_test.go
+++ b/cmd/bytes_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import "testing"
+
+// formatBytes (capture.go) and humanBytes (inspect.go) are byte-for-byte
+// identical IEC formatters; this exercises both so either implementation
+// drifting would be caught.
+func TestByteFormatters(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KiB"},
+		{1536, "1.5 KiB"},
+		{1048576, "1.0 MiB"},
+		{1073741824, "1.0 GiB"},
+	}
+	for _, c := range cases {
+		if got := formatBytes(c.in); got != c.want {
+			t.Errorf("formatBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
+		if got := humanBytes(c.in); got != c.want {
+			t.Errorf("humanBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/cmd/inspect_test.go
+++ b/cmd/inspect_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newTestInspectCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().StringP("output", "o", "table", "")
+	cmd.Flags().BoolP("wide", "w", false, "")
+	return cmd
+}
+
+func TestRunInspect_JSON(t *testing.T) {
+	arch := buildDiffArchive(t, `{"apiVersion":"v1","kind":"PodList","items":[{"metadata":{"name":"p","namespace":"default"}}]}`)
+
+	cmd := newTestInspectCommand()
+	if err := cmd.Flags().Set("output", "json"); err != nil {
+		t.Fatalf("set output: %v", err)
+	}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runInspect(cmd, []string{arch}); err != nil {
+		t.Fatalf("runInspect: %v", err)
+	}
+
+	// Output must be valid JSON carrying the capture metadata.
+	var report map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("inspect output is not valid JSON: %v\n%s", err, buf.String())
+	}
+	if !strings.Contains(buf.String(), "test-capture") {
+		t.Errorf("expected capture id in report:\n%s", buf.String())
+	}
+}
+
+func TestRunInspect_Table(t *testing.T) {
+	arch := buildDiffArchive(t, `{"apiVersion":"v1","kind":"PodList","items":[{"metadata":{"name":"p","namespace":"default"}}]}`)
+
+	cmd := newTestInspectCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runInspect(cmd, []string{arch}); err != nil {
+		t.Fatalf("runInspect: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "pods") {
+		t.Errorf("expected pods row in table output:\n%s", out)
+	}
+}
+
+func TestRunInspect_MissingArchive(t *testing.T) {
+	cmd := newTestInspectCommand()
+	if err := runInspect(cmd, []string{"/no/such/archive.khsrk"}); err == nil {
+		t.Error("expected error for missing archive")
+	}
+}

--- a/cmd/open_test.go
+++ b/cmd/open_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newTestOpenCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.PersistentFlags().BoolP("verbose", "v", false, "")
+	cmd.Flags().String("port", "0", "")
+	cmd.Flags().String("kubeconfig-out", "", "")
+	cmd.Flags().String("at", "", "")
+	return cmd
+}
+
+func TestRunOpen_MissingArchive(t *testing.T) {
+	cmd := newTestOpenCommand()
+	// A nonexistent archive must fail before the server starts (which would
+	// otherwise block on Wait()).
+	if err := runOpen(cmd, []string{"/no/such/archive.khsrk"}); err == nil {
+		t.Error("expected error for missing archive")
+	}
+}
+
+func TestRunOpen_BadAtFlag(t *testing.T) {
+	arch := buildDiffArchive(t, `{"apiVersion":"v1","kind":"PodList","items":[]}`)
+	cmd := newTestOpenCommand()
+	if err := cmd.Flags().Set("at", "not-a-timestamp"); err != nil {
+		t.Fatalf("set at: %v", err)
+	}
+	if err := runOpen(cmd, []string{arch}); err == nil {
+		t.Error("expected error for invalid --at value")
+	}
+}

--- a/cmd/redact_test.go
+++ b/cmd/redact_test.go
@@ -29,15 +29,16 @@ func TestParseRedactField(t *testing.T) {
 		}
 	})
 
-	t.Run("replacement may contain colons", func(t *testing.T) {
-		// SplitN(…, 4) keeps everything after the 3rd colon as valueType, so a
-		// replacement with a colon and an explicit valueType still parses.
-		rule, err := parseRedactField("f:Kind:a:b")
+	t.Run("valueType keeps everything after the 3rd colon", func(t *testing.T) {
+		// SplitN(…, 4) caps the split at 4 fields, so any further colons stay in
+		// the 4th field (valueType). The replacement is still just the 3rd field.
+		rule, err := parseRedactField("f:Kind:a:b:c")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if rule.Replacement != "a" || rule.ValueType != "b" {
-			t.Errorf("got replacement=%q valueType=%q", rule.Replacement, rule.ValueType)
+		if rule.Replacement != "a" || rule.ValueType != "b:c" {
+			t.Errorf("got replacement=%q valueType=%q, want replacement=%q valueType=%q",
+				rule.Replacement, rule.ValueType, "a", "b:c")
 		}
 	})
 

--- a/cmd/redact_test.go
+++ b/cmd/redact_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import "testing"
+
+func TestParseRedactField(t *testing.T) {
+	t.Run("three parts", func(t *testing.T) {
+		rule, err := parseRedactField("metadata.name:Pod:REDACTED")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rule.FieldPath != "metadata.name" || rule.Kind != "Pod" || rule.Replacement != "REDACTED" {
+			t.Errorf("got %+v", rule)
+		}
+		if rule.ValueType != "" {
+			t.Errorf("ValueType = %q, want empty", rule.ValueType)
+		}
+	})
+
+	t.Run("four parts with valueType", func(t *testing.T) {
+		rule, err := parseRedactField("data.token:Secret:XXX:base64")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rule.ValueType != "base64" {
+			t.Errorf("ValueType = %q, want base64", rule.ValueType)
+		}
+		if rule.Replacement != "XXX" {
+			t.Errorf("Replacement = %q, want XXX", rule.Replacement)
+		}
+	})
+
+	t.Run("replacement may contain colons", func(t *testing.T) {
+		// SplitN(…, 4) keeps everything after the 3rd colon as valueType, so a
+		// replacement with a colon and an explicit valueType still parses.
+		rule, err := parseRedactField("f:Kind:a:b")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rule.Replacement != "a" || rule.ValueType != "b" {
+			t.Errorf("got replacement=%q valueType=%q", rule.Replacement, rule.ValueType)
+		}
+	})
+
+	t.Run("too few parts errors", func(t *testing.T) {
+		if _, err := parseRedactField("metadata.name:Pod"); err == nil {
+			t.Error("expected error for fewer than 3 parts")
+		}
+		if _, err := parseRedactField("justonefield"); err == nil {
+			t.Error("expected error for a single field")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
The `cmd` package previously had unit tests only for `diff`. This adds focused tests for several untested subcommands and helpers:

- **`parseRedactField`** — 3-part and 4-part (`:valueType`) rules, `SplitN` colon handling, and error cases (too few parts).
- **`formatBytes` (capture) + `humanBytes` (inspect)** — exercises both IEC formatters with the same table; they're byte-for-byte identical today, so this catches any drift between them.
- **`runInspect`** — JSON output parses and carries capture metadata, table output lists resource rows, and a missing-archive errors.
- **`runOpen`** — missing-archive and invalid `--at` error paths, asserted before the server starts (so the test never blocks on `Wait()`).

Reuses the existing `buildDiffArchive` helper from `diff_test.go`.

## Testing
`go test ./cmd/`, `go vet ./cmd/`, and `go build ./...` all pass.

## Note
`formatBytes` and `humanBytes` are duplicate implementations in `capture.go` and `inspect.go`. The shared test documents that; a small follow-up could de-dupe them into one helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)