### PR TITLE
docs: add American English convention to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,13 @@
 Guidance for Claude Code when working in this repository. For full dev setup,
 the KinD cluster, and the Make target reference, see `docs/development.md`.
 
+## Conventions
+
+- **American English** everywhere — docs, code comments, identifiers, log/error
+  strings, and commit messages. Use `color`, `behavior`, `summarize`,
+  `canceled`, `recognize`, `serialization`, etc. (not the `-our`/`-ise`/`-lled`
+  British forms). The repo was normalized to American English in #105.
+
 ## Building & verifying
 
 Use the Makefile rather than raw `go` commands:


### PR DESCRIPTION
## Summary
Adds a **Conventions** section to `CLAUDE.md` recording **American English** as the standard for all docs, code comments, identifiers, log/error strings, and commit messages (the repo was normalized to American English in #105).

This note was originally authored on the `docs/claude-md` branch *after* #104 had already squash-merged, so it never made it onto `main`. Re-applying it cleanly on top of current `main` here.

## Testing
Docs-only; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)