### PR TITLE
refactor(cmd): de-duplicate the IEC byte formatter

### DIFF
--- a/cmd/bytes_test.go
+++ b/cmd/bytes_test.go
@@ -2,10 +2,9 @@ package cmd
 
 import "testing"
 
-// formatBytes (capture.go) and humanBytes (inspect.go) are byte-for-byte
-// identical IEC formatters; this exercises both so either implementation
-// drifting would be caught.
-func TestByteFormatters(t *testing.T) {
+// formatBytes is the single shared IEC byte formatter (cmd/format.go), used by
+// both the capture summary and the inspect output.
+func TestFormatBytes(t *testing.T) {
 	cases := []struct {
 		in   int64
 		want string
@@ -21,9 +20,6 @@ func TestByteFormatters(t *testing.T) {
 	for _, c := range cases {
 		if got := formatBytes(c.in); got != c.want {
 			t.Errorf("formatBytes(%d) = %q, want %q", c.in, got, c.want)
-		}
-		if got := humanBytes(c.in); got != c.want {
-			t.Errorf("humanBytes(%d) = %q, want %q", c.in, got, c.want)
 		}
 	}
 }

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -176,17 +176,3 @@ func startSpinner(w *os.File) func() {
 		<-done
 	}
 }
-
-// formatBytes returns a human-readable byte size string.
-func formatBytes(b int64) string {
-	const unit = 1024
-	if b < unit {
-		return fmt.Sprintf("%d B", b)
-	}
-	div, exp := int64(unit), 0
-	for n := b / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
-}

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -1,0 +1,17 @@
+package cmd
+
+import "fmt"
+
+// formatBytes returns a human-readable IEC byte size string (e.g. "1.5 KiB").
+func formatBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
+}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -49,19 +49,6 @@ func runInspect(cmd *cobra.Command, args []string) error {
 	}
 }
 
-func humanBytes(b int64) string {
-	const unit = 1024
-	if b < unit {
-		return fmt.Sprintf("%d B", b)
-	}
-	div, exp := int64(unit), 0
-	for n := b / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
-}
-
 func printInspectTable(cmd *cobra.Command, r *inspect.Report, wide bool) {
 	out := cmd.OutOrStdout()
 	duration := r.CapturedUntil.Sub(r.CapturedAt).Truncate(time.Second)
@@ -73,7 +60,7 @@ func printInspectTable(cmd *cobra.Command, r *inspect.Report, wide bool) {
 		duration)
 	fmt.Fprintf(out, "Kubernetes:   %s\n", r.KubernetesVersion)
 	fmt.Fprintf(out, "Server:       %s\n", r.ServerAddress)
-	fmt.Fprintf(out, "Archive:      %s (%s)\n", r.ArchivePath, humanBytes(r.ArchiveSize))
+	fmt.Fprintf(out, "Archive:      %s (%s)\n", r.ArchivePath, formatBytes(r.ArchiveSize))
 	fmt.Fprintf(out, "Records:      %d\n\n", r.RecordCount)
 
 	if len(r.Resources) == 0 {


### PR DESCRIPTION
## Summary
`formatBytes` (capture.go) and `humanBytes` (inspect.go) were byte-for-byte identical IEC formatters. This consolidates them into a single `formatBytes` in a new `cmd/format.go`, removes both copies, and updates the inspect output to use it. The shared test collapses from exercising both names to the one function.

Follow-up to the note in #92, which had added a test covering both copies precisely to catch this kind of drift.

## Testing
`go build ./...`, `go vet ./cmd/`, and `go test ./cmd/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)