### PR TITLE
docs: correct capture format references (tar.gz → .khsrk, ZIP+Zstd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ A customer hands over one file. A support engineer queries the environment inter
 
 ```mermaid
 flowchart LR
-    A[Your Cluster] -->|kshrk capture| B(capture.tar.gz)
+    A[Your Cluster] -->|kshrk capture| B(capture.khsrk)
     B -->|kshrk open| C[Mock API Server]
     C -->|kubectl| D[Offline Debugging]
 ```
 
-1. **Capture** — `kshrk capture` polls the Kubernetes API at configured intervals for a set duration and packages all responses into a `.tar.gz` file.
-2. **Open** — `kshrk open capture.tar.gz` extracts the archive, starts a local mock HTTPS API server, and writes a kubeconfig. Set `KUBECONFIG` and use `kubectl` normally.
+1. **Capture** — `kshrk capture` polls the Kubernetes API at configured intervals for a set duration and packages all responses into a single `.khsrk` archive.
+2. **Open** — `kshrk open capture.khsrk` reads the archive, starts a local mock HTTPS API server, and writes a kubeconfig. Set `KUBECONFIG` and use `kubectl` normally.
 
 ## Quick start
 
@@ -38,7 +38,7 @@ brew install phenixblue/tap/k8shark
 kshrk capture --config k8shark.yaml
 
 # Replay the capture
-kshrk open capture.tar.gz
+kshrk open capture.khsrk
 export KUBECONFIG=~/.kube/k8shark-<id>.yaml
 kubectl get pods -A
 ```
@@ -62,7 +62,7 @@ timeline, and a time-travel scrubber. See **[docs/web-ui.md](docs/web-ui.md)** f
 | [docs/config.md](docs/config.md) | Config file reference, namespaced vs cluster-scoped resources, example configs |
 | [docs/releases.md](docs/releases.md) | How to cut a release, GoReleaser pipeline, signing, Homebrew tap |
 | [docs/development.md](docs/development.md) | Building, testing, linting, KinD dev cluster, E2E tests, package layout |
-| [docs/archive-format.md](docs/archive-format.md) | Internal `.tar.gz` layout, record and index JSON schemas |
+| [docs/archive-format.md](docs/archive-format.md) | Internal `.khsrk` (ZIP+Zstd) layout, record and index JSON schemas |
 
 ## License
 

--- a/docs/archive-format.md
+++ b/docs/archive-format.md
@@ -137,7 +137,7 @@ In addition to resource paths, k8shark captures API discovery and OpenAPI endpoi
 
 ## Reading a capture manually
 
-`kshrk inspect <archive>` is the easiest way to summarise a capture. To poke at
+`kshrk inspect <archive>` is the easiest way to summarize a capture. To poke at
 the raw entries, use a ZIP tool plus a Zstd decompressor (`metadata.json` is the
 only uncompressed entry):
 
@@ -170,8 +170,8 @@ Secret record has its `data` and `stringData` fields scrubbed:
 - All other Secret fields (name, namespace, labels, annotations, type) are unchanged
 - Non-Secret records are written verbatim
 
-The index is written unchanged; `metadata.json` records the redaction counts
-(`redacted`, `secrets_redacted`, `fields_redacted`). A redacted archive is fully
+The index is written unchanged; `metadata.json` records a `redacted` flag plus
+the counts `secrets_redacted` and `fields_redacted`. A redacted archive is fully
 usable with `kshrk open` — `kubectl get secret` will show the secret names and
 types, but all values will be `REDACTED`.
 

--- a/docs/archive-format.md
+++ b/docs/archive-format.md
@@ -1,22 +1,30 @@
 # Archive Format
 
-A k8shark capture is a standard `.tar.gz` file. It can be inspected with any tar tool.
+A k8shark capture is a `.khsrk` file: a ZIP container whose entries are
+individually Zstandard-compressed JSON (except `metadata.json`, which is stored
+uncompressed for fast header reads). It can be listed with any ZIP tool.
 
 ```sh
-tar -tzf capture.tar.gz
+unzip -l capture.khsrk
 ```
 
 ## Layout
 
 ```
 k8shark-capture/
-  metadata.json
-  index.json
+  metadata.json              # uncompressed
+  index.json.zst             # zstd-compressed
+  watch-index.json.zst       # zstd-compressed; only when watch: true was used
   records/
-    <uuid>.json
-    <uuid>.json
-    ...
+    <pathDir>/               # <pathDir> = first 16 hex chars of SHA-256(apiPath)
+      0.json.zst             # one file per record, named by sequence number
+      1.json.zst
+      ...
 ```
+
+Each record lives under a directory derived from a hash of its API path, and is
+named by its 0-based sequence number within that path (`<seq>.json.zst`). The
+`index.json.zst` maps each API path to its ordered sequence numbers.
 
 ## metadata.json
 
@@ -63,34 +71,35 @@ schema. The current version is **1**.
   clear "upgrade kshrk" error rather than risk misreading an incompatible
   layout. Run `kshrk inspect <archive>` to see an archive's format version.
 
-## index.json
+## index.json.zst
 
-Maps canonical API paths to the ordered list of record IDs captured for each path. The mock server uses this to find records without scanning all files.
+Maps canonical API paths to the ordered sequence numbers captured for each path. The mock server uses this to find records without scanning all files. The entry is Zstd-compressed JSON.
 
 ```json
 {
   "/api/v1/namespaces/default/pods": {
     "api_path": "/api/v1/namespaces/default/pods",
-    "record_ids": ["uuid-1", "uuid-2", "uuid-3"],
-    "times":      ["2026-04-09T10:00:00Z", "2026-04-09T10:00:30Z", "2026-04-09T10:01:00Z"]
+    "seqs":     [0, 1, 2],
+    "times":    ["2026-04-09T10:00:00Z", "2026-04-09T10:00:30Z", "2026-04-09T10:01:00Z"],
+    "counts":   [4, 4, 5]
   },
   "/api/v1/namespaces/default/pods?as=Table": {
     "api_path": "/api/v1/namespaces/default/pods?as=Table",
-    "record_ids": ["uuid-4", "uuid-5"],
-    "times":      ["2026-04-09T10:00:00Z", "2026-04-09T10:00:30Z"]
+    "seqs":     [0, 1],
+    "times":    ["2026-04-09T10:00:00Z", "2026-04-09T10:00:30Z"]
   }
 }
 ```
 
-`record_ids` and `times` are parallel arrays, both ordered by capture time ascending.
+`seqs`, `times`, and `counts` are parallel arrays, ordered by capture time ascending. `seqs[i]` is the sequence number used in the record filename (`records/<pathDir>/<seq>.json.zst`). `counts` is optional — it records the number of top-level items in each list response and is omitted in older archives.
 
 ### Table response keys
 
 For each resource path, k8shark also captures the Kubernetes Table-format response (the data `kubectl get -o wide` uses). These are stored under the same path with a `?as=Table` suffix. This suffix is a convention internal to k8shark — it does not appear in real API URLs.
 
-## records/\<uuid\>.json
+## records/\<pathDir\>/\<seq\>.json.zst
 
-One file per polled API response.
+One Zstd-compressed file per polled API response, named by its sequence number.
 
 ```json
 {
@@ -105,7 +114,7 @@ One file per polled API response.
 
 | Field | Description |
 |-------|-------------|
-| `id` | UUID, matches the filename. |
+| `id` | UUID identifying this record (the on-disk filename is the sequence number, not this id). |
 | `captured_at` | When this specific poll was recorded. |
 | `api_path` | The canonical path key (includes `?as=Table` suffix for Table records). |
 | `http_method` | Always `GET`. |
@@ -128,25 +137,27 @@ In addition to resource paths, k8shark captures API discovery and OpenAPI endpoi
 
 ## Reading a capture manually
 
-```sh
-# List all captured API paths
-python3 -c "
-import json, sys
-idx = json.load(open('k8shark-capture/index.json'))
-for path in sorted(idx):
-    print(len(idx[path]['record_ids']), path)
-" 
+`kshrk inspect <archive>` is the easiest way to summarise a capture. To poke at
+the raw entries, use a ZIP tool plus a Zstd decompressor (`metadata.json` is the
+only uncompressed entry):
 
-# Extract the most recent pod list from default namespace
-tar -xOf capture.tar.gz k8shark-capture/index.json \
+```sh
+# List entries
+unzip -l capture.khsrk
+
+# Read the (uncompressed) metadata
+unzip -p capture.khsrk k8shark-capture/metadata.json | python3 -m json.tool
+
+# Read the (zstd-compressed) index and find the latest seq for a path
+unzip -p capture.khsrk k8shark-capture/index.json.zst | zstd -d \
   | python3 -c "
 import json,sys
 idx=json.load(sys.stdin)
 entry=idx['/api/v1/namespaces/default/pods']
-print(entry['record_ids'][-1])
+print('latest seq:', entry['seqs'][-1])
 "
-# then:
-# tar -xOf capture.tar.gz k8shark-capture/records/<uuid>.json | python3 -m json.tool
+# then read that record (replace <pathDir> and <seq>):
+# unzip -p capture.khsrk k8shark-capture/records/<pathDir>/<seq>.json.zst | zstd -d | python3 -m json.tool
 ```
 
 ## Redacted archives
@@ -159,17 +170,18 @@ Secret record has its `data` and `stringData` fields scrubbed:
 - All other Secret fields (name, namespace, labels, annotations, type) are unchanged
 - Non-Secret records are written verbatim
 
-The `index.json` and `metadata.json` are written unchanged. A redacted archive is
-fully usable with `kshrk open` — `kubectl get secret` will show the secret names
-and types, but all values will be `REDACTED`.
+The index is written unchanged; `metadata.json` records the redaction counts
+(`redacted`, `secrets_redacted`, `fields_redacted`). A redacted archive is fully
+usable with `kshrk open` — `kubectl get secret` will show the secret names and
+types, but all values will be `REDACTED`.
 
 ```sh
-kshrk redact --in capture.tar.gz --out capture-redacted.tar.gz
+kshrk redact --in capture.khsrk --out capture-redacted.khsrk
 ```
 
 ## Streaming mode (NDJSON stdout)
 
-When `output: "-"` is set in the configuration (or `--output -` on the command line), k8shark writes records to stdout in **newline-delimited JSON (NDJSON)** format instead of writing a `.tar.gz` file. Each line is a complete JSON record object identical to the individual record files described above.
+When `output: "-"` is set in the configuration (or `--output -` on the command line), k8shark writes records to stdout in **newline-delimited JSON (NDJSON)** format instead of writing a `.khsrk` file. Each line is a complete JSON record object identical to the individual record files described above.
 
 ```sh
 kshrk capture --config capture.yaml --output - | jq 'select(.api_path == "/api/v1/namespaces/default/pods")'

--- a/docs/config.md
+++ b/docs/config.md
@@ -111,7 +111,7 @@ Use `"*"` as a namespace value to automatically capture from all namespaces disc
   interval: 30s
 ```
 
-**Behaviour:**
+**Behavior:**
 - `namespaces: ["*"]` expands to every namespace present at the start of the capture. Namespaces created _during_ the capture are not included.
 - Mixed lists such as `namespaces: ["production", "*"]` are supported — explicit namespaces appear first, then all remaining discovered namespaces are appended, deduplicated.
 - If namespace discovery fails (e.g. RBAC permissions), the capture exits with a clear error.
@@ -561,7 +561,7 @@ resources:
     interval: 60s
 ```
 
-**Auto-discovery behaviour:**
+**Auto-discovery behavior:**
 - Walks `/apis` once at the start of the capture.
 - For each discovered non-core group-version, reads the resource list and adds
   an entry for every non-sub-resource type.

--- a/docs/config.md
+++ b/docs/config.md
@@ -7,7 +7,7 @@ k8shark reads a YAML config file that controls what gets captured, from which na
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `duration` | duration string | `10m` | Total time to run the capture. Polling continues until time runs out. |
-| `output` | string | `./k8shark-<timestamp>.tar.gz` | Path for the output archive. |
+| `output` | string | `./k8shark-<timestamp>.khsrk` | Path for the output archive. |
 | `kubeconfig` | string | `$KUBECONFIG` → `~/.kube/config` | Path to the kubeconfig for the source cluster. |
 | `resources` | list | required | Resource types to capture. See below. |
 | `auto_discover` | bool | `false` | Legacy global discovery toggle. Prefer `resources: - all: true` for fine-grained control. |
@@ -56,7 +56,7 @@ Use `all: true` to auto-discover resources via Kubernetes API discovery (includi
 
 ```yaml
 duration: 10m
-output: ./cluster-snapshot.tar.gz
+output: ./cluster-snapshot.khsrk
 
 resources:
   - all: true
@@ -161,7 +161,7 @@ Behavior:
 
 ```yaml
 duration: 5m
-output: ./capture.tar.gz
+output: ./capture.khsrk
 
 resources:
   - group: ""
@@ -175,7 +175,7 @@ resources:
 
 ```yaml
 duration: 10m
-output: ./workload-capture.tar.gz
+output: ./workload-capture.khsrk
 
 resources:
   - group: ""
@@ -212,7 +212,7 @@ resources:
 
 ```yaml
 duration: 10m
-output: ./storage-capture.tar.gz
+output: ./storage-capture.khsrk
 
 resources:
   - group: ""
@@ -242,7 +242,7 @@ resources:
 
 ```yaml
 duration: 30m
-output: ./support-capture.tar.gz
+output: ./support-capture.khsrk
 kubeconfig: /path/to/customer.kubeconfig
 
 resources:
@@ -397,7 +397,7 @@ Invalid replacements (e.g. `"not-a-number"` for an integer field) fail early wit
 
 ```yaml
 duration: 10m
-output: ./capture.tar.gz
+output: ./capture.khsrk
 kubeconfig: ~/.kube/config
 
 resources:
@@ -448,7 +448,7 @@ redaction:
 The same config can be passed to `kshrk redact` to apply exactly the same rules to an existing archive:
 
 ```bash
-kshrk redact --in capture.tar.gz --out redacted.tar.gz --config k8shark.yaml
+kshrk redact --in capture.khsrk --out redacted.khsrk --config k8shark.yaml
 ```
 
 ---
@@ -488,7 +488,7 @@ kubectl api-resources --api-group=networking.istio.io
 
 ```yaml
 duration: 10m
-output: ./istio-capture.tar.gz
+output: ./istio-capture.khsrk
 
 resources:
   - group: ""
@@ -542,7 +542,7 @@ automatically add every non-core resource type it finds.
 
 ```yaml
 duration: 10m
-output: ./full-capture.tar.gz
+output: ./full-capture.khsrk
 auto_discover: true
 
 # Explicit entries are still captured and take precedence over auto-discovered

--- a/docs/demo/demo-capture.yaml
+++ b/docs/demo/demo-capture.yaml
@@ -1,5 +1,5 @@
 duration: 2s
-output: ./demo-capture.tar.gz
+output: ./demo-capture.khsrk
 kubeconfig: /tmp/k8shark-dev.yaml
 
 resources:

--- a/docs/demo/demo.tape
+++ b/docs/demo/demo.tape
@@ -18,13 +18,13 @@ Enter
 Sleep 7500ms
 
 # ── Inspect the capture ────────────────────────────────────────────────────────
-Type "kshrk inspect demo-capture.tar.gz"
+Type "kshrk inspect demo-capture.khsrk"
 Sleep 300ms
 Enter
 Sleep 3s
 
 # ── Open the archive in the background ────────────────────────────────────────
-Type "kshrk open demo-capture.tar.gz &"
+Type "kshrk open demo-capture.khsrk &"
 Sleep 500ms
 Enter
 Sleep 3750ms

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@
 
 | Tool | Minimum version | Notes |
 |------|----------------|-------|
-| Go | 1.22 | Check `go.mod` for the exact minimum |
+| Go | 1.26 | Check `go.mod` for the exact minimum |
 | `kind` | any recent | Required for `make e2e` and `make kind-up` |
 | `kubectl` | any recent | Required for E2E and manual testing |
 | `goreleaser` | v2 | Required for `make release-snapshot` / `make release-local` only |
@@ -107,9 +107,15 @@ Run `make help` to print all targets:
 .
 ├── main.go                    # entry point — calls cmd.Execute()
 ├── cmd/                       # cobra CLI commands
-│   ├── root.go                # kshrk root command + config init
+│   ├── root.go                # root command + config discovery
 │   ├── capture.go             # kshrk capture
 │   ├── open.go                # kshrk open
+│   ├── ui.go                  # kshrk ui
+│   ├── inspect.go             # kshrk inspect
+│   ├── diff.go                # kshrk diff
+│   ├── redact.go              # kshrk redact
+│   ├── transitions.go         # kshrk transitions
+│   ├── validate.go            # kshrk validate
 │   └── version.go             # kshrk version
 └── internal/
     ├── archive/               # .khsrk (ZIP+Zstd) read/write
@@ -117,11 +123,17 @@ Run `make help` to print all targets:
     │   ├── engine.go          # polling loop, doFetch, buildAPIPath
     │   └── record.go          # Record, Index, CaptureMetadata types
     ├── config/                # config file loading + validation
-    └── server/                # mock API server
-        ├── server.go          # TLS server lifecycle, archive extraction
-        ├── handler.go         # HTTP routing + serveResource
-        ├── store.go           # CaptureStore, Latest, Aggregate*, parseAPIPath
-        ├── selector.go        # label + field selector filtering
-        ├── tls.go             # self-signed cert generation
-        └── kubeconfig.go      # kubeconfig writer
+    ├── server/                # mock API server
+    │   ├── server.go          # TLS server lifecycle, archive loading
+    │   ├── handler.go         # HTTP routing + serveResource
+    │   ├── store.go           # CaptureStore, Latest, Aggregate*, parseAPIPath
+    │   ├── selector.go        # label + field selector filtering
+    │   ├── tls.go             # self-signed cert generation
+    │   └── kubeconfig.go      # kubeconfig writer
+    ├── ui/                    # web UI server (hosts the v2 dashboard)
+    │   └── v2/                # dashboard handlers + embedded static assets
+    ├── inspect/               # archive summary (kshrk inspect)
+    ├── diff/                  # before/after archive diff
+    ├── redact/                # secret + field redaction
+    └── transitions/           # watch-event state-change timeline
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -112,7 +112,7 @@ Run `make help` to print all targets:
 │   ├── open.go                # kshrk open
 │   └── version.go             # kshrk version
 └── internal/
-    ├── archive/               # tar.gz read/write
+    ├── archive/               # .khsrk (ZIP+Zstd) read/write
     ├── capture/               # capture engine + record types
     │   ├── engine.go          # polling loop, doFetch, buildAPIPath
     │   └── record.go          # Record, Index, CaptureMetadata types

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,7 +4,7 @@
 
 - `kubectl` in your `PATH`
 - A valid `~/.kube/config` (or `KUBECONFIG` env set) pointing at a cluster — for `capture` only
-- Go 1.22+ if building from source
+- Go 1.26+ if building from source
 
 ## Installation
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -166,7 +166,7 @@ kshrk inspect capture.khsrk -o yaml
 
 ## Open
 
-`kshrk open` extracts the archive, starts a local mock HTTPS API server on `127.0.0.1`, and writes a kubeconfig pointing at it.
+`kshrk open` reads the archive, starts a local mock HTTPS API server on `127.0.0.1`, and writes a kubeconfig pointing at it.
 
 ```sh
 kshrk open capture.khsrk

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -416,7 +416,7 @@ See [config.md](config.md#redaction) for the full `redaction:` config block refe
 
 ## kubectl compatibility
 
-The mock server is designed to be a drop-in replacement for `kubectl`'s real server. Supported behaviours:
+The mock server is designed to be a drop-in replacement for `kubectl`'s real server. Supported behaviors:
 
 | kubectl feature | Status |
 |-----------------|--------|

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,7 +35,7 @@ make build
 
 ## Capture
 
-Run `kshrk capture` while connected to the cluster. It polls the Kubernetes API at defined intervals and packages all responses into a `.tar.gz` archive.
+Run `kshrk capture` while connected to the cluster. It polls the Kubernetes API at defined intervals and packages all responses into a `.khsrk` archive.
 
 ```sh
 kshrk capture --config k8shark.yaml
@@ -44,10 +44,10 @@ kshrk capture --config k8shark.yaml
 The command shows a spinner while running, then prints a summary:
 
 ```
-Starting capture -> ./capture.tar.gz
+Starting capture -> ./capture.khsrk
   capturing |
 Capture complete
-  Output:    ./capture.tar.gz (1.2 MB)
+  Output:    ./capture.khsrk (1.2 MB)
   Records:   480 across 12 resource path(s)
   Duration:  10m0s
 ```
@@ -57,7 +57,7 @@ Capture complete
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--config` | | `./config.yaml`, then `~/.config/kshrk/config.yaml` | Path to config file |
-| `--output` | `-o` | `./k8shark-<timestamp>.tar.gz` | Output archive path |
+| `--output` | `-o` | `./k8shark-<timestamp>.khsrk` | Output archive path |
 | `--duration` | | from config | Override capture duration (e.g. `5m`) |
 | `--kubeconfig` | | `$KUBECONFIG` / `~/.kube/config` | Source cluster kubeconfig |
 | `--auto-discover` | | false | Auto-discover and capture all available API resources |
@@ -128,7 +128,7 @@ warning: resources[3] (events): interval 2s is very short and may produce a larg
 `kshrk inspect` reads a capture archive and prints a summary of its contents without starting a server.
 
 ```sh
-kshrk inspect capture.tar.gz
+kshrk inspect capture.khsrk
 ```
 
 Example output:
@@ -138,7 +138,7 @@ Capture ID:   a1b2c3d4-e5f6-7890-abcd-ef1234567890
 Captured:     2026-04-09T08:00:00Z → 2026-04-09T08:10:00Z  (10m0s)
 Kubernetes:   v1.29.0
 Server:       https://192.168.1.100:6443
-Archive:      capture.tar.gz (1245184 bytes)
+Archive:      capture.khsrk (1245184 bytes)
 Records:      480
 
 RESOURCE              GROUP  VERSION  NAMESPACED  NAMESPACES              RECORDS
@@ -152,8 +152,8 @@ statefulsets          apps   v1       yes         production              30
 Use `-o json` or `-o yaml` for machine-readable output:
 
 ```sh
-kshrk inspect capture.tar.gz -o json
-kshrk inspect capture.tar.gz -o yaml
+kshrk inspect capture.khsrk -o json
+kshrk inspect capture.khsrk -o yaml
 ```
 
 ### Inspect flags
@@ -169,7 +169,7 @@ kshrk inspect capture.tar.gz -o yaml
 `kshrk open` extracts the archive, starts a local mock HTTPS API server on `127.0.0.1`, and writes a kubeconfig pointing at it.
 
 ```sh
-kshrk open capture.tar.gz
+kshrk open capture.khsrk
 ```
 
 Output:
@@ -216,8 +216,8 @@ The server stays running until `Ctrl+C`.
 Every captured record is timestamped. `--at` lets you replay the capture as it looked at a specific point in time — the server returns the most recent record for each resource whose timestamp is ≤ the given time.
 
 ```sh
-kshrk open capture.tar.gz --at 2026-04-09T10:30:00Z
-kshrk open capture.tar.gz --at -5m
+kshrk open capture.khsrk --at 2026-04-09T10:30:00Z
+kshrk open capture.khsrk --at -5m
 ```
 
 `--at` accepts either:
@@ -236,7 +236,7 @@ This is useful when you have a long capture (e.g. 1h) and want to compare cluste
 `kshrk ui` starts a local web-based explorer and the mock Kubernetes API server for a capture archive.
 
 ```sh
-kshrk ui capture.tar.gz
+kshrk ui capture.khsrk
 ```
 
 Example output:
@@ -289,13 +289,13 @@ flags override it.
 Compare two archives:
 
 ```sh
-kshrk diff --before before.tar.gz --after after.tar.gz
+kshrk diff --before before.khsrk --after after.khsrk
 ```
 
 Compare two points within one archive:
 
 ```sh
-kshrk diff --archive capture.tar.gz \
+kshrk diff --archive capture.khsrk \
   --before-at 2026-04-09T10:40:00Z \
   --after-at -1m
 ```
@@ -303,14 +303,14 @@ kshrk diff --archive capture.tar.gz \
 Scope the output:
 
 ```sh
-kshrk diff --before before.tar.gz --after after.tar.gz \
+kshrk diff --before before.khsrk --after after.khsrk \
   --resource pods --namespace default
 ```
 
 Emit machine-readable JSON instead of unified diff text:
 
 ```sh
-kshrk diff --before before.tar.gz --after after.tar.gz --output json
+kshrk diff --before before.khsrk --after after.khsrk --output json
 ```
 
 ### Diff flags
@@ -343,18 +343,18 @@ Produces a **new** archive with Kubernetes Secret data replaced and any configur
 
 ```sh
 # Redact secrets only
-kshrk redact --in capture.tar.gz --redact-secrets
+kshrk redact --in capture.khsrk --redact-secrets
 
 # Redact secrets + specific fields via CLI flags
-kshrk redact --in capture.tar.gz --redact-secrets \
+kshrk redact --in capture.khsrk --redact-secrets \
   --redact-field "data.api-key:ConfigMap:REDACTED" \
   --redact-field "spec.containers[*].env[*].value:Pod:REDACTED:string"
 
 # Reuse the redaction rules from your capture config
-kshrk redact --in capture.tar.gz --out safe-capture.tar.gz --config k8shark.yaml
+kshrk redact --in capture.khsrk --out safe-capture.khsrk --config k8shark.yaml
 
 # Preserve specific secrets from redaction
-kshrk redact --in capture.tar.gz --redact-secrets \
+kshrk redact --in capture.khsrk --redact-secrets \
   --allow-secret default/pull-secret \
   --allow-secret kube-system/bootstrap-token
 ```
@@ -402,7 +402,7 @@ Examples:
 | Flag | Command | Default | Description |
 |------|---------|---------|-------------|
 | `--in` | `redact` | (required) | Source capture archive |
-| `--out` | `redact` | `<in>-redacted.tar.gz` | Output archive path |
+| `--out` | `redact` | `<in>-redacted.khsrk` | Output archive path |
 | `--redact-secrets` | both | `false` | Redact all Secret `data`/`stringData` values |
 | `--allow-secret` | both | | `namespace/name` of secret to preserve (repeatable) |
 | `--redact-field` | both | | Field redaction rule (repeatable). Format: `<path>:<Kind>:<replacement>[:<type>]` |
@@ -544,7 +544,7 @@ the mock server. Any tool that can be configured with a kubeconfig or a
 
 ```sh
 # Start the mock server
-kshrk open capture.tar.gz
+kshrk open capture.khsrk
 # Note the printed kubeconfig path, e.g. /tmp/k8shark-kubeconfig-1234
 
 # Use with istioctl

--- a/examples/k8shark.yaml
+++ b/examples/k8shark.yaml
@@ -6,8 +6,8 @@
 # How long to run the capture. Polling continues until time runs out.
 duration: 10m
 
-# Output archive path. Defaults to ./k8shark-<timestamp>.tar.gz if omitted.
-output: ./capture.tar.gz
+# Output archive path. Defaults to ./k8shark-<timestamp>.khsrk if omitted.
+output: ./capture.khsrk
 
 # Path to kubeconfig for the source cluster.
 # Defaults to $KUBECONFIG env, then ~/.kube/config.

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -197,7 +197,7 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 	defer cancel()
 
 	// Install SIGTERM/SIGINT handler so the capture can be wound down gracefully:
-	// the context is cancelled, polling stops, and Finish() still writes a valid
+	// the context is canceled, polling stops, and Finish() still writes a valid
 	// (partial) archive.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
@@ -1470,7 +1470,7 @@ func (e *Engine) storeRecord(indexKey string, body []byte, statusCode int, dedup
 }
 
 // countListItems peeks at a JSON response body and returns the number of
-// top-level items in it. Recognises both standard <Kind>List responses
+// top-level items in it. Recognizes both standard <Kind>List responses
 // (items[]) and meta.k8s.io/v1 Table responses (rows[]). Returns 0 for
 // non-list bodies (single objects, discovery, OpenAPI). Used to populate
 // IndexEntry.Counts so the UI can show namespace card counts without
@@ -1789,7 +1789,7 @@ func (e *Engine) expandWildcardNamespaces(ctx context.Context) error {
 		if code != http.StatusOK || nsBody == nil {
 			if code == 0 {
 				if err := ctx.Err(); err != nil {
-					return fmt.Errorf("namespace discovery failed: request cancelled before completion (try a longer --duration): %w", err)
+					return fmt.Errorf("namespace discovery failed: request canceled before completion (try a longer --duration): %w", err)
 				}
 				return fmt.Errorf("namespace discovery failed (HTTP 0): request could not be completed; check kubeconfig/context and cluster connectivity")
 			}

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -839,7 +839,7 @@ func TestExpandWildcard_DiscoveryCancelledByDuration(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected timeout/cancellation error, got nil")
 	}
-	if !strings.Contains(err.Error(), "request cancelled before completion") {
+	if !strings.Contains(err.Error(), "request canceled before completion") {
 		t.Errorf("expected cancellation hint in error, got: %v", err)
 	}
 }

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -11,7 +11,7 @@ import (
 	"github.com/phenixblue/k8shark/internal/capture"
 )
 
-// Report summarises the contents of a capture archive.
+// Report summarizes the contents of a capture archive.
 type Report struct {
 	FormatVersion     int               `json:"format_version"`
 	CaptureID         string            `json:"capture_id"`
@@ -57,7 +57,7 @@ func Run(archivePath string) (*Report, error) {
 		return nil, fmt.Errorf("reading index: %w", err)
 	}
 
-	resources := summariseResources(ar, idx)
+	resources := summarizeResources(ar, idx)
 
 	// Pre-versioning archives (0) are treated as version 1.
 	formatVersion := meta.FormatVersion
@@ -79,9 +79,9 @@ func Run(archivePath string) (*Report, error) {
 	}, nil
 }
 
-// summariseResources aggregates per-resource information from the index.
+// summarizeResources aggregates per-resource information from the index.
 // Item counts are read from the latest record for each path directly from the archive.
-func summariseResources(ar *archive.Archive, idx capture.Index) []ResourceSummary {
+func summarizeResources(ar *archive.Archive, idx capture.Index) []ResourceSummary {
 	type key struct{ group, version, resource string }
 	type accum struct {
 		namespaced bool

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -169,7 +169,7 @@ func TestRun_TableKeysSkipped(t *testing.T) {
 	}
 	defer ar.Close()
 
-	// Manually inject a Table index entry; verify that summariseResources skips
+	// Manually inject a Table index entry; verify that summarizeResources skips
 	// paths containing "?" via the unit function directly.
 	idx := capture.Index{
 		"/api/v1/namespaces/default/pods": {
@@ -183,7 +183,7 @@ func TestRun_TableKeysSkipped(t *testing.T) {
 			Times:   []time.Time{time.Now()},
 		},
 	}
-	summaries := summariseResources(ar, idx)
+	summaries := summarizeResources(ar, idx)
 	if len(summaries) != 1 {
 		t.Errorf("expected 1 summary (Table key excluded), got %d", len(summaries))
 	}

--- a/internal/redact/fields.go
+++ b/internal/redact/fields.go
@@ -122,7 +122,7 @@ func inferType(v interface{}) string {
 }
 
 // convertReplacement parses the string replacement into a typed Go value whose
-// JSON serialisation will match the expected type.
+// JSON serialization will match the expected type.
 func convertReplacement(replacement, valueType string) (interface{}, error) {
 	switch strings.ToLower(valueType) {
 	case "string":

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -811,7 +811,7 @@ func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path strin
 }
 
 // serveLog serves a pod log sub-resource (e.g. /api/v1/namespaces/<ns>/pods/<name>/log).
-// Recognised query parameters:
+// Recognized query parameters:
 //   - container=<c>  — request a specific container's log
 //   - previous=true  — request the previous-container log (kubectl logs --previous)
 //

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -871,7 +871,7 @@ func TestHandler_ProxySubResource405(t *testing.T) {
 // TestHandler_NamespaceQueryFallsBackToClusterPath verifies that a request for
 // namespace-scoped pods (e.g. kubectl get pods -n default) returns the correct
 // items even when the capture only stored the cluster-scoped /api/v1/pods path
-// (no per-namespace paths in the index). This matches the behaviour when a
+// (no per-namespace paths in the index). This matches the behavior when a
 // config entry for pods omits namespaces: or when the allNotFound fallback fires
 // during auto-discovery.
 func TestHandler_NamespaceQueryFallsBackToClusterPath(t *testing.T) {

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -606,7 +606,7 @@ func (s *CaptureStore) AggregateAcrossNamespaces(clusterPath string, at time.Tim
 	suffix := "/" + resource
 
 	// Safety cap: resources like packagemanifests return the full cluster list
-	// for every namespace (OLM behaviour). Aggregating across all namespaces
+	// for every namespace (OLM behavior). Aggregating across all namespaces
 	// would multiply the item count by the number of namespaces and materialise
 	// hundreds of millions of items. Cap the aggregate at 10 000 unique items
 	// (keyed by uid or name) to prevent unbounded memory use.

--- a/internal/ui/v2/diff.go
+++ b/internal/ui/v2/diff.go
@@ -123,7 +123,7 @@ func toYAML(body []byte) string {
 }
 
 // unifiedDiffLines computes a unified diff and breaks it into typed lines so
-// the frontend can colour add/del/context distinctly.
+// the frontend can color add/del/context distinctly.
 func unifiedDiffLines(before, after, beforeName, afterName string) []DiffHunk {
 	diff := difflib.UnifiedDiff{
 		A:        difflib.SplitLines(before),

--- a/internal/ui/v2/overview.go
+++ b/internal/ui/v2/overview.go
@@ -19,7 +19,7 @@ const (
 	maxIssuesShown   = 8
 )
 
-// workloadResources is the set of resource types categorised as "workloads"
+// workloadResources is the set of resource types categorized as "workloads"
 // for KPI counting. Mirrors the existing /api/ui drill-down classifier.
 var workloadResources = map[string]bool{
 	"deployments":  true,

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -623,7 +623,7 @@ out=$(kubectl "${EKC[@]}" get pods -n k8shark-test \
 assert_not_empty "field selector metadata.namespace returns pods" "$out"
 
 # ── Watch: --request-timeout=5s lets kubectl exit naturally when the server
-#           closes the stream (our server honours timeoutSeconds).
+#           closes the stream (our server honors timeoutSeconds).
 WATCH_LOG=$(mktemp)
 kubectl --kubeconfig "$E2E_KUBECONFIG" --request-timeout=5s \
   get pods -n k8shark-test --watch -o name >"$WATCH_LOG" 2>&1 || true


### PR DESCRIPTION
## Summary
The capture archive is a **ZIP container of Zstd-compressed JSON** with a **`.khsrk`** extension, but the docs still described a `.tar.gz` tarball and the pre-rewrite internal layout. This brings all user-facing docs in line with the code.

### Extension fixes (capture archive → `.khsrk`)
README, `docs/usage.md`, `docs/config.md`, `examples/k8shark.yaml`, and the demo files: every capture-archive reference moved from `.tar.gz` to `.khsrk` (the real default output is `k8shark-<timestamp>.khsrk`). ~40 references across the docs.

### `docs/archive-format.md` — substantive rewrite
This doc was the most wrong. Corrected:
- **Format description** — it's a ZIP+Zstd archive, not a tarball; inspect with `unzip`/`zstd`, not `tar -tzf`.
- **On-disk layout** — `records/<pathDir>/<seq>.json.zst` (pathDir = first 16 hex of SHA-256(apiPath)); `metadata.json` uncompressed, other entries zstd-compressed; optional `watch-index.json.zst`.
- **Index schema** — `seqs`/`times`/`counts` parallel arrays, not `record_ids`.
- **Records section** — heading and the `id`-vs-filename note.
- **Manual-reading example** — `unzip -p … | zstd -d` instead of `tar -xOf`.
- **Redacted archives** — metadata now records redaction counts (no longer "written unchanged").

### Other
- `docs/development.md`: archive package comment now says "ZIP+Zstd".
- **Left untouched:** `docs/releases.md` — its `.tar.gz` references are the GoReleaser **binary release** archives, which genuinely are tarballs.

## Verification
Cross-referenced every change against the code (`internal/archive/archive.go`, `internal/capture/record.go`, `cmd/`). Confirmed no `.tar.gz`/`record_ids`/`<uuid>.json` left in the capture docs; release tarball refs preserved; example YAMLs still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)