### PR TITLE
chore: add Copilot code-review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,45 @@
+# Copilot instructions for k8shark
+
+Guidance for GitHub Copilot when reviewing pull requests and assisting in this
+repository. (For the human/CLI-agent conventions, see `CLAUDE.md` and
+`.github/instructions/`.)
+
+## Code-review approach
+
+- **Be comprehensive on the first review.** Review the entire changed surface in
+  a single pass and report all substantive findings together, grouped by file
+  or theme. Don't trickle findings across many rounds — surface everything you
+  can in the initial review.
+- **Scope re-reviews to what changed.** On subsequent pushes, review only the
+  new diff since your previous review. Do not re-raise points that were already
+  addressed or resolved, and do not repeat findings on unchanged lines.
+- **Prioritize substance over nits.** Focus on correctness bugs, security
+  issues, data loss, resource leaks, race conditions, incorrect error handling,
+  and public API / contract mistakes. Skip purely stylistic remarks.
+- **Group repeated findings.** If the same issue pattern appears in several
+  places, raise it once with the list of locations rather than one comment per
+  occurrence.
+- **Don't flag what tooling already enforces.** Formatting is handled by
+  `gofmt`; linting by `golangci-lint` and `go vet`; vulnerabilities by
+  `govulncheck`. Don't raise issues these tools already cover in CI.
+- **Respect established patterns.** If a construct is used consistently across
+  the codebase or documented in `CLAUDE.md`, don't flag a single instance in
+  isolation.
+
+## Repository conventions
+
+- **American English** everywhere — docs, comments, identifiers, log/error
+  strings, and commit messages (`color`, `behavior`, `canceled`, `normalize`,
+  `recognize`, etc.), not the British forms.
+- Build and verify through the **Makefile** (`make build`, `make test`,
+  `make lint`, `make fmt`) rather than raw `go` commands.
+- CI tools (`golangci-lint`, `govulncheck`) are pinned to explicit versions,
+  not `@latest`; the `go` directive in `go.mod` is pinned to a specific patch
+  release.
+
+## Known false positives — do not flag
+
+- `capture.Index` map literals that elide `&IndexEntry{...}` (e.g.
+  `capture.Index{"/api/...": {APIPath: "...", Seqs: []int{0}}}`) are valid Go:
+  the spec allows eliding `&T` for composite-literal values whose element type
+  is `*T`. These compile and are correct.


### PR DESCRIPTION
Adds `.github/copilot-instructions.md` to make Copilot's PR reviews more holistic.

## Why

On recent PRs, Copilot has trickled review comments across many pushes (a few new comments after each push) rather than surfacing findings up front. These instructions ask it to:

- **Review the whole changed surface in a single comprehensive first pass**, grouped by file/theme.
- **Scope re-reviews to what actually changed** on later pushes, and not re-raise resolved or unchanged-line findings.
- Prioritize substance (correctness, security, leaks, error handling, contract) over nits.
- Group repeated findings into one comment.
- Skip issues already enforced by `gofmt` / `golangci-lint` / `go vet` / `govulncheck`.

It also records repo conventions (American English, Makefile workflow, pinned tool/`go` versions) and the known `capture.Index` map-literal false positive, so reviews stop re-flagging them.

## Note on scope / effect

Per the [GitHub docs](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/request-a-code-review/use-code-review#customizing-copilots-reviews-with-custom-instructions), **Copilot reads review instructions from the PR's _base branch_** — so this only takes effect for PRs opened against `main` after it merges. It won't retroactively change in-flight reviews on existing PRs.

Kept as its own small PR (rather than bundled into a feature branch) precisely because it needs to be on `main` to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)