### PR TITLE
feat(archive): version the capture format with a compatibility guard

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -66,6 +66,7 @@ func printInspectTable(cmd *cobra.Command, r *inspect.Report, wide bool) {
 	out := cmd.OutOrStdout()
 	duration := r.CapturedUntil.Sub(r.CapturedAt).Truncate(time.Second)
 
+	fmt.Fprintf(out, "Format:       v%d\n", r.FormatVersion)
 	fmt.Fprintf(out, "Capture ID:   %s\n", r.CaptureID)
 	fmt.Fprintf(out, "Captured:     %s → %s  (%s)\n",
 		r.CapturedAt.UTC().Format(time.RFC3339),

--- a/docs/archive-format.md
+++ b/docs/archive-format.md
@@ -24,6 +24,7 @@ Capture-level information. Written once at the end of the capture run.
 
 ```json
 {
+  "format_version":      1,
   "capture_id":          "550e8400-e29b-41d4-a716-446655440000",
   "captured_at":         "2026-04-09T10:00:00Z",
   "captured_until":      "2026-04-09T10:10:00Z",
@@ -35,12 +36,32 @@ Capture-level information. Written once at the end of the capture run.
 
 | Field | Description |
 |-------|-------------|
+| `format_version` | Archive schema version (see [below](#format-version--compatibility)). Absent in pre-versioning archives, which are read as version 1. |
 | `capture_id` | UUID, unique per capture run. Used in the generated kubeconfig filename. |
 | `captured_at` | UTC timestamp when the first poll fired (approximately `now - duration`). |
 | `captured_until` | UTC timestamp when the capture ended. |
 | `kubernetes_version` | `gitVersion` from `/version` on the source cluster. |
 | `server_address` | API server URL from the kubeconfig used during capture. |
 | `record_count` | Total number of individual records written. |
+
+## Format version & compatibility
+
+`metadata.json` carries an integer `format_version` identifying the archive
+schema. The current version is **1**.
+
+- **Additive changes don't bump it.** New optional metadata fields
+  (`omitempty`) and new optional archive entries (e.g. the watch index) are
+  backward-compatible: older readers ignore what they don't recognize and
+  newer readers tolerate their absence. These keep `format_version` at 1.
+- **Breaking changes bump it.** A structural change that an older reader cannot
+  safely parse increments the version.
+- **Pre-versioning archives** (captured before the field existed) omit
+  `format_version`; readers treat them as version 1, since they are
+  structurally identical.
+- **Newer archives are refused.** If an archive's `format_version` is greater
+  than the version a given `kshrk` build understands, the tool stops with a
+  clear "upgrade kshrk" error rather than risk misreading an incompatible
+  layout. Run `kshrk inspect <archive>` to see an archive's format version.
 
 ## index.json
 

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -296,6 +296,7 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 	}
 
 	meta := &CaptureMetadata{
+		FormatVersion:     CurrentFormatVersion,
 		CaptureID:         uuid.New().String(),
 		CapturedAt:        time.Now().UTC().Add(-e.cfg.Duration),
 		CapturedUntil:     time.Now().UTC(),

--- a/internal/capture/record.go
+++ b/internal/capture/record.go
@@ -2,8 +2,28 @@ package capture
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 )
+
+// CurrentFormatVersion is the .khsrk archive schema version written by this
+// build. It is bumped ONLY on a breaking, structurally-incompatible change.
+// Additive, backward-compatible changes (new omitempty metadata fields, new
+// optional archive entries) keep the same version. Archives written before this
+// field existed report 0 and are treated as version 1 — they are structurally
+// identical, the marker is simply the only addition.
+const CurrentFormatVersion = 1
+
+// CheckFormatVersion reports whether an archive can be read by this build.
+// A version newer than this build understands is rejected so we never silently
+// misread an incompatible layout. A zero version (pre-versioning archive) is
+// compatible.
+func CheckFormatVersion(m CaptureMetadata) error {
+	if m.FormatVersion > CurrentFormatVersion {
+		return fmt.Errorf("archive format version %d is newer than this kshrk supports (%d); upgrade kshrk to read it", m.FormatVersion, CurrentFormatVersion)
+	}
+	return nil
+}
 
 // Record holds one polled API response.
 type Record struct {
@@ -19,6 +39,9 @@ type Record struct {
 
 // CaptureMetadata is written as metadata.json inside the archive.
 type CaptureMetadata struct {
+	// FormatVersion is the archive schema version (see CurrentFormatVersion).
+	// Omitted/zero in pre-versioning archives, which are treated as version 1.
+	FormatVersion     int       `json:"format_version,omitempty"`
 	CaptureID         string    `json:"capture_id"`
 	CapturedAt        time.Time `json:"captured_at"`
 	CapturedUntil     time.Time `json:"captured_until"`

--- a/internal/capture/record.go
+++ b/internal/capture/record.go
@@ -17,8 +17,12 @@ const CurrentFormatVersion = 1
 // CheckFormatVersion reports whether an archive can be read by this build.
 // A version newer than this build understands is rejected so we never silently
 // misread an incompatible layout. A zero version (pre-versioning archive) is
-// compatible.
+// compatible. A negative version is invalid — it only arises from a corrupt or
+// tampered metadata.json, so it is rejected rather than rendered as "v-1".
 func CheckFormatVersion(m CaptureMetadata) error {
+	if m.FormatVersion < 0 {
+		return fmt.Errorf("archive format version %d is invalid (corrupt metadata?)", m.FormatVersion)
+	}
 	if m.FormatVersion > CurrentFormatVersion {
 		return fmt.Errorf("archive format version %d is newer than this kshrk supports (%d); upgrade kshrk to read it", m.FormatVersion, CurrentFormatVersion)
 	}

--- a/internal/capture/record_test.go
+++ b/internal/capture/record_test.go
@@ -1,0 +1,21 @@
+package capture
+
+import "testing"
+
+func TestCheckFormatVersion(t *testing.T) {
+	t.Run("zero is legacy-compatible", func(t *testing.T) {
+		if err := CheckFormatVersion(CaptureMetadata{FormatVersion: 0}); err != nil {
+			t.Errorf("pre-versioning archive rejected: %v", err)
+		}
+	})
+	t.Run("current is accepted", func(t *testing.T) {
+		if err := CheckFormatVersion(CaptureMetadata{FormatVersion: CurrentFormatVersion}); err != nil {
+			t.Errorf("current version rejected: %v", err)
+		}
+	})
+	t.Run("newer is rejected", func(t *testing.T) {
+		if err := CheckFormatVersion(CaptureMetadata{FormatVersion: CurrentFormatVersion + 1}); err == nil {
+			t.Error("expected error for a newer-than-supported format version")
+		}
+	})
+}

--- a/internal/capture/record_test.go
+++ b/internal/capture/record_test.go
@@ -18,4 +18,9 @@ func TestCheckFormatVersion(t *testing.T) {
 			t.Error("expected error for a newer-than-supported format version")
 		}
 	})
+	t.Run("negative is rejected", func(t *testing.T) {
+		if err := CheckFormatVersion(CaptureMetadata{FormatVersion: -1}); err == nil {
+			t.Error("expected error for a negative (corrupt) format version")
+		}
+	})
 }

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -13,6 +13,7 @@ import (
 
 // Report summarises the contents of a capture archive.
 type Report struct {
+	FormatVersion     int               `json:"format_version"`
 	CaptureID         string            `json:"capture_id"`
 	CapturedAt        time.Time         `json:"captured_at"`
 	CapturedUntil     time.Time         `json:"captured_until"`
@@ -47,6 +48,9 @@ func Run(archivePath string) (*Report, error) {
 	if err := ar.ReadMetadata(&meta); err != nil {
 		return nil, fmt.Errorf("reading metadata: %w", err)
 	}
+	if err := capture.CheckFormatVersion(meta); err != nil {
+		return nil, err
+	}
 
 	var idx capture.Index
 	if err := ar.ReadIndex(&idx); err != nil {
@@ -55,7 +59,14 @@ func Run(archivePath string) (*Report, error) {
 
 	resources := summariseResources(ar, idx)
 
+	// Pre-versioning archives (0) are treated as version 1.
+	formatVersion := meta.FormatVersion
+	if formatVersion == 0 {
+		formatVersion = 1
+	}
+
 	return &Report{
+		FormatVersion:     formatVersion,
 		CaptureID:         meta.CaptureID,
 		CapturedAt:        meta.CapturedAt,
 		CapturedUntil:     meta.CapturedUntil,

--- a/internal/inspect/version_test.go
+++ b/internal/inspect/version_test.go
@@ -1,0 +1,60 @@
+package inspect
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+func TestRun_ReportsFormatVersion_LegacyNormalizedToOne(t *testing.T) {
+	// buildArchive writes no format_version (pre-versioning archive); inspect
+	// should report it as version 1.
+	path := buildArchive(t, []*capture.Record{rec("r1", "/api/v1/namespaces/default/pods")})
+	report, err := Run(path)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if report.FormatVersion != 1 {
+		t.Errorf("FormatVersion = %d, want 1", report.FormatVersion)
+	}
+}
+
+func TestRun_RejectsFutureFormatVersion(t *testing.T) {
+	path := buildArchiveWithVersion(t, capture.CurrentFormatVersion+1)
+	if _, err := Run(path); err == nil {
+		t.Fatal("expected Run to reject an archive with a newer format version")
+	}
+}
+
+// buildArchiveWithVersion writes a minimal archive stamped with the given
+// format version.
+func buildArchiveWithVersion(t *testing.T, version int) string {
+	t.Helper()
+	now := time.Date(2026, 4, 9, 8, 0, 0, 0, time.UTC)
+	r := rec("r1", "/api/v1/namespaces/default/pods")
+	idx := capture.Index{
+		r.APIPath: {APIPath: r.APIPath, Seqs: []int{0}, Times: []time.Time{now}},
+	}
+	meta := &capture.CaptureMetadata{
+		FormatVersion: version,
+		CaptureID:     "future-archive",
+		CapturedAt:    now,
+		CapturedUntil: now,
+		RecordCount:   1,
+	}
+	out := filepath.Join(t.TempDir(), "future.khsrk")
+	sw, err := archive.NewStreamWriter(out)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	if err := sw.WriteRecord(r); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+	if err := sw.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	return out
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -46,6 +46,12 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	if err := ar.ReadMetadata(&meta); err != nil {
 		return Result{}, fmt.Errorf("reading metadata: %w", err)
 	}
+	if err := capture.CheckFormatVersion(meta); err != nil {
+		return Result{}, err
+	}
+	// The redacted archive is written by the current writer, so stamp it with
+	// the current format version.
+	meta.FormatVersion = capture.CurrentFormatVersion
 
 	var idx capture.Index
 	if err := ar.ReadIndex(&idx); err != nil {

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -86,6 +86,9 @@ func LoadStore(ar *archive.Archive) (*CaptureStore, error) {
 	if err := ar.ReadMetadata(&meta); err != nil {
 		return nil, fmt.Errorf("reading metadata: %w", err)
 	}
+	if err := capture.CheckFormatVersion(meta); err != nil {
+		return nil, err
+	}
 
 	var idx capture.Index
 	if err := ar.ReadIndex(&idx); err != nil {

--- a/internal/server/version_test.go
+++ b/internal/server/version_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+func TestLoadStore_FormatVersionGuard(t *testing.T) {
+	t.Run("legacy (no version) loads", func(t *testing.T) {
+		if _, err := loadStoreWithVersion(t, 0); err != nil {
+			t.Errorf("pre-versioning archive should load: %v", err)
+		}
+	})
+	t.Run("current loads", func(t *testing.T) {
+		if _, err := loadStoreWithVersion(t, capture.CurrentFormatVersion); err != nil {
+			t.Errorf("current-version archive should load: %v", err)
+		}
+	})
+	t.Run("newer is rejected", func(t *testing.T) {
+		if _, err := loadStoreWithVersion(t, capture.CurrentFormatVersion+1); err == nil {
+			t.Error("expected LoadStore to reject a newer format version")
+		}
+	})
+}
+
+func loadStoreWithVersion(t *testing.T, version int) (*CaptureStore, error) {
+	t.Helper()
+	now := time.Date(2026, 4, 9, 8, 0, 0, 0, time.UTC)
+	body := []byte(`{"apiVersion":"v1","kind":"PodList","items":[{"metadata":{"name":"p","namespace":"default"}}]}`)
+	r := &capture.Record{ID: "r1", CapturedAt: now, APIPath: "/api/v1/namespaces/default/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: body}
+	idx := capture.Index{
+		r.APIPath: {APIPath: r.APIPath, Seqs: []int{0}, Times: []time.Time{now}},
+	}
+	meta := &capture.CaptureMetadata{FormatVersion: version, CaptureID: "ver-test", CapturedAt: now, CapturedUntil: now, RecordCount: 1}
+
+	out := filepath.Join(t.TempDir(), "capture.khsrk")
+	sw, err := archive.NewStreamWriter(out)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	if err := sw.WriteRecord(r); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+	if err := sw.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	ar, err := archive.Open(out)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	t.Cleanup(func() { ar.Close() })
+	return LoadStore(ar)
+}


### PR DESCRIPTION
## Summary
Introduces an explicit archive schema version so the `.khsrk` format can be declared stable and genuinely incompatible archives can be detected — replacing the prior purely-informal evolution (additive `omitempty` fields / optional entries with no marker).

Per the agreed plan: **integer version**, **hard error on newer archives**, **versioning-only scope**.

- **`CurrentFormatVersion = 1`** + a `format_version` field on `CaptureMetadata` ([internal/capture/record.go](internal/capture/record.go)); the capture engine stamps it on every new archive.
- **`CheckFormatVersion` guard** — an archive whose version exceeds what this build understands is refused with a clear *"upgrade kshrk"* error; a missing/zero version (pre-versioning archive) is treated as **v1** (structurally identical). Applied in `server.LoadStore` (covers `open`/`ui`/`diff`), `inspect`, and `redact` (which also re-stamps the current version on rewrite).
- **`inspect`** surfaces the version: a `format_version` report field (json/yaml) and a `Format: vN` line in the table.
- **Docs** — a "Format version & compatibility" section in [docs/archive-format.md](docs/archive-format.md) documenting the field and the bump policy.

### Compatibility policy
Additive, backward-compatible changes (new `omitempty` fields, new optional entries) **keep** the version; only a breaking structural change bumps it. The on-disk layout is otherwise unchanged, so **all existing archives stay readable** (they report v1).

## Testing
- New tests: `CheckFormatVersion` (legacy/current/newer), `LoadStore` guard (legacy loads, current loads, newer rejected), and `inspect` (reports v1 for legacy, rejects a future-version archive).
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- Manually verified `kshrk inspect` on a pre-versioning archive reports `Format: v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)