### PR TITLE
feat(diagnose): findings engine + kshrk diagnose CLI

### DIFF
--- a/cmd/diagnose.go
+++ b/cmd/diagnose.go
@@ -131,12 +131,19 @@ func parseDiagnoseAt(raw string, start, end time.Time) (time.Time, error) {
 	if raw == "" {
 		return time.Time{}, nil
 	}
+	var at time.Time
 	if t, err := time.Parse(time.RFC3339, raw); err == nil {
-		return t, nil
-	}
-	d, err := time.ParseDuration(raw)
-	if err != nil {
+		at = t
+	} else if d, derr := time.ParseDuration(raw); derr == nil {
+		at = end.Add(d)
+	} else {
 		return time.Time{}, fmt.Errorf("parsing --at %q: must be RFC3339 or a relative duration like -5m", raw)
 	}
-	return end.Add(d), nil
+	// Reject times outside the capture window — otherwise reconstruction returns
+	// 404s and diagnose would misleadingly report "No findings".
+	if (!start.IsZero() && at.Before(start)) || (!end.IsZero() && at.After(end)) {
+		return time.Time{}, fmt.Errorf("--at %q resolves to %s, outside the capture window %s..%s",
+			raw, at.UTC().Format(time.RFC3339), start.UTC().Format(time.RFC3339), end.UTC().Format(time.RFC3339))
+	}
+	return at, nil
 }

--- a/cmd/diagnose.go
+++ b/cmd/diagnose.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/diagnose"
+	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+var diagnoseCmd = &cobra.Command{
+	Use:   "diagnose <capture.kshrk>",
+	Short: "Analyze a capture and report likely problems",
+	Long: `Runs a diagnostic pass over a capture and prints severity-ranked findings
+(CrashLoopBackOff, OOMKilled, image-pull failures, unschedulable pods, unbound
+PVCs, version skew, …) — without starting a server.
+
+Use -o json/yaml for automation, and --fail-on to exit non-zero for CI gating.`,
+	Example: `  # Ranked findings as a table
+  kshrk diagnose capture.kshrk
+
+  # Only warnings and above, scheduling category, as JSON
+  kshrk diagnose capture.kshrk --severity warning --category scheduling -o json
+
+  # Fail the build if anything critical is found
+  kshrk diagnose capture.kshrk --fail-on critical`,
+	Args: cobra.ExactArgs(1),
+	RunE: runDiagnose,
+}
+
+func init() {
+	rootCmd.AddCommand(diagnoseCmd)
+	diagnoseCmd.Flags().StringP("output", "o", "table", "output format: table, json, or yaml")
+	diagnoseCmd.Flags().String("at", "", "analyze state at a timestamp (RFC3339 or relative duration like -5m); default latest")
+	diagnoseCmd.Flags().String("severity", "info", "minimum severity to report: info, warning, or critical")
+	diagnoseCmd.Flags().String("category", "", "only report this category (workload, scheduling, storage, node, cluster)")
+	diagnoseCmd.Flags().String("fail-on", "", "exit non-zero if any finding is at least this severity (info, warning, critical)")
+}
+
+func runDiagnose(cmd *cobra.Command, args []string) error {
+	output, _ := cmd.Flags().GetString("output")
+	atRaw, _ := cmd.Flags().GetString("at")
+	severity, _ := cmd.Flags().GetString("severity")
+	category, _ := cmd.Flags().GetString("category")
+	failOn, _ := cmd.Flags().GetString("fail-on")
+
+	for name, v := range map[string]string{"severity": severity, "fail-on": failOn} {
+		if v != "" && v != diagnose.SeverityInfo && v != diagnose.SeverityWarning && v != diagnose.SeverityCritical {
+			return fmt.Errorf("--%s must be one of info, warning, critical (got %q)", name, v)
+		}
+	}
+
+	ar, err := archive.Open(args[0])
+	if err != nil {
+		return fmt.Errorf("opening archive: %w", err)
+	}
+	defer ar.Close()
+	store, err := server.LoadStore(ar)
+	if err != nil {
+		return fmt.Errorf("loading capture: %w", err)
+	}
+
+	at, err := parseDiagnoseAt(atRaw, store.Metadata.CapturedAt, store.Metadata.CapturedUntil)
+	if err != nil {
+		return err
+	}
+
+	report := diagnose.Run(store, diagnose.Options{At: at, MinSeverity: severity, Category: category})
+
+	switch strings.ToLower(output) {
+	case "json":
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			return err
+		}
+	case "yaml":
+		if err := yaml.NewEncoder(cmd.OutOrStdout()).Encode(report); err != nil {
+			return err
+		}
+	default:
+		printDiagnoseTable(cmd, report)
+	}
+
+	if failOn != "" {
+		for _, f := range report.Findings {
+			if diagnose.SeverityAtLeast(f.Severity, failOn) {
+				return exitError{msg: "", code: 1}
+			}
+		}
+	}
+	return nil
+}
+
+func printDiagnoseTable(cmd *cobra.Command, r diagnose.Report) {
+	out := cmd.OutOrStdout()
+	if len(r.Findings) == 0 {
+		fmt.Fprintln(out, "No findings. ✓")
+		return
+	}
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "SEVERITY\tCATEGORY\tOBJECT\tFINDING")
+	for _, f := range r.Findings {
+		obj := f.Object.Name
+		if f.Object.Namespace != "" {
+			obj = f.Object.Namespace + "/" + f.Object.Name
+		}
+		if f.Count > 1 {
+			obj = fmt.Sprintf("%s (+%d)", obj, f.Count-1)
+		}
+		finding := f.Title
+		if f.Evidence != "" {
+			finding = f.Title + " — " + f.Evidence
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", strings.ToUpper(f.Severity), f.Category, obj, finding)
+	}
+	_ = tw.Flush()
+	fmt.Fprintf(out, "\n%d finding(s): %d critical, %d warning, %d info\n",
+		len(r.Findings), r.Summary.Critical, r.Summary.Warning, r.Summary.Info)
+}
+
+// parseDiagnoseAt resolves --at: empty = latest; RFC3339 timestamp; or a
+// relative duration like -5m against the capture end.
+func parseDiagnoseAt(raw string, start, end time.Time) (time.Time, error) {
+	if raw == "" {
+		return time.Time{}, nil
+	}
+	if t, err := time.Parse(time.RFC3339, raw); err == nil {
+		return t, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parsing --at %q: must be RFC3339 or a relative duration like -5m", raw)
+	}
+	return end.Add(d), nil
+}

