### PR TITLE
feat(ui): dashboard Diagnostics view (#111, PR 3)

### DIFF
--- a/internal/ui/v2/diagnostics.go
+++ b/internal/ui/v2/diagnostics.go
@@ -1,0 +1,19 @@
+package v2
+
+import (
+	"net/http"
+
+	"github.com/phenixblue/k8shark/internal/diagnose"
+)
+
+// serveDiagnostics runs the diagnose engine over the capture at the resolved
+// time and returns the ranked Report. Backs the dashboard Diagnostics view.
+func (h *Handler) serveDiagnostics(w http.ResponseWriter, r *http.Request) {
+	if h.Store == nil {
+		writeError(w, http.StatusInternalServerError, "store not initialized")
+		return
+	}
+	at := h.resolveAt(r)
+	rep := diagnose.Run(h.Store, diagnose.Options{At: at})
+	writeJSON(w, http.StatusOK, rep)
+}

--- a/internal/ui/v2/diagnostics_test.go
+++ b/internal/ui/v2/diagnostics_test.go
@@ -1,0 +1,62 @@
+package v2
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/diagnose"
+)
+
+func TestServeDiagnostics(t *testing.T) {
+	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	pods := `{"kind":"PodList","apiVersion":"v1","items":[` +
+		`{"metadata":{"name":"web"},"status":{"phase":"Running","containerStatuses":[{"name":"app","ready":false,"restartCount":7,"state":{"waiting":{"reason":"CrashLoopBackOff"}}}]}}]}`
+	recs := []*capture.Record{
+		{ID: "p1", CapturedAt: now, APIPath: "/api/v1/namespaces/default/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(pods)},
+	}
+	idx := capture.Index{
+		"/api/v1/namespaces/default/pods": {APIPath: "/api/v1/namespaces/default/pods", Seqs: []int{0}, Times: []time.Time{now}},
+	}
+	meta := &capture.CaptureMetadata{CaptureID: "diag-ui", CapturedAt: now, CapturedUntil: now, RecordCount: 1}
+	h := &Handler{Store: buildV2TestStore(t, recs, idx, meta), At: now}
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/api/diagnostics", nil)
+	w := httptest.NewRecorder()
+	h.serveDiagnostics(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", w.Code, w.Body.String())
+	}
+	var rep diagnose.Report
+	if err := json.Unmarshal(w.Body.Bytes(), &rep); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if rep.SchemaVersion != diagnose.SchemaVersion {
+		t.Errorf("schema_version = %d", rep.SchemaVersion)
+	}
+	found := false
+	for _, f := range rep.Findings {
+		if f.RuleID == "pod.crashloopbackoff" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a crashloop finding, got %+v", rep.Findings)
+	}
+	if rep.Summary.Critical < 1 {
+		t.Errorf("expected a critical finding, summary=%+v", rep.Summary)
+	}
+}
+
+func TestServeDiagnostics_NilStore(t *testing.T) {
+	h := &Handler{}
+	req := httptest.NewRequest(http.MethodGet, "/v2/api/diagnostics", nil)
+	w := httptest.NewRecorder()
+	h.serveDiagnostics(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -94,7 +94,7 @@
     if (qIdx >= 0) h = h.slice(0, qIdx);
     const parts = h.split('/').filter(Boolean);
     if (parts.length === 0) return { name: 'overview' };
-    if (parts[0] === 'overview' || parts[0] === 'namespaces' || parts[0] === 'pods' || parts[0] === 'workloads' || parts[0] === 'resources' || parts[0] === 'resource' || parts[0] === 'object' || parts[0] === 'timeline' || parts[0] === 'logs' || parts[0] === 'diff') {
+    if (parts[0] === 'overview' || parts[0] === 'namespaces' || parts[0] === 'pods' || parts[0] === 'workloads' || parts[0] === 'resources' || parts[0] === 'resource' || parts[0] === 'object' || parts[0] === 'timeline' || parts[0] === 'logs' || parts[0] === 'diff' || parts[0] === 'diagnostics') {
       return { name: parts[0] };
     }
     if (parts[0] === 'ns' && parts[1]) {
@@ -128,6 +128,7 @@
       { key: 'workloads',  label: 'Workloads',  hash: '#/workloads' },
       { key: 'pods',       label: 'Pods',       hash: '#/pods' },
       { key: 'resources',  label: 'Resources',  hash: '#/resources' },
+      { key: 'diagnostics', label: 'Diagnostics', hash: '#/diagnostics' },
       { key: 'timeline',   label: 'Timeline',   hash: '#/timeline' },
     ];
     const activeKey = state.route.name === 'namespace' ? 'namespaces'
@@ -1832,6 +1833,50 @@
   }
 
   // ── Timeline ─────────────────────────────────────────────────────────────
+  async function renderDiagnostics() {
+    setContent(loadingState('Running diagnostics…'));
+    let rep;
+    try {
+      rep = await getJSON('/v2/api/diagnostics');
+    } catch (e) {
+      setContent(errorState(e.message));
+      return;
+    }
+    const findings = rep.findings || [];
+    const s = rep.summary || {};
+    const root = el('div', {});
+    root.appendChild(el('div', { class: 'section-title', style: 'font-size:15px; margin-bottom:2px;' }, 'Diagnostics'));
+    root.appendChild(el('div', { style: 'color:var(--fg-dim); font-size:12px; margin-bottom:14px;' },
+      findings.length + ' finding(s) · ' + (s.critical || 0) + ' critical · ' + (s.warning || 0) + ' warning · ' + (s.info || 0) + ' info'));
+
+    if (!findings.length) {
+      root.appendChild(el('div', { class: 'state', style: 'padding:24px;' }, 'No findings — the captured cluster looks healthy. ✓'));
+      setContent(root);
+      return;
+    }
+
+    const sevColor = (sev) => sev === 'critical' ? 'var(--bad)' : sev === 'warning' ? 'var(--warn)' : 'var(--fg-dim)';
+    const card = el('div', { class: 'card' });
+    for (const f of findings) {
+      const o = f.object || {};
+      const obj = (o.namespace ? o.namespace + '/' : '') + (o.name || o.kind || '');
+      const countSuffix = f.count > 1 ? ' (+' + (f.count - 1) + ')' : '';
+      const link = o.namespace ? '#/ns/' + encodeURIComponent(o.namespace) : '';
+      const row = el('div', { style: 'display:flex; gap:12px; padding:10px 4px; border-bottom:1px solid var(--border);' + (link ? ' cursor:pointer;' : '') });
+      if (link) row.addEventListener('click', () => go(link));
+      const color = sevColor(f.severity);
+      row.appendChild(el('span', { style: 'flex:none; align-self:flex-start; font-size:10.5px; font-weight:600; text-transform:uppercase; color:' + color + '; border:1px solid ' + color + '; border-radius:5px; padding:1px 6px;' }, f.severity));
+      row.appendChild(el('div', { style: 'min-width:0;' },
+        el('div', { style: 'font-size:13px;' }, f.title || f.rule_id),
+        el('div', { style: 'font-size:12px; color:var(--fg-dim);' }, [f.category, obj + countSuffix].filter(Boolean).join(' · ')),
+        f.evidence ? el('div', { style: 'font-size:12px; color:var(--fg-dim); margin-top:2px;' }, f.evidence) : null,
+        f.suggestion ? el('div', { style: 'font-size:12px; color:var(--fg-faint); margin-top:2px;' }, '→ ' + f.suggestion) : null));
+      card.appendChild(row);
+    }
+    root.appendChild(card);
+    setContent(root);
+  }
+
   async function renderTimeline() {
     setContent(loadingState('Loading timeline…'));
     let data;
@@ -2069,6 +2114,7 @@
     if (r.name === 'object') return renderObject();
     if (r.name === 'namespace') return renderNamespace(r.ns);
     if (r.name === 'pod') return renderPod(r.ns, r.pod);
+    if (r.name === 'diagnostics') return renderDiagnostics();
     if (r.name === 'timeline') return renderTimeline();
     if (r.name === 'logs') return renderLogs();
     if (r.name === 'diff') return renderDiff();

--- a/internal/ui/v2/v2.go
+++ b/internal/ui/v2/v2.go
@@ -34,6 +34,7 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	mux.Handle("/v2/", http.StripPrefix("/v2/", http.FileServer(http.FS(sub))))
 
 	mux.HandleFunc("/v2/api/overview", h.serveOverview)
+	mux.HandleFunc("/v2/api/diagnostics", h.serveDiagnostics)
 	mux.HandleFunc("/v2/api/capture", h.serveCaptureInfo)
 	mux.HandleFunc("/v2/api/namespace", h.serveNamespace)
 	mux.HandleFunc("/v2/api/pods", h.serveAllPods)


### PR DESCRIPTION
Part of #111 (PR 3). Surfaces the diagnose engine (merged in #131) in the web UI. Branches from `main` — independent of #132 (it shows whatever rules are registered).

## What this adds
- **`/v2/api/diagnostics`** endpoint — runs `diagnose.Run` over the capture at the resolved time (`?at`/scrubber-aware) and returns the ranked `Report`.
- **"Diagnostics" view** — new nav item + hash route + render. Findings are grouped/sorted by severity (critical → warning → info) with a colored chip, category, affected object (with grouped `(+N)` count), evidence, and a remediation hint. Namespaced findings deep-link to the namespace drilldown.
- **Tests** — `serveDiagnostics` returns findings + `schema_version`; nil-store guard.

## Scope note (re: the earlier "unify the Issues panel" decision)
I kept this PR to the **additive** Diagnostics view and **deferred unifying the overview/namespace "Issues" panels** onto the engine to a focused follow-up. Reason: `buildIssues` backs **two** views (overview + namespace) and a clean unification needs namespace filtering added to the engine plus careful link handling — a cross-cutting, hard-to-UI-verify change that's safer isolated from this feature. Flagging since you'd approved doing it here; happy to do it next as PR 3b.

## Testing
`go build`/`go vet`/`go test ./internal/ui/v2/` pass. (UI assets are embedded; the view ships in a freshly built binary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)