### PR TITLE
feat(cli): add usage examples and richer help text to commands

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -17,7 +17,23 @@ var captureCmd = &cobra.Command{
 	Short: "Capture Kubernetes cluster state to a .kshrk archive",
 	Long: `Runs a series of Kubernetes API read operations at defined intervals
 for a configured duration. All responses are recorded and packaged into a
-single .kshrk capture file for later replay.`,
+single .kshrk capture file for later replay.
+
+Resources, namespaces, and intervals come from the --config file. Use
+--auto-discover to capture every available API resource without listing them,
+--output - to stream records as NDJSON to stdout, and --redact-secrets to
+scrub Secret values from the archive after capture.`,
+	Example: `  # Capture using a config file
+  kshrk capture --config k8shark.yaml
+
+  # Auto-discover and capture all resources for 5 minutes
+  kshrk capture --auto-discover --duration 5m
+
+  # Stream records as NDJSON to stdout instead of writing an archive
+  kshrk capture --config k8shark.yaml --output -
+
+  # Capture, then redact Secret values from the archive
+  kshrk capture --config k8shark.yaml --redact-secrets`,
 	RunE: runCapture,
 }
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -21,8 +21,19 @@ func (e exitError) ExitCode() int { return e.code }
 var diffCmd = &cobra.Command{
 	Use:   "diff",
 	Short: "Compare two capture snapshots",
-	Long: `Compares resource state between two capture archives, or between two
-points in time within the same archive, and prints a diff.`,
+	Long: `Compares resource state between two capture archives (--before/--after),
+or between two points in time within a single archive (--archive with
+--before-at/--after-at), and prints a diff. Limit the scope with --resource and
+--namespace, and choose text or json output with -o. Exits non-zero when
+differences are found.`,
+	Example: `  # Diff two separate captures
+  kshrk diff --before before.kshrk --after after.kshrk
+
+  # Diff two points in time within one capture
+  kshrk diff --archive capture.kshrk --before-at -10m --after-at -1m
+
+  # Limit to a resource and namespace, as JSON
+  kshrk diff --before before.kshrk --after after.kshrk --resource pods --namespace default -o json`,
 	Args: cobra.NoArgs,
 	RunE: runDiff,
 }

--- a/cmd/help_examples_test.go
+++ b/cmd/help_examples_test.go
@@ -1,0 +1,18 @@
+package cmd
+
+import "testing"
+
+// Every user-facing subcommand should ship copy-pasteable examples so
+// `kshrk <cmd> --help` renders an "Examples:" section. version/help/completion
+// are exempt.
+func TestUserFacingCommandsHaveExamples(t *testing.T) {
+	exempt := map[string]bool{"version": true, "help": true, "completion": true}
+	for _, c := range rootCmd.Commands() {
+		if exempt[c.Name()] {
+			continue
+		}
+		if c.Example == "" {
+			t.Errorf("command %q has no Example (add a Cobra Example field)", c.Name())
+		}
+	}
+}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -15,8 +15,16 @@ import (
 var inspectCmd = &cobra.Command{
 	Use:   "inspect <capture.kshrk>",
 	Short: "Display a summary of a capture archive's contents",
-	Long: `Reads a k8shark capture archive and prints capture metadata and a
-table of captured resource types without starting a server.`,
+	Long: `Reads a k8shark capture archive and prints capture metadata (format
+version, capture window, Kubernetes version, record count) and a table of
+captured resource types, without starting a server. Use -o json or -o yaml
+for machine-readable output.`,
+	Example: `  # Summarize a capture as a table
+  kshrk inspect capture.kshrk
+
+  # Machine-readable output
+  kshrk inspect capture.kshrk -o json
+  kshrk inspect capture.kshrk -o yaml`,
 	Args: cobra.ExactArgs(1),
 	RunE: runInspect,
 }

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -10,8 +10,18 @@ import (
 var openCmd = &cobra.Command{
 	Use:   "open <capture.kshrk>",
 	Short: "Open a capture file and start a mock Kubernetes API server",
-	Long: `Extracts a k8shark capture archive, starts a local mock Kubernetes
-API server, and writes a kubeconfig so kubectl can connect immediately.`,
+	Long: `Reads a k8shark capture archive (in memory, without extracting to disk),
+starts a local mock Kubernetes API server, and writes a kubeconfig so kubectl
+can connect immediately. Use --at to replay the cluster as it looked at a
+specific point in the capture window.`,
+	Example: `  # Open a capture and start the mock API server
+  kshrk open capture.kshrk
+
+  # Replay the state 5 minutes before the capture ended
+  kshrk open capture.kshrk --at -5m
+
+  # Replay at a specific timestamp, on a fixed port
+  kshrk open capture.kshrk --at 2026-04-09T10:30:00Z --port 8443`,
 	Args: cobra.ExactArgs(1),
 	RunE: runOpen,
 }

--- a/cmd/redact.go
+++ b/cmd/redact.go
@@ -15,16 +15,21 @@ var redactCmd = &cobra.Command{
 	Use:   "redact --in <capture.kshrk> [--out <redacted.kshrk>]",
 	Short: "Redact Secret data and arbitrary fields from a capture archive",
 	Long: `Produces a new capture archive with Kubernetes Secret data replaced by
-"REDACTED" and any configured field-level redaction rules applied.
-The original archive is not modified.
+"REDACTED" and any configured field-level redaction rules applied. The original
+archive is not modified; the output defaults to <in>-redacted.kshrk.
 
 Field rules can be supplied via --redact-field (repeatable) with the format:
   <fieldPath>:<Kind>:<replacement>[:<valueType>]
 
-Examples:
+Rules may also be loaded from a config file's redaction.rules block via --config.`,
+	Example: `  # Redact all Secret data and stringData values
   kshrk redact --in capture.kshrk --redact-secrets
+
+  # Apply a single field-level redaction rule
   kshrk redact --in capture.kshrk --redact-field "data.api-key:ConfigMap:REDACTED"
-  kshrk redact --in capture.kshrk --config k8shark.yaml`,
+
+  # Use redaction.rules from a config file, writing to a chosen path
+  kshrk redact --in capture.kshrk --out safe.kshrk --config k8shark.yaml`,
 	RunE: runRedact,
 }
 

--- a/cmd/transitions.go
+++ b/cmd/transitions.go
@@ -18,7 +18,22 @@ var transitionsCmd = &cobra.Command{
 events for captured resources, without starting a replay server.
 
 For watch-enabled captures, events are read directly from the watch-event index.
-For poll-only captures, consecutive snapshots are diff'd to infer changes.`,
+For poll-only captures, consecutive snapshots are diff'd to infer changes.
+
+Narrow the output with --resource / --namespace / --name and the --since/--until
+time window, add --diff to show field-level changes for MODIFIED events, and use
+-o json for machine-readable output.`,
+	Example: `  # List all state changes in a capture
+  kshrk transitions capture.kshrk
+
+  # Only Deployment changes in the "prod" namespace
+  kshrk transitions capture.kshrk --resource deployments --namespace prod
+
+  # Show field diffs for MODIFIED events within a time window
+  kshrk transitions capture.kshrk --diff --since 2026-04-09T10:00:00Z --until 2026-04-09T10:05:00Z
+
+  # Machine-readable output
+  kshrk transitions capture.kshrk -o json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runTransitions,
 }

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -16,8 +16,19 @@ import (
 var uiCmd = &cobra.Command{
 	Use:   "ui <capture.kshrk>",
 	Short: "Open an interactive web explorer for a capture archive",
-	Long: `Starts a local web UI for browsing a k8shark capture and also runs
-the mock Kubernetes API server with generated kubeconfig output.`,
+	Long: `Starts a local web UI for browsing a k8shark capture — namespaces,
+workloads, pods, object YAML/JSON, relationships, and a watch-event timeline —
+and also runs the mock Kubernetes API server with generated kubeconfig output.
+Ports default to random; pin them with --port / --api-port (or a ui: block in
+the config file).`,
+	Example: `  # Browse a capture in the web UI
+  kshrk ui capture.kshrk
+
+  # Pin the UI and mock API server ports
+  kshrk ui capture.kshrk --port 8080 --api-port 8081
+
+  # Open the UI pinned to a point in time
+  kshrk ui capture.kshrk --at -5m`,
 	Args: cobra.ExactArgs(1),
 	RunE: runUI,
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -13,8 +13,8 @@ func init() {
 }
 
 var validateCmd = &cobra.Command{
-	Use:          "validate",
-	Short:        "Validate a capture config file without connecting to a cluster",
+	Use:   "validate",
+	Short: "Validate a capture config file without connecting to a cluster",
 	Long: `Parse and validate a k8shark capture config file, reporting any errors or
 warnings without connecting to a cluster or making any API calls. Hard errors
 (e.g. a missing resource/version, an unparseable duration) exit non-zero;

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -15,7 +15,12 @@ func init() {
 var validateCmd = &cobra.Command{
 	Use:          "validate",
 	Short:        "Validate a capture config file without connecting to a cluster",
-	Long:         `Parse and validate a k8shark capture config file, reporting any errors or warnings without connecting to a cluster or making any API calls.`,
+	Long: `Parse and validate a k8shark capture config file, reporting any errors or
+warnings without connecting to a cluster or making any API calls. Hard errors
+(e.g. a missing resource/version, an unparseable duration) exit non-zero;
+warnings (e.g. a very short interval) are printed but exit zero.`,
+	Example: `  # Validate a capture config before running it
+  kshrk validate --config k8shark.yaml`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if cfgFile == "" {


### PR DESCRIPTION
Closes #107.

## Summary
Every `kshrk` subcommand now defines a Cobra `Example`, so `kshrk <cmd> --help` renders a copy-pasteable **Examples:** section instead of sending users to `docs/usage.md`. Thin `Long` descriptions were also expanded to explain each command's key flags at a glance.

**Examples added** (covering the common cases + notable flags):
- `capture` — config-driven, `--auto-discover`, `--output -` streaming, `--redact-secrets`
- `validate`
- `inspect` — table + `-o json`/`-o yaml`
- `open` — basic, `--at` time-travel, `--port`
- `ui` — `--port`/`--api-port`, `--at`
- `transitions` — `--resource`/`--namespace`, `--since`/`--until`, `--diff`, `-o json`
- `redact` — `--redact-secrets`, `--redact-field` rule format, `--config` (its examples were promoted out of `Long` into the proper `Example` field)
- `diff` — `--before`/`--after` and `--archive` + `--before-at`/`--after-at`

## Accuracy fix folded in
`open`'s `Long` said *"Extracts a k8shark capture archive…"* — the archive is read **in memory**, not extracted to disk (same wording corrected in docs in #105). Now: *"Reads a k8shark capture archive (in memory, without extracting to disk)…"*.

## Conventions
American English throughout; examples mirror `docs/usage.md` and use the `.kshrk` extension.

## Testing
- Added `TestUserFacingCommandsHaveExamples` asserting every user-facing command has a non-empty `Example` (version/help/completion exempt).
- Verified `kshrk <cmd> --help` renders the Examples section; `go build ./...`, `go vet ./...`, `go test ./cmd/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)