--- a/cmd/diagnose_test.go
+++ b/cmd/diagnose_test.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/diagnose"
+	"github.com/spf13/cobra"
+)
+
+func newTestDiagnoseCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().StringP("output", "o", "table", "")
+	cmd.Flags().String("at", "", "")
+	cmd.Flags().String("severity", "info", "")
+	cmd.Flags().String("category", "", "")
+	cmd.Flags().String("fail-on", "", "")
+	return cmd
+}
+
+const crashloopPodList = `{"apiVersion":"v1","kind":"PodList","items":[` +
+	`{"metadata":{"name":"c","namespace":"default"},"status":{"phase":"Running","containerStatuses":[` +
+	`{"name":"app","ready":false,"restartCount":4,"state":{"waiting":{"reason":"CrashLoopBackOff"}}}]}}]}`
+
+const healthyPodList = `{"apiVersion":"v1","kind":"PodList","items":[` +
+	`{"metadata":{"name":"h","namespace":"default"},"status":{"phase":"Running","containerStatuses":[` +
+	`{"name":"app","ready":true,"restartCount":0,"state":{"running":{}}}]}}]}`
+
+func TestRunDiagnose_JSON(t *testing.T) {
+	arch := buildDiffArchive(t, crashloopPodList) // writes /api/v1/namespaces/default/pods
+	cmd := newTestDiagnoseCommand()
+	_ = cmd.Flags().Set("output", "json")
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runDiagnose(cmd, []string{arch}); err != nil {
+		t.Fatalf("runDiagnose: %v", err)
+	}
+	var rep diagnose.Report
+	if err := json.Unmarshal(buf.Bytes(), &rep); err != nil {
+		t.Fatalf("output not valid JSON: %v\n%s", err, buf.String())
+	}
+	if rep.SchemaVersion != diagnose.SchemaVersion {
+		t.Errorf("schema_version = %d", rep.SchemaVersion)
+	}
+	if !strings.Contains(buf.String(), "pod.crashloopbackoff") {
+		t.Errorf("expected crashloop finding:\n%s", buf.String())
+	}
+	if rep.Summary.Critical < 1 {
+		t.Errorf("expected a critical finding, got summary %+v", rep.Summary)
+	}
+}
+
+func TestRunDiagnose_FailOn(t *testing.T) {
+	arch := buildDiffArchive(t, crashloopPodList)
+	cmd := newTestDiagnoseCommand()
+	_ = cmd.Flags().Set("output", "json")
+	_ = cmd.Flags().Set("fail-on", "critical")
+	cmd.SetOut(&bytes.Buffer{})
+
+	err := runDiagnose(cmd, []string{arch})
+	ee, ok := err.(exitError)
+	if !ok || ee.ExitCode() != 1 {
+		t.Fatalf("expected exitError code 1 for critical findings, got %v (%T)", err, err)
+	}
+}
+
+func TestRunDiagnose_FailOn_Clean(t *testing.T) {
+	arch := buildDiffArchive(t, healthyPodList)
+	cmd := newTestDiagnoseCommand()
+	_ = cmd.Flags().Set("fail-on", "critical")
+	cmd.SetOut(&bytes.Buffer{})
+
+	if err := runDiagnose(cmd, []string{arch}); err != nil {
+		t.Errorf("clean capture should not fail, got %v", err)
+	}
+}
+
+func TestRunDiagnose_BadSeverity(t *testing.T) {
+	arch := buildDiffArchive(t, healthyPodList)
+	cmd := newTestDiagnoseCommand()
+	_ = cmd.Flags().Set("severity", "bogus")
+	cmd.SetOut(&bytes.Buffer{})
+	if err := runDiagnose(cmd, []string{arch}); err == nil {
+		t.Error("expected error for invalid --severity")
+	}
+}

--- a/cmd/diagnose_test.go
+++ b/cmd/diagnose_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/phenixblue/k8shark/internal/diagnose"
 	"github.com/spf13/cobra"
@@ -85,5 +86,19 @@ func TestRunDiagnose_BadSeverity(t *testing.T) {
 	cmd.SetOut(&bytes.Buffer{})
 	if err := runDiagnose(cmd, []string{arch}); err == nil {
 		t.Error("expected error for invalid --severity")
+	}
+}
+
+func TestParseDiagnoseAt_Window(t *testing.T) {
+	start := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 4, 10, 10, 10, 0, 0, time.UTC)
+	if _, err := parseDiagnoseAt("2026-04-10T10:05:00Z", start, end); err != nil {
+		t.Errorf("in-window time rejected: %v", err)
+	}
+	if _, err := parseDiagnoseAt("-1h", start, end); err == nil {
+		t.Error("expected out-of-window (before start) to error")
+	}
+	if _, err := parseDiagnoseAt("2026-04-10T11:00:00Z", start, end); err == nil {
+		t.Error("expected out-of-window (after end) to error")
 	}
 }

--- a/internal/diagnose/classify.go
+++ b/internal/diagnose/classify.go
@@ -1,0 +1,141 @@
+package diagnose
+
+import "encoding/json"
+
+// PodHealth is a compact summary of one pod's state, derived from a pod object
+// body. Used by the diagnose rules and (via aliases) the web UI.
+type PodHealth struct {
+	Phase      string            // "Running", "Pending", "Succeeded", "Failed", "Unknown"
+	Ready      int               // ready container count
+	Total      int               // total container count
+	Restarts   int               // sum of restart counts
+	Issues     []string          // unique reasons: "CrashLoopBackOff", "OOMKilled", "ImagePullBackOff", …
+	Containers []ContainerHealth // per-container detail
+}
+
+// ContainerHealth is the per-container slice of PodHealth.
+type ContainerHealth struct {
+	Name           string `json:"name"`
+	Image          string `json:"image,omitempty"`
+	Ready          bool   `json:"ready"`
+	RestartCount   int    `json:"restart_count"`
+	IsInit         bool   `json:"is_init,omitempty"`
+	State          string `json:"state"` // "Running" | "Waiting" | "Terminated"
+	StateReason    string `json:"state_reason,omitempty"`
+	StateMessage   string `json:"state_message,omitempty"`
+	LastTerminated string `json:"last_terminated,omitempty"` // reason of lastState.terminated if present
+	LastExitCode   int    `json:"last_exit_code,omitempty"`
+}
+
+// IsHealthy reports whether a pod is in a benign state. A pod with zero issues
+// is considered healthy.
+func (h PodHealth) IsHealthy() bool { return len(h.Issues) == 0 }
+
+// ClassifyPod parses a pod body and returns its PodHealth. Returns zero
+// PodHealth on a malformed body — callers should treat that as "unknown".
+func ClassifyPod(body []byte) PodHealth {
+	var pod struct {
+		Status struct {
+			Phase                 string            `json:"phase"`
+			ContainerStatuses     []containerStatus `json:"containerStatuses"`
+			InitContainerStatuses []containerStatus `json:"initContainerStatuses"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal(body, &pod); err != nil {
+		return PodHealth{}
+	}
+
+	h := PodHealth{Phase: pod.Status.Phase}
+	seenIssue := map[string]bool{}
+	addIssue := func(reason string) {
+		if reason == "" || seenIssue[reason] {
+			return
+		}
+		seenIssue[reason] = true
+		h.Issues = append(h.Issues, reason)
+	}
+
+	switch h.Phase {
+	case "Failed":
+		addIssue("Failed")
+	case "Unknown":
+		addIssue("Unknown")
+	case "Pending":
+		// Pending alone isn't an issue — that's just "still scheduling".
+		// We surface a container-level reason below if there is one.
+	}
+
+	consume := func(cs containerStatus, isInit bool) {
+		h.Total++
+		h.Restarts += cs.RestartCount
+		c := ContainerHealth{
+			Name:         cs.Name,
+			Image:        cs.Image,
+			Ready:        cs.Ready,
+			RestartCount: cs.RestartCount,
+			IsInit:       isInit,
+		}
+		if cs.Ready {
+			h.Ready++
+		}
+		switch {
+		case cs.State.Running != nil:
+			c.State = "Running"
+		case cs.State.Waiting != nil:
+			c.State = "Waiting"
+			c.StateReason = cs.State.Waiting.Reason
+			c.StateMessage = cs.State.Waiting.Message
+			addIssue(cs.State.Waiting.Reason)
+		case cs.State.Terminated != nil:
+			c.State = "Terminated"
+			c.StateReason = cs.State.Terminated.Reason
+			c.StateMessage = cs.State.Terminated.Message
+			c.LastExitCode = cs.State.Terminated.ExitCode
+			// A terminated init container that exited 0 is normal — don't flag.
+			if !isInit || cs.State.Terminated.ExitCode != 0 {
+				addIssue(cs.State.Terminated.Reason)
+			}
+		}
+		if cs.LastState.Terminated != nil {
+			c.LastTerminated = cs.LastState.Terminated.Reason
+			if c.LastExitCode == 0 {
+				c.LastExitCode = cs.LastState.Terminated.ExitCode
+			}
+		}
+		h.Containers = append(h.Containers, c)
+	}
+
+	for _, cs := range pod.Status.InitContainerStatuses {
+		consume(cs, true)
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		consume(cs, false)
+	}
+	return h
+}
+
+type containerStatus struct {
+	Name         string         `json:"name"`
+	Image        string         `json:"image"`
+	Ready        bool           `json:"ready"`
+	RestartCount int            `json:"restartCount"`
+	State        containerState `json:"state"`
+	LastState    containerState `json:"lastState"`
+}
+
+type containerState struct {
+	Running    *struct{}              `json:"running,omitempty"`
+	Waiting    *containerStateWaiting `json:"waiting,omitempty"`
+	Terminated *containerStateTerm    `json:"terminated,omitempty"`
+}
+
+type containerStateWaiting struct {
+	Reason  string `json:"reason"`
+	Message string `json:"message"`
+}
+
+type containerStateTerm struct {
+	Reason   string `json:"reason"`
+	Message  string `json:"message"`
+	ExitCode int    `json:"exitCode"`
+}

--- a/internal/diagnose/engine.go
+++ b/internal/diagnose/engine.go
@@ -1,0 +1,168 @@
+package diagnose
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/server"
+)
+
+// Options configures a diagnose run.
+type Options struct {
+	At          time.Time // zero = latest snapshot
+	MinSeverity string    // "" or "info" = all; "warning"/"critical" filter
+	Category    string    // "" = all categories
+}
+
+// Run analyzes the capture in store and returns a ranked Report.
+func Run(store *server.CaptureStore, opts Options) Report {
+	at := opts.At
+	if at.IsZero() {
+		at = store.Metadata.CapturedUntil
+	}
+
+	var fs []Finding
+	fs = append(fs, podHealthFindings(store, at)...)
+	fs = append(fs, schedulingFindings(store, at)...)
+	fs = append(fs, pvcFindings(store, at)...)
+	fs = append(fs, versionSkewFindings(store, at)...)
+
+	// Filter.
+	min := opts.MinSeverity
+	if min == "" {
+		min = SeverityInfo
+	}
+	filtered := fs[:0:0]
+	for _, f := range fs {
+		if !SeverityAtLeast(f.Severity, min) {
+			continue
+		}
+		if opts.Category != "" && f.Category != opts.Category {
+			continue
+		}
+		filtered = append(filtered, f)
+	}
+	sortFindings(filtered)
+
+	rep := Report{SchemaVersion: SchemaVersion, CaptureID: store.Metadata.CaptureID, Findings: filtered}
+	if !opts.At.IsZero() {
+		rep.At = opts.At.UTC().Format(time.RFC3339)
+	}
+	for _, f := range filtered {
+		switch f.Severity {
+		case SeverityCritical:
+			rep.Summary.Critical++
+		case SeverityWarning:
+			rep.Summary.Warning++
+		default:
+			rep.Summary.Info++
+		}
+	}
+	return rep
+}
+
+// ── shared helpers ───────────────────────────────────────────────────────────
+
+// forEachResource calls fn for every captured list of the given resource
+// (skipping Table/query variants), passing the namespace, list path, and items.
+func forEachResource(store *server.CaptureStore, at time.Time, resource string, fn func(ns, path string, items []json.RawMessage)) {
+	for path := range store.Index {
+		if strings.Contains(path, "?") {
+			continue
+		}
+		_, _, res, ns := parseAPIPath(path)
+		if res != resource {
+			continue
+		}
+		body, code, err := store.ReconstructAt(path, at)
+		if err != nil || code != 200 || len(body) == 0 {
+			continue
+		}
+		var list struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		if json.Unmarshal(body, &list) != nil {
+			continue
+		}
+		fn(ns, path, list.Items)
+	}
+}
+
+// parseAPIPath extracts group, version, resource, and namespace from a canonical
+// API list path. Cluster-scoped paths return an empty namespace.
+func parseAPIPath(path string) (group, version, resource, namespace string) {
+	p := path
+	if i := strings.IndexByte(p, '?'); i >= 0 {
+		p = p[:i]
+	}
+	parts := strings.Split(strings.TrimPrefix(p, "/"), "/")
+	switch {
+	case len(parts) >= 3 && parts[0] == "api": // /api/v1/...
+		version = parts[1]
+		rest := parts[2:]
+		if len(rest) >= 3 && rest[0] == "namespaces" {
+			namespace = rest[1]
+			resource = rest[2]
+		} else {
+			resource = rest[0]
+		}
+	case len(parts) >= 4 && parts[0] == "apis": // /apis/<group>/<version>/...
+		group, version = parts[1], parts[2]
+		rest := parts[3:]
+		if len(rest) >= 3 && rest[0] == "namespaces" {
+			namespace = rest[1]
+			resource = rest[2]
+		} else if len(rest) >= 1 {
+			resource = rest[0]
+		}
+	}
+	return
+}
+
+type objMeta struct {
+	Metadata struct {
+		Name            string `json:"name"`
+		Namespace       string `json:"namespace"`
+		OwnerReferences []struct {
+			Kind string `json:"kind"`
+			Name string `json:"name"`
+		} `json:"ownerReferences"`
+	} `json:"metadata"`
+}
+
+// owner returns a stable grouping key + display name for an object: its first
+// ownerReference name, else its own name.
+func (m objMeta) owner() string {
+	if len(m.Metadata.OwnerReferences) > 0 && m.Metadata.OwnerReferences[0].Name != "" {
+		return m.Metadata.OwnerReferences[0].Name
+	}
+	return m.Metadata.Name
+}
+
+// grouper accumulates findings keyed by (rule, namespace, owner), counting
+// affected objects and keeping the first as representative.
+type grouper struct {
+	order []string
+	byKey map[string]*Finding
+}
+
+func newGrouper() *grouper { return &grouper{byKey: map[string]*Finding{}} }
+
+func (g *grouper) add(key string, f Finding) {
+	if existing, ok := g.byKey[key]; ok {
+		existing.Count++
+		return
+	}
+	f.Count = 1
+	g.byKey[key] = &f
+	g.order = append(g.order, key)
+}
+
+func (g *grouper) findings() []Finding {
+	out := make([]Finding, 0, len(g.order))
+	for _, k := range g.order {
+		out = append(out, *g.byKey[k])
+	}
+	return out
+}

--- a/internal/diagnose/engine_test.go
+++ b/internal/diagnose/engine_test.go
@@ -1,0 +1,157 @@
+package diagnose
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/server"
+)
+
+func buildDiagStore(t *testing.T, bodies map[string]string) *server.CaptureStore {
+	t.Helper()
+	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	out := filepath.Join(t.TempDir(), "diag.kshrk")
+	sw, err := archive.NewStreamWriter(out)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	idx := capture.Index{}
+	i := 0
+	for path, body := range bodies {
+		rec := &capture.Record{ID: path, CapturedAt: now, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body)}
+		if err := sw.WriteRecord(rec); err != nil {
+			t.Fatalf("WriteRecord: %v", err)
+		}
+		idx[path] = &capture.IndexEntry{APIPath: path, Seqs: []int{0}, Times: []time.Time{now}}
+		i++
+	}
+	meta := &capture.CaptureMetadata{
+		FormatVersion: capture.CurrentFormatVersion, CaptureID: "diag-test",
+		KubernetesVersion: "v1.30.0", CapturedAt: now.Add(-time.Minute), CapturedUntil: now, RecordCount: i,
+	}
+	if err := sw.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	ar, err := archive.Open(out)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	t.Cleanup(func() { ar.Close() })
+	store, err := server.LoadStore(ar)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	return store
+}
+
+// fullFixture exercises every PR-1 rule plus a healthy pod (which must yield
+// nothing) and two crashloopers under one owner (which must group to count=2).
+func fullFixture() map[string]string {
+	pods := `{"kind":"PodList","apiVersion":"v1","items":[
+	  {"metadata":{"name":"web-1"},"status":{"phase":"Running","containerStatuses":[{"name":"app","ready":true,"restartCount":0,"state":{"running":{}}}]}},
+	  {"metadata":{"name":"web-rs-aaa","ownerReferences":[{"kind":"ReplicaSet","name":"web-rs"}]},"status":{"phase":"Running","containerStatuses":[{"name":"app","ready":false,"restartCount":5,"state":{"waiting":{"reason":"CrashLoopBackOff","message":"back-off"}}}]}},
+	  {"metadata":{"name":"web-rs-bbb","ownerReferences":[{"kind":"ReplicaSet","name":"web-rs"}]},"status":{"phase":"Running","containerStatuses":[{"name":"app","ready":false,"restartCount":6,"state":{"waiting":{"reason":"CrashLoopBackOff","message":"back-off"}}}]}},
+	  {"metadata":{"name":"cache-1"},"status":{"phase":"Running","containerStatuses":[{"name":"c","ready":false,"restartCount":3,"state":{"terminated":{"reason":"OOMKilled","exitCode":137}}}]}},
+	  {"metadata":{"name":"api-1"},"status":{"phase":"Pending","containerStatuses":[{"name":"c","ready":false,"restartCount":0,"state":{"waiting":{"reason":"ImagePullBackOff","message":"cannot pull"}}}]}},
+	  {"metadata":{"name":"job-1"},"status":{"phase":"Pending","conditions":[{"type":"PodScheduled","status":"False","reason":"Unschedulable","message":"0/3 nodes available: insufficient cpu"}]}}
+	]}`
+	pvcs := `{"kind":"PersistentVolumeClaimList","apiVersion":"v1","items":[
+	  {"metadata":{"name":"data-claim"},"spec":{"storageClassName":"missing-sc"},"status":{"phase":"Pending"}}
+	]}`
+	nodes := `{"kind":"NodeList","apiVersion":"v1","items":[
+	  {"metadata":{"name":"node-1"},"status":{"nodeInfo":{"kubeletVersion":"v1.24.0"}}}
+	]}`
+	return map[string]string{
+		"/api/v1/namespaces/prod/pods":                   pods,
+		"/api/v1/namespaces/prod/persistentvolumeclaims": pvcs,
+		"/api/v1/nodes": nodes,
+	}
+}
+
+func ruleIDs(fs []Finding) map[string]Finding {
+	m := map[string]Finding{}
+	for _, f := range fs {
+		m[f.RuleID] = f
+	}
+	return m
+}
+
+func TestRun_AllRules(t *testing.T) {
+	store := buildDiagStore(t, fullFixture())
+	rep := Run(store, Options{})
+
+	by := ruleIDs(rep.Findings)
+	for _, want := range []string{
+		"pod.crashloopbackoff", "pod.oomkilled", "pod.image-pull",
+		"scheduling.unschedulable", "storage.pvc-unbound", "cluster.version-skew",
+	} {
+		if _, ok := by[want]; !ok {
+			t.Errorf("missing expected finding %q; got %v", want, keys(by))
+		}
+	}
+	// Healthy pod must not produce a finding.
+	if len(rep.Findings) != 6 {
+		t.Errorf("expected 6 findings, got %d: %v", len(rep.Findings), keys(by))
+	}
+	// Two crashloopers share an owner → grouped.
+	if c := by["pod.crashloopbackoff"].Count; c != 2 {
+		t.Errorf("crashloop count = %d, want 2", c)
+	}
+	// Severities.
+	if by["pod.oomkilled"].Severity != SeverityCritical {
+		t.Errorf("oomkilled severity = %q", by["pod.oomkilled"].Severity)
+	}
+	if by["storage.pvc-unbound"].Severity != SeverityWarning {
+		t.Errorf("pvc severity = %q", by["storage.pvc-unbound"].Severity)
+	}
+	// Summary.
+	if rep.Summary.Critical != 3 || rep.Summary.Warning != 3 {
+		t.Errorf("summary = %+v, want 3 critical / 3 warning", rep.Summary)
+	}
+	// Sorted: critical findings come first.
+	if rep.Findings[0].Severity != SeverityCritical {
+		t.Errorf("first finding not critical: %+v", rep.Findings[0])
+	}
+}
+
+func TestRun_SeverityFilter(t *testing.T) {
+	store := buildDiagStore(t, fullFixture())
+	rep := Run(store, Options{MinSeverity: SeverityCritical})
+	for _, f := range rep.Findings {
+		if f.Severity != SeverityCritical {
+			t.Errorf("severity filter leaked %q", f.Severity)
+		}
+	}
+	if rep.Summary.Warning != 0 || rep.Summary.Critical != 3 {
+		t.Errorf("filtered summary = %+v", rep.Summary)
+	}
+}
+
+func TestRun_CategoryFilter(t *testing.T) {
+	store := buildDiagStore(t, fullFixture())
+	rep := Run(store, Options{Category: "storage"})
+	if len(rep.Findings) != 1 || rep.Findings[0].RuleID != "storage.pvc-unbound" {
+		t.Errorf("category filter = %v", keys(ruleIDs(rep.Findings)))
+	}
+}
+
+func TestSeverityAtLeast(t *testing.T) {
+	if !SeverityAtLeast(SeverityCritical, SeverityWarning) {
+		t.Error("critical should satisfy >= warning")
+	}
+	if SeverityAtLeast(SeverityInfo, SeverityWarning) {
+		t.Error("info should not satisfy >= warning")
+	}
+}
+
+func keys(m map[string]Finding) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/diagnose/finding.go
+++ b/internal/diagnose/finding.go
@@ -1,0 +1,80 @@
+// Package diagnose analyzes a captured cluster archive and produces
+// severity-ranked findings — the offline equivalent of popeye/kube-score.
+// It is shared by the `kshrk diagnose` CLI and the web UI.
+package diagnose
+
+import "sort"
+
+// SchemaVersion is the version of the Report/Finding JSON shape. Bump on a
+// breaking change to the documented `-o json` output so CI consumers can pin it.
+const SchemaVersion = 1
+
+// Severity levels, ordered.
+const (
+	SeverityInfo     = "info"
+	SeverityWarning  = "warning"
+	SeverityCritical = "critical"
+)
+
+// severityRank orders severities for sorting and --fail-on comparisons.
+var severityRank = map[string]int{SeverityInfo: 0, SeverityWarning: 1, SeverityCritical: 2}
+
+// SeverityAtLeast reports whether a is at least as severe as min.
+func SeverityAtLeast(a, min string) bool { return severityRank[a] >= severityRank[min] }
+
+// ObjectRef identifies the object a finding is about.
+type ObjectRef struct {
+	Kind      string `json:"kind,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name,omitempty"`
+	APIPath   string `json:"api_path,omitempty"`
+}
+
+// Finding is a single diagnostic result. The JSON shape is a stable contract
+// (see SchemaVersion).
+type Finding struct {
+	RuleID     string    `json:"rule_id"`            // stable id, e.g. "pod.crashloopbackoff"
+	Severity   string    `json:"severity"`           // info | warning | critical
+	Category   string    `json:"category"`           // workload|scheduling|storage|node|cluster
+	Title      string    `json:"title"`              // short human summary
+	Object     ObjectRef `json:"object"`             // the (representative) affected object
+	Evidence   string    `json:"evidence,omitempty"` // what was observed
+	Suggestion string    `json:"suggestion,omitempty"`
+	Count      int       `json:"count,omitempty"` // >1 when this finding groups several objects
+}
+
+// Report is the top-level diagnose output.
+type Report struct {
+	SchemaVersion int       `json:"schema_version"`
+	CaptureID     string    `json:"capture_id,omitempty"`
+	At            string    `json:"at,omitempty"`
+	Summary       Summary   `json:"summary"`
+	Findings      []Finding `json:"findings"`
+}
+
+// Summary counts findings by severity.
+type Summary struct {
+	Critical int `json:"critical"`
+	Warning  int `json:"warning"`
+	Info     int `json:"info"`
+}
+
+// sortFindings orders findings by severity (critical first), then category,
+// then rule id, then object — deterministic for stable output and golden tests.
+func sortFindings(fs []Finding) {
+	sort.SliceStable(fs, func(i, j int) bool {
+		if ri, rj := severityRank[fs[i].Severity], severityRank[fs[j].Severity]; ri != rj {
+			return ri > rj
+		}
+		if fs[i].Category != fs[j].Category {
+			return fs[i].Category < fs[j].Category
+		}
+		if fs[i].RuleID != fs[j].RuleID {
+			return fs[i].RuleID < fs[j].RuleID
+		}
+		if fs[i].Object.Namespace != fs[j].Object.Namespace {
+			return fs[i].Object.Namespace < fs[j].Object.Namespace
+		}
+		return fs[i].Object.Name < fs[j].Object.Name
+	})
+}

--- a/internal/diagnose/finding.go
+++ b/internal/diagnose/finding.go
@@ -19,8 +19,17 @@ const (
 // severityRank orders severities for sorting and --fail-on comparisons.
 var severityRank = map[string]int{SeverityInfo: 0, SeverityWarning: 1, SeverityCritical: 2}
 
-// SeverityAtLeast reports whether a is at least as severe as min.
-func SeverityAtLeast(a, min string) bool { return severityRank[a] >= severityRank[min] }
+// SeverityAtLeast reports whether a is at least as severe as min. Unknown
+// severities never satisfy the comparison, so a stray/typo'd value can't
+// silently pass a filter.
+func SeverityAtLeast(a, min string) bool {
+	ra, okA := severityRank[a]
+	rm, okMin := severityRank[min]
+	if !okA || !okMin {
+		return false
+	}
+	return ra >= rm
+}
 
 // ObjectRef identifies the object a finding is about.
 type ObjectRef struct {

--- a/internal/diagnose/rules.go
+++ b/internal/diagnose/rules.go
@@ -1,0 +1,221 @@
+package diagnose
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/server"
+)
+
+// ── workload: pod health ─────────────────────────────────────────────────────
+
+// reasonRule maps a container/pod issue reason to a finding template. ok=false
+// means the reason is benign/transient and should not be reported.
+func reasonRule(reason string) (ruleID, severity, title, suggestion string, ok bool) {
+	switch reason {
+	case "CrashLoopBackOff":
+		return "pod.crashloopbackoff", SeverityCritical, "CrashLoopBackOff", "Container is repeatedly crashing — check its logs and previous exit code.", true
+	case "OOMKilled":
+		return "pod.oomkilled", SeverityCritical, "OOMKilled", "Container exceeded its memory limit — raise limits or fix the leak.", true
+	case "ImagePullBackOff", "ErrImagePull", "InvalidImageName":
+		return "pod.image-pull", SeverityCritical, "Image pull failure", "Verify the image name/tag and registry credentials.", true
+	case "CreateContainerConfigError", "CreateContainerError":
+		return "pod.config-error", SeverityCritical, "Container config error", "A referenced ConfigMap/Secret or key is likely missing.", true
+	case "Error":
+		return "pod.container-error", SeverityWarning, "Container terminated with error", "Inspect the container logs and termination message.", true
+	case "Failed":
+		return "pod.failed", SeverityWarning, "Pod in Failed phase", "Inspect pod status and events for the failure cause.", true
+	case "Unknown":
+		return "pod.unknown", SeverityWarning, "Pod in Unknown phase", "The node may be unreachable — check node status.", true
+	case "ContainerCreating", "PodInitializing", "Completed", "":
+		return "", "", "", "", false // benign / transient
+	default:
+		return "pod." + sanitizeReason(reason), SeverityWarning, reason, "Inspect the pod for details on this condition.", true
+	}
+}
+
+func podHealthFindings(store *server.CaptureStore, at time.Time) []Finding {
+	g := newGrouper()
+	forEachResource(store, at, "pods", func(ns, path string, items []json.RawMessage) {
+		for _, raw := range items {
+			var m objMeta
+			_ = json.Unmarshal(raw, &m)
+			for _, reason := range ClassifyPod(raw).Issues {
+				ruleID, sev, title, sug, ok := reasonRule(reason)
+				if !ok {
+					continue
+				}
+				owner := m.owner()
+				key := ruleID + "|" + ns + "|" + owner
+				g.add(key, Finding{
+					RuleID: ruleID, Severity: sev, Category: "workload", Title: title,
+					Object:     ObjectRef{Kind: "Pod", Namespace: ns, Name: owner, APIPath: path},
+					Evidence:   reason,
+					Suggestion: sug,
+				})
+			}
+		}
+	})
+	return g.findings()
+}
+
+func sanitizeReason(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// ── scheduling: unschedulable pods ───────────────────────────────────────────
+
+func schedulingFindings(store *server.CaptureStore, at time.Time) []Finding {
+	g := newGrouper()
+	forEachResource(store, at, "pods", func(ns, path string, items []json.RawMessage) {
+		for _, raw := range items {
+			var p struct {
+				objMeta
+				Status struct {
+					Phase      string `json:"phase"`
+					Conditions []struct {
+						Type, Status, Reason, Message string
+					} `json:"conditions"`
+				} `json:"status"`
+			}
+			if json.Unmarshal(raw, &p) != nil || p.Status.Phase != "Pending" {
+				continue
+			}
+			for _, c := range p.Status.Conditions {
+				if c.Type == "PodScheduled" && c.Status == "False" {
+					msg := c.Message
+					if msg == "" {
+						msg = c.Reason
+					}
+					key := "scheduling.unschedulable|" + ns + "|" + msg
+					g.add(key, Finding{
+						RuleID: "scheduling.unschedulable", Severity: SeverityWarning, Category: "scheduling",
+						Title:      "Pod cannot be scheduled",
+						Object:     ObjectRef{Kind: "Pod", Namespace: ns, Name: p.owner(), APIPath: path},
+						Evidence:   msg,
+						Suggestion: "Add capacity or adjust resource requests, node selectors, affinity, or tolerations.",
+					})
+				}
+			}
+		}
+	})
+	return g.findings()
+}
+
+// ── storage: unbound PVCs ────────────────────────────────────────────────────
+
+func pvcFindings(store *server.CaptureStore, at time.Time) []Finding {
+	g := newGrouper()
+	forEachResource(store, at, "persistentvolumeclaims", func(ns, path string, items []json.RawMessage) {
+		for _, raw := range items {
+			var pvc struct {
+				objMeta
+				Spec struct {
+					StorageClassName *string `json:"storageClassName"`
+				} `json:"spec"`
+				Status struct {
+					Phase string `json:"phase"`
+				} `json:"status"`
+			}
+			if json.Unmarshal(raw, &pvc) != nil {
+				continue
+			}
+			if pvc.Status.Phase == "Bound" || pvc.Status.Phase == "" {
+				continue
+			}
+			sc := "(default)"
+			if pvc.Spec.StorageClassName != nil {
+				sc = *pvc.Spec.StorageClassName
+			}
+			key := "storage.pvc-unbound|" + ns + "|" + sc + "|" + pvc.Status.Phase
+			g.add(key, Finding{
+				RuleID: "storage.pvc-unbound", Severity: SeverityWarning, Category: "storage",
+				Title:      "PersistentVolumeClaim not bound",
+				Object:     ObjectRef{Kind: "PersistentVolumeClaim", Namespace: ns, Name: pvc.Metadata.Name, APIPath: path},
+				Evidence:   fmt.Sprintf("phase=%s, storageClass=%s", pvc.Status.Phase, sc),
+				Suggestion: "Ensure a matching StorageClass and provisioner (or a suitable PV) exist.",
+			})
+		}
+	})
+	return g.findings()
+}
+
+// ── cluster: control-plane / node version skew ───────────────────────────────
+
+func versionSkewFindings(store *server.CaptureStore, at time.Time) []Finding {
+	cpMinor, okCP := parseMinor(store.Metadata.KubernetesVersion)
+	if !okCP {
+		return nil
+	}
+	var out []Finding
+	forEachResource(store, at, "nodes", func(_, path string, items []json.RawMessage) {
+		for _, raw := range items {
+			var node struct {
+				Metadata struct {
+					Name string `json:"name"`
+				} `json:"metadata"`
+				Status struct {
+					NodeInfo struct {
+						KubeletVersion string `json:"kubeletVersion"`
+					} `json:"nodeInfo"`
+				} `json:"status"`
+			}
+			if json.Unmarshal(raw, &node) != nil {
+				continue
+			}
+			nMinor, ok := parseMinor(node.Status.NodeInfo.KubeletVersion)
+			if !ok {
+				continue
+			}
+			skew := cpMinor - nMinor
+			if skew < 0 {
+				skew = -skew
+			}
+			if skew < 3 { // within the supported version-skew window
+				continue
+			}
+			out = append(out, Finding{
+				RuleID: "cluster.version-skew", Severity: SeverityWarning, Category: "cluster",
+				Title:  "Node/control-plane version skew",
+				Object: ObjectRef{Kind: "Node", Name: node.Metadata.Name, APIPath: path},
+				Evidence: fmt.Sprintf("control plane %s, kubelet %s (%d minor versions apart)",
+					store.Metadata.KubernetesVersion, node.Status.NodeInfo.KubeletVersion, skew),
+				Suggestion: "Bring the node's kubelet within the supported skew (≤2 minor versions) of the control plane.",
+			})
+		}
+	})
+	return out
+}
+
+// parseMinor extracts the minor version from a "vMAJOR.MINOR.PATCH" string.
+func parseMinor(v string) (int, bool) {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	parts := strings.Split(v, ".")
+	if len(parts) < 2 {
+		return 0, false
+	}
+	// trim any suffix like "27+" or "27-eks".
+	minor := parts[1]
+	for i, r := range minor {
+		if r < '0' || r > '9' {
+			minor = minor[:i]
+			break
+		}
+	}
+	n, err := strconv.Atoi(minor)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}

--- a/internal/diagnose/rules.go
+++ b/internal/diagnose/rules.go
@@ -98,7 +98,9 @@ func schedulingFindings(store *server.CaptureStore, at time.Time) []Finding {
 					if msg == "" {
 						msg = c.Reason
 					}
-					key := "scheduling.unschedulable|" + ns + "|" + msg
+					// Key on owner too so distinct workloads with the same generic
+					// message ("0/N nodes available…") aren't merged into one finding.
+					key := "scheduling.unschedulable|" + ns + "|" + p.owner() + "|" + msg
 					g.add(key, Finding{
 						RuleID: "scheduling.unschedulable", Severity: SeverityWarning, Category: "scheduling",
 						Title:      "Pod cannot be scheduled",
@@ -138,7 +140,8 @@ func pvcFindings(store *server.CaptureStore, at time.Time) []Finding {
 			if pvc.Spec.StorageClassName != nil {
 				sc = *pvc.Spec.StorageClassName
 			}
-			key := "storage.pvc-unbound|" + ns + "|" + sc + "|" + pvc.Status.Phase
+			// Key per claim — each PVC is a distinct object, don't collapse them.
+			key := "storage.pvc-unbound|" + ns + "|" + pvc.Metadata.Name
 			g.add(key, Finding{
 				RuleID: "storage.pvc-unbound", Severity: SeverityWarning, Category: "storage",
 				Title:      "PersistentVolumeClaim not bound",

--- a/internal/diagnose/scheduling_test.go
+++ b/internal/diagnose/scheduling_test.go
@@ -1,0 +1,26 @@
+package diagnose
+
+import "testing"
+
+// Two distinct workloads with the same generic unschedulable message must NOT
+// be merged into one finding (regression for the owner-less grouping key).
+func TestScheduling_DistinctOwnersNotMerged(t *testing.T) {
+	pods := `{"kind":"PodList","apiVersion":"v1","items":[
+	  {"metadata":{"name":"a-1","ownerReferences":[{"kind":"ReplicaSet","name":"a-rs"}]},"status":{"phase":"Pending","conditions":[{"type":"PodScheduled","status":"False","reason":"Unschedulable","message":"0/3 nodes available: insufficient cpu"}]}},
+	  {"metadata":{"name":"b-1","ownerReferences":[{"kind":"ReplicaSet","name":"b-rs"}]},"status":{"phase":"Pending","conditions":[{"type":"PodScheduled","status":"False","reason":"Unschedulable","message":"0/3 nodes available: insufficient cpu"}]}}
+	]}`
+	store := buildDiagStore(t, map[string]string{"/api/v1/namespaces/x/pods": pods})
+	rep := Run(store, Options{Category: "scheduling"})
+	if len(rep.Findings) != 2 {
+		t.Fatalf("expected 2 separate unschedulable findings, got %d", len(rep.Findings))
+	}
+}
+
+func TestSeverityAtLeast_UnknownRejected(t *testing.T) {
+	if SeverityAtLeast("info", "bogus") {
+		t.Error("unknown min severity should not be satisfied")
+	}
+	if SeverityAtLeast("bogus", "info") {
+		t.Error("unknown finding severity should not satisfy a real min")
+	}
+}

--- a/internal/ui/v2/health.go
+++ b/internal/ui/v2/health.go
@@ -1,151 +1,20 @@
 package v2
 
 import (
-	"encoding/json"
 	"strings"
+
+	"github.com/phenixblue/k8shark/internal/diagnose"
 )
 
-// PodHealth is a compact summary of one pod's state, derived from the body of
-// a pod object. Used by issue detection, KPI counters, and the pod-drilldown
-// container cards.
-type PodHealth struct {
-	Phase      string            // "Running", "Pending", "Succeeded", "Failed", "Unknown"
-	Ready      int               // ready container count
-	Total      int               // total container count
-	Restarts   int               // sum of restart counts
-	Issues     []string          // unique reasons: "CrashLoopBackOff", "OOMKilled", "ImagePullBackOff", …
-	Containers []ContainerHealth // per-container detail
-}
+// Pod-health classification lives in internal/diagnose so the CLI and UI share
+// one implementation. These aliases keep the v2 call sites unchanged.
+type (
+	PodHealth       = diagnose.PodHealth
+	ContainerHealth = diagnose.ContainerHealth
+)
 
-// ContainerHealth is the per-container slice of PodHealth.
-type ContainerHealth struct {
-	Name           string `json:"name"`
-	Image          string `json:"image,omitempty"`
-	Ready          bool   `json:"ready"`
-	RestartCount   int    `json:"restart_count"`
-	IsInit         bool   `json:"is_init,omitempty"`
-	State          string `json:"state"` // "Running" | "Waiting" | "Terminated"
-	StateReason    string `json:"state_reason,omitempty"`
-	StateMessage   string `json:"state_message,omitempty"`
-	LastTerminated string `json:"last_terminated,omitempty"` // reason of lastState.terminated if present
-	LastExitCode   int    `json:"last_exit_code,omitempty"`
-}
-
-// IsHealthy reports whether a pod is in a benign state for KPI counting.
-// A pod with zero issues is considered healthy.
-func (h PodHealth) IsHealthy() bool { return len(h.Issues) == 0 }
-
-// ClassifyPod parses a pod body and returns its PodHealth. Returns zero
-// PodHealth on a malformed body — callers should treat that as "unknown".
-func ClassifyPod(body []byte) PodHealth {
-	var pod struct {
-		Status struct {
-			Phase                 string            `json:"phase"`
-			ContainerStatuses     []containerStatus `json:"containerStatuses"`
-			InitContainerStatuses []containerStatus `json:"initContainerStatuses"`
-		} `json:"status"`
-	}
-	if err := json.Unmarshal(body, &pod); err != nil {
-		return PodHealth{}
-	}
-
-	h := PodHealth{Phase: pod.Status.Phase}
-	seenIssue := map[string]bool{}
-	addIssue := func(reason string) {
-		if reason == "" || seenIssue[reason] {
-			return
-		}
-		seenIssue[reason] = true
-		h.Issues = append(h.Issues, reason)
-	}
-
-	switch h.Phase {
-	case "Failed":
-		addIssue("Failed")
-	case "Unknown":
-		addIssue("Unknown")
-	case "Pending":
-		// Pending alone isn't an issue — that's just "still scheduling".
-		// We surface a container-level reason below if there is one.
-	}
-
-	consume := func(cs containerStatus, isInit bool) {
-		h.Total++
-		h.Restarts += cs.RestartCount
-		c := ContainerHealth{
-			Name:         cs.Name,
-			Image:        cs.Image,
-			Ready:        cs.Ready,
-			RestartCount: cs.RestartCount,
-			IsInit:       isInit,
-		}
-		if cs.Ready {
-			h.Ready++
-		}
-		switch {
-		case cs.State.Running != nil:
-			c.State = "Running"
-		case cs.State.Waiting != nil:
-			c.State = "Waiting"
-			c.StateReason = cs.State.Waiting.Reason
-			c.StateMessage = cs.State.Waiting.Message
-			addIssue(cs.State.Waiting.Reason)
-		case cs.State.Terminated != nil:
-			c.State = "Terminated"
-			c.StateReason = cs.State.Terminated.Reason
-			c.StateMessage = cs.State.Terminated.Message
-			c.LastExitCode = cs.State.Terminated.ExitCode
-			// A terminated init container that exited 0 is normal — don't flag.
-			if !isInit || cs.State.Terminated.ExitCode != 0 {
-				addIssue(cs.State.Terminated.Reason)
-			}
-		}
-		if cs.LastState.Terminated != nil {
-			c.LastTerminated = cs.LastState.Terminated.Reason
-			if c.LastExitCode == 0 {
-				c.LastExitCode = cs.LastState.Terminated.ExitCode
-			}
-			// CrashLoopBackOff usually pairs with a previous OOMKilled / Error.
-			// Don't add it as a top-level issue (it's stale) but keep the reason
-			// on the container card for context.
-		}
-		h.Containers = append(h.Containers, c)
-	}
-
-	for _, cs := range pod.Status.InitContainerStatuses {
-		consume(cs, true)
-	}
-	for _, cs := range pod.Status.ContainerStatuses {
-		consume(cs, false)
-	}
-	return h
-}
-
-type containerStatus struct {
-	Name         string         `json:"name"`
-	Image        string         `json:"image"`
-	Ready        bool           `json:"ready"`
-	RestartCount int            `json:"restartCount"`
-	State        containerState `json:"state"`
-	LastState    containerState `json:"lastState"`
-}
-
-type containerState struct {
-	Running    *struct{}              `json:"running,omitempty"`
-	Waiting    *containerStateWaiting `json:"waiting,omitempty"`
-	Terminated *containerStateTerm    `json:"terminated,omitempty"`
-}
-
-type containerStateWaiting struct {
-	Reason  string `json:"reason"`
-	Message string `json:"message"`
-}
-
-type containerStateTerm struct {
-	Reason   string `json:"reason"`
-	Message  string `json:"message"`
-	ExitCode int    `json:"exitCode"`
-}
+// ClassifyPod parses a pod body and returns its PodHealth.
+func ClassifyPod(body []byte) PodHealth { return diagnose.ClassifyPod(body) }
 
 // PodNamePrefix groups pods that share an owning ReplicaSet/Deployment by
 // stripping the trailing hash segment(s). "kubevirt-migration-controller-


### PR DESCRIPTION
Part of #111 (PR 1 of the planned series). Adds the offline diagnostics engine and the `kshrk diagnose` command.

## What this delivers
Turns a capture's raw state into **severity-ranked findings with evidence + remediation hints** — no server needed.

- **`internal/diagnose` package**
  - `Finding`/`Report` schema with `SchemaVersion` (the stable `-o json` contract).
  - Engine that runs rules, groups duplicates by owner+reason (`count`), filters, and sorts deterministically (critical first).
  - **`ClassifyPod`/`PodHealth` moved here** from `internal/ui/v2` and aliased back, so the CLI and UI share one classifier (v2 call sites unchanged).
- **Rules — the #111 acceptance set:**
  - Pod health: CrashLoopBackOff, OOMKilled, image-pull, container/config errors, Failed/Unknown (ports the existing classification).
  - Scheduling: unschedulable pods **with reason** (PodScheduled=False message).
  - Storage: unbound PVCs (phase + storageClass).
  - Cluster: control-plane ↔ node **version skew** (≥3 minor → warning).
  - Rules degrade gracefully when their inputs weren't captured (no nodes → no skew rule, etc.).
- **`kshrk diagnose <capture.kshrk>`** — `-o table|json|yaml`, `--at`, `--severity`, `--category`, and **`--fail-on <severity>`** for CI gating (exits non-zero via the existing `exitError`).

## Example
```
kshrk diagnose capture.kshrk
kshrk diagnose capture.kshrk --severity warning --category scheduling -o json
kshrk diagnose capture.kshrk --fail-on critical   # CI gate
```

## Tests
- Engine: a fixture exercising every rule (incl. owner-grouping → count, healthy pod → no finding, severity/category filters, summary, sort order).
- CLI: JSON shape + `schema_version`, `--fail-on` exit code, clean-capture passes, bad-flag validation.
- `go build`/`go vet`/`go test ./...` all pass.

## Follow-ups (per the #111 plan)
- **PR 2:** more rules (missing requests/limits, replica shortfall, node conditions, deprecated APIs, event↔log correlation).
- **PR 3:** dashboard Diagnostics view + unify the overview "Issues" panel onto the engine.
- **PR 4:** docs + `-o json` schema reference.

This PR does **not** close #111 (UI + docs phases remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)