### PR TITLE
feat(replay): phase 1 — replay clock + event-streaming watch + `kshrk replay`

### DIFF
--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -39,7 +39,7 @@ A kubeconfig is written just like 'open'; point kubectl or a controller at it.`,
 func init() {
 	rootCmd.AddCommand(replayCmd)
 	replayCmd.Flags().String("port", "0", "port for the mock API server (0 = random available port)")
-	replayCmd.Flags().String("kubeconfig-out", "", "where to write the generated kubeconfig (default: ~/.kube/k8shark-<id>)")
+	replayCmd.Flags().String("kubeconfig-out", "", "where to write the generated kubeconfig (default: ~/.kube/k8shark-<id>.yaml)")
 	replayCmd.Flags().String("speed", "1x", "playback speed factor, e.g. 2x, 3x, 0.5x")
 	replayCmd.Flags().String("from", "", "replay window start: RFC3339 or relative duration like -10m (default: capture start)")
 	replayCmd.Flags().String("to", "", "replay window end: RFC3339 or relative duration like -1m (default: capture end)")

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/spf13/cobra"
+)
+
+var replayCmd = &cobra.Command{
+	Use:   "replay <capture.kshrk>",
+	Short: "Replay a capture forward through time at a chosen speed",
+	Long: `Plays a k8shark capture forward through time, streaming captured watch
+events (ADDED/MODIFIED/DELETED) to clients as a replay clock advances. Unlike
+'open --at', which jumps the whole view to a single instant, replay advances a
+clock and streams change over time — so controllers/operators and 'kubectl get
+--watch' observe the cluster changing exactly as it did during capture.
+
+A kubeconfig is written just like 'open'; point kubectl or a controller at it.`,
+	Example: `  # Replay the whole capture at twice its original speed
+  kshrk replay capture.kshrk --speed 2x
+
+  # Replay in slow motion
+  kshrk replay capture.kshrk --speed 0.5x
+
+  # Loop the last 10 minutes of the capture
+  kshrk replay capture.kshrk --from -10m --to -1m --loop
+
+  # Start paused (press Enter to begin)
+  kshrk replay capture.kshrk --start-paused`,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeArchiveArg,
+	RunE:              runReplay,
+}
+
+func init() {
+	rootCmd.AddCommand(replayCmd)
+	replayCmd.Flags().String("port", "0", "port for the mock API server (0 = random available port)")
+	replayCmd.Flags().String("kubeconfig-out", "", "where to write the generated kubeconfig (default: ~/.kube/k8shark-<id>)")
+	replayCmd.Flags().String("speed", "1x", "playback speed factor, e.g. 2x, 3x, 0.5x")
+	replayCmd.Flags().String("from", "", "replay window start: RFC3339 or relative duration like -10m (default: capture start)")
+	replayCmd.Flags().String("to", "", "replay window end: RFC3339 or relative duration like -1m (default: capture end)")
+	replayCmd.Flags().Bool("loop", false, "restart the replay from the window start when it reaches the end")
+	replayCmd.Flags().Bool("start-paused", false, "start paused; press Enter to begin playback")
+}
+
+func runReplay(cmd *cobra.Command, args []string) error {
+	port, _ := cmd.Flags().GetString("port")
+	kubeconfigOut, _ := cmd.Flags().GetString("kubeconfig-out")
+	speed, _ := cmd.Flags().GetString("speed")
+	from, _ := cmd.Flags().GetString("from")
+	to, _ := cmd.Flags().GetString("to")
+	loop, _ := cmd.Flags().GetBool("loop")
+	startPaused, _ := cmd.Flags().GetBool("start-paused")
+	verbose, _ := cmd.Root().PersistentFlags().GetBool("verbose")
+
+	srv, err := server.Replay(server.ReplayOptions{
+		ArchivePath:   args[0],
+		Port:          port,
+		KubeconfigOut: kubeconfigOut,
+		Speed:         speed,
+		From:          from,
+		To:            to,
+		Loop:          loop,
+		StartPaused:   startPaused,
+		Verbose:       verbose,
+	})
+	if err != nil {
+		return fmt.Errorf("starting replay: %w", err)
+	}
+
+	clock := srv.Clock()
+	winStart, winEnd := clock.Window()
+
+	fmt.Printf("k8shark replay server running\n")
+	fmt.Printf("  Address:    %s\n", srv.Address())
+	fmt.Printf("  Kubeconfig: %s\n", srv.KubeconfigPath())
+	fmt.Printf("  Window:     %s → %s (%s)\n", winStart.Format(time.RFC3339), winEnd.Format(time.RFC3339), winEnd.Sub(winStart).Round(time.Second))
+	fmt.Printf("  Speed:      %s\n", formatSpeed(clock.Speed()))
+	if loop {
+		fmt.Printf("  Loop:       on\n")
+	}
+	fmt.Printf("\nRun: export KUBECONFIG=%s\n", srv.KubeconfigPath())
+	fmt.Printf("Then watch it change, e.g.: kubectl get pods -A --watch\n")
+
+	if !srv.HasWatchEvents() {
+		fmt.Printf("\nNote: this capture has no watch events, so no changes will stream.\n")
+		fmt.Printf("      Re-capture with 'watch: true' to record ADDED/MODIFIED/DELETED over time.\n")
+	}
+
+	if startPaused {
+		fmt.Printf("\nPaused. Press Enter to begin playback (Ctrl+C to stop).\n")
+		_, _ = bufio.NewReader(os.Stdin).ReadString('\n')
+		clock.Resume()
+	} else {
+		fmt.Printf("\nPress Ctrl+C to stop.\n")
+	}
+
+	// Live status line until shutdown.
+	stop := make(chan struct{})
+	go replayStatusLoop(srv, stop)
+	err = srv.Wait()
+	close(stop)
+	fmt.Println()
+	return err
+}
+
+// replayStatusLoop repaints a single status line showing clock position, speed,
+// and events emitted, until stop is closed.
+func replayStatusLoop(srv *server.Server, stop <-chan struct{}) {
+	clock := srv.Clock()
+	winStart, winEnd := clock.Window()
+	total := winEnd.Sub(winStart)
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			pos, _, ended := clock.Sample()
+			state := ""
+			switch {
+			case clock.Paused():
+				state = " · paused"
+			case ended:
+				state = " · ended"
+			}
+			fmt.Printf("\r  replaying %s (+%s / %s) · %s · %d events emitted%s   ",
+				pos.Format("15:04:05Z07:00"),
+				pos.Sub(winStart).Round(time.Second),
+				total.Round(time.Second),
+				formatSpeed(clock.Speed()),
+				clock.EventsEmitted(),
+				state,
+			)
+		}
+	}
+}
+
+// formatSpeed renders a speed factor as e.g. "2x" or "0.5x".
+func formatSpeed(s float64) string {
+	if s == float64(int64(s)) {
+		return fmt.Sprintf("%dx", int64(s))
+	}
+	return fmt.Sprintf("%gx", s)
+}

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -83,8 +83,10 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	if loop {
 		fmt.Printf("  Loop:       on\n")
 	}
+	fmt.Printf("  Control:    %s/_k8shark/replay\n", srv.Address())
 	fmt.Printf("\nRun: export KUBECONFIG=%s\n", srv.KubeconfigPath())
 	fmt.Printf("Then watch it change, e.g.: kubectl get pods -A --watch\n")
+	fmt.Printf("Drive playback, e.g.: curl -sk -X POST %s/_k8shark/replay/pause\n", srv.Address())
 
 	if !srv.HasWatchEvents() {
 		fmt.Printf("\nNote: this capture has no watch events, so no changes will stream.\n")

--- a/cmd/replay_test.go
+++ b/cmd/replay_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newTestReplayCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("port", "0", "")
+	cmd.Flags().String("kubeconfig-out", "", "")
+	cmd.Flags().String("speed", "1x", "")
+	cmd.Flags().String("from", "", "")
+	cmd.Flags().String("to", "", "")
+	cmd.Flags().Bool("loop", false, "")
+	cmd.Flags().Bool("start-paused", false, "")
+	return cmd
+}
+
+func TestRunReplay_InvalidSpeed(t *testing.T) {
+	arch := buildDiffArchive(t, healthyPodList)
+	cmd := newTestReplayCommand()
+	_ = cmd.Flags().Set("speed", "fast")
+
+	err := runReplay(cmd, []string{arch})
+	if err == nil {
+		t.Fatal("expected error for invalid --speed")
+	}
+	if !strings.Contains(err.Error(), "speed") {
+		t.Errorf("error = %v, want it to mention speed", err)
+	}
+}
+
+func TestRunReplay_MissingArchive(t *testing.T) {
+	cmd := newTestReplayCommand()
+	if err := runReplay(cmd, []string{"/no/such/capture.kshrk"}); err == nil {
+		t.Fatal("expected error for missing archive")
+	}
+}
+
+func TestRunReplay_InvalidWindow(t *testing.T) {
+	arch := buildDiffArchive(t, healthyPodList)
+	cmd := newTestReplayCommand()
+	// --to before --from is rejected.
+	_ = cmd.Flags().Set("from", "-1m")
+	_ = cmd.Flags().Set("to", "-5m")
+
+	if err := runReplay(cmd, []string{arch}); err == nil {
+		t.Fatal("expected error when --to precedes --from")
+	}
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -439,6 +439,7 @@ The status response looks like:
   "paused": false,
   "loop": false,
   "ended": false,
+  "epoch": 0,
   "events_emitted": 47
 }
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -355,6 +355,58 @@ This is useful when you have a long capture (e.g. 1h) and want to compare cluste
 
 ---
 
+## Replay
+
+`kshrk replay` plays a capture **forward through time** at a chosen speed, streaming captured watch events (ADDED / MODIFIED / DELETED) to clients as a replay clock advances. This is different from `open --at`, which jumps the whole view to a single instant: replay advances a clock and streams change *over time*, so controllers/operators and `kubectl get --watch` observe the cluster changing exactly as it did during capture.
+
+```sh
+# Replay the whole capture at twice its original speed
+kshrk replay capture.kshrk --speed 2x
+
+# Slow motion
+kshrk replay capture.kshrk --speed 0.5x
+
+# Loop the last 10 minutes of the capture
+kshrk replay capture.kshrk --from -10m --to -1m --loop
+
+# Start paused, then press Enter to begin
+kshrk replay capture.kshrk --start-paused
+```
+
+Like `open`, it writes a kubeconfig — point `kubectl` or a controller at it:
+
+```sh
+export KUBECONFIG=~/.kube/k8shark-<id>.yaml
+kubectl get pods -A --watch
+```
+
+A live status line shows the clock position, speed, and how many events have streamed:
+
+```
+replaying 14:03:12Z (+2m18s / 10m) · 2x · 47 events emitted
+```
+
+The primary use case is **local development and testing of controllers/operators**: point one at a replayed capture and watch how it reacts to a real (or reproduced-incident) sequence of changes. LIST and GET return state as-of the clock (the same time-travel semantics as `--at`), and the watch stream delivers events in timestamp order, paced by clock × speed.
+
+> **Read-only.** The mock server replays a captured timeline; a controller's writes won't persist or feed back into the replay. You observe "how my controller reacts to this sequence," not a closed loop.
+>
+> **Watch events required.** Replay streams the events recorded with `watch: true` (see [docs/config.md](config.md)). A poll-only capture has no watch events, so `replay` still serves LIST/GET as-of the clock but streams nothing — `kshrk replay` prints a note when this is the case. (Inferring events for poll-only captures by diffing snapshots is a planned enhancement.)
+
+### Replay flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--speed` | `1x` | Playback speed factor, e.g. `2x`, `3x`, `0.5x` |
+| `--from` | capture start | Window start: RFC3339 or relative duration like `-10m` |
+| `--to` | capture end | Window end: RFC3339 or relative duration like `-1m` |
+| `--loop` | false | Restart from the window start when the end is reached |
+| `--start-paused` | false | Start paused; press Enter to begin playback |
+| `--port` | random | Port for the mock API server |
+| `--kubeconfig-out` | `~/.kube/k8shark-<id>.yaml` | Where to write the generated kubeconfig |
+| `--verbose` / `-v` | false | Log every request the server receives |
+
+---
+
 ## UI
 
 `kshrk ui` starts a local web-based explorer and the mock Kubernetes API server for a capture archive.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -405,6 +405,44 @@ The primary use case is **local development and testing of controllers/operators
 | `--kubeconfig-out` | `~/.kube/k8shark-<id>.yaml` | Where to write the generated kubeconfig |
 | `--verbose` / `-v` | false | Log every request the server receives |
 
+### Controlling playback
+
+The replay server exposes a small HTTP control API under `/_k8shark/replay` on the same address (a reserved prefix that never collides with the Kubernetes API). Every response returns the current status, so a script — or a future UI scrubber — can drive playback:
+
+| Request | Effect |
+|---------|--------|
+| `GET /_k8shark/replay` | Return current status |
+| `POST /_k8shark/replay/pause` | Pause the clock |
+| `POST /_k8shark/replay/play` | Resume the clock |
+| `POST /_k8shark/replay/speed?value=2x` | Change speed |
+| `POST /_k8shark/replay/seek?to=<RFC3339\|duration>` | Seek to a time (duration is relative to the window end, e.g. `-2m`) |
+| `POST /_k8shark/replay/seek?offset=<duration>` | Seek to `window start + duration`, e.g. `90s` |
+
+```sh
+# The server uses a self-signed cert, so pass -k
+curl -sk https://127.0.0.1:<port>/_k8shark/replay
+curl -sk -X POST https://127.0.0.1:<port>/_k8shark/replay/pause
+curl -sk -X POST "https://127.0.0.1:<port>/_k8shark/replay/speed?value=0.5x"
+curl -sk -X POST "https://127.0.0.1:<port>/_k8shark/replay/seek?offset=30s"
+```
+
+The status response looks like:
+
+```json
+{
+  "position": "2026-04-09T10:03:12Z",
+  "from": "2026-04-09T10:00:00Z",
+  "to": "2026-04-09T10:10:00Z",
+  "elapsed_seconds": 192,
+  "total_seconds": 600,
+  "speed": 2,
+  "paused": false,
+  "loop": false,
+  "ended": false,
+  "events_emitted": 47
+}
+```
+
 ---
 
 ## UI

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -407,7 +407,7 @@ The primary use case is **local development and testing of controllers/operators
 
 ### Controlling playback
 
-The replay server exposes a small HTTP control API under `/_k8shark/replay` on the same address (a reserved prefix that never collides with the Kubernetes API). Every response returns the current status, so a script — or a future UI scrubber — can drive playback:
+The replay server exposes a small HTTP control API under `/_k8shark/replay` on the same address (a reserved prefix that never collides with the Kubernetes API). A successful request returns the current status as JSON (so a script — or a future UI scrubber — can drive playback); an invalid request returns a Kubernetes-style Status JSON body with the appropriate code (`405` wrong method, `400` bad argument, `404` unknown control):
 
 | Request | Effect |
 |---------|--------|

--- a/internal/server/clock.go
+++ b/internal/server/clock.go
@@ -78,6 +78,12 @@ func (c *ReplayClock) sample() (pos time.Time, epoch int, ended bool) {
 	if !c.loop {
 		return c.to, c.baseEpoch, true
 	}
+	// Loop: position `to` is the end of the current epoch, not the start of the
+	// next — wrap only once raw is strictly after `to`, so events timestamped
+	// exactly at the window end aren't skipped by an early epoch change.
+	if !raw.After(c.to) {
+		return c.to, c.baseEpoch, false
+	}
 	over := raw.Sub(c.from)
 	wraps := int(over / span)
 	rem := over % span

--- a/internal/server/clock.go
+++ b/internal/server/clock.go
@@ -70,7 +70,20 @@ func (c *ReplayClock) sample() (pos time.Time, epoch int, ended bool) {
 	if span <= 0 {
 		return c.to, c.baseEpoch, !c.loop
 	}
-	elapsed := time.Duration(float64(c.now().Sub(c.wallAnchor)) * c.speed)
+	// Clamp the scaled elapsed time to the representable Duration range before
+	// converting: wallDelta × speed can exceed int64 nanoseconds over a long run
+	// at a high speed, and an overflowing conversion would produce a negative
+	// elapsed (making the clock jump backward or spin).
+	scaled := float64(c.now().Sub(c.wallAnchor)) * c.speed
+	var elapsed time.Duration
+	switch {
+	case scaled <= 0:
+		elapsed = 0
+	case scaled >= float64(math.MaxInt64):
+		elapsed = time.Duration(math.MaxInt64)
+	default:
+		elapsed = time.Duration(scaled)
+	}
 	raw := c.captureAnchor.Add(elapsed)
 	if raw.Before(c.to) {
 		return raw, c.baseEpoch, false

--- a/internal/server/clock.go
+++ b/internal/server/clock.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"sync"
@@ -205,8 +206,16 @@ func parseSpeed(raw string) (float64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("invalid --speed %q: use forms like 2x, 0.5x, 3", raw)
 	}
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0, fmt.Errorf("invalid --speed %q: must be a finite number", raw)
+	}
 	if f <= 0 {
 		return 0, fmt.Errorf("invalid --speed %q: must be greater than 0", raw)
+	}
+	// Cap absurd values so speed × elapsed can't overflow time.Duration later.
+	const maxSpeed = 1e6
+	if f > maxSpeed {
+		return 0, fmt.Errorf("invalid --speed %q: must be at most %g", raw, maxSpeed)
 	}
 	return f, nil
 }

--- a/internal/server/clock.go
+++ b/internal/server/clock.go
@@ -29,6 +29,7 @@ type ReplayClock struct {
 	wallAnchor    time.Time // wall-clock instant the current segment started
 	captureAnchor time.Time // capture-time position at wallAnchor (within [from,to])
 	baseEpoch     int       // loop wraps accumulated before the current segment
+	seekGen       int       // increments on each Seek, so watchers can restart
 
 	events atomic.Int64
 
@@ -150,6 +151,16 @@ func (c *ReplayClock) Seek(t time.Time) {
 	}
 	c.captureAnchor = t
 	c.wallAnchor = c.now()
+	c.seekGen++
+}
+
+// SeekGen returns a counter that increments on every Seek. A watch stream polls
+// it to detect a seek (which, unlike a loop wrap, doesn't change the epoch) and
+// restart from the new position.
+func (c *ReplayClock) SeekGen() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.seekGen
 }
 
 // SetSpeed changes the speed factor, preserving the current position.

--- a/internal/server/clock.go
+++ b/internal/server/clock.go
@@ -1,0 +1,201 @@
+package server
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ReplayClock maps wall-clock time onto capture time at a configurable speed,
+// advancing a position within a [from, to] window. It is the heart of replay
+// mode: LIST/GET reconstruct state as-of the clock's current position, and the
+// watch stream emits captured events as the clock crosses their timestamps.
+//
+// A single global clock backs a replay server (phase 1). It supports pause,
+// resume, seek, and speed changes so later phases can expose transport
+// controls; the streaming path polls the clock and adapts automatically.
+type ReplayClock struct {
+	mu sync.Mutex
+
+	from  time.Time
+	to    time.Time
+	speed float64
+	loop  bool
+
+	paused        bool
+	wallAnchor    time.Time // wall-clock instant the current segment started
+	captureAnchor time.Time // capture-time position at wallAnchor (within [from,to])
+	baseEpoch     int       // loop wraps accumulated before the current segment
+
+	events atomic.Int64
+
+	now func() time.Time // injectable wall clock (tests)
+}
+
+// NewReplayClock creates a clock over [from, to] advancing at speed (a factor:
+// 1 = real time, 2 = twice as fast, 0.5 = half). When loop is true the position
+// wraps back to from on reaching to; otherwise it stops at to. When paused the
+// clock does not advance until Resume is called.
+func NewReplayClock(from, to time.Time, speed float64, loop, paused bool) *ReplayClock {
+	if !to.After(from) {
+		to = from // degenerate window; Sample reports ended immediately
+	}
+	if speed <= 0 {
+		speed = 1
+	}
+	c := &ReplayClock{
+		from:          from,
+		to:            to,
+		speed:         speed,
+		loop:          loop,
+		paused:        paused,
+		captureAnchor: from,
+		now:           time.Now,
+	}
+	c.wallAnchor = c.now()
+	return c
+}
+
+// sample computes the current position. Callers must hold c.mu.
+func (c *ReplayClock) sample() (pos time.Time, epoch int, ended bool) {
+	if c.paused {
+		return c.captureAnchor, c.baseEpoch, !c.loop && !c.captureAnchor.Before(c.to)
+	}
+	span := c.to.Sub(c.from)
+	if span <= 0 {
+		return c.to, c.baseEpoch, !c.loop
+	}
+	elapsed := time.Duration(float64(c.now().Sub(c.wallAnchor)) * c.speed)
+	raw := c.captureAnchor.Add(elapsed)
+	if raw.Before(c.to) {
+		return raw, c.baseEpoch, false
+	}
+	if !c.loop {
+		return c.to, c.baseEpoch, true
+	}
+	over := raw.Sub(c.from)
+	wraps := int(over / span)
+	rem := over % span
+	return c.from.Add(rem), c.baseEpoch + wraps, false
+}
+
+// reanchor freezes the current position into the anchors so a subsequent state
+// change (pause, speed) does not jump the clock. Callers must hold c.mu.
+func (c *ReplayClock) reanchor() {
+	p, e, _ := c.sample()
+	c.captureAnchor = p
+	c.baseEpoch = e
+	c.wallAnchor = c.now()
+}
+
+// Now returns the clock's current capture-time position.
+func (c *ReplayClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	p, _, _ := c.sample()
+	return p
+}
+
+// Sample returns the current position, the loop epoch (which increments each
+// time the window wraps under loop), and whether the clock has reached the end
+// (only possible when loop is disabled).
+func (c *ReplayClock) Sample() (pos time.Time, epoch int, ended bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.sample()
+}
+
+// Pause stops the clock at its current position.
+func (c *ReplayClock) Pause() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.paused {
+		return
+	}
+	c.reanchor()
+	c.paused = true
+}
+
+// Resume restarts a paused clock from where it stopped.
+func (c *ReplayClock) Resume() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.paused {
+		return
+	}
+	c.paused = false
+	c.wallAnchor = c.now()
+}
+
+// Paused reports whether the clock is currently paused.
+func (c *ReplayClock) Paused() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.paused
+}
+
+// Seek jumps the position to t, clamped to [from, to]. The loop epoch is
+// unchanged.
+func (c *ReplayClock) Seek(t time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if t.Before(c.from) {
+		t = c.from
+	}
+	if t.After(c.to) {
+		t = c.to
+	}
+	c.captureAnchor = t
+	c.wallAnchor = c.now()
+}
+
+// SetSpeed changes the speed factor, preserving the current position.
+func (c *ReplayClock) SetSpeed(s float64) {
+	if s <= 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.reanchor()
+	c.speed = s
+}
+
+// Speed returns the current speed factor.
+func (c *ReplayClock) Speed() float64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.speed
+}
+
+// Window returns the immutable [from, to] replay window.
+func (c *ReplayClock) Window() (time.Time, time.Time) { return c.from, c.to }
+
+// Loop reports whether the clock wraps at the end of the window.
+func (c *ReplayClock) Loop() bool { return c.loop }
+
+// AddEvents increments the emitted-event counter (surfaced on the status line).
+func (c *ReplayClock) AddEvents(n int64) { c.events.Add(n) }
+
+// EventsEmitted returns how many watch events have been streamed so far.
+func (c *ReplayClock) EventsEmitted() int64 { return c.events.Load() }
+
+// parseSpeed parses a speed factor such as "2x", "0.5x", "3", or "1.5x".
+// An empty string means real time (1x).
+func parseSpeed(raw string) (float64, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return 1, nil
+	}
+	s = strings.TrimSuffix(strings.TrimSuffix(s, "x"), "X")
+	f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --speed %q: use forms like 2x, 0.5x, 3", raw)
+	}
+	if f <= 0 {
+		return 0, fmt.Errorf("invalid --speed %q: must be greater than 0", raw)
+	}
+	return f, nil
+}

--- a/internal/server/clock_test.go
+++ b/internal/server/clock_test.go
@@ -193,4 +193,14 @@ func TestParseReplayWindow(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "--from") {
 		t.Errorf("invalid --from error = %v, want it to mention --from", err)
 	}
+
+	// Missing capture bounds give an actionable error, not a zero-time compare.
+	_, _, err = parseReplayWindow(capture.CaptureMetadata{}, "", "")
+	if err == nil || !strings.Contains(err.Error(), "--from") {
+		t.Errorf("zero-bounds error = %v, want it to ask for --from", err)
+	}
+	_, _, err = parseReplayWindow(capture.CaptureMetadata{}, "2026-04-09T10:00:00Z", "")
+	if err == nil || !strings.Contains(err.Error(), "--to") {
+		t.Errorf("zero end-bound error = %v, want it to ask for --to", err)
+	}
 }

--- a/internal/server/clock_test.go
+++ b/internal/server/clock_test.go
@@ -207,4 +207,11 @@ func TestParseReplayWindow(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "--to") {
 		t.Errorf("zero end-bound error = %v, want it to ask for --to", err)
 	}
+
+	// A relative duration with no capture end bound is an actionable error, not a
+	// silent resolve against year 0001.
+	_, _, err = parseReplayWindow(capture.CaptureMetadata{}, "-5m", "")
+	if err == nil || !strings.Contains(err.Error(), "capture end time is unknown") {
+		t.Errorf("relative --from with no end bound: err = %v, want 'capture end time is unknown'", err)
+	}
 }

--- a/internal/server/clock_test.go
+++ b/internal/server/clock_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -185,5 +186,11 @@ func TestParseReplayWindow(t *testing.T) {
 	// to must be after from.
 	if _, _, err := parseReplayWindow(meta, "-1m", "-5m"); err == nil {
 		t.Error("expected error when --to precedes --from")
+	}
+
+	// Errors name the offending flag, not "--at".
+	_, _, err = parseReplayWindow(meta, "garbage", "")
+	if err == nil || !strings.Contains(err.Error(), "--from") {
+		t.Errorf("invalid --from error = %v, want it to mention --from", err)
 	}
 }

--- a/internal/server/clock_test.go
+++ b/internal/server/clock_test.go
@@ -1,0 +1,189 @@
+package server
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// newTestClock builds a clock whose wall-clock source is driven manually via the
+// returned setter, so tests can advance time deterministically.
+func newTestClock(t *testing.T, from, to time.Time, speed float64, loop, paused bool) (*ReplayClock, func(d time.Duration)) {
+	t.Helper()
+	base := time.Unix(1_700_000_000, 0).UTC()
+	var wall atomic.Int64
+	wall.Store(base.UnixNano())
+	c := NewReplayClock(from, to, speed, loop, paused)
+	c.now = func() time.Time { return time.Unix(0, wall.Load()).UTC() }
+	c.wallAnchor = c.now()
+	advance := func(d time.Duration) { wall.Add(int64(d)) }
+	return c, advance
+}
+
+func TestReplayClock_AdvancesAtSpeed(t *testing.T) {
+	from := time.Unix(2_000_000, 0).UTC()
+	to := from.Add(10 * time.Second)
+	c, advance := newTestClock(t, from, to, 2, false, false)
+
+	if got := c.Now(); !got.Equal(from) {
+		t.Fatalf("start position = %s, want %s", got, from)
+	}
+	advance(1 * time.Second) // 1s wall × 2 = 2s capture
+	if got, want := c.Now(), from.Add(2*time.Second); !got.Equal(want) {
+		t.Errorf("after 1s at 2x: pos = %s, want %s", got, want)
+	}
+}
+
+func TestReplayClock_StopsAtEndWithoutLoop(t *testing.T) {
+	from := time.Unix(2_000_000, 0).UTC()
+	to := from.Add(10 * time.Second)
+	c, advance := newTestClock(t, from, to, 1, false, false)
+
+	advance(25 * time.Second)
+	pos, epoch, ended := c.Sample()
+	if !pos.Equal(to) {
+		t.Errorf("pos = %s, want end %s", pos, to)
+	}
+	if !ended {
+		t.Error("expected ended=true past the window")
+	}
+	if epoch != 0 {
+		t.Errorf("epoch = %d, want 0 (no loop)", epoch)
+	}
+}
+
+func TestReplayClock_LoopWraps(t *testing.T) {
+	from := time.Unix(2_000_000, 0).UTC()
+	to := from.Add(10 * time.Second)
+	c, advance := newTestClock(t, from, to, 1, true, false)
+
+	advance(25 * time.Second) // 2 full wraps + 5s
+	pos, epoch, ended := c.Sample()
+	if want := from.Add(5 * time.Second); !pos.Equal(want) {
+		t.Errorf("looped pos = %s, want %s", pos, want)
+	}
+	if epoch != 2 {
+		t.Errorf("epoch = %d, want 2", epoch)
+	}
+	if ended {
+		t.Error("looping clock should never report ended")
+	}
+}
+
+func TestReplayClock_PauseResume(t *testing.T) {
+	from := time.Unix(2_000_000, 0).UTC()
+	to := from.Add(60 * time.Second)
+	c, advance := newTestClock(t, from, to, 1, false, false)
+
+	advance(3 * time.Second)
+	c.Pause()
+	if !c.Paused() {
+		t.Fatal("expected paused")
+	}
+	advance(5 * time.Second) // ignored while paused
+	if got, want := c.Now(), from.Add(3*time.Second); !got.Equal(want) {
+		t.Errorf("paused pos = %s, want %s", got, want)
+	}
+	c.Resume()
+	advance(2 * time.Second)
+	if got, want := c.Now(), from.Add(5*time.Second); !got.Equal(want) {
+		t.Errorf("resumed pos = %s, want %s", got, want)
+	}
+}
+
+func TestReplayClock_Seek(t *testing.T) {
+	from := time.Unix(2_000_000, 0).UTC()
+	to := from.Add(60 * time.Second)
+	c, advance := newTestClock(t, from, to, 1, false, false)
+
+	c.Seek(from.Add(30 * time.Second))
+	advance(1 * time.Second)
+	if got, want := c.Now(), from.Add(31*time.Second); !got.Equal(want) {
+		t.Errorf("after seek: pos = %s, want %s", got, want)
+	}
+	// Clamp beyond the window.
+	c.Seek(to.Add(time.Hour))
+	if got := c.Now(); !got.Equal(to) {
+		t.Errorf("seek past end: pos = %s, want %s", got, to)
+	}
+}
+
+func TestReplayClock_SetSpeedPreservesPosition(t *testing.T) {
+	from := time.Unix(2_000_000, 0).UTC()
+	to := from.Add(60 * time.Second)
+	c, advance := newTestClock(t, from, to, 1, false, false)
+
+	advance(3 * time.Second)
+	c.SetSpeed(4)
+	if got, want := c.Now(), from.Add(3*time.Second); !got.Equal(want) {
+		t.Errorf("position jumped on speed change: %s, want %s", got, want)
+	}
+	advance(1 * time.Second) // now 4x
+	if got, want := c.Now(), from.Add(7*time.Second); !got.Equal(want) {
+		t.Errorf("after speed change: pos = %s, want %s", got, want)
+	}
+}
+
+func TestParseSpeed(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    float64
+		wantErr bool
+	}{
+		{"", 1, false},
+		{"2x", 2, false},
+		{"0.5x", 0.5, false},
+		{"3", 3, false},
+		{"1.5X", 1.5, false},
+		{"0x", 0, true},
+		{"-2x", 0, true},
+		{"fast", 0, true},
+	}
+	for _, tc := range cases {
+		got, err := parseSpeed(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseSpeed(%q): expected error", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseSpeed(%q): unexpected error %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("parseSpeed(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseReplayWindow(t *testing.T) {
+	start := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	end := start.Add(10 * time.Minute)
+	meta := capture.CaptureMetadata{CapturedAt: start, CapturedUntil: end}
+
+	// Defaults to the capture bounds.
+	from, to, err := parseReplayWindow(meta, "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !from.Equal(start) || !to.Equal(end) {
+		t.Errorf("defaults = [%s, %s], want [%s, %s]", from, to, start, end)
+	}
+
+	// Relative durations resolve against the capture end.
+	from, to, err = parseReplayWindow(meta, "-10m", "-1m")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !from.Equal(start) || !to.Equal(end.Add(-time.Minute)) {
+		t.Errorf("relative window = [%s, %s]", from, to)
+	}
+
+	// to must be after from.
+	if _, _, err := parseReplayWindow(meta, "-1m", "-5m"); err == nil {
+		t.Error("expected error when --to precedes --from")
+	}
+}

--- a/internal/server/clock_test.go
+++ b/internal/server/clock_test.go
@@ -141,6 +141,10 @@ func TestParseSpeed(t *testing.T) {
 		{"0x", 0, true},
 		{"-2x", 0, true},
 		{"fast", 0, true},
+		{"inf", 0, true},
+		{"Inf", 0, true},
+		{"NaN", 0, true},
+		{"1e9", 0, true}, // above the sanity cap
 	}
 	for _, tc := range cases {
 		got, err := parseSpeed(tc.in)

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -725,12 +725,12 @@ func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path strin
 		}
 	}
 
-	// Use resourceVersion from the list metadata; fall back to capture timestamp.
+	// Use resourceVersion from the list metadata; fall back to a capture time.
 	// Treat "0" as unspecified too — aggregated/synthesized empty lists carry
 	// RV "0", but watch clients expect a non-zero BOOKMARK resourceVersion.
 	rv := list.ResourceVersion
 	if rv == "" || rv == "0" {
-		rv = fmt.Sprintf("%d", h.store.Metadata.CapturedAt.Unix())
+		rv = bookmarkResourceVersion(h.store.Metadata.CapturedAt, h.store.Metadata.CapturedUntil, at)
 	}
 
 	// BOOKMARK signals end of initial list; kubectl -w then waits for new events.
@@ -871,4 +871,17 @@ func statusObj(code int, msg string) map[string]any {
 		"message":    msg,
 		"code":       code,
 	}
+}
+
+// bookmarkResourceVersion returns a non-zero, non-negative resourceVersion for a
+// BOOKMARK. It uses the first candidate time with a positive Unix value, falling
+// back to wall-clock so watch clients get a sensible RV even for older/corrupt
+// archives whose metadata bounds are missing (zero → negative Unix).
+func bookmarkResourceVersion(candidates ...time.Time) string {
+	for _, t := range candidates {
+		if u := t.Unix(); u > 0 {
+			return strconv.FormatInt(u, 10)
+		}
+	}
+	return strconv.FormatInt(time.Now().Unix(), 10)
 }

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -726,7 +726,9 @@ func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path strin
 	// RV "0", but watch clients expect a non-zero BOOKMARK resourceVersion.
 	rv := list.ResourceVersion
 	if rv == "" || rv == "0" {
-		rv = bookmarkResourceVersion(h.store.Metadata.CapturedAt, h.store.Metadata.CapturedUntil, at)
+		// Lead with the list-as-of time so the BOOKMARK RV aligns with --at / UI
+		// time travel; fall back to the capture bounds when `at` is unset.
+		rv = bookmarkResourceVersion(at, h.store.Metadata.CapturedAt, h.store.Metadata.CapturedUntil)
 	}
 
 	// BOOKMARK signals end of initial list; kubectl -w then waits for new events.
@@ -882,7 +884,16 @@ func watchTimeout(secs string) (<-chan time.Time, func()) {
 		return nil, func() {}
 	}
 	t := time.NewTimer(time.Duration(n) * time.Second)
-	return t.C, func() { t.Stop() }
+	return t.C, func() {
+		// Drain if the timer already fired, so no value stays buffered on the
+		// channel keeping the timer reachable.
+		if !t.Stop() {
+			select {
+			case <-t.C:
+			default:
+			}
+		}
+	}
 }
 
 // bookmarkResourceVersion returns a non-zero, non-negative resourceVersion for a

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -45,8 +45,10 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Replay transport controls live under a reserved prefix that can't collide
 	// with the Kubernetes API (which is served under /api, /apis, …). They accept
-	// POST, so intercept before the read-only method check below.
-	if h.clock != nil && strings.HasPrefix(path, replayControlPrefix) {
+	// POST, so intercept before the read-only method check below. Match the exact
+	// prefix or a subpath boundary so paths like "/_k8shark/replayfoo" don't route
+	// here.
+	if h.clock != nil && (path == replayControlPrefix || strings.HasPrefix(path, replayControlPrefix+"/")) {
 		h.handleReplayControl(w, r, path)
 		return
 	}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -704,12 +704,8 @@ func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path strin
 	}
 
 	// Honor ?timeoutSeconds: nil channel blocks forever (no timeout).
-	var timer <-chan time.Time
-	if secs := r.URL.Query().Get("timeoutSeconds"); secs != "" {
-		if n, err := strconv.Atoi(secs); err == nil && n > 0 {
-			timer = time.After(time.Duration(n) * time.Second)
-		}
-	}
+	timer, stopTimer := watchTimeout(r.URL.Query().Get("timeoutSeconds"))
+	defer stopTimer()
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Transfer-Encoding", "chunked")
@@ -871,6 +867,22 @@ func statusObj(code int, msg string) map[string]any {
 		"message":    msg,
 		"code":       code,
 	}
+}
+
+// watchTimeout parses ?timeoutSeconds into a channel that fires after the given
+// duration, plus a stop function to release the underlying timer when the watch
+// ends early (a plain time.After can't be stopped and would linger). An empty or
+// non-positive value yields a nil channel (no timeout) and a no-op stop.
+func watchTimeout(secs string) (<-chan time.Time, func()) {
+	if secs == "" {
+		return nil, func() {}
+	}
+	n, err := strconv.Atoi(secs)
+	if err != nil || n <= 0 {
+		return nil, func() {}
+	}
+	t := time.NewTimer(time.Duration(n) * time.Second)
+	return t.C, func() { t.Stop() }
 }
 
 // bookmarkResourceVersion returns a non-zero, non-negative resourceVersion for a

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -726,8 +726,10 @@ func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path strin
 	}
 
 	// Use resourceVersion from the list metadata; fall back to capture timestamp.
+	// Treat "0" as unspecified too — aggregated/synthesized empty lists carry
+	// RV "0", but watch clients expect a non-zero BOOKMARK resourceVersion.
 	rv := list.ResourceVersion
-	if rv == "" {
+	if rv == "" || rv == "0" {
 		rv = fmt.Sprintf("%d", h.store.Metadata.CapturedAt.Unix())
 	}
 

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -43,6 +43,14 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("  --> %s %s\n", r.Method, path)
 	}
 
+	// Replay transport controls live under a reserved prefix that can't collide
+	// with the Kubernetes API (which is served under /api, /apis, …). They accept
+	// POST, so intercept before the read-only method check below.
+	if h.clock != nil && strings.HasPrefix(path, replayControlPrefix) {
+		h.handleReplayControl(w, r, path)
+		return
+	}
+
 	// Intercept interactive sub-resources that can never work against a capture
 	// replay. Doing this before the method check ensures we return a specific,
 	// actionable error instead of the generic "write operations are not

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -14,6 +14,10 @@ type handler struct {
 	store   *CaptureStore
 	at      time.Time
 	verbose bool
+	// clock, when non-nil, puts the handler in replay mode: LIST/GET reconstruct
+	// state as-of the clock's advancing position and watches stream captured
+	// events over time (see streamReplayWatch). nil for plain `open`/`ui`.
+	clock *ReplayClock
 }
 
 func newHandler(store *CaptureStore, at time.Time, verbose bool) *handler {
@@ -21,8 +25,13 @@ func newHandler(store *CaptureStore, at time.Time, verbose bool) *handler {
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Per-request timestamp override via header.
+	// In replay mode the effective time is the clock's current position;
+	// otherwise it's the server's fixed --at.
 	replayAt := h.at
+	if h.clock != nil {
+		replayAt = h.clock.Now()
+	}
+	// Per-request timestamp override via header (UI time travel).
 	if v := r.Header.Get("X-K8shark-At"); v != "" {
 		if t, err := time.Parse(time.RFC3339, v); err == nil {
 			replayAt = t
@@ -110,9 +119,14 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Watch requests get a synthetic event stream.
+	// Watch requests get a synthetic event stream. In replay mode the stream is
+	// paced by the clock; otherwise it's the snapshot-burst-then-idle behavior.
 	if r.URL.Query().Get("watch") == "1" || r.URL.Query().Get("watch") == "true" {
-		h.handleWatch(w, r, path, replayAt)
+		if h.clock != nil {
+			h.streamReplayWatch(w, r, path)
+		} else {
+			h.handleWatch(w, r, path, replayAt)
+		}
 		return
 	}
 
@@ -671,82 +685,13 @@ func (h *handler) trySingleItemGet(path string, at time.Time) ([]byte, int) {
 
 func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path string, at time.Time) {
 	watchPath := strings.TrimSuffix(path, "/")
-	rawBody, code, err := h.store.ReconstructAt(watchPath, at)
+	list, ok, err := h.resolveWatchList(watchPath, at, r.URL.Query().Get("labelSelector"), r.URL.Query().Get("fieldSelector"))
 	if err != nil {
 		h.writeStatus(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-
-	if code == 404 {
-		// Only aggregate across namespaces for cluster-wide watch paths.
-		if _, _, _, reqNS := parseAPIPath(watchPath); reqNS == "" {
-			rawBody, code, err = h.store.AggregateAcrossNamespaces(watchPath, at)
-			if err != nil {
-				h.writeStatus(w, http.StatusInternalServerError, err.Error())
-				return
-			}
-		}
-	}
-
-	if code == 404 {
-		// Cluster-scoped fallback: resource was captured at the cluster path
-		// (e.g. /api/v1/pods) but the watch targets a specific namespace.
-		// Filter by metadata.namespace so k9s pod/container watchers that use
-		// a namespaced watch path see the right items.
-		g, v, resource, ns := parseAPIPath(watchPath)
-		if ns != "" && resource != "" {
-			var clusterPath string
-			if g == "" {
-				clusterPath = "/api/" + v + "/" + resource
-			} else {
-				clusterPath = "/apis/" + g + "/" + v + "/" + resource
-			}
-			clusterBody, clusterCode, cerr := h.store.ReconstructAt(clusterPath, at)
-			if cerr == nil && clusterCode == 200 {
-				filtered, ferr := applySelectors(clusterBody, "", "metadata.namespace="+ns)
-				if ferr == nil {
-					rawBody, code = filtered, 200
-				}
-			}
-		}
-	}
-
-	if code == 404 {
-		g, v, resource, _ := parseAPIPath(watchPath)
-		if resource != "" {
-			av := v
-			if g != "" {
-				av = g + "/" + v
-			}
-			emptyList, _ := json.Marshal(map[string]any{
-				"apiVersion": av,
-				"kind":       resourceToKind(resource) + "List",
-				"metadata":   map[string]string{"resourceVersion": "0"},
-				"items":      []any{},
-			})
-			rawBody = emptyList
-			code = 200
-		}
-	}
-
-	if code != 200 {
+	if !ok {
 		h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q not found in capture", path))
-		return
-	}
-
-	// Apply selectors before streaming watch events.
-	body, _ := applySelectors(rawBody, r.URL.Query().Get("labelSelector"), r.URL.Query().Get("fieldSelector"))
-
-	var list struct {
-		APIVersion string `json:"apiVersion"`
-		Kind       string `json:"kind"`
-		Metadata   struct {
-			ResourceVersion string `json:"resourceVersion"`
-		} `json:"metadata"`
-		Items []json.RawMessage `json:"items"`
-	}
-	if err := json.Unmarshal(body, &list); err != nil {
-		h.writeStatus(w, http.StatusInternalServerError, "parsing list")
 		return
 	}
 
@@ -773,7 +718,7 @@ func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path strin
 	}
 
 	// Use resourceVersion from the list metadata; fall back to capture timestamp.
-	rv := list.Metadata.ResourceVersion
+	rv := list.ResourceVersion
 	if rv == "" {
 		rv = fmt.Sprintf("%d", h.store.Metadata.CapturedAt.Unix())
 	}

--- a/internal/server/replay_control.go
+++ b/internal/server/replay_control.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// replayControlPrefix is the reserved path under which the replay transport
+// controls are served. It cannot collide with the Kubernetes API, which lives
+// under /api and /apis.
+const replayControlPrefix = "/_k8shark/replay"
+
+// handleReplayControl implements the replay transport-control API. All responses
+// are the current replay status so a client (CLI, UI scrubber, script) always
+// sees the resulting state.
+//
+//	GET  /_k8shark/replay              → current status
+//	POST /_k8shark/replay/pause        → pause the clock
+//	POST /_k8shark/replay/play         → resume the clock
+//	POST /_k8shark/replay/speed?value= → set speed (e.g. 2x, 0.5x)
+//	POST /_k8shark/replay/seek?to=     → seek to an RFC3339 time or duration
+//	                          ?offset= →   relative to the window end / start
+func (h *handler) handleReplayControl(w http.ResponseWriter, r *http.Request, path string) {
+	clock := h.clock
+	action := strings.Trim(strings.TrimPrefix(path, replayControlPrefix), "/")
+
+	switch action {
+	case "":
+		if !requireMethod(w, r, http.MethodGet) {
+			return
+		}
+	case "pause":
+		if !requireMethod(w, r, http.MethodPost) {
+			return
+		}
+		clock.Pause()
+	case "play", "resume":
+		if !requireMethod(w, r, http.MethodPost) {
+			return
+		}
+		clock.Resume()
+	case "speed":
+		if !requireMethod(w, r, http.MethodPost) {
+			return
+		}
+		s, err := parseSpeed(r.URL.Query().Get("value"))
+		if err != nil {
+			h.writeStatus(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		clock.SetSpeed(s)
+	case "seek":
+		if !requireMethod(w, r, http.MethodPost) {
+			return
+		}
+		target, err := parseSeekTarget(clock, r.URL.Query())
+		if err != nil {
+			h.writeStatus(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		clock.Seek(target)
+	default:
+		h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("unknown replay control %q", action))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, replayStatus(clock))
+}
+
+// requireMethod writes a 405 (with an Allow header) and returns false if the
+// request method doesn't match.
+func requireMethod(w http.ResponseWriter, r *http.Request, method string) bool {
+	if r.Method == method {
+		return true
+	}
+	w.Header().Set("Allow", method)
+	w.WriteHeader(http.StatusMethodNotAllowed)
+	_, _ = w.Write([]byte(fmt.Sprintf("%s required", method)))
+	return false
+}
+
+// parseSeekTarget resolves a seek target from the query. `to` is an RFC3339
+// timestamp or a duration relative to the window end (e.g. -2m); `offset` is a
+// duration from the window start (e.g. 90s). The clock clamps to the window.
+func parseSeekTarget(clock *ReplayClock, q url.Values) (time.Time, error) {
+	from, to := clock.Window()
+	if v := q.Get("to"); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			return t, nil
+		}
+		if d, err := time.ParseDuration(v); err == nil {
+			return to.Add(d), nil
+		}
+		return time.Time{}, fmt.Errorf("invalid seek to %q: use RFC3339 or a duration like -2m", v)
+	}
+	if v := q.Get("offset"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid seek offset %q: use a duration like 90s", v)
+		}
+		return from.Add(d), nil
+	}
+	return time.Time{}, fmt.Errorf("seek requires ?to= (RFC3339 or duration) or ?offset= (duration)")
+}
+
+// replayStatus builds the status map returned by every control-API response.
+func replayStatus(clock *ReplayClock) map[string]any {
+	from, to := clock.Window()
+	pos, epoch, ended := clock.Sample()
+	return map[string]any{
+		"position":        pos.Format(time.RFC3339),
+		"from":            from.Format(time.RFC3339),
+		"to":              to.Format(time.RFC3339),
+		"elapsed_seconds": int64(pos.Sub(from).Round(time.Second) / time.Second),
+		"total_seconds":   int64(to.Sub(from).Round(time.Second) / time.Second),
+		"speed":           clock.Speed(),
+		"paused":          clock.Paused(),
+		"loop":            clock.Loop(),
+		"ended":           ended,
+		"epoch":           epoch,
+		"events_emitted":  clock.EventsEmitted(),
+	}
+}

--- a/internal/server/replay_control.go
+++ b/internal/server/replay_control.go
@@ -13,9 +13,10 @@ import (
 // under /api and /apis.
 const replayControlPrefix = "/_k8shark/replay"
 
-// handleReplayControl implements the replay transport-control API. All responses
-// are the current replay status so a client (CLI, UI scrubber, script) always
-// sees the resulting state.
+// handleReplayControl implements the replay transport-control API. A successful
+// request returns the current replay status (JSON) so a client (CLI, UI
+// scrubber, script) sees the resulting state; invalid requests return an error
+// status (405/400/404) with a plain-text message.
 //
 //	GET  /_k8shark/replay              → current status
 //	POST /_k8shark/replay/pause        → pause the clock

--- a/internal/server/replay_control.go
+++ b/internal/server/replay_control.go
@@ -14,9 +14,9 @@ import (
 const replayControlPrefix = "/_k8shark/replay"
 
 // handleReplayControl implements the replay transport-control API. A successful
-// request returns the current replay status (JSON) so a client (CLI, UI
-// scrubber, script) sees the resulting state; invalid requests return an error
-// status (405/400/404) with a plain-text message.
+// request returns the current replay status as JSON so a client (CLI, UI
+// scrubber, script) sees the resulting state; an invalid request returns a
+// Kubernetes-style Status JSON body with the appropriate code (405/400/404).
 //
 //	GET  /_k8shark/replay              → current status
 //	POST /_k8shark/replay/pause        → pause the clock
@@ -30,21 +30,21 @@ func (h *handler) handleReplayControl(w http.ResponseWriter, r *http.Request, pa
 
 	switch action {
 	case "":
-		if !requireMethod(w, r, http.MethodGet) {
+		if !h.requireMethod(w, r, http.MethodGet) {
 			return
 		}
 	case "pause":
-		if !requireMethod(w, r, http.MethodPost) {
+		if !h.requireMethod(w, r, http.MethodPost) {
 			return
 		}
 		clock.Pause()
 	case "play", "resume":
-		if !requireMethod(w, r, http.MethodPost) {
+		if !h.requireMethod(w, r, http.MethodPost) {
 			return
 		}
 		clock.Resume()
 	case "speed":
-		if !requireMethod(w, r, http.MethodPost) {
+		if !h.requireMethod(w, r, http.MethodPost) {
 			return
 		}
 		s, err := parseSpeed(r.URL.Query().Get("value"))
@@ -54,7 +54,7 @@ func (h *handler) handleReplayControl(w http.ResponseWriter, r *http.Request, pa
 		}
 		clock.SetSpeed(s)
 	case "seek":
-		if !requireMethod(w, r, http.MethodPost) {
+		if !h.requireMethod(w, r, http.MethodPost) {
 			return
 		}
 		target, err := parseSeekTarget(clock, r.URL.Query())
@@ -71,15 +71,15 @@ func (h *handler) handleReplayControl(w http.ResponseWriter, r *http.Request, pa
 	writeJSON(w, http.StatusOK, replayStatus(clock))
 }
 
-// requireMethod writes a 405 (with an Allow header) and returns false if the
-// request method doesn't match.
-func requireMethod(w http.ResponseWriter, r *http.Request, method string) bool {
+// requireMethod writes a 405 Status JSON (with an Allow header) and returns
+// false if the request method doesn't match, keeping control-API error
+// responses consistently JSON.
+func (h *handler) requireMethod(w http.ResponseWriter, r *http.Request, method string) bool {
 	if r.Method == method {
 		return true
 	}
 	w.Header().Set("Allow", method)
-	w.WriteHeader(http.StatusMethodNotAllowed)
-	_, _ = w.Write([]byte(fmt.Sprintf("%s required", method)))
+	h.writeStatus(w, http.StatusMethodNotAllowed, fmt.Sprintf("%s required for this replay control", method))
 	return false
 }
 

--- a/internal/server/replay_control_test.go
+++ b/internal/server/replay_control_test.go
@@ -1,0 +1,144 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func newControlTestServer(t *testing.T, loop bool) (*httptest.Server, *ReplayClock, func(time.Duration)) {
+	t.Helper()
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	to := from.Add(60 * time.Second)
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{
+			"/api/v1/namespaces/default/pods": {id: "s", at: from, body: emptyPodList},
+		}, nil)
+	clock, advance := newTestClock(t, from, to, 1, loop, false)
+	h := newHandler(store, time.Time{}, false)
+	h.clock = clock
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return srv, clock, advance
+}
+
+// doControl issues a control request and decodes the status response.
+func doControl(t *testing.T, srv *httptest.Server, method, path string) map[string]any {
+	t.Helper()
+	req, err := http.NewRequest(method, srv.URL+path, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("%s %s: status %d: %s", method, path, resp.StatusCode, body)
+	}
+	var status map[string]any
+	if err := json.Unmarshal(body, &status); err != nil {
+		t.Fatalf("decode status: %v\n%s", err, body)
+	}
+	return status
+}
+
+func TestReplayControl_StatusPauseResume(t *testing.T) {
+	srv, _, _ := newControlTestServer(t, false)
+
+	st := doControl(t, srv, http.MethodGet, "/_k8shark/replay")
+	if st["paused"] != false {
+		t.Errorf("initial paused = %v, want false", st["paused"])
+	}
+	if st["total_seconds"].(float64) != 60 {
+		t.Errorf("total_seconds = %v, want 60", st["total_seconds"])
+	}
+
+	st = doControl(t, srv, http.MethodPost, "/_k8shark/replay/pause")
+	if st["paused"] != true {
+		t.Errorf("after pause: paused = %v, want true", st["paused"])
+	}
+
+	st = doControl(t, srv, http.MethodPost, "/_k8shark/replay/play")
+	if st["paused"] != false {
+		t.Errorf("after play: paused = %v, want false", st["paused"])
+	}
+}
+
+func TestReplayControl_Speed(t *testing.T) {
+	srv, clock, _ := newControlTestServer(t, false)
+	st := doControl(t, srv, http.MethodPost, "/_k8shark/replay/speed?value=2.5x")
+	if st["speed"].(float64) != 2.5 {
+		t.Errorf("speed = %v, want 2.5", st["speed"])
+	}
+	if clock.Speed() != 2.5 {
+		t.Errorf("clock speed = %v, want 2.5", clock.Speed())
+	}
+}
+
+func TestReplayControl_Seek(t *testing.T) {
+	srv, clock, _ := newControlTestServer(t, false)
+	from, _ := clock.Window()
+
+	// Seek by offset from the window start.
+	st := doControl(t, srv, http.MethodPost, "/_k8shark/replay/seek?offset=30s")
+	if got, want := st["position"].(string), from.Add(30*time.Second).Format(time.RFC3339); got != want {
+		t.Errorf("after offset seek: position = %s, want %s", got, want)
+	}
+
+	// Seek to an absolute RFC3339 time.
+	target := from.Add(10 * time.Second).Format(time.RFC3339)
+	st = doControl(t, srv, http.MethodPost, "/_k8shark/replay/seek?to="+target)
+	if got := st["position"].(string); got != target {
+		t.Errorf("after absolute seek: position = %s, want %s", got, target)
+	}
+}
+
+func TestReplayControl_Errors(t *testing.T) {
+	srv, _, _ := newControlTestServer(t, false)
+
+	// Wrong method.
+	resp, err := http.Get(srv.URL + "/_k8shark/replay/pause")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("GET pause: status = %d, want 405", resp.StatusCode)
+	}
+
+	// Bad speed.
+	resp, err = http.Post(srv.URL+"/_k8shark/replay/speed?value=nope", "", nil)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("bad speed: status = %d, want 400", resp.StatusCode)
+	}
+
+	// Seek with no target.
+	resp, err = http.Post(srv.URL+"/_k8shark/replay/seek", "", nil)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("empty seek: status = %d, want 400", resp.StatusCode)
+	}
+
+	// Unknown action.
+	resp, err = http.Post(srv.URL+"/_k8shark/replay/frobnicate", "", nil)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("unknown action: status = %d, want 404", resp.StatusCode)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -25,6 +25,19 @@ type OpenOptions struct {
 	Verbose       bool
 }
 
+// ReplayOptions holds parameters for replaying a capture forward through time.
+type ReplayOptions struct {
+	ArchivePath   string
+	Port          string
+	KubeconfigOut string
+	Speed         string // speed factor, e.g. "2x", "0.5x" (empty = real time)
+	From          string // window start: RFC3339 or relative like -10m (empty = capture start)
+	To            string // window end: RFC3339 or relative like -1m (empty = capture end)
+	Loop          bool
+	StartPaused   bool
+	Verbose       bool
+}
+
 // Server represents a running mock API server.
 type Server struct {
 	address        string
@@ -32,32 +45,60 @@ type Server struct {
 	ar             *archive.Archive
 	httpServer     *http.Server
 	done           chan struct{}
+	clock          *ReplayClock // non-nil in replay mode
+	hasWatch       bool         // capture contains watch events
 }
 
 // Open opens a capture archive, starts the mock HTTPS server, and writes
 // a kubeconfig pointing at it.
 func Open(opts OpenOptions) (*Server, error) {
-	// Open the archive for direct in-memory access (no extraction).
 	ar, err := archive.Open(opts.ArchivePath)
 	if err != nil {
 		return nil, fmt.Errorf("opening archive: %w", err)
 	}
-
-	// Load the capture index into memory.
 	store, err := LoadStore(ar)
 	if err != nil {
 		_ = ar.Close()
 		return nil, fmt.Errorf("loading capture: %w", err)
 	}
-
-	// Parse optional replay timestamp.
 	at, err := parseReplayAt(store.Metadata, opts.At)
 	if err != nil {
 		_ = ar.Close()
 		return nil, err
 	}
+	return serve(ar, store, at, nil, opts.Port, opts.KubeconfigOut, opts.Verbose)
+}
 
-	// Generate a self-signed TLS certificate.
+// Replay opens a capture and starts the mock HTTPS server in replay mode: a
+// clock advances through the [from, to] window at the given speed, streaming
+// captured watch events over time. LIST/GET return state as-of the clock.
+func Replay(opts ReplayOptions) (*Server, error) {
+	ar, err := archive.Open(opts.ArchivePath)
+	if err != nil {
+		return nil, fmt.Errorf("opening archive: %w", err)
+	}
+	store, err := LoadStore(ar)
+	if err != nil {
+		_ = ar.Close()
+		return nil, fmt.Errorf("loading capture: %w", err)
+	}
+	speed, err := parseSpeed(opts.Speed)
+	if err != nil {
+		_ = ar.Close()
+		return nil, err
+	}
+	from, to, err := parseReplayWindow(store.Metadata, opts.From, opts.To)
+	if err != nil {
+		_ = ar.Close()
+		return nil, err
+	}
+	clock := NewReplayClock(from, to, speed, opts.Loop, opts.StartPaused)
+	return serve(ar, store, time.Time{}, clock, opts.Port, opts.KubeconfigOut, opts.Verbose)
+}
+
+// serve brings up the shared TLS listener, kubeconfig, and HTTP server. When
+// clock is non-nil the handler runs in replay mode.
+func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *ReplayClock, port, kubeconfigOut string, verbose bool) (*Server, error) {
 	certPEM, keyPEM, err := generateSelfSignedCert()
 	if err != nil {
 		_ = ar.Close()
@@ -69,8 +110,6 @@ func Open(opts OpenOptions) (*Server, error) {
 		return nil, fmt.Errorf("loading TLS cert: %w", err)
 	}
 
-	// Listen on requested port (0 = any available port).
-	port := opts.Port
 	if port == "" || port == "0" {
 		port = "0"
 	}
@@ -82,8 +121,7 @@ func Open(opts OpenOptions) (*Server, error) {
 
 	addr := fmt.Sprintf("https://127.0.0.1:%d", ln.Addr().(*net.TCPAddr).Port)
 
-	// Write kubeconfig.
-	kubeconfigPath := opts.KubeconfigOut
+	kubeconfigPath := kubeconfigOut
 	if kubeconfigPath == "" {
 		home, _ := os.UserHomeDir()
 		kubeconfigPath = filepath.Join(home, ".kube", "k8shark-"+store.Metadata.CaptureID+".yaml")
@@ -94,13 +132,14 @@ func Open(opts OpenOptions) (*Server, error) {
 		return nil, fmt.Errorf("writing kubeconfig: %w", err)
 	}
 
-	// Wrap the listener with TLS.
 	tlsListener := tls.NewListener(ln, &tls.Config{
 		Certificates: []tls.Certificate{tlsCert},
 		MinVersion:   tls.VersionTLS12,
 	})
 
-	httpSrv := &http.Server{Handler: newHandler(store, at, opts.Verbose)}
+	h := newHandler(store, at, verbose)
+	h.clock = clock
+	httpSrv := &http.Server{Handler: h}
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -113,6 +152,8 @@ func Open(opts OpenOptions) (*Server, error) {
 		ar:             ar,
 		httpServer:     httpSrv,
 		done:           done,
+		clock:          clock,
+		hasWatch:       len(store.WatchIndex) > 0,
 	}, nil
 }
 
@@ -121,6 +162,15 @@ func (s *Server) Address() string { return s.address }
 
 // KubeconfigPath returns the path to the generated kubeconfig.
 func (s *Server) KubeconfigPath() string { return s.kubeconfigPath }
+
+// Clock returns the replay clock, or nil when the server is not in replay mode.
+func (s *Server) Clock() *ReplayClock { return s.clock }
+
+// HasWatchEvents reports whether the capture contains watch events to stream.
+// Poll-only captures return false; replay still serves LIST/GET as-of the clock
+// but emits no watch events (inferring events for poll-only captures is a later
+// phase).
+func (s *Server) HasWatchEvents() bool { return s.hasWatch }
 
 // Shutdown immediately stops the server and closes the archive.
 // Useful in tests and programmatic usage; Wait() is preferred for CLI use.
@@ -174,4 +224,29 @@ func parseReplayAt(meta capture.CaptureMetadata, raw string) (time.Time, error) 
 	}
 
 	return at, nil
+}
+
+// parseReplayWindow resolves the [from, to] replay window. Empty from/to default
+// to the capture bounds; non-empty values are RFC3339 timestamps or durations
+// relative to the capture end (e.g. -10m), validated to lie within the capture.
+func parseReplayWindow(meta capture.CaptureMetadata, fromRaw, toRaw string) (from, to time.Time, err error) {
+	from = meta.CapturedAt
+	to = meta.CapturedUntil
+
+	if fromRaw != "" {
+		from, err = parseReplayAt(meta, fromRaw)
+		if err != nil {
+			return time.Time{}, time.Time{}, err
+		}
+	}
+	if toRaw != "" {
+		to, err = parseReplayAt(meta, toRaw)
+		if err != nil {
+			return time.Time{}, time.Time{}, err
+		}
+	}
+	if !to.After(from) {
+		return time.Time{}, time.Time{}, fmt.Errorf("--to %s must be after --from %s", to.Format(time.RFC3339), from.Format(time.RFC3339))
+	}
+	return from, to, nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -220,6 +220,11 @@ func parseReplayTime(meta capture.CaptureMetadata, raw, flag string) (time.Time,
 		if derr != nil {
 			return time.Time{}, fmt.Errorf("parsing %s %q: must be RFC3339 or a relative duration like -5m", flag, raw)
 		}
+		// Relative durations are anchored to the capture end; without one we'd
+		// silently resolve against year 0001, so require an absolute time instead.
+		if meta.CapturedUntil.IsZero() {
+			return time.Time{}, fmt.Errorf("parsing %s %q: capture end time is unknown; use an absolute RFC3339 time", flag, raw)
+		}
 		at = meta.CapturedUntil.Add(d)
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -252,6 +252,14 @@ func parseReplayWindow(meta capture.CaptureMetadata, fromRaw, toRaw string) (fro
 			return time.Time{}, time.Time{}, err
 		}
 	}
+	// If the capture metadata lacks bounds (absent/corrupt) and the caller didn't
+	// supply them, report that clearly instead of comparing zero times.
+	if from.IsZero() {
+		return time.Time{}, time.Time{}, fmt.Errorf("capture start time is unknown; specify an explicit --from")
+	}
+	if to.IsZero() {
+		return time.Time{}, time.Time{}, fmt.Errorf("capture end time is unknown; specify an explicit --to")
+	}
 	if !to.After(from) {
 		return time.Time{}, time.Time{}, fmt.Errorf("--to %s must be after --from %s", to.Format(time.RFC3339), from.Format(time.RFC3339))
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -203,6 +203,13 @@ func (s *Server) Wait() error {
 }
 
 func parseReplayAt(meta capture.CaptureMetadata, raw string) (time.Time, error) {
+	return parseReplayTime(meta, raw, "--at")
+}
+
+// parseReplayTime parses an RFC3339 timestamp or a duration relative to the
+// capture end (e.g. -5m), validating it lies within the capture window. flag is
+// the CLI flag name used in error messages so callers report the right flag.
+func parseReplayTime(meta capture.CaptureMetadata, raw, flag string) (time.Time, error) {
 	if raw == "" {
 		return time.Time{}, nil
 	}
@@ -211,16 +218,16 @@ func parseReplayAt(meta capture.CaptureMetadata, raw string) (time.Time, error) 
 	if err != nil {
 		d, derr := time.ParseDuration(raw)
 		if derr != nil {
-			return time.Time{}, fmt.Errorf("parsing --at %q: must be RFC3339 or a relative duration like -5m", raw)
+			return time.Time{}, fmt.Errorf("parsing %s %q: must be RFC3339 or a relative duration like -5m", flag, raw)
 		}
 		at = meta.CapturedUntil.Add(d)
 	}
 
 	if !meta.CapturedAt.IsZero() && at.Before(meta.CapturedAt) {
-		return time.Time{}, fmt.Errorf("parsing --at %q: requested replay time %s is before capture start %s", raw, at.Format(time.RFC3339), meta.CapturedAt.Format(time.RFC3339))
+		return time.Time{}, fmt.Errorf("parsing %s %q: requested replay time %s is before capture start %s", flag, raw, at.Format(time.RFC3339), meta.CapturedAt.Format(time.RFC3339))
 	}
 	if !meta.CapturedUntil.IsZero() && at.After(meta.CapturedUntil) {
-		return time.Time{}, fmt.Errorf("parsing --at %q: requested replay time %s is after capture end %s", raw, at.Format(time.RFC3339), meta.CapturedUntil.Format(time.RFC3339))
+		return time.Time{}, fmt.Errorf("parsing %s %q: requested replay time %s is after capture end %s", flag, raw, at.Format(time.RFC3339), meta.CapturedUntil.Format(time.RFC3339))
 	}
 
 	return at, nil
@@ -234,13 +241,13 @@ func parseReplayWindow(meta capture.CaptureMetadata, fromRaw, toRaw string) (fro
 	to = meta.CapturedUntil
 
 	if fromRaw != "" {
-		from, err = parseReplayAt(meta, fromRaw)
+		from, err = parseReplayTime(meta, fromRaw, "--from")
 		if err != nil {
 			return time.Time{}, time.Time{}, err
 		}
 	}
 	if toRaw != "" {
-		to, err = parseReplayAt(meta, toRaw)
+		to, err = parseReplayTime(meta, toRaw, "--to")
 		if err != nil {
 			return time.Time{}, time.Time{}, err
 		}

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -86,7 +86,12 @@ func (h *handler) resolveWatchList(watchPath string, at time.Time, labelSelector
 		return watchList{}, false, nil
 	}
 
-	body, _ := applySelectors(rawBody, labelSelector, fieldSelector)
+	body, serr := applySelectors(rawBody, labelSelector, fieldSelector)
+	if serr != nil {
+		// Best-effort: fall back to the unfiltered list rather than failing the
+		// whole watch on a selector/marshal error.
+		body = rawBody
+	}
 
 	var parsed struct {
 		APIVersion string `json:"apiVersion"`
@@ -97,7 +102,7 @@ func (h *handler) resolveWatchList(watchPath string, at time.Time, labelSelector
 		Items []json.RawMessage `json:"items"`
 	}
 	if err := json.Unmarshal(body, &parsed); err != nil {
-		return watchList{}, false, fmt.Errorf("parsing list")
+		return watchList{}, false, fmt.Errorf("parsing watch list for %s: %w", watchPath, err)
 	}
 	return watchList{
 		APIVersion:      parsed.APIVersion,
@@ -146,7 +151,18 @@ func (s *CaptureStore) watchTimeline(watchPath string) []replayEvent {
 		}
 	}
 
-	sort.SliceStable(evs, func(i, j int) bool { return evs[i].t.Before(evs[j].t) })
+	// Sort by timestamp, with a deterministic tiebreak (apiPath then seq) so
+	// equal-time events don't flip order across runs — the merged input order
+	// depends on map iteration for the cluster-wide aggregation case.
+	sort.Slice(evs, func(i, j int) bool {
+		if !evs[i].t.Equal(evs[j].t) {
+			return evs[i].t.Before(evs[j].t)
+		}
+		if evs[i].apiPath != evs[j].apiPath {
+			return evs[i].apiPath < evs[j].apiPath
+		}
+		return evs[i].seq < evs[j].seq
+	})
 	return evs
 }
 
@@ -343,8 +359,14 @@ func (h *handler) replayPass(ctx context.Context, timer <-chan time.Time, clock 
 				break
 			}
 			wait := time.Duration(float64(ev.t.Sub(pos)) / clock.Speed())
-			if wait > replayPollInterval || wait <= 0 {
+			// Cap the wait so we stay responsive to pause/seek/loop, but never
+			// impose a floor: closely-spaced events at high speed must not each
+			// incur an artificial poll-interval delay.
+			if wait > replayPollInterval {
 				wait = replayPollInterval
+			}
+			if wait < 0 {
+				wait = 0
 			}
 			select {
 			case <-ctx.Done():

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -237,11 +237,13 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 	}
 	emitBookmark := func(l watchList) {
 		// Treat "0" as unspecified — aggregated/synthesized empty lists carry RV
-		// "0", but watch clients expect a non-zero BOOKMARK resourceVersion. In
-		// replay mode the window start is always a valid, positive time.
+		// "0", but watch clients expect a non-zero BOOKMARK resourceVersion. Lead
+		// with the clock's current position so the bookmark aligns with the
+		// list-as-of time (after a seek/relist the emitted state is as-of the
+		// clock, not the window start).
 		rv := l.ResourceVersion
 		if rv == "" || rv == "0" {
-			rv = bookmarkResourceVersion(windowStart, h.store.Metadata.CapturedAt, h.store.Metadata.CapturedUntil)
+			rv = bookmarkResourceVersion(clock.Now(), windowStart, h.store.Metadata.CapturedAt, h.store.Metadata.CapturedUntil)
 		}
 		bookmarkKind := strings.TrimSuffix(l.Kind, "List")
 		bookmarkAPIVersion := l.APIVersion

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -238,15 +238,16 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 		}
 		return true
 	}
-	emitBookmark := func(l watchList) {
+	// emitBookmark writes the BOOKMARK marking the end of a (re)list. `at` is the
+	// time the list was reconstructed at, used for the RV fallback so the bookmark
+	// stays coherent with the list-as-of time (rather than drifting to clock.Now()
+	// if the clock advances while a large list streams).
+	emitBookmark := func(l watchList, at time.Time) {
 		// Treat "0" as unspecified — aggregated/synthesized empty lists carry RV
-		// "0", but watch clients expect a non-zero BOOKMARK resourceVersion. Lead
-		// with the clock's current position so the bookmark aligns with the
-		// list-as-of time (after a seek/relist the emitted state is as-of the
-		// clock, not the window start).
+		// "0", but watch clients expect a non-zero BOOKMARK resourceVersion.
 		rv := l.ResourceVersion
 		if rv == "" || rv == "0" {
-			rv = bookmarkResourceVersion(clock.Now(), windowStart, h.store.Metadata.CapturedAt, h.store.Metadata.CapturedUntil)
+			rv = bookmarkResourceVersion(at, windowStart, h.store.Metadata.CapturedAt, h.store.Metadata.CapturedUntil)
 		}
 		bookmarkKind := strings.TrimSuffix(l.Kind, "List")
 		bookmarkAPIVersion := l.APIVersion
@@ -283,14 +284,14 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 		for _, item := range l.Items {
 			emit("ADDED", item)
 		}
-		emitBookmark(l)
+		emitBookmark(l, at)
 	}
 
-	// Initial list burst + bookmark.
+	// Initial list burst + bookmark (as-of startAt).
 	for _, item := range list.Items {
 		emit("ADDED", item)
 	}
-	emitBookmark(list)
+	emitBookmark(list, startAt)
 
 	after := startAt
 	epoch := startEpoch

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -236,8 +236,10 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 		}
 	}
 	emitBookmark := func(l watchList) {
+		// Treat "0" as unspecified — aggregated/synthesized empty lists carry RV
+		// "0", but watch clients expect a non-zero BOOKMARK resourceVersion.
 		rv := l.ResourceVersion
-		if rv == "" {
+		if rv == "" || rv == "0" {
 			rv = fmt.Sprintf("%d", h.store.Metadata.CapturedAt.Unix())
 		}
 		bookmarkKind := strings.TrimSuffix(l.Kind, "List")

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -264,16 +264,18 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 
 	ctx := r.Context()
 
-	// relist re-emits the state as-of the window start as an ADDED burst; used on
-	// each loop wrap so a long-lived watcher sees the timeline replay again.
-	relist := func() {
-		l, ok, err := h.resolveWatchList(watchPath, windowStart, labelSel, fieldSel)
+	// relistAt re-emits the state as-of `at` as an ADDED burst + BOOKMARK, so a
+	// long-lived watcher sees a fresh, clearly-delimited list after a loop wrap
+	// or a seek — mirroring the initial list behavior.
+	relistAt := func(at time.Time) {
+		l, ok, err := h.resolveWatchList(watchPath, at, labelSel, fieldSel)
 		if err != nil || !ok {
 			return
 		}
 		for _, item := range l.Items {
 			emit("ADDED", item)
 		}
+		emitBookmark(l)
 	}
 
 	// Initial list burst + bookmark.
@@ -284,49 +286,67 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 
 	after := startAt
 	epoch := startEpoch
+	seekGen := clock.SeekGen()
 	for {
-		switch h.replayPass(ctx, timer, clock, timeline, after, epoch, labelSel, fieldSel, emit) {
-		case passCanceled:
+		res := h.replayPass(ctx, timer, clock, timeline, after, epoch, seekGen, labelSel, fieldSel, emit)
+		if res == passCanceled {
 			return
-		case passLooped:
-			// Clock wrapped mid-pass: re-list and replay from the window start.
-			relist()
-			_, epoch, _ = clock.Sample()
-			after = windowStart
-		case passDone:
-			// Timeline exhausted for this epoch. Without loop, hold open until the
-			// client disconnects or the watch times out.
-			if !clock.Loop() {
-				select {
-				case <-ctx.Done():
-				case <-timer:
-				}
-				return
-			}
-			// With loop, wait for the next wrap, then re-list and replay again.
-			if !waitForLoop(ctx, timer, clock, epoch) {
-				return
-			}
-			relist()
-			_, epoch, _ = clock.Sample()
-			after = windowStart
 		}
+		if res == passDone {
+			// Timeline exhausted for this epoch. Wait for a restart trigger (a
+			// loop wrap or a seek) or shutdown.
+			switch waitForRestart(ctx, timer, clock, epoch, seekGen) {
+			case restartNone:
+				return
+			case restartLoop:
+				res = passLooped
+			case restartSeek:
+				res = passSeeked
+			}
+		}
+
+		// Re-list and choose the next start point: a loop wrap replays the whole
+		// window from the start; a seek resumes from the new clock position.
+		if res == passLooped {
+			relistAt(windowStart)
+			after = windowStart
+		} else { // passSeeked
+			pos := clock.Now()
+			relistAt(pos)
+			after = pos
+		}
+		_, epoch, _ = clock.Sample()
+		seekGen = clock.SeekGen()
 	}
 }
 
-// waitForLoop blocks until the clock's epoch advances past `epoch` (a loop
-// wrap), returning true. It returns false if the request is canceled or the
-// watch times out first.
-func waitForLoop(ctx context.Context, timer <-chan time.Time, clock *ReplayClock, epoch int) bool {
+// restartTrigger explains why a paused/idle stream should resume streaming.
+type restartTrigger int
+
+const (
+	restartNone restartTrigger = iota // canceled or timed out
+	restartLoop                       // the clock wrapped (loop)
+	restartSeek                       // the clock was seeked
+)
+
+// waitForRestart blocks until the clock wraps past `epoch`, is seeked past
+// `seekGen`, or the request is canceled/times out. A single ticker avoids
+// allocating a timer on every poll.
+func waitForRestart(ctx context.Context, timer <-chan time.Time, clock *ReplayClock, epoch, seekGen int) restartTrigger {
+	ticker := time.NewTicker(replayPollInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
-			return false
+			return restartNone
 		case <-timer:
-			return false
-		case <-time.After(replayPollInterval):
+			return restartNone
+		case <-ticker.C:
+			if clock.SeekGen() != seekGen {
+				return restartSeek
+			}
 			if _, e, _ := clock.Sample(); e != epoch {
-				return true
+				return restartLoop
 			}
 		}
 	}
@@ -336,21 +356,52 @@ type passResult int
 
 const (
 	passDone     passResult = iota // reached the end of the timeline
-	passLooped                     // clock wrapped mid-pass; caller should re-list
+	passLooped                     // clock wrapped mid-pass; caller should re-list at window start
+	passSeeked                     // clock was seeked mid-pass; caller should re-list at new position
 	passCanceled                   // client disconnected or timeout elapsed
 )
 
+// sleepInterruptible waits for d, returning true if the request is canceled or
+// the watch times out first. It uses a stoppable timer (stopped on return) so
+// canceled waits don't leave timers lingering under load; a non-positive d
+// returns immediately after a non-blocking cancellation check.
+func sleepInterruptible(ctx context.Context, timer <-chan time.Time, d time.Duration) bool {
+	if d <= 0 {
+		select {
+		case <-ctx.Done():
+			return true
+		case <-timer:
+			return true
+		default:
+			return false
+		}
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return true
+	case <-timer:
+		return true
+	case <-t.C:
+		return false
+	}
+}
+
 // replayPass streams timeline events with timestamp after `after`, each held
 // until the clock crosses it, until the timeline is exhausted (passDone), the
-// clock loops past the current epoch (passLooped), or the request is canceled
-// or times out (passCanceled).
-func (h *handler) replayPass(ctx context.Context, timer <-chan time.Time, clock *ReplayClock, timeline []replayEvent, after time.Time, epoch int, labelSel, fieldSel string, emit func(string, json.RawMessage)) passResult {
+// clock loops past `epoch` (passLooped) or is seeked past `seekGen`
+// (passSeeked), or the request is canceled/times out (passCanceled).
+func (h *handler) replayPass(ctx context.Context, timer <-chan time.Time, clock *ReplayClock, timeline []replayEvent, after time.Time, epoch, seekGen int, labelSel, fieldSel string, emit func(string, json.RawMessage)) passResult {
 	for _, ev := range timeline {
 		if !ev.t.After(after) {
 			continue
 		}
 		// Wait until the clock reaches this event's timestamp.
 		for {
+			if clock.SeekGen() != seekGen {
+				return passSeeked
+			}
 			pos, ep, _ := clock.Sample()
 			if ep != epoch {
 				return passLooped
@@ -368,12 +419,8 @@ func (h *handler) replayPass(ctx context.Context, timer <-chan time.Time, clock 
 			if wait < 0 {
 				wait = 0
 			}
-			select {
-			case <-ctx.Done():
+			if sleepInterruptible(ctx, timer, wait) {
 				return passCanceled
-			case <-timer:
-				return passCanceled
-			case <-time.After(wait):
 			}
 		}
 

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -410,12 +410,19 @@ func (h *handler) replayPass(ctx context.Context, timer <-chan time.Time, clock 
 			if clock.SeekGen() != seekGen {
 				return passSeeked
 			}
-			pos, ep, _ := clock.Sample()
+			pos, ep, ended := clock.Sample()
 			if ep != epoch {
 				return passLooped
 			}
 			if !pos.Before(ev.t) {
 				break
+			}
+			// Window ended (loop disabled) and the clock won't advance to this
+			// event's timestamp — e.g. events after a --to sub-range end. Stop the
+			// pass so the stream goes idle (a later seek restarts it) instead of
+			// waiting forever.
+			if ended {
+				return passDone
 			}
 			// Compute the scaled wait in float space and cap it BEFORE converting
 			// to a time.Duration: a very small speed makes the division huge, and

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -1,0 +1,369 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// watchList is a parsed list body ready to be streamed as watch events.
+type watchList struct {
+	APIVersion      string
+	Kind            string
+	ResourceVersion string
+	Items           []json.RawMessage
+}
+
+// resolveWatchList reconstructs the list for a watch path as-of at, applying the
+// same fallback chain used for plain watches (cross-namespace aggregation,
+// cluster-scoped namespace filtering, empty-list synthesis), then applies label
+// and field selectors. ok is false only when the resource can't be resolved at
+// all; err is non-nil only for internal reconstruction failures.
+func (h *handler) resolveWatchList(watchPath string, at time.Time, labelSelector, fieldSelector string) (watchList, bool, error) {
+	rawBody, code, err := h.store.ReconstructAt(watchPath, at)
+	if err != nil {
+		return watchList{}, false, err
+	}
+
+	if code == 404 {
+		// Only aggregate across namespaces for cluster-wide watch paths.
+		if _, _, _, reqNS := parseAPIPath(watchPath); reqNS == "" {
+			rawBody, code, err = h.store.AggregateAcrossNamespaces(watchPath, at)
+			if err != nil {
+				return watchList{}, false, err
+			}
+		}
+	}
+
+	if code == 404 {
+		// Cluster-scoped fallback: resource was captured at the cluster path
+		// (e.g. /api/v1/pods) but the watch targets a specific namespace. Filter
+		// by metadata.namespace so namespaced watchers see the right items.
+		g, v, resource, ns := parseAPIPath(watchPath)
+		if ns != "" && resource != "" {
+			var clusterPath string
+			if g == "" {
+				clusterPath = "/api/" + v + "/" + resource
+			} else {
+				clusterPath = "/apis/" + g + "/" + v + "/" + resource
+			}
+			clusterBody, clusterCode, cerr := h.store.ReconstructAt(clusterPath, at)
+			if cerr == nil && clusterCode == 200 {
+				filtered, ferr := applySelectors(clusterBody, "", "metadata.namespace="+ns)
+				if ferr == nil {
+					rawBody, code = filtered, 200
+				}
+			}
+		}
+	}
+
+	if code == 404 {
+		g, v, resource, _ := parseAPIPath(watchPath)
+		if resource != "" {
+			av := v
+			if g != "" {
+				av = g + "/" + v
+			}
+			emptyList, _ := json.Marshal(map[string]any{
+				"apiVersion": av,
+				"kind":       resourceToKind(resource) + "List",
+				"metadata":   map[string]string{"resourceVersion": "0"},
+				"items":      []any{},
+			})
+			rawBody = emptyList
+			code = 200
+		}
+	}
+
+	if code != 200 {
+		return watchList{}, false, nil
+	}
+
+	body, _ := applySelectors(rawBody, labelSelector, fieldSelector)
+
+	var parsed struct {
+		APIVersion string `json:"apiVersion"`
+		Kind       string `json:"kind"`
+		Metadata   struct {
+			ResourceVersion string `json:"resourceVersion"`
+		} `json:"metadata"`
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return watchList{}, false, fmt.Errorf("parsing list")
+	}
+	return watchList{
+		APIVersion:      parsed.APIVersion,
+		Kind:            parsed.Kind,
+		ResourceVersion: parsed.Metadata.ResourceVersion,
+		Items:           parsed.Items,
+	}, true, nil
+}
+
+// replayEvent is one captured watch event on the merged replay timeline.
+type replayEvent struct {
+	t       time.Time
+	typ     string // ADDED | MODIFIED | DELETED
+	apiPath string
+	seq     int
+}
+
+// watchTimeline returns the captured watch events for a watch path, merged and
+// sorted by timestamp. For a cluster-wide path (no namespace) it aggregates the
+// per-namespace watch-index entries the capture demultiplexed.
+func (s *CaptureStore) watchTimeline(watchPath string) []replayEvent {
+	var evs []replayEvent
+	add := func(apiPath string, wi *capture.WatchIndexEntry) {
+		for i := range wi.Seqs {
+			if i >= len(wi.Times) || i >= len(wi.EventTypes) {
+				break
+			}
+			evs = append(evs, replayEvent{t: wi.Times[i], typ: wi.EventTypes[i], apiPath: apiPath, seq: wi.Seqs[i]})
+		}
+	}
+
+	if wi, ok := s.WatchIndex[watchPath]; ok {
+		add(watchPath, wi)
+	} else if g, v, resource, ns := parseAPIPath(watchPath); ns == "" && resource != "" {
+		var prefix string
+		if g == "" {
+			prefix = "/api/" + v + "/namespaces/"
+		} else {
+			prefix = "/apis/" + g + "/" + v + "/namespaces/"
+		}
+		suffix := "/" + resource
+		for p, wi := range s.WatchIndex {
+			if strings.HasPrefix(p, prefix) && strings.HasSuffix(p, suffix) {
+				add(p, wi)
+			}
+		}
+	}
+
+	sort.SliceStable(evs, func(i, j int) bool { return evs[i].t.Before(evs[j].t) })
+	return evs
+}
+
+// matchesSelectors reports whether a single object satisfies the label and
+// field selectors. An empty selector matches everything; a malformed selector
+// or unparseable object is treated as a match (best-effort, never hides data).
+func matchesSelectors(raw json.RawMessage, labelSelector, fieldSelector string) bool {
+	if labelSelector == "" && fieldSelector == "" {
+		return true
+	}
+	labelReqs, err := parseRequirements(labelSelector)
+	if err != nil {
+		return true
+	}
+	fieldReqs := parseFieldSelector(fieldSelector)
+	var obj k8sObject
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return true
+	}
+	return matchesLabels(&obj, labelReqs) && matchesFields(&obj, fieldReqs)
+}
+
+// replayPollInterval bounds how long the streamer sleeps between clock checks so
+// it stays responsive to pause, seek, speed changes, and loop wraps.
+const replayPollInterval = 200 * time.Millisecond
+
+// streamReplayWatch streams a captured watch as the replay clock advances. It
+// sends the state as-of the clock's current position as an ADDED burst (the
+// informer's initial list), a BOOKMARK, then the captured events in timestamp
+// order — each held until the clock crosses its timestamp. Under --loop the
+// stream re-lists and replays from the window start on each wrap.
+func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path string) {
+	clock := h.clock
+	watchPath := strings.TrimSuffix(path, "/")
+	labelSel := r.URL.Query().Get("labelSelector")
+	fieldSel := r.URL.Query().Get("fieldSelector")
+
+	windowStart, _ := clock.Window()
+	startAt, startEpoch, _ := clock.Sample()
+
+	list, ok, err := h.resolveWatchList(watchPath, startAt, labelSel, fieldSel)
+	if err != nil {
+		h.writeStatus(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if !ok {
+		h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q not found in capture", path))
+		return
+	}
+
+	timeline := h.store.watchTimeline(watchPath)
+
+	// Honor ?timeoutSeconds: nil channel blocks forever (no timeout).
+	var timer <-chan time.Time
+	if secs := r.URL.Query().Get("timeoutSeconds"); secs != "" {
+		if n, err := strconv.Atoi(secs); err == nil && n > 0 {
+			timer = time.After(time.Duration(n) * time.Second)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Transfer-Encoding", "chunked")
+	w.WriteHeader(http.StatusOK)
+	flusher, canFlush := w.(http.Flusher)
+
+	emit := func(typ string, obj json.RawMessage) {
+		data, _ := json.Marshal(map[string]any{"type": typ, "object": obj})
+		_, _ = fmt.Fprintf(w, "%s\n", data)
+		if canFlush {
+			flusher.Flush()
+		}
+	}
+	emitBookmark := func(l watchList) {
+		rv := l.ResourceVersion
+		if rv == "" {
+			rv = fmt.Sprintf("%d", h.store.Metadata.CapturedAt.Unix())
+		}
+		bookmarkKind := strings.TrimSuffix(l.Kind, "List")
+		bookmarkAPIVersion := l.APIVersion
+		if bookmarkKind == "" {
+			bookmarkKind = "Status"
+		}
+		if bookmarkAPIVersion == "" {
+			bookmarkAPIVersion = "v1"
+		}
+		data, _ := json.Marshal(map[string]any{
+			"type": "BOOKMARK",
+			"object": map[string]any{
+				"apiVersion": bookmarkAPIVersion,
+				"kind":       bookmarkKind,
+				"metadata":   map[string]string{"resourceVersion": rv},
+			},
+		})
+		_, _ = fmt.Fprintf(w, "%s\n", data)
+		if canFlush {
+			flusher.Flush()
+		}
+	}
+
+	ctx := r.Context()
+
+	// relist re-emits the state as-of the window start as an ADDED burst; used on
+	// each loop wrap so a long-lived watcher sees the timeline replay again.
+	relist := func() {
+		l, ok, err := h.resolveWatchList(watchPath, windowStart, labelSel, fieldSel)
+		if err != nil || !ok {
+			return
+		}
+		for _, item := range l.Items {
+			emit("ADDED", item)
+		}
+	}
+
+	// Initial list burst + bookmark.
+	for _, item := range list.Items {
+		emit("ADDED", item)
+	}
+	emitBookmark(list)
+
+	after := startAt
+	epoch := startEpoch
+	for {
+		switch h.replayPass(ctx, timer, clock, timeline, after, epoch, labelSel, fieldSel, emit) {
+		case passCanceled:
+			return
+		case passLooped:
+			// Clock wrapped mid-pass: re-list and replay from the window start.
+			relist()
+			_, epoch, _ = clock.Sample()
+			after = windowStart
+		case passDone:
+			// Timeline exhausted for this epoch. Without loop, hold open until the
+			// client disconnects or the watch times out.
+			if !clock.Loop() {
+				select {
+				case <-ctx.Done():
+				case <-timer:
+				}
+				return
+			}
+			// With loop, wait for the next wrap, then re-list and replay again.
+			if !waitForLoop(ctx, timer, clock, epoch) {
+				return
+			}
+			relist()
+			_, epoch, _ = clock.Sample()
+			after = windowStart
+		}
+	}
+}
+
+// waitForLoop blocks until the clock's epoch advances past `epoch` (a loop
+// wrap), returning true. It returns false if the request is canceled or the
+// watch times out first.
+func waitForLoop(ctx context.Context, timer <-chan time.Time, clock *ReplayClock, epoch int) bool {
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-timer:
+			return false
+		case <-time.After(replayPollInterval):
+			if _, e, _ := clock.Sample(); e != epoch {
+				return true
+			}
+		}
+	}
+}
+
+type passResult int
+
+const (
+	passDone     passResult = iota // reached the end of the timeline
+	passLooped                     // clock wrapped mid-pass; caller should re-list
+	passCanceled                   // client disconnected or timeout elapsed
+)
+
+// replayPass streams timeline events with timestamp after `after`, each held
+// until the clock crosses it, until the timeline is exhausted (passDone), the
+// clock loops past the current epoch (passLooped), or the request is canceled
+// or times out (passCanceled).
+func (h *handler) replayPass(ctx context.Context, timer <-chan time.Time, clock *ReplayClock, timeline []replayEvent, after time.Time, epoch int, labelSel, fieldSel string, emit func(string, json.RawMessage)) passResult {
+	for _, ev := range timeline {
+		if !ev.t.After(after) {
+			continue
+		}
+		// Wait until the clock reaches this event's timestamp.
+		for {
+			pos, ep, _ := clock.Sample()
+			if ep != epoch {
+				return passLooped
+			}
+			if !pos.Before(ev.t) {
+				break
+			}
+			wait := time.Duration(float64(ev.t.Sub(pos)) / clock.Speed())
+			if wait > replayPollInterval || wait <= 0 {
+				wait = replayPollInterval
+			}
+			select {
+			case <-ctx.Done():
+				return passCanceled
+			case <-timer:
+				return passCanceled
+			case <-time.After(wait):
+			}
+		}
+
+		rec, err := h.store.readRecord(ev.apiPath, ev.seq)
+		if err != nil {
+			continue
+		}
+		if !matchesSelectors(rec.ResponseBody, labelSel, fieldSel) {
+			continue
+		}
+		emit(ev.typ, rec.ResponseBody)
+		clock.AddEvents(1)
+	}
+	return passDone
+}

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -414,15 +414,21 @@ func (h *handler) replayPass(ctx context.Context, timer <-chan time.Time, clock 
 			if !pos.Before(ev.t) {
 				break
 			}
-			wait := time.Duration(float64(ev.t.Sub(pos)) / clock.Speed())
-			// Cap the wait so we stay responsive to pause/seek/loop, but never
-			// impose a floor: closely-spaced events at high speed must not each
-			// incur an artificial poll-interval delay.
-			if wait > replayPollInterval {
-				wait = replayPollInterval
-			}
-			if wait < 0 {
+			// Compute the scaled wait in float space and cap it BEFORE converting
+			// to a time.Duration: a very small speed makes the division huge, and
+			// converting that to int64 nanoseconds would overflow to a negative
+			// value (collapsing to 0 and spinning). Cap keeps us responsive to
+			// pause/seek/loop; no floor, so closely-spaced events at high speed
+			// aren't each delayed a poll interval.
+			scaled := float64(ev.t.Sub(pos)) / clock.Speed()
+			var wait time.Duration
+			switch {
+			case scaled <= 0:
 				wait = 0
+			case scaled >= float64(replayPollInterval):
+				wait = replayPollInterval
+			default:
+				wait = time.Duration(scaled)
 			}
 			if sleepInterruptible(ctx, timer, wait) {
 				return passCanceled

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -237,10 +237,11 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 	}
 	emitBookmark := func(l watchList) {
 		// Treat "0" as unspecified — aggregated/synthesized empty lists carry RV
-		// "0", but watch clients expect a non-zero BOOKMARK resourceVersion.
+		// "0", but watch clients expect a non-zero BOOKMARK resourceVersion. In
+		// replay mode the window start is always a valid, positive time.
 		rv := l.ResourceVersion
 		if rv == "" || rv == "0" {
-			rv = fmt.Sprintf("%d", h.store.Metadata.CapturedAt.Unix())
+			rv = bookmarkResourceVersion(windowStart, h.store.Metadata.CapturedAt, h.store.Metadata.CapturedUntil)
 		}
 		bookmarkKind := strings.TrimSuffix(l.Kind, "List")
 		bookmarkAPIVersion := l.APIVersion

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -216,12 +215,8 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 	timeline := h.store.watchTimeline(watchPath)
 
 	// Honor ?timeoutSeconds: nil channel blocks forever (no timeout).
-	var timer <-chan time.Time
-	if secs := r.URL.Query().Get("timeoutSeconds"); secs != "" {
-		if n, err := strconv.Atoi(secs); err == nil && n > 0 {
-			timer = time.After(time.Duration(n) * time.Second)
-		}
-	}
+	timer, stopTimer := watchTimeout(r.URL.Query().Get("timeoutSeconds"))
+	defer stopTimer()
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Transfer-Encoding", "chunked")
@@ -229,7 +224,12 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 	flusher, canFlush := w.(http.Flusher)
 
 	emit := func(typ string, obj json.RawMessage) {
-		data, _ := json.Marshal(map[string]any{"type": typ, "object": obj})
+		// Skip malformed frames rather than writing a blank line: a captured
+		// object body could be invalid JSON, which would fail to marshal.
+		data, err := json.Marshal(map[string]any{"type": typ, "object": obj})
+		if err != nil {
+			return
+		}
 		_, _ = fmt.Fprintf(w, "%s\n", data)
 		if canFlush {
 			flusher.Flush()

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -223,17 +223,20 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 	w.WriteHeader(http.StatusOK)
 	flusher, canFlush := w.(http.Flusher)
 
-	emit := func(typ string, obj json.RawMessage) {
+	// emit writes a watch frame and reports whether it was actually written, so
+	// callers only count frames that reached the client.
+	emit := func(typ string, obj json.RawMessage) bool {
 		// Skip malformed frames rather than writing a blank line: a captured
 		// object body could be invalid JSON, which would fail to marshal.
 		data, err := json.Marshal(map[string]any{"type": typ, "object": obj})
 		if err != nil {
-			return
+			return false
 		}
 		_, _ = fmt.Fprintf(w, "%s\n", data)
 		if canFlush {
 			flusher.Flush()
 		}
+		return true
 	}
 	emitBookmark := func(l watchList) {
 		// Treat "0" as unspecified — aggregated/synthesized empty lists carry RV
@@ -397,7 +400,7 @@ func sleepInterruptible(ctx context.Context, timer <-chan time.Time, d time.Dura
 // until the clock crosses it, until the timeline is exhausted (passDone), the
 // clock loops past `epoch` (passLooped) or is seeked past `seekGen`
 // (passSeeked), or the request is canceled/times out (passCanceled).
-func (h *handler) replayPass(ctx context.Context, timer <-chan time.Time, clock *ReplayClock, timeline []replayEvent, after time.Time, epoch, seekGen int, labelSel, fieldSel string, emit func(string, json.RawMessage)) passResult {
+func (h *handler) replayPass(ctx context.Context, timer <-chan time.Time, clock *ReplayClock, timeline []replayEvent, after time.Time, epoch, seekGen int, labelSel, fieldSel string, emit func(string, json.RawMessage) bool) passResult {
 	for _, ev := range timeline {
 		if !ev.t.After(after) {
 			continue
@@ -442,8 +445,9 @@ func (h *handler) replayPass(ctx context.Context, timer <-chan time.Time, clock 
 		if !matchesSelectors(rec.ResponseBody, labelSel, fieldSel) {
 			continue
 		}
-		emit(ev.typ, rec.ResponseBody)
-		clock.AddEvents(1)
+		if emit(ev.typ, rec.ResponseBody) {
+			clock.AddEvents(1)
+		}
 	}
 	return passDone
 }

--- a/internal/server/watch_replay_test.go
+++ b/internal/server/watch_replay_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -42,6 +43,12 @@ func openWatchStream(t *testing.T, url string) (next func() watchEvent, cancel f
 	if err != nil {
 		cancelCtx()
 		t.Fatalf("watch request: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		cancelCtx()
+		t.Fatalf("watch request: status %d: %s", resp.StatusCode, body)
 	}
 	lines := make(chan watchEvent, 32)
 	go func() {

--- a/internal/server/watch_replay_test.go
+++ b/internal/server/watch_replay_test.go
@@ -21,7 +21,8 @@ type watchEvent struct {
 	Type   string `json:"type"`
 	Object struct {
 		Metadata struct {
-			Name string `json:"name"`
+			Name            string `json:"name"`
+			ResourceVersion string `json:"resourceVersion"`
 		} `json:"metadata"`
 	} `json:"object"`
 }
@@ -287,5 +288,27 @@ func TestStreamReplayWatch_LoopRelistsWithBookmark(t *testing.T) {
 	advance(6 * time.Second) // cross the window end → loop wrap
 	if e := next(); e.Type != "BOOKMARK" {
 		t.Fatalf("on loop wrap: frame = %q, want relist BOOKMARK", e.Type)
+	}
+}
+
+// TestStreamReplayWatch_BookmarkRVNonZero verifies that a synthesized empty list
+// (a watch on a resource with no captured data) still yields a non-zero BOOKMARK
+// resourceVersion, which watch clients require.
+func TestStreamReplayWatch_BookmarkRVNonZero(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	h, _, _ := buildPodWatchStore(t, from, 20, false)
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	// Watch a resource with no captured data → empty-list synthesis (RV "0").
+	next, cancel := openWatchStream(t, srv.URL+"/api/v1/namespaces/default/services?watch=1")
+	defer cancel()
+
+	e := next()
+	if e.Type != "BOOKMARK" {
+		t.Fatalf("first frame = %q, want BOOKMARK", e.Type)
+	}
+	if rv := e.Object.Metadata.ResourceVersion; rv == "" || rv == "0" {
+		t.Errorf("BOOKMARK resourceVersion = %q, want non-zero", rv)
 	}
 }

--- a/internal/server/watch_replay_test.go
+++ b/internal/server/watch_replay_test.go
@@ -16,6 +16,62 @@ func podBody(name string) string {
 	return `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"` + name + `","namespace":"default"}}`
 }
 
+// watchEvent is a decoded frame from a watch stream.
+type watchEvent struct {
+	Type   string `json:"type"`
+	Object struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	} `json:"object"`
+}
+
+// openWatchStream connects to a watch URL and returns a `next` that reads the
+// following frame (failing on a 3s timeout). The returned cancel closes the
+// stream.
+func openWatchStream(t *testing.T, url string) (next func() watchEvent, cancel func()) {
+	t.Helper()
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		cancelCtx()
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		cancelCtx()
+		t.Fatalf("watch request: %v", err)
+	}
+	lines := make(chan watchEvent, 32)
+	go func() {
+		sc := bufio.NewScanner(resp.Body)
+		sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+		for sc.Scan() {
+			var e watchEvent
+			if err := json.Unmarshal(sc.Bytes(), &e); err != nil {
+				continue
+			}
+			select {
+			case lines <- e:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	next = func() watchEvent {
+		t.Helper()
+		select {
+		case e := <-lines:
+			return e
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for watch event")
+			return watchEvent{}
+		}
+	}
+	cancel = func() { cancelCtx(); resp.Body.Close() }
+	return next, cancel
+}
+
 // TestStreamReplayWatch_EmitsEventsInOrder is the core acceptance test: a watch
 // client receives the captured ADDED/MODIFIED/DELETED events in timestamp order
 // as the replay clock advances.
@@ -149,5 +205,87 @@ func TestWatchTimeline_AggregatesAcrossNamespaces(t *testing.T) {
 	}
 	if timeline[0].apiPath != ns1 || timeline[1].apiPath != ns2 {
 		t.Errorf("unexpected merge order: %s then %s", timeline[0].apiPath, timeline[1].apiPath)
+	}
+}
+
+// buildPodWatchStore builds a store with an empty initial pod list and two
+// ADDED events, plus a manually-driven clock over [from, from+windowSecs].
+func buildPodWatchStore(t *testing.T, from time.Time, windowSecs int, loop bool) (*handler, *ReplayClock, func(time.Duration)) {
+	t.Helper()
+	const podsPath = "/api/v1/namespaces/default/pods"
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{
+			podsPath: {id: "snap0", at: from, body: emptyPodList},
+		},
+		[]watchTestEvent{
+			{id: "e1", apiPath: podsPath, at: from.Add(2 * time.Second), eventType: "ADDED", objectBody: podBody("pod-a")},
+			{id: "e2", apiPath: podsPath, at: from.Add(4 * time.Second), eventType: "ADDED", objectBody: podBody("pod-b")},
+		},
+	)
+	clock, advance := newTestClock(t, from, from.Add(time.Duration(windowSecs)*time.Second), 1, loop, false)
+	h := newHandler(store, time.Time{}, false)
+	h.clock = clock
+	return h, clock, advance
+}
+
+// TestStreamReplayWatch_SeekTriggersRelist verifies that a seek during an idle
+// watch (timeline exhausted) restarts the stream: it re-lists (BOOKMARK) and
+// replays events after the new position.
+func TestStreamReplayWatch_SeekTriggersRelist(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	h, clock, advance := buildPodWatchStore(t, from, 20, false)
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	next, cancel := openWatchStream(t, srv.URL+"/api/v1/namespaces/default/pods?watch=1")
+	defer cancel()
+
+	if e := next(); e.Type != "BOOKMARK" {
+		t.Fatalf("first frame = %q, want BOOKMARK", e.Type)
+	}
+	advance(20 * time.Second) // stream both events
+	if e := next(); e.Type != "ADDED" || e.Object.Metadata.Name != "pod-a" {
+		t.Fatalf("frame = (%s %s), want ADDED pod-a", e.Type, e.Object.Metadata.Name)
+	}
+	if e := next(); e.Object.Metadata.Name != "pod-b" {
+		t.Fatalf("frame = %s, want pod-b", e.Object.Metadata.Name)
+	}
+
+	// Seek back to the start: the idle stream should re-list (BOOKMARK) and then,
+	// once the clock advances again, replay the events.
+	clock.Seek(from)
+	if e := next(); e.Type != "BOOKMARK" {
+		t.Fatalf("after seek: frame = %q, want relist BOOKMARK", e.Type)
+	}
+	advance(20 * time.Second)
+	if e := next(); e.Type != "ADDED" || e.Object.Metadata.Name != "pod-a" {
+		t.Fatalf("after seek+advance: frame = (%s %s), want ADDED pod-a", e.Type, e.Object.Metadata.Name)
+	}
+}
+
+// TestStreamReplayWatch_LoopRelistsWithBookmark verifies that on a loop wrap the
+// stream re-lists with a BOOKMARK (matching the initial list behavior).
+func TestStreamReplayWatch_LoopRelistsWithBookmark(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	h, _, advance := buildPodWatchStore(t, from, 10, true)
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	next, cancel := openWatchStream(t, srv.URL+"/api/v1/namespaces/default/pods?watch=1")
+	defer cancel()
+
+	if e := next(); e.Type != "BOOKMARK" {
+		t.Fatalf("first frame = %q, want BOOKMARK", e.Type)
+	}
+	advance(5 * time.Second) // within the window: stream both events
+	if e := next(); e.Object.Metadata.Name != "pod-a" {
+		t.Fatalf("frame = %s, want pod-a", e.Object.Metadata.Name)
+	}
+	if e := next(); e.Object.Metadata.Name != "pod-b" {
+		t.Fatalf("frame = %s, want pod-b", e.Object.Metadata.Name)
+	}
+	advance(6 * time.Second) // cross the window end → loop wrap
+	if e := next(); e.Type != "BOOKMARK" {
+		t.Fatalf("on loop wrap: frame = %q, want relist BOOKMARK", e.Type)
 	}
 }

--- a/internal/server/watch_replay_test.go
+++ b/internal/server/watch_replay_test.go
@@ -1,0 +1,153 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+const emptyPodList = `{"apiVersion":"v1","kind":"PodList","metadata":{"resourceVersion":"1"},"items":[]}`
+
+func podBody(name string) string {
+	return `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"` + name + `","namespace":"default"}}`
+}
+
+// TestStreamReplayWatch_EmitsEventsInOrder is the core acceptance test: a watch
+// client receives the captured ADDED/MODIFIED/DELETED events in timestamp order
+// as the replay clock advances.
+func TestStreamReplayWatch_EmitsEventsInOrder(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	to := from.Add(20 * time.Second)
+	const podsPath = "/api/v1/namespaces/default/pods"
+
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{
+			podsPath: {id: "snap0", at: from, body: emptyPodList},
+		},
+		[]watchTestEvent{
+			{id: "e1", apiPath: podsPath, at: from.Add(2 * time.Second), eventType: "ADDED", objectBody: podBody("pod-a")},
+			{id: "e2", apiPath: podsPath, at: from.Add(4 * time.Second), eventType: "ADDED", objectBody: podBody("pod-b")},
+			{id: "e3", apiPath: podsPath, at: from.Add(6 * time.Second), eventType: "MODIFIED", objectBody: podBody("pod-a")},
+			{id: "e4", apiPath: podsPath, at: from.Add(8 * time.Second), eventType: "DELETED", objectBody: podBody("pod-b")},
+		},
+	)
+
+	clock, advance := newTestClock(t, from, to, 1, false, false)
+	h := newHandler(store, time.Time{}, false)
+	h.clock = clock
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+podsPath+"?watch=1", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("watch request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	type ev struct {
+		Type   string `json:"type"`
+		Object struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+		} `json:"object"`
+	}
+	lines := make(chan ev, 16)
+	go func() {
+		sc := bufio.NewScanner(resp.Body)
+		sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+		for sc.Scan() {
+			var e ev
+			if err := json.Unmarshal(sc.Bytes(), &e); err != nil {
+				continue
+			}
+			select {
+			case lines <- e:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	next := func() ev {
+		t.Helper()
+		select {
+		case e := <-lines:
+			return e
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for watch event")
+			return ev{}
+		}
+	}
+
+	// The initial list is empty, so the first frame is the BOOKMARK. Only after
+	// it do we advance the clock, so the four events are streamed (not folded
+	// into the initial snapshot).
+	if e := next(); e.Type != "BOOKMARK" {
+		t.Fatalf("first frame = %q, want BOOKMARK", e.Type)
+	}
+	advance(20 * time.Second)
+
+	want := []struct{ typ, name string }{
+		{"ADDED", "pod-a"},
+		{"ADDED", "pod-b"},
+		{"MODIFIED", "pod-a"},
+		{"DELETED", "pod-b"},
+	}
+	for i, w := range want {
+		e := next()
+		if e.Type != w.typ || e.Object.Metadata.Name != w.name {
+			t.Errorf("event %d = (%s %s), want (%s %s)", i, e.Type, e.Object.Metadata.Name, w.typ, w.name)
+		}
+	}
+
+	if got := clock.EventsEmitted(); got != 4 {
+		t.Errorf("EventsEmitted = %d, want 4", got)
+	}
+}
+
+// TestWatchTimeline_AggregatesAcrossNamespaces covers the `kubectl get pods -A
+// --watch` case: a cluster-wide watch path merges the per-namespace watch-index
+// entries into one timestamp-ordered timeline.
+func TestWatchTimeline_AggregatesAcrossNamespaces(t *testing.T) {
+	base := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	ns1 := "/api/v1/namespaces/ns1/pods"
+	ns2 := "/api/v1/namespaces/ns2/pods"
+
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{
+			ns1: {id: "s1", at: base, body: emptyPodList},
+			ns2: {id: "s2", at: base, body: emptyPodList},
+		},
+		[]watchTestEvent{
+			{id: "a", apiPath: ns1, at: base.Add(1 * time.Second), eventType: "ADDED", objectBody: podBody("p1")},
+			{id: "b", apiPath: ns2, at: base.Add(2 * time.Second), eventType: "ADDED", objectBody: podBody("p2")},
+			{id: "c", apiPath: ns1, at: base.Add(3 * time.Second), eventType: "MODIFIED", objectBody: podBody("p1")},
+		},
+	)
+
+	timeline := store.watchTimeline("/api/v1/pods")
+	if len(timeline) != 3 {
+		t.Fatalf("timeline length = %d, want 3", len(timeline))
+	}
+	for i := 1; i < len(timeline); i++ {
+		if timeline[i].t.Before(timeline[i-1].t) {
+			t.Errorf("timeline not sorted at %d: %s before %s", i, timeline[i].t, timeline[i-1].t)
+		}
+	}
+	if timeline[0].apiPath != ns1 || timeline[1].apiPath != ns2 {
+		t.Errorf("unexpected merge order: %s then %s", timeline[0].apiPath, timeline[1].apiPath)
+	}
+}

--- a/internal/server/watch_replay_test.go
+++ b/internal/server/watch_replay_test.go
@@ -28,10 +28,11 @@ type watchEvent struct {
 	} `json:"object"`
 }
 
-// openWatchStream connects to a watch URL and returns a `next` that reads the
-// following frame (failing on a 3s timeout). The returned cancel closes the
-// stream.
-func openWatchStream(t *testing.T, url string) (next func() watchEvent, cancel func()) {
+// openWatchStream connects to a watch URL and returns `next` (reads the next
+// frame, failing on a 3s timeout), `tryNext` (reads the next frame within a
+// caller-supplied timeout, reporting ok=false if none arrives), and a cancel
+// that closes the stream.
+func openWatchStream(t *testing.T, url string) (next func() watchEvent, tryNext func(time.Duration) (watchEvent, bool), cancel func()) {
 	t.Helper()
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -76,8 +77,16 @@ func openWatchStream(t *testing.T, url string) (next func() watchEvent, cancel f
 			return watchEvent{}
 		}
 	}
+	tryNext = func(d time.Duration) (watchEvent, bool) {
+		select {
+		case e := <-lines:
+			return e, true
+		case <-time.After(d):
+			return watchEvent{}, false
+		}
+	}
 	cancel = func() { cancelCtx(); resp.Body.Close() }
-	return next, cancel
+	return next, tryNext, cancel
 }
 
 // TestStreamReplayWatch_EmitsEventsInOrder is the core acceptance test: a watch
@@ -245,7 +254,7 @@ func TestStreamReplayWatch_SeekTriggersRelist(t *testing.T) {
 
 	srv := httptest.NewServer(h)
 	defer srv.Close()
-	next, cancel := openWatchStream(t, srv.URL+"/api/v1/namespaces/default/pods?watch=1")
+	next, _, cancel := openWatchStream(t, srv.URL+"/api/v1/namespaces/default/pods?watch=1")
 	defer cancel()
 
 	if e := next(); e.Type != "BOOKMARK" {
@@ -279,7 +288,7 @@ func TestStreamReplayWatch_LoopRelistsWithBookmark(t *testing.T) {
 
 	srv := httptest.NewServer(h)
 	defer srv.Close()
-	next, cancel := openWatchStream(t, srv.URL+"/api/v1/namespaces/default/pods?watch=1")
+	next, _, cancel := openWatchStream(t, srv.URL+"/api/v1/namespaces/default/pods?watch=1")
 	defer cancel()
 
 	if e := next(); e.Type != "BOOKMARK" {
@@ -308,7 +317,7 @@ func TestStreamReplayWatch_BookmarkRVNonZero(t *testing.T) {
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 	// Watch a resource with no captured data → empty-list synthesis (RV "0").
-	next, cancel := openWatchStream(t, srv.URL+"/api/v1/namespaces/default/services?watch=1")
+	next, _, cancel := openWatchStream(t, srv.URL+"/api/v1/namespaces/default/services?watch=1")
 	defer cancel()
 
 	e := next()
@@ -317,5 +326,34 @@ func TestStreamReplayWatch_BookmarkRVNonZero(t *testing.T) {
 	}
 	if rv := e.Object.Metadata.ResourceVersion; rv == "" || rv == "0" {
 		t.Errorf("BOOKMARK resourceVersion = %q, want non-zero", rv)
+	}
+}
+
+// TestStreamReplayWatch_EventsAfterWindowEnd verifies that events timestamped
+// after a --to sub-range end don't hang the stream: in-window events are emitted
+// and the stream goes idle (rather than waiting forever for the clock to reach
+// an event it will never advance to).
+func TestStreamReplayWatch_EventsAfterWindowEnd(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	// Window ends at from+3s: pod-a (at +2s) is inside; pod-b (at +4s) is after.
+	h, _, advance := buildPodWatchStore(t, from, 3, false)
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	next, tryNext, cancel := openWatchStream(t, srv.URL+"/api/v1/namespaces/default/pods?watch=1")
+	defer cancel()
+
+	if e := next(); e.Type != "BOOKMARK" {
+		t.Fatalf("first frame = %q, want BOOKMARK", e.Type)
+	}
+	advance(10 * time.Second) // clock clamps at the window end (from+3s)
+
+	if e := next(); e.Type != "ADDED" || e.Object.Metadata.Name != "pod-a" {
+		t.Fatalf("frame = (%s %s), want ADDED pod-a", e.Type, e.Object.Metadata.Name)
+	}
+	// pod-b is past the window end: it must not be emitted, and the stream must
+	// not hang — it should simply idle.
+	if e, ok := tryNext(500 * time.Millisecond); ok {
+		t.Errorf("unexpected frame after window end: (%s %s)", e.Type, e.Object.Metadata.Name)
 	}
 }


### PR DESCRIPTION
Implements **phase 1** of time-based replay (#120, part of #119).

Play a watch-enabled capture *forward through time* at a configurable speed, streaming captured events to clients as a replay clock advances. Unlike `open --at` (which jumps the whole view to a single instant), replay advances a clock and **streams change over time** — so controllers/operators and `kubectl get --watch` observe the cluster changing exactly as it did during capture.

## What's here
- **Replay clock** (`internal/server/clock.go`) — maps wall-clock → capture-time at a speed factor over a `[from, to]` window; internal pause/resume/seek/speed and loop-epoch tracking. `parseSpeed` accepts `2x`/`0.5x`/`3`.
- **Event-streaming watch** (`internal/server/watch_replay.go`) — in replay mode the watch path emits the state as-of the clock as an initial `ADDED` burst, a `BOOKMARK`, then the captured `ADDED`/`MODIFIED`/`DELETED` events in timestamp order, each held until the clock crosses its timestamp. Cluster-wide watches (`-A`) merge the per-namespace watch-index entries into one timeline; `--loop` re-lists and replays on each wrap; label/field selectors are honored per event.
- **Shared list resolution** — the fallback chain (cross-namespace aggregation, cluster-scoped namespace filtering, empty-list synthesis) is factored out of `handleWatch` into `resolveWatchList`, shared by both the plain and replay watch paths.
- **Server** — new `Replay()`/`ReplayOptions` sharing bring-up with `Open()` via `serve()`; `parseReplayWindow` resolves `--from`/`--to`. LIST/GET reconstruct as-of the clock (same time-travel semantics as `--at`).
- **CLI** — `kshrk replay <capture> --speed --from --to --loop --start-paused`; writes a kubeconfig like `open`, prints a live status line (`replaying 14:03:12Z (+2m18s / 10m) · 2x · 47 events emitted`), and notes when a poll-only capture has no watch events to stream.

## Acceptance criteria
- [x] `kshrk replay capture.kshrk --speed 2x` streams events over time to a `kubectl get pods -A --watch` at ~2× the original cadence (clock × speed; `-A` timeline merge covered by tests).
- [x] `--from`/`--to`/`--loop`/`--start-paused` behave as documented.
- [x] Existing `open`/`--at` behavior unchanged (clock is nil there; `handleWatch` path preserved).
- [x] Unit/integration test that a watch client receives the expected event sequence **in order**.

## Out of scope (later phases, per #119)
- Poll-only captures (event inference by diffing snapshots), resourceVersion hardening, reconnect/relist correctness — phase 2. Replay prints a note when a capture has no watch events.
- UI transport controls / HTTP control endpoint — phase 3. (The clock already exposes pause/seek/speed internally, ready to wire up.)
- Writable overlay — phase 4.

## Testing
`internal/server`: clock mapping/pause/seek/loop/speed, `parseSpeed`, `parseReplayWindow`, an end-to-end HTTP watch stream asserting event order, and cross-namespace timeline merge. `cmd`: replay-command error paths. Full `go test -race ./...`, `go vet`, `gofmt`, `go mod tidy`, and pinned `golangci-lint` all clean locally. Also smoke-tested the binary against a real capture (boots, writes kubeconfig, status line advances at the set speed, serves LIST).

🤖 Generated with [Claude Code](https://claude.com/claude-code)