### PR TITLE
docs: formalize the .kshrk format-compatibility guarantee (#115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ timeline, and a time-travel scrubber. See **[docs/web-ui.md](docs/web-ui.md)** f
 | [docs/config.md](docs/config.md) | Config file reference, namespaced vs cluster-scoped resources, example configs |
 | [docs/releases.md](docs/releases.md) | How to cut a release, GoReleaser pipeline, signing, Homebrew tap |
 | [docs/development.md](docs/development.md) | Building, testing, linting, KinD dev cluster, E2E tests, package layout |
-| [docs/archive-format.md](docs/archive-format.md) | Internal `.kshrk` (ZIP+Zstd) layout, record and index JSON schemas |
+| [docs/archive-format.md](docs/archive-format.md) | Internal `.kshrk` (ZIP+Zstd) layout, record and index JSON schemas, and the format-compatibility guarantee |
 
 ## License
 

--- a/docs/archive-format.md
+++ b/docs/archive-format.md
@@ -75,13 +75,15 @@ The **stable surface** is the logical structure, not the bytes:
 These are implementation details and may change without a version bump, because
 the reader does not depend on them:
 
-- The **ZIP compression method** of each entry (Store vs Deflate). Payloads
-  carry their own Zstd compression; the ZIP layer just stores them.
+- The **ZIP compression method** of each entry (Store vs Deflate). The payload
+  entries are already Zstd-compressed, so the writer typically just stores them
+  in the ZIP — but Deflate-stored archives are equally valid and still read.
 - Entry **ordering** within the ZIP and per-entry **timestamps**.
 - Exact byte size / Zstd encoder level.
 
-Read `.kshrk` files via a ZIP reader + a Zstd decoder and the documented
-schemas — never by assuming a fixed byte layout.
+Read `.kshrk` files via a ZIP reader plus the documented schemas, Zstd-decoding
+only the `*.json.zst` entries (`metadata.json` is plain JSON) — never by
+assuming a fixed byte layout.
 
 ### Evolution rules
 

--- a/docs/archive-format.md
+++ b/docs/archive-format.md
@@ -55,21 +55,62 @@ Capture-level information. Written once at the end of the capture run.
 ## Format version & compatibility
 
 `metadata.json` carries an integer `format_version` identifying the archive
-schema. The current version is **1**.
+schema. The current version is **1**. This is the stability promise for the
+`.kshrk` format.
 
-- **Additive changes don't bump it.** New optional metadata fields
+### What is guaranteed (the contract)
+
+The **stable surface** is the logical structure, not the bytes:
+
+- The **entry layout** — the `k8shark-capture/` tree and the names/roles of
+  `metadata.json`, `index.json.zst`, `watch-index.json.zst`, and
+  `records/<pathDir>/<seq>.json.zst`.
+- The **JSON schemas** of the metadata, index, watch-index, and record objects
+  documented on this page.
+- The **`pathDir` derivation** (first 16 hex chars of SHA-256 of the API path)
+  and the per-path 0-based `seq` numbering.
+
+### What is NOT part of the contract
+
+These are implementation details and may change without a version bump, because
+the reader does not depend on them:
+
+- The **ZIP compression method** of each entry (Store vs Deflate). Payloads
+  carry their own Zstd compression; the ZIP layer just stores them.
+- Entry **ordering** within the ZIP and per-entry **timestamps**.
+- Exact byte size / Zstd encoder level.
+
+Read `.kshrk` files via a ZIP reader + a Zstd decoder and the documented
+schemas — never by assuming a fixed byte layout.
+
+### Evolution rules
+
+- **Additive changes don't bump the version.** New optional metadata fields
   (`omitempty`) and new optional archive entries (e.g. the watch index) are
-  backward-compatible: older readers ignore what they don't recognize and
-  newer readers tolerate their absence. These keep `format_version` at 1.
-- **Breaking changes bump it.** A structural change that an older reader cannot
-  safely parse increments the version.
+  backward-compatible. Consumers **must ignore unknown fields and entries** so
+  they keep working against newer archives.
+- **Breaking changes bump `format_version`** — any structural change an older
+  reader could not safely parse.
+
+### Reader compatibility promise
+
+- A given `kshrk` **MAJOR** release reads **every** archive whose
+  `format_version` is ≤ the version that build understands. The `1.x` line reads
+  all version-1 archives for the life of the `1.x` series.
 - **Pre-versioning archives** (captured before the field existed) omit
-  `format_version`; readers treat them as version 1, since they are
-  structurally identical.
-- **Newer archives are refused.** If an archive's `format_version` is greater
-  than the version a given `kshrk` build understands, the tool stops with a
-  clear "upgrade kshrk" error rather than risk misreading an incompatible
-  layout. Run `kshrk inspect <archive>` to see an archive's format version.
+  `format_version`; they are treated as version 1, since they are structurally
+  identical.
+- **Newer archives are refused, not mis-read.** If an archive's `format_version`
+  is greater than the build understands, `kshrk` stops with a clear "upgrade
+  kshrk" error. Run `kshrk inspect <archive>` to see an archive's format
+  version.
+
+### Changing the format (for contributors)
+
+A breaking format change must, in one change: bump `CurrentFormatVersion`
+(`internal/capture`), update this section, and extend the golden-fixture test
+(`internal/archive`) so the new build still reads older fixtures. Additive
+changes need only an `omitempty` field / optional entry and a note here.
 
 ## index.json.zst
 


### PR DESCRIPTION
Closes #115. Pairs with #128 (format hardening).

## Summary
Turns the existing "Format version & compatibility" notes into an explicit **stability promise** for the `.kshrk` format, ready for v1.0.

- **Contract surface (guaranteed):** entry layout, the JSON schemas of metadata/index/watch-index/record, and the `pathDir`/`seq` derivation.
- **Explicitly NOT contractual:** ZIP compression method (Store vs Deflate), entry order, timestamps, byte size / Zstd level — so the encoding can keep being optimized (e.g. #128's Store change) without a version bump. Read via a ZIP reader + Zstd decoder + the documented schemas, never a fixed byte layout.
- **Evolution rules:** additive changes (new `omitempty` fields / optional entries) don't bump the version; consumers must ignore unknowns. Breaking changes bump `format_version`.
- **Reader compatibility promise:** a given MAJOR reads all `format_version ≤` its own; pre-versioning archives are treated as v1; newer archives are refused with an "upgrade kshrk" error (already enforced by `CheckFormatVersion`).
- **Contributor note:** a breaking change must bump `CurrentFormatVersion`, update this section, and extend the golden-fixture test.

Also cross-links the guarantee from the README docs table.

## Notes
Docs-only. The in-page anchor (`#format-version--compatibility`) is preserved (heading text unchanged). The "what is NOT contractual" wording is what makes #128's Deflate→Store switch a non-breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)