### PR TITLE
feat(cli): shell completion for archive args, flags, and output formats

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -50,6 +50,7 @@ func init() {
 	_ = viper.BindPFlag("kubeconfig", captureCmd.Flags().Lookup("kubeconfig"))
 	_ = viper.BindPFlag("duration", captureCmd.Flags().Lookup("duration"))
 	_ = viper.BindPFlag("auto_discover", captureCmd.Flags().Lookup("auto-discover"))
+	_ = captureCmd.MarkFlagFilename("output", captureExt)
 }
 
 func runCapture(cmd *cobra.Command, args []string) error {

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/phenixblue/k8shark/internal/capture"
@@ -50,7 +51,14 @@ func init() {
 	_ = viper.BindPFlag("kubeconfig", captureCmd.Flags().Lookup("kubeconfig"))
 	_ = viper.BindPFlag("duration", captureCmd.Flags().Lookup("duration"))
 	_ = viper.BindPFlag("auto_discover", captureCmd.Flags().Lookup("auto-discover"))
-	_ = captureCmd.MarkFlagFilename("output", captureExt)
+	// --output writes a *.kshrk archive, but also accepts "-" to stream NDJSON
+	// to stdout. Scope file completion to *.kshrk while still offering "-".
+	_ = captureCmd.RegisterFlagCompletionFunc("output", func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if strings.HasPrefix(toComplete, "-") {
+			return []string{"-\tstream NDJSON to stdout"}, cobra.ShellCompDirectiveNoFileComp
+		}
+		return []string{captureExt}, cobra.ShellCompDirectiveFilterFileExt
+	})
 }
 
 func runCapture(cmd *cobra.Command, args []string) error {

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,23 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+// captureExt is the file extension (without the leading dot) for k8shark
+// capture archives. It scopes file completion to capture files for both
+// positional archive arguments and archive-valued flags.
+const captureExt = "kshrk"
+
+// configExts are the file extensions (without the leading dot) for k8shark
+// config files, used to scope completion of --config-style flags.
+var configExts = []string{"yaml", "yml"}
+
+// completeArchiveArg offers k8shark capture archives (*.kshrk) for a command's
+// single positional archive argument, and nothing once that argument is filled.
+// Cobra's default behavior would complete every file; this narrows it to the
+// archives the command can actually open.
+func completeArchiveArg(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return []string{captureExt}, cobra.ShellCompDirectiveFilterFileExt
+}

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -10,8 +11,8 @@ import (
 
 // runCompletion drives Cobra's hidden completion command (the same entry point
 // the generated shell scripts call) and returns the suggested completions plus
-// the trailing ShellCompDirective token (e.g. ":8").
-func runCompletion(t *testing.T, args ...string) ([]string, string) {
+// the parsed ShellCompDirective.
+func runCompletion(t *testing.T, args ...string) ([]string, cobra.ShellCompDirective) {
 	t.Helper()
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
@@ -22,13 +23,17 @@ func runCompletion(t *testing.T, args ...string) ([]string, string) {
 	}
 
 	var comps []string
-	var directive string
+	directive := cobra.ShellCompDirectiveError
 	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
 		if line == "" {
 			continue
 		}
 		if strings.HasPrefix(line, ":") {
-			directive = line
+			n, err := strconv.Atoi(line[1:])
+			if err != nil {
+				t.Fatalf("completion request %v: bad directive line %q: %v", args, line, err)
+			}
+			directive = cobra.ShellCompDirective(n)
 			continue
 		}
 		// Suggestions may carry a tab-separated description; keep the value.
@@ -63,8 +68,8 @@ func TestPositionalArchiveCompletionRegistered(t *testing.T) {
 		if !contains(comps, captureExt) {
 			t.Errorf("%s positional completion = %v, want it to include %q", name, comps, captureExt)
 		}
-		if !strings.HasSuffix(directive, "8") { // ShellCompDirectiveFilterFileExt == 8
-			t.Errorf("%s directive = %q, want file-extension filter", name, directive)
+		if directive&cobra.ShellCompDirectiveFilterFileExt == 0 {
+			t.Errorf("%s directive = %d, want the FilterFileExt bit set", name, directive)
 		}
 	}
 }
@@ -89,21 +94,53 @@ func TestOutputFlagEnumCompletion(t *testing.T) {
 }
 
 func TestArchiveFlagFilenameCompletion(t *testing.T) {
-	// diff's --before/--after/--archive and redact's --in/--out are scoped to
-	// *.kshrk via MarkFlagFilename, which yields a file-extension-filter
+	// diff's --before/--after/--archive, redact's --in/--out, and capture's
+	// --output are scoped to *.kshrk, which yields a file-extension-filter
 	// directive.
 	for _, c := range [][2]string{
 		{"diff", "--before"},
+		{"diff", "--after"},
 		{"diff", "--archive"},
 		{"redact", "--in"},
 		{"redact", "--out"},
+		{"capture", "--output"},
 	} {
 		comps, directive := runCompletion(t, c[0], c[1], "")
 		if !contains(comps, captureExt) {
 			t.Errorf("%s %s completion = %v, want %q", c[0], c[1], comps, captureExt)
 		}
-		if !strings.HasSuffix(directive, "8") {
-			t.Errorf("%s %s directive = %q, want file-extension filter", c[0], c[1], directive)
+		if directive&cobra.ShellCompDirectiveFilterFileExt == 0 {
+			t.Errorf("%s %s directive = %d, want the FilterFileExt bit set", c[0], c[1], directive)
+		}
+	}
+}
+
+func TestCaptureOutputCompletesStdout(t *testing.T) {
+	// "-" (stream NDJSON to stdout) is still offered when the user starts
+	// typing it, even though plain completion is scoped to *.kshrk files.
+	// A dash-prefixed flag value is completed via the "--flag=value" form
+	// (Cobra can't tell a space-separated "-" from the start of a new flag).
+	comps, directive := runCompletion(t, "capture", "--output=-")
+	if !contains(comps, "-") {
+		t.Errorf("capture --output completion = %v, want it to include %q", comps, "-")
+	}
+	if directive&cobra.ShellCompDirectiveNoFileComp == 0 {
+		t.Errorf("capture --output - directive = %d, want the NoFileComp bit set", directive)
+	}
+}
+
+func TestConfigFlagYAMLCompletion(t *testing.T) {
+	// The root persistent --config flag (used here via validate) and redact's
+	// own --config flag are both scoped to YAML files.
+	for _, name := range []string{"validate", "redact"} {
+		comps, directive := runCompletion(t, name, "--config", "")
+		for _, ext := range configExts {
+			if !contains(comps, ext) {
+				t.Errorf("%s --config completion = %v, want it to include %q", name, comps, ext)
+			}
+		}
+		if directive&cobra.ShellCompDirectiveFilterFileExt == 0 {
+			t.Errorf("%s --config directive = %d, want the FilterFileExt bit set", name, directive)
 		}
 	}
 }

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// runCompletion drives Cobra's hidden completion command (the same entry point
+// the generated shell scripts call) and returns the suggested completions plus
+// the trailing ShellCompDirective token (e.g. ":8").
+func runCompletion(t *testing.T, args ...string) ([]string, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs(append([]string{cobra.ShellCompRequestCmd}, args...))
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("completion request %v: %v", args, err)
+	}
+
+	var comps []string
+	var directive string
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			directive = line
+			continue
+		}
+		// Suggestions may carry a tab-separated description; keep the value.
+		comps = append(comps, strings.SplitN(line, "\t", 2)[0])
+	}
+	return comps, directive
+}
+
+func TestCompleteArchiveArg(t *testing.T) {
+	// No positional arg yet: offer *.kshrk files.
+	comps, directive := completeArchiveArg(nil, nil, "")
+	if want := []string{captureExt}; len(comps) != 1 || comps[0] != want[0] {
+		t.Fatalf("comps = %v, want %v", comps, want)
+	}
+	if directive != cobra.ShellCompDirectiveFilterFileExt {
+		t.Fatalf("directive = %d, want FilterFileExt (%d)", directive, cobra.ShellCompDirectiveFilterFileExt)
+	}
+
+	// Argument already supplied: nothing more to complete.
+	comps, directive = completeArchiveArg(nil, []string{"capture.kshrk"}, "")
+	if len(comps) != 0 {
+		t.Fatalf("comps = %v, want none once the arg is filled", comps)
+	}
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("directive = %d, want NoFileComp (%d)", directive, cobra.ShellCompDirectiveNoFileComp)
+	}
+}
+
+func TestPositionalArchiveCompletionRegistered(t *testing.T) {
+	for _, name := range []string{"inspect", "open", "ui", "transitions"} {
+		comps, directive := runCompletion(t, name, "")
+		if !contains(comps, captureExt) {
+			t.Errorf("%s positional completion = %v, want it to include %q", name, comps, captureExt)
+		}
+		if !strings.HasSuffix(directive, "8") { // ShellCompDirectiveFilterFileExt == 8
+			t.Errorf("%s directive = %q, want file-extension filter", name, directive)
+		}
+	}
+}
+
+func TestOutputFlagEnumCompletion(t *testing.T) {
+	cases := []struct {
+		cmd  string
+		want []string
+	}{
+		{"inspect", []string{"table", "json", "yaml"}},
+		{"transitions", []string{"table", "json"}},
+		{"diff", []string{"text", "json"}},
+	}
+	for _, tc := range cases {
+		comps, _ := runCompletion(t, tc.cmd, "--output", "")
+		for _, w := range tc.want {
+			if !contains(comps, w) {
+				t.Errorf("%s --output completion = %v, want it to include %q", tc.cmd, comps, w)
+			}
+		}
+	}
+}
+
+func TestArchiveFlagFilenameCompletion(t *testing.T) {
+	// diff's --before/--after/--archive and redact's --in/--out are scoped to
+	// *.kshrk via MarkFlagFilename, which yields a file-extension-filter
+	// directive.
+	for _, c := range [][2]string{
+		{"diff", "--before"},
+		{"diff", "--archive"},
+		{"redact", "--in"},
+		{"redact", "--out"},
+	} {
+		comps, directive := runCompletion(t, c[0], c[1], "")
+		if !contains(comps, captureExt) {
+			t.Errorf("%s %s completion = %v, want %q", c[0], c[1], comps, captureExt)
+		}
+		if !strings.HasSuffix(directive, "8") {
+			t.Errorf("%s %s directive = %q, want file-extension filter", c[0], c[1], directive)
+		}
+	}
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -48,6 +48,11 @@ func init() {
 	diffCmd.Flags().String("resource", "", "limit diff to one resource type, e.g. pods")
 	diffCmd.Flags().String("namespace", "", "limit diff to one namespace")
 	diffCmd.Flags().StringP("output", "o", "text", "output format: text or json")
+	for _, f := range []string{"before", "after", "archive"} {
+		_ = diffCmd.MarkFlagFilename(f, captureExt)
+	}
+	_ = diffCmd.RegisterFlagCompletionFunc("output",
+		cobra.FixedCompletions([]string{"text", "json"}, cobra.ShellCompDirectiveNoFileComp))
 }
 
 func runDiff(cmd *cobra.Command, _ []string) error {

--- a/cmd/help_examples_test.go
+++ b/cmd/help_examples_test.go
@@ -8,7 +8,9 @@ import "testing"
 func TestUserFacingCommandsHaveExamples(t *testing.T) {
 	exempt := map[string]bool{"version": true, "help": true, "completion": true}
 	for _, c := range rootCmd.Commands() {
-		if exempt[c.Name()] {
+		// Hidden commands (e.g. Cobra's "__complete" helper, added once
+		// completion is requested) aren't user-facing.
+		if c.Hidden || exempt[c.Name()] {
 			continue
 		}
 		if c.Example == "" {

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -25,14 +25,17 @@ for machine-readable output.`,
   # Machine-readable output
   kshrk inspect capture.kshrk -o json
   kshrk inspect capture.kshrk -o yaml`,
-	Args: cobra.ExactArgs(1),
-	RunE: runInspect,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeArchiveArg,
+	RunE:              runInspect,
 }
 
 func init() {
 	rootCmd.AddCommand(inspectCmd)
 	inspectCmd.Flags().StringP("output", "o", "table", "Output format: table, json, or yaml")
 	inspectCmd.Flags().BoolP("wide", "w", false, "Show full namespace list in table output")
+	_ = inspectCmd.RegisterFlagCompletionFunc("output",
+		cobra.FixedCompletions([]string{"table", "json", "yaml"}, cobra.ShellCompDirectiveNoFileComp))
 }
 
 func runInspect(cmd *cobra.Command, args []string) error {

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -22,8 +22,9 @@ specific point in the capture window.`,
 
   # Replay at a specific timestamp, on a fixed port
   kshrk open capture.kshrk --at 2026-04-09T10:30:00Z --port 8443`,
-	Args: cobra.ExactArgs(1),
-	RunE: runOpen,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeArchiveArg,
+	RunE:              runOpen,
 }
 
 func init() {

--- a/cmd/redact.go
+++ b/cmd/redact.go
@@ -42,6 +42,9 @@ func init() {
 	redactCmd.Flags().StringArray("redact-field", nil, "field redaction rule: <fieldPath>:<Kind>:<replacement>[:<valueType>] (repeatable)")
 	redactCmd.Flags().String("config", "", "capture config file whose redaction.rules block is applied")
 	_ = redactCmd.MarkFlagRequired("in")
+	_ = redactCmd.MarkFlagFilename("in", captureExt)
+	_ = redactCmd.MarkFlagFilename("out", captureExt)
+	_ = redactCmd.MarkFlagFilename("config", configExts...)
 }
 
 // parseRedactField parses a --redact-field flag value of the form:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default: ./config.yaml, then ~/.config/kshrk/config.yaml)")
+	_ = rootCmd.MarkPersistentFlagFilename("config", configExts...)
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "enable verbose output")
 	_ = viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
 }

--- a/cmd/transitions.go
+++ b/cmd/transitions.go
@@ -34,8 +34,9 @@ time window, add --diff to show field-level changes for MODIFIED events, and use
 
   # Machine-readable output
   kshrk transitions capture.kshrk -o json`,
-	Args: cobra.ExactArgs(1),
-	RunE: runTransitions,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeArchiveArg,
+	RunE:              runTransitions,
 }
 
 func init() {
@@ -47,6 +48,8 @@ func init() {
 	transitionsCmd.Flags().String("until", "", "end of time window (RFC3339)")
 	transitionsCmd.Flags().Bool("diff", false, "show field diffs for MODIFIED events")
 	transitionsCmd.Flags().StringP("output", "o", "table", "output format: table or json")
+	_ = transitionsCmd.RegisterFlagCompletionFunc("output",
+		cobra.FixedCompletions([]string{"table", "json"}, cobra.ShellCompDirectiveNoFileComp))
 }
 
 func runTransitions(cmd *cobra.Command, args []string) error {

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -29,8 +29,9 @@ the config file).`,
 
   # Open the UI pinned to a point in time
   kshrk ui capture.kshrk --at -5m`,
-	Args: cobra.ExactArgs(1),
-	RunE: runUI,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeArchiveArg,
+	RunE:              runUI,
 }
 
 func init() {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,6 +31,41 @@ make build
 # binary written to ./kshrk
 ```
 
+### Shell completion
+
+`kshrk` ships tab-completion for `bash`, `zsh`, `fish`, and PowerShell. It
+completes subcommand and `--flag` names, scopes positional and archive-valued
+flags (`--in`, `--out`, `--before`, `--after`, `--archive`) to `*.kshrk` files,
+restricts `--config` to YAML files, and offers the valid choices for output
+formats (e.g. `-o table|json|yaml`).
+
+Generate the script for your shell with `kshrk completion <shell>`:
+
+```sh
+# zsh — write into a directory on your fpath, then restart the shell
+kshrk completion zsh > "${fpath[1]}/_kshrk"
+
+# bash — Linux
+kshrk completion bash > /etc/bash_completion.d/kshrk
+# bash — macOS (Homebrew bash-completion@2)
+kshrk completion bash > "$(brew --prefix)/etc/bash_completion.d/kshrk"
+
+# fish
+kshrk completion fish > ~/.config/fish/completions/kshrk.fish
+
+# PowerShell — add to your profile to persist across sessions
+kshrk completion powershell | Out-String | Invoke-Expression
+```
+
+To try completion in the current shell without installing it, source the script
+directly, e.g. `source <(kshrk completion bash)`. Run
+`kshrk completion <shell> --help` for shell-specific installation notes.
+
+> **kubectl plugin:** when `kshrk` is installed as the `kubectl-k8shark` plugin
+> (see [#27](https://github.com/phenixblue/k8shark/issues/27)), `kubectl`
+> drives completion through its own plugin-completion mechanism rather than the
+> scripts above.
+
 ---
 
 ## Capture

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,9 +35,9 @@ make build
 
 `kshrk` ships tab-completion for `bash`, `zsh`, `fish`, and PowerShell. It
 completes subcommand and `--flag` names, scopes positional and archive-valued
-flags (`--in`, `--out`, `--before`, `--after`, `--archive`) to `*.kshrk` files,
-restricts `--config` to YAML files, and offers the valid choices for output
-formats (e.g. `-o table|json|yaml`).
+flags (`--in`, `--out`, `--before`, `--after`, `--archive`, and `capture
+--output`) to `*.kshrk` files, restricts `--config` to YAML files, and offers
+the valid choices for output formats (e.g. `-o table|json|yaml`).
 
 Generate the script for your shell with `kshrk completion <shell>`:
 


### PR DESCRIPTION
Closes #32

## Summary

Cobra already auto-generates the `completion` subcommand (bash/zsh/fish/PowerShell), so subcommand- and `--flag`-name completion worked out of the box. This PR fills the remaining gap — **value-level completion** — and documents installation.

- **Positional `<capture.kshrk>` args** (`inspect`, `open`, `ui`, `transitions`) complete to `*.kshrk` files only, and stop offering once the arg is filled.
- **Archive-valued flags** (`--in`, `--out`, `--before`, `--after`, `--archive`, and `capture --output`) scoped to `*.kshrk` via `MarkFlagFilename`.
- **`--config`** scoped to YAML via `MarkPersistentFlagFilename` on the root persistent flag.
- **`-o/--output`** enum completion: `inspect` → `table|json|yaml`, `transitions` → `table|json`, `diff` → `text|json`.
- **`docs/usage.md`** — a "Shell completion" install section for all four shells.
- **`cmd/completion.go`** — shared `completeArchiveArg` helper + `captureExt`/`configExts` constants.

## Implementation note

The issue suggested explicitly registering a `completion` subcommand, but Cobra's auto-generated one already satisfies every criterion (and the existing help-examples test already exempts it), so a custom one would be redundant. Only value-level completion needed wiring.

## Tests

`cmd/completion_test.go` drives Cobra's `__complete` entry point (the same path the generated shell scripts call) to assert positional, archive-flag, and enum-flag completion. The help-examples test now skips hidden commands so the lazily-added `__complete` helper doesn't trip it.

Verified locally: `make build`, `make test`, `make lint` all pass; `gofmt` and `go mod tidy` are clean.

## Acceptance criteria
- [x] `completion bash|zsh|fish|powershell` outputs a valid script (Cobra built-in)
- [x] Subcommand names and `--flag` names complete
- [x] Flag values complete where applicable (archive paths → `*.kshrk`, `--config` → YAML, `-o` → enum)
- [x] Installation instructions added to `docs/usage.md`
- [ ] kubectl-k8shark plugin binary name (#27) — #27 is not yet implemented; kubectl drives plugin completion through its own mechanism, noted in the docs. Deferred to #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)