### PR TITLE
feat(replay): phase 2 — resourceVersion coherence, poll-only support, reconnect (#121)

### DIFF
--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -89,8 +89,9 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Drive playback, e.g.: curl -sk -X POST %s/_k8shark/replay/pause\n", srv.Address())
 
 	if !srv.HasWatchEvents() {
-		fmt.Printf("\nNote: this capture has no watch events, so no changes will stream.\n")
-		fmt.Printf("      Re-capture with 'watch: true' to record ADDED/MODIFIED/DELETED over time.\n")
+		fmt.Printf("\nNote: this capture has no watch events; changes will be inferred by diffing\n")
+		fmt.Printf("      consecutive snapshots. Re-capture with 'watch: true' for precise,\n")
+		fmt.Printf("      higher-resolution ADDED/MODIFIED/DELETED events.\n")
 	}
 
 	if startPaused {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -390,7 +390,9 @@ The primary use case is **local development and testing of controllers/operators
 
 > **Read-only.** The mock server replays a captured timeline; a controller's writes won't persist or feed back into the replay. You observe "how my controller reacts to this sequence," not a closed loop.
 >
-> **Watch events required.** Replay streams the events recorded with `watch: true` (see [docs/config.md](config.md)). A poll-only capture has no watch events, so `replay` still serves LIST/GET as-of the clock but streams nothing — `kshrk replay` prints a note when this is the case. (Inferring events for poll-only captures by diffing snapshots is a planned enhancement.)
+> **Watch events.** Replay streams the events recorded with `watch: true` (see [docs/config.md](config.md)) at full fidelity. A poll-only capture (no watch index) still replays: `kshrk replay` infers ADDED/MODIFIED/DELETED events by diffing consecutive snapshots, so you get an event stream bounded by the poll interval's resolution. Use `watch: true` when you need precise, higher-resolution events.
+>
+> **resourceVersion & informers.** Replay assigns a coherent, monotonic `resourceVersion` to every object so real controller informers work: a LIST returns `resourceVersion = rvAsOf(clock)`, a `WATCH?resourceVersion=X` resumes by streaming only events newer than `X` (each carrying its own RV), and a stale/unknown RV returns `410 Gone` so the informer relists cleanly. A reconnecting client resumes from its last RV without dropped or duplicated events.
 
 ### Replay flags
 

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -18,10 +19,31 @@ type handler struct {
 	// state as-of the clock's advancing position and watches stream captured
 	// events over time (see streamReplayWatch). nil for plain `open`/`ui`.
 	clock *ReplayClock
+
+	// timelineCache memoizes the (immutable) per-path replay event timeline so
+	// LIST and WATCH don't rebuild it per request — important for poll-only
+	// captures, whose timeline requires diffing every snapshot.
+	timelineMu    sync.Mutex
+	timelineCache map[string][]replayEvent
 }
 
 func newHandler(store *CaptureStore, at time.Time, verbose bool) *handler {
 	return &handler{store: store, at: at, verbose: verbose}
+}
+
+// timelineFor returns the memoized replay timeline for a watch path.
+func (h *handler) timelineFor(watchPath string) []replayEvent {
+	h.timelineMu.Lock()
+	defer h.timelineMu.Unlock()
+	if h.timelineCache == nil {
+		h.timelineCache = map[string][]replayEvent{}
+	}
+	if tl, ok := h.timelineCache[watchPath]; ok {
+		return tl
+	}
+	tl := h.store.buildReplayTimeline(watchPath)
+	h.timelineCache[watchPath] = tl
+	return tl
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -498,6 +520,13 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		if tb, err2 := buildTable(body); err2 == nil {
 			body = tb
 		}
+	}
+
+	// In replay mode, override a list's resourceVersion with the coherent RV
+	// as-of the clock, so a following WATCH(resourceVersion=RV) aligns with the
+	// event stream's monotonic RVs.
+	if h.clock != nil {
+		body = rewriteListResourceVersion(body, rvAsOf(h.timelineFor(path), at))
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -34,17 +34,30 @@ func newHandler(store *CaptureStore, at time.Time, verbose bool) *handler {
 // timelineFor returns the memoized replay timeline for a watch path. The key is
 // normalized (trailing "/" trimmed) so a LIST on ".../pods/" and a WATCH on
 // ".../pods" share one timeline — keeping their RVs coherent and the cache warm.
+//
+// The (potentially expensive, for poll-only) build runs without the lock held so
+// it doesn't block concurrent requests for other paths; at worst two goroutines
+// build the same timeline once, and the first stored result wins.
 func (h *handler) timelineFor(watchPath string) []replayEvent {
 	watchPath = strings.TrimSuffix(watchPath, "/")
+
 	h.timelineMu.Lock()
-	defer h.timelineMu.Unlock()
 	if h.timelineCache == nil {
 		h.timelineCache = map[string][]replayEvent{}
 	}
 	if tl, ok := h.timelineCache[watchPath]; ok {
+		h.timelineMu.Unlock()
 		return tl
 	}
+	h.timelineMu.Unlock()
+
 	tl := h.store.buildReplayTimeline(watchPath)
+
+	h.timelineMu.Lock()
+	defer h.timelineMu.Unlock()
+	if existing, ok := h.timelineCache[watchPath]; ok {
+		return existing // another goroutine won the race; use its result
+	}
 	h.timelineCache[watchPath] = tl
 	return tl
 }

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -36,8 +36,10 @@ func newHandler(store *CaptureStore, at time.Time, verbose bool) *handler {
 // ".../pods" share one timeline — keeping their RVs coherent and the cache warm.
 //
 // The (potentially expensive, for poll-only) build runs without the lock held so
-// it doesn't block concurrent requests for other paths; at worst two goroutines
-// build the same timeline once, and the first stored result wins.
+// it doesn't block concurrent requests for other paths. On a cold cache, several
+// concurrent callers for the same path may each build it; the first stored result
+// wins and the rest are discarded. (A singleflight-style guard could dedupe the
+// redundant builds if that ever matters — in practice the cold window is brief.)
 func (h *handler) timelineFor(watchPath string) []replayEvent {
 	watchPath = strings.TrimSuffix(watchPath, "/")
 

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -31,8 +31,11 @@ func newHandler(store *CaptureStore, at time.Time, verbose bool) *handler {
 	return &handler{store: store, at: at, verbose: verbose}
 }
 
-// timelineFor returns the memoized replay timeline for a watch path.
+// timelineFor returns the memoized replay timeline for a watch path. The key is
+// normalized (trailing "/" trimmed) so a LIST on ".../pods/" and a WATCH on
+// ".../pods" share one timeline — keeping their RVs coherent and the cache warm.
 func (h *handler) timelineFor(watchPath string) []replayEvent {
+	watchPath = strings.TrimSuffix(watchPath, "/")
 	h.timelineMu.Lock()
 	defer h.timelineMu.Unlock()
 	if h.timelineCache == nil {
@@ -526,7 +529,9 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 	// as-of the clock, so a following WATCH(resourceVersion=RV) aligns with the
 	// event stream's monotonic RVs.
 	if h.clock != nil {
-		body = rewriteListResourceVersion(body, rvAsOf(h.timelineFor(path), at))
+		body = rewriteListResourceVersion(body, func() int64 {
+			return rvAsOf(h.timelineFor(path), at)
+		})
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/server/replay_rv.go
+++ b/internal/server/replay_rv.go
@@ -1,0 +1,217 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/transitions"
+)
+
+// Replay resourceVersion (RV) scheme
+// ----------------------------------
+// For informer-grade correctness, replay assigns every object a monotonic RV
+// derived from a single time-sorted event timeline per watch path:
+//
+//   - rv(event i) = i + 1            (strictly increasing, 1-based)
+//   - rvAsOf(T)   = count(t <= T)    (the RV of the state as-of clock time T)
+//
+// The LIST served at clock T returns metadata.resourceVersion = rvAsOf(T); a
+// WATCH streams events with rv > the requested RV, each carrying its own rv on
+// the object. Because rv is a strict sequence (not a raw timestamp), events that
+// share a timestamp — common for poll-only captures whose diffs all carry the
+// snapshot time — still get distinct, ordered RVs, so a reconnecting client
+// resumes cleanly with no dropped or duplicated events.
+
+// replayRVBase is the smallest resourceVersion the scheme emits. Starting at 1
+// (rather than 0) keeps the window-start / empty-timeline RV non-zero, which
+// clients require (RV "0" has special "unset" meaning to client-go).
+const replayRVBase = 1
+
+// watchIndexPaths returns the capture watch-index paths feeding a watch on
+// watchPath: the exact path if captured, else (for a cluster-wide path) the
+// per-namespace demultiplexed paths. The result is sorted for determinism.
+func (s *CaptureStore) watchIndexPaths(watchPath string) []string {
+	if _, ok := s.WatchIndex[watchPath]; ok {
+		return []string{watchPath}
+	}
+	prefix, suffix, ok := clusterWideChildPrefix(watchPath)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for p := range s.WatchIndex {
+		if strings.HasPrefix(p, prefix) && strings.HasSuffix(p, suffix) {
+			out = append(out, p)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// snapshotPaths returns the capture snapshot (index) paths feeding a watch on
+// watchPath for poll-only inference. Same resolution as watchIndexPaths but over
+// the snapshot index, skipping Table-format keys.
+func (s *CaptureStore) snapshotPaths(watchPath string) []string {
+	if _, ok := s.Index[watchPath]; ok {
+		return []string{watchPath}
+	}
+	prefix, suffix, ok := clusterWideChildPrefix(watchPath)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for p := range s.Index {
+		if strings.Contains(p, "?") {
+			continue
+		}
+		if strings.HasPrefix(p, prefix) && strings.HasSuffix(p, suffix) {
+			out = append(out, p)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// clusterWideChildPrefix returns the "/namespaces/" prefix and "/<resource>"
+// suffix used to find the per-namespace children of a cluster-wide watch path.
+// ok is false when watchPath is namespaced or not a resource path.
+func clusterWideChildPrefix(watchPath string) (prefix, suffix string, ok bool) {
+	g, v, resource, ns := parseAPIPath(watchPath)
+	if ns != "" || resource == "" {
+		return "", "", false
+	}
+	if g == "" {
+		prefix = "/api/" + v + "/namespaces/"
+	} else {
+		prefix = "/apis/" + g + "/" + v + "/namespaces/"
+	}
+	return prefix, "/" + resource, true
+}
+
+// buildReplayTimeline builds the merged, time-sorted event timeline for a watch
+// path and assigns each event a monotonic rv. Watch-enabled paths use the watch
+// index (bodies read lazily); poll-only paths synthesize events by diffing
+// consecutive snapshots (bodies inlined).
+func (s *CaptureStore) buildReplayTimeline(watchPath string) []replayEvent {
+	var evs []replayEvent
+
+	if wps := s.watchIndexPaths(watchPath); len(wps) > 0 {
+		for _, p := range wps {
+			wi := s.WatchIndex[p]
+			for i := range wi.Seqs {
+				if i >= len(wi.Times) || i >= len(wi.EventTypes) {
+					break
+				}
+				evs = append(evs, replayEvent{t: wi.Times[i], typ: wi.EventTypes[i], apiPath: p, seq: wi.Seqs[i]})
+			}
+		}
+	} else {
+		// Poll-only: infer events from snapshot diffs.
+		for _, p := range s.snapshotPaths(watchPath) {
+			entry := s.Index[p]
+			if entry == nil {
+				continue
+			}
+			trs, err := transitions.InferPollTransitions(s.ar, p, entry)
+			if err != nil {
+				continue
+			}
+			for _, tr := range trs {
+				body := tr.After
+				if tr.EventType == "DELETED" {
+					body = tr.Before
+				}
+				evs = append(evs, replayEvent{t: tr.Time, typ: tr.EventType, apiPath: p, seq: -1, body: body})
+			}
+		}
+	}
+
+	// Sort by time with a deterministic tiebreak so equal-time events keep a
+	// stable order (SliceStable preserves per-path append order for poll events,
+	// whose seq is -1).
+	sort.SliceStable(evs, func(i, j int) bool {
+		if !evs[i].t.Equal(evs[j].t) {
+			return evs[i].t.Before(evs[j].t)
+		}
+		if evs[i].apiPath != evs[j].apiPath {
+			return evs[i].apiPath < evs[j].apiPath
+		}
+		return evs[i].seq < evs[j].seq
+	})
+	for i := range evs {
+		evs[i].rv = replayRVBase + int64(i) + 1
+	}
+	return evs
+}
+
+// rvAsOf returns the resourceVersion of the state as-of time at: replayRVBase
+// plus the number of timeline events with t <= at. This equals the rv of the
+// last such event, and is never below replayRVBase (so it's never "0").
+func rvAsOf(timeline []replayEvent, at time.Time) int64 {
+	n := sort.Search(len(timeline), func(i int) bool { return timeline[i].t.After(at) })
+	return replayRVBase + int64(n)
+}
+
+// withResourceVersion returns obj with metadata.resourceVersion set to rv,
+// preserving all other fields. On any parse error it returns obj unchanged.
+func withResourceVersion(obj json.RawMessage, rv int64) json.RawMessage {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(obj, &m); err != nil {
+		return obj
+	}
+	meta := map[string]json.RawMessage{}
+	if raw, ok := m["metadata"]; ok {
+		if err := json.Unmarshal(raw, &meta); err != nil {
+			meta = map[string]json.RawMessage{}
+		}
+	}
+	meta["resourceVersion"], _ = json.Marshal(strconv.FormatInt(rv, 10))
+	m["metadata"], _ = json.Marshal(meta)
+	out, err := json.Marshal(m)
+	if err != nil {
+		return obj
+	}
+	return out
+}
+
+// rewriteListResourceVersion sets metadata.resourceVersion to rv on a list body
+// (one with an "items" field), leaving non-list bodies untouched.
+func rewriteListResourceVersion(body []byte, rv int64) []byte {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(body, &m); err != nil {
+		return body
+	}
+	if _, ok := m["items"]; !ok {
+		return body
+	}
+	meta := map[string]json.RawMessage{}
+	if raw, ok := m["metadata"]; ok {
+		if err := json.Unmarshal(raw, &meta); err != nil {
+			meta = map[string]json.RawMessage{}
+		}
+	}
+	meta["resourceVersion"], _ = json.Marshal(strconv.FormatInt(rv, 10))
+	m["metadata"], _ = json.Marshal(meta)
+	out, err := json.Marshal(m)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+// writeGone writes a 410 Status (reason "Expired") so a client-go informer
+// relists cleanly instead of trying to resume from a stale resourceVersion.
+func (h *handler) writeGone(w http.ResponseWriter, msg string) {
+	writeJSON(w, http.StatusGone, map[string]any{
+		"kind":       "Status",
+		"apiVersion": "v1",
+		"status":     "Failure",
+		"reason":     "Expired",
+		"message":    msg,
+		"code":       http.StatusGone,
+	})
+}

--- a/internal/server/replay_rv.go
+++ b/internal/server/replay_rv.go
@@ -69,7 +69,9 @@ func (s *CaptureStore) snapshotPaths(watchPath string) []string {
 	}
 	var out []string
 	for p := range s.Index {
-		if strings.Contains(p, "?") {
+		// Skip the Table-format sentinel; a bare list snapshot is what we diff.
+		// Other query keys (e.g. log ?container=) never match the resource suffix.
+		if strings.HasSuffix(p, tableIndexKeySuffix) {
 			continue
 		}
 		if strings.HasPrefix(p, prefix) && strings.HasSuffix(p, suffix) {
@@ -79,6 +81,9 @@ func (s *CaptureStore) snapshotPaths(watchPath string) []string {
 	sort.Strings(out)
 	return out
 }
+
+// tableIndexKeySuffix marks captured Table-format list responses in the index.
+const tableIndexKeySuffix = "?as=Table"
 
 // clusterWideChildPrefix returns the "/namespaces/" prefix and "/<resource>"
 // suffix used to find the per-namespace children of a cluster-wide watch path.

--- a/internal/server/replay_rv.go
+++ b/internal/server/replay_rv.go
@@ -16,8 +16,12 @@ import (
 // For informer-grade correctness, replay assigns every object a monotonic RV
 // derived from a single time-sorted event timeline per watch path:
 //
-//   - rv(event i) = i + 1            (strictly increasing, 1-based)
-//   - rvAsOf(T)   = count(t <= T)    (the RV of the state as-of clock time T)
+//   - rv(event i) = replayRVBase + i + 1          (strictly increasing)
+//   - rvAsOf(T)   = replayRVBase + count(t <= T)  (RV of the state as-of T)
+//
+// replayRVBase (1) offsets every RV so the window-start / empty-timeline value
+// is 1, not the special "0"; consequently the first event's RV is 2. rvAsOf(T)
+// equals the rv of the last event with t <= T (or replayRVBase when none).
 //
 // The LIST served at clock T returns metadata.resourceVersion = rvAsOf(T); a
 // WATCH streams events with rv > the requested RV, each carrying its own rv on
@@ -178,9 +182,12 @@ func withResourceVersion(obj json.RawMessage, rv int64) json.RawMessage {
 	return out
 }
 
-// rewriteListResourceVersion sets metadata.resourceVersion to rv on a list body
-// (one with an "items" field), leaving non-list bodies untouched.
-func rewriteListResourceVersion(body []byte, rv int64) []byte {
+// rewriteListResourceVersion sets metadata.resourceVersion on a list body (one
+// with an "items" field), leaving non-list bodies untouched. rvFn is called only
+// once the body is confirmed to be a list, so callers can avoid computing an
+// expensive RV (e.g. building a poll-only timeline) for single-object, discovery,
+// or Table responses.
+func rewriteListResourceVersion(body []byte, rvFn func() int64) []byte {
 	var m map[string]json.RawMessage
 	if err := json.Unmarshal(body, &m); err != nil {
 		return body
@@ -188,6 +195,7 @@ func rewriteListResourceVersion(body []byte, rv int64) []byte {
 	if _, ok := m["items"]; !ok {
 		return body
 	}
+	rv := rvFn()
 	meta := map[string]json.RawMessage{}
 	if raw, ok := m["metadata"]; ok {
 		if err := json.Unmarshal(raw, &meta); err != nil {

--- a/internal/server/replay_rv_test.go
+++ b/internal/server/replay_rv_test.go
@@ -170,7 +170,8 @@ func TestReplayWatch_StaleRVReturns410(t *testing.T) {
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
-	for _, rv := range []string{"not-a-number", "1"} {
+	// not-a-number → invalid; 1 → below window; 999999999 → newer than any event.
+	for _, rv := range []string{"not-a-number", "1", "999999999"} {
 		resp, err := http.Get(srv.URL + "/api/v1/namespaces/default/pods?watch=1&resourceVersion=" + rv)
 		if err != nil {
 			t.Fatalf("watch rv=%s: %v", rv, err)

--- a/internal/server/replay_rv_test.go
+++ b/internal/server/replay_rv_test.go
@@ -183,6 +183,35 @@ func TestReplayWatch_StaleRVReturns410(t *testing.T) {
 	}
 }
 
+// TestReplayWatch_ListBurstCarriesCoherentRV verifies the initial ADDED burst
+// stamps items with the coherent rvAsOf value, not the captured object RV, so a
+// client resuming from an observed object RV aligns with the event stream.
+func TestReplayWatch_ListBurstCarriesCoherentRV(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	path := "/api/v1/namespaces/default/pods"
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{path: {id: "s", at: from, body: podList("pod-x")}},
+		[]watchTestEvent{
+			{id: "e1", apiPath: path, at: from.Add(2 * time.Second), eventType: "ADDED", objectBody: podBody("pod-y")},
+		})
+	clock, _ := newTestClock(t, from, from.Add(20*time.Second), 1, false, false)
+	h := newHandler(store, time.Time{}, false)
+	h.clock = clock
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	next, _, cancel := openWatchStream(t, srv.URL+path+"?watch=1")
+	defer cancel()
+
+	e := next()
+	if e.Type != "ADDED" || e.Object.Metadata.Name != "pod-x" {
+		t.Fatalf("first frame = (%s %s), want ADDED pod-x", e.Type, e.Object.Metadata.Name)
+	}
+	if e.Object.Metadata.ResourceVersion != "1" {
+		t.Errorf("burst item rv = %q, want \"1\" (rvAsOf(start), not captured RV)", e.Object.Metadata.ResourceVersion)
+	}
+}
+
 // TestReplayWatch_ZeroRVListsNotGone verifies any zero-valued resourceVersion
 // ("0", "00", …) is treated as unset (list+stream), not resume/410.
 func TestReplayWatch_ZeroRVListsNotGone(t *testing.T) {

--- a/internal/server/replay_rv_test.go
+++ b/internal/server/replay_rv_test.go
@@ -1,0 +1,228 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// buildPollStore writes a capture with multiple snapshots for one path and NO
+// watch index, so replay must infer events by diffing snapshots.
+func buildPollStore(t *testing.T, apiPath string, snaps []struct {
+	at   time.Time
+	body string
+}) *CaptureStore {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "poll.kshrk")
+	sw, err := archive.NewStreamWriter(out)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	idx := capture.Index{}
+	entry := &capture.IndexEntry{APIPath: apiPath}
+	for i, s := range snaps {
+		rec := &capture.Record{ID: apiPath, CapturedAt: s.at, APIPath: apiPath, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(s.body)}
+		if err := sw.WriteRecord(rec); err != nil {
+			t.Fatalf("WriteRecord: %v", err)
+		}
+		entry.Seqs = append(entry.Seqs, i)
+		entry.Times = append(entry.Times, s.at)
+	}
+	idx[apiPath] = entry
+	meta := &capture.CaptureMetadata{
+		FormatVersion: capture.CurrentFormatVersion, CaptureID: "poll-test",
+		KubernetesVersion: "v1.30.0", CapturedAt: snaps[0].at, CapturedUntil: snaps[len(snaps)-1].at,
+	}
+	if err := sw.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	ar, err := archive.Open(out)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	t.Cleanup(func() { ar.Close() })
+	store, err := LoadStore(ar)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	return store
+}
+
+func podList(names ...string) string {
+	items := ""
+	for i, n := range names {
+		if i > 0 {
+			items += ","
+		}
+		items += podBody(n)
+	}
+	return `{"apiVersion":"v1","kind":"PodList","metadata":{"resourceVersion":"999"},"items":[` + items + `]}`
+}
+
+// TestReplayList_ResourceVersionTracksClock verifies the LIST resourceVersion is
+// the coherent rvAsOf(clock), advancing as the clock crosses events.
+func TestReplayList_ResourceVersionTracksClock(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	h, _, advance := buildPodWatchStore(t, from, 20, false)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	listRV := func() string {
+		t.Helper()
+		resp, err := http.Get(srv.URL + "/api/v1/namespaces/default/pods")
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		var l struct {
+			Metadata struct {
+				ResourceVersion string `json:"resourceVersion"`
+			} `json:"metadata"`
+		}
+		if err := json.Unmarshal(body, &l); err != nil {
+			t.Fatalf("decode list: %v\n%s", err, body)
+		}
+		return l.Metadata.ResourceVersion
+	}
+
+	// At window start (no events yet), RV is the base.
+	if got := listRV(); got != "1" {
+		t.Errorf("list RV at start = %q, want \"1\"", got)
+	}
+	advance(20 * time.Second) // clock crosses both events
+	if got := listRV(); got != "3" {
+		t.Errorf("list RV after both events = %q, want \"3\" (base 1 + 2 events)", got)
+	}
+}
+
+// TestReplayWatch_ResumeFromRV verifies a watch with ?resourceVersion=X streams
+// only events with rv > X, with no initial ADDED burst, and stamps each object
+// with its monotonic rv.
+func TestReplayWatch_ResumeFromRV(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	h, _, advance := buildPodWatchStore(t, from, 20, false)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	advance(20 * time.Second) // both events are now in the past
+
+	// Resume from RV=1 (the window-start RV): expect pod-a (rv 2) then pod-b (rv 3),
+	// with no leading BOOKMARK/ADDED-burst.
+	next, _, cancel := openWatchStream(t, srv.URL+"/api/v1/namespaces/default/pods?watch=1&resourceVersion=1")
+	defer cancel()
+
+	e := next()
+	if e.Type != "ADDED" || e.Object.Metadata.Name != "pod-a" {
+		t.Fatalf("first frame = (%s %s), want ADDED pod-a", e.Type, e.Object.Metadata.Name)
+	}
+	if e.Object.Metadata.ResourceVersion != "2" {
+		t.Errorf("pod-a rv = %q, want \"2\"", e.Object.Metadata.ResourceVersion)
+	}
+	e = next()
+	if e.Object.Metadata.Name != "pod-b" || e.Object.Metadata.ResourceVersion != "3" {
+		t.Errorf("second frame = (%s rv=%s), want pod-b rv=3", e.Object.Metadata.Name, e.Object.Metadata.ResourceVersion)
+	}
+}
+
+// TestReplayWatch_ReconnectNoDuplicate simulates a client that saw pod-a (rv 2)
+// then dropped: reconnecting with resourceVersion=2 must resume at pod-b (rv 3)
+// with no re-delivery of pod-a.
+func TestReplayWatch_ReconnectNoDuplicate(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	h, _, advance := buildPodWatchStore(t, from, 20, false)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	advance(20 * time.Second)
+
+	next, _, cancel := openWatchStream(t, srv.URL+"/api/v1/namespaces/default/pods?watch=1&resourceVersion=2")
+	defer cancel()
+
+	e := next()
+	if e.Object.Metadata.Name != "pod-b" || e.Object.Metadata.ResourceVersion != "3" {
+		t.Fatalf("resume from rv=2: first frame = (%s rv=%s), want pod-b rv=3 (pod-a must not repeat)",
+			e.Object.Metadata.Name, e.Object.Metadata.ResourceVersion)
+	}
+}
+
+// TestReplayWatch_StaleRVReturns410 verifies bogus and below-window RVs yield a
+// 410 Gone so the client relists.
+func TestReplayWatch_StaleRVReturns410(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{
+			"/api/v1/namespaces/default/pods": {id: "s", at: from, body: emptyPodList},
+		},
+		[]watchTestEvent{
+			{id: "e1", apiPath: "/api/v1/namespaces/default/pods", at: from.Add(2 * time.Second), eventType: "ADDED", objectBody: podBody("pod-a")},
+		})
+	// Window starts after pod-a, so rvAsOf(windowStart) = 2; RV 1 is "too old".
+	clock, _ := newTestClock(t, from.Add(3*time.Second), from.Add(20*time.Second), 1, false, false)
+	h := newHandler(store, time.Time{}, false)
+	h.clock = clock
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	for _, rv := range []string{"not-a-number", "1"} {
+		resp, err := http.Get(srv.URL + "/api/v1/namespaces/default/pods?watch=1&resourceVersion=" + rv)
+		if err != nil {
+			t.Fatalf("watch rv=%s: %v", rv, err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusGone {
+			t.Errorf("watch rv=%s: status = %d, want 410\n%s", rv, resp.StatusCode, body)
+		}
+	}
+}
+
+// TestReplayWatch_PollOnly verifies replay works for a capture with no watch
+// index by inferring events from snapshot diffs.
+func TestReplayWatch_PollOnly(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	path := "/api/v1/namespaces/default/pods"
+	store := buildPollStore(t, path, []struct {
+		at   time.Time
+		body string
+	}{
+		{from, podList()}, // empty
+		{from.Add(2 * time.Second), podList("pod-a")},          // pod-a ADDED
+		{from.Add(4 * time.Second), podList("pod-a", "pod-b")}, // pod-b ADDED
+	})
+
+	// No watch index → timeline is inferred from diffs.
+	if len(store.WatchIndex) != 0 {
+		t.Fatalf("expected poll-only store (no watch index), got %d entries", len(store.WatchIndex))
+	}
+	tl := store.buildReplayTimeline(path)
+	if len(tl) != 2 {
+		t.Fatalf("inferred timeline length = %d, want 2 (pod-a, pod-b ADDED)", len(tl))
+	}
+
+	clock, advance := newTestClock(t, from, from.Add(10*time.Second), 1, false, false)
+	h := newHandler(store, time.Time{}, false)
+	h.clock = clock
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	next, _, cancel := openWatchStream(t, srv.URL+path+"?watch=1")
+	defer cancel()
+
+	if e := next(); e.Type != "BOOKMARK" {
+		t.Fatalf("first frame = %q, want BOOKMARK (empty initial list)", e.Type)
+	}
+	advance(10 * time.Second)
+	if e := next(); e.Type != "ADDED" || e.Object.Metadata.Name != "pod-a" {
+		t.Fatalf("frame = (%s %s), want ADDED pod-a", e.Type, e.Object.Metadata.Name)
+	}
+	if e := next(); e.Object.Metadata.Name != "pod-b" {
+		t.Fatalf("frame = %s, want pod-b", e.Object.Metadata.Name)
+	}
+}

--- a/internal/server/replay_rv_test.go
+++ b/internal/server/replay_rv_test.go
@@ -183,6 +183,25 @@ func TestReplayWatch_StaleRVReturns410(t *testing.T) {
 	}
 }
 
+// TestReplayWatch_ZeroRVListsNotGone verifies any zero-valued resourceVersion
+// ("0", "00", …) is treated as unset (list+stream), not resume/410.
+func TestReplayWatch_ZeroRVListsNotGone(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	h, _, _ := buildPodWatchStore(t, from, 20, false)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	for _, rv := range []string{"0", "00"} {
+		next, _, cancel := openWatchStream(t, srv.URL+"/api/v1/namespaces/default/pods?watch=1&resourceVersion="+rv)
+		// Initial list is empty → first frame is the BOOKMARK (a 410 would have
+		// failed openWatchStream on the non-200 status).
+		if e := next(); e.Type != "BOOKMARK" {
+			t.Errorf("rv=%q: first frame = %q, want BOOKMARK", rv, e.Type)
+		}
+		cancel()
+	}
+}
+
 // TestReplayWatch_PollOnly verifies replay works for a capture with no watch
 // index by inferring events from snapshot diffs.
 func TestReplayWatch_PollOnly(t *testing.T) {

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -275,16 +275,20 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 			return rv
 		}
 		for _, item := range l.Items {
-			emit("ADDED", item)
+			// Stamp burst items with the list's coherent rv so a client that
+			// resumes from an observed object RV aligns with the event stream.
+			emit("ADDED", withResourceVersion(item, rv))
 		}
 		emitBookmark(l, rv)
 		return rv
 	}
 
 	// Initial list burst + bookmark, unless resuming from a client-supplied RV.
+	// Burst items carry the list's coherent rv (minRV = rvAsOf(startAt)) so a
+	// client resuming from an observed object RV aligns with the event stream.
 	if !resume {
 		for _, item := range list.Items {
-			emit("ADDED", item)
+			emit("ADDED", withResourceVersion(item, minRV))
 		}
 		emitBookmark(list, minRV)
 	}

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -205,18 +205,19 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 		defAPIVersion = g + "/" + v
 	}
 
-	var list watchList
+	// Always resolve the list — even when resuming — so a watch on a path that
+	// can't be resolved returns 404 rather than a 200 that streams nothing. The
+	// reconstruction is response-cached; resume mode just doesn't emit the burst.
+	list, ok, err := h.resolveWatchList(watchPath, startAt, labelSel, fieldSel)
+	if err != nil {
+		h.writeStatus(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if !ok {
+		h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q not found in capture", path))
+		return
+	}
 	if !resume {
-		l, ok, err := h.resolveWatchList(watchPath, startAt, labelSel, fieldSel)
-		if err != nil {
-			h.writeStatus(w, http.StatusInternalServerError, err.Error())
-			return
-		}
-		if !ok {
-			h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q not found in capture", path))
-			return
-		}
-		list = l
 		minRV = rvAsOf(timeline, startAt)
 	}
 

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -164,21 +164,24 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 	timeline := h.timelineFor(watchPath)
 	windowStart, _ := clock.Window()
 
-	// Resume vs list+stream, plus stale-RV → 410.
+	// Resume vs list+stream, plus stale-RV → 410. Parse the RV first so any zero
+	// value ("0", "00", …) is treated as unset (list+stream), not resume.
 	resume := false
 	var minRV int64
-	if rvParam := r.URL.Query().Get("resourceVersion"); rvParam != "" && rvParam != "0" {
+	if rvParam := r.URL.Query().Get("resourceVersion"); rvParam != "" {
 		v, err := strconv.ParseInt(rvParam, 10, 64)
 		if err != nil || v < 0 {
 			h.writeGone(w, fmt.Sprintf("resourceVersion %q is not valid; relist", rvParam))
 			return
 		}
-		if v < rvAsOf(timeline, windowStart) {
-			h.writeGone(w, fmt.Sprintf("resourceVersion %d is before the replay window; relist", v))
-			return
+		if v > 0 {
+			if v < rvAsOf(timeline, windowStart) {
+				h.writeGone(w, fmt.Sprintf("resourceVersion %d is before the replay window; relist", v))
+				return
+			}
+			resume = true
+			minRV = v
 		}
-		resume = true
-		minRV = v
 	}
 
 	startAt, startEpoch, _ := clock.Sample()

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -5,11 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sort"
+	"strconv"
 	"strings"
 	"time"
-
-	"github.com/phenixblue/k8shark/internal/capture"
 )
 
 // watchList is a parsed list body ready to be streamed as watch events.
@@ -111,58 +109,16 @@ func (h *handler) resolveWatchList(watchPath string, at time.Time, labelSelector
 	}, true, nil
 }
 
-// replayEvent is one captured watch event on the merged replay timeline.
+// replayEvent is one event on the merged, RV-assigned replay timeline. Watch
+// events read their body lazily via (apiPath, seq); poll-only inferred events
+// carry the body inline (seq is -1).
 type replayEvent struct {
 	t       time.Time
 	typ     string // ADDED | MODIFIED | DELETED
+	rv      int64  // monotonic resourceVersion (1-based sequence)
 	apiPath string
 	seq     int
-}
-
-// watchTimeline returns the captured watch events for a watch path, merged and
-// sorted by timestamp. For a cluster-wide path (no namespace) it aggregates the
-// per-namespace watch-index entries the capture demultiplexed.
-func (s *CaptureStore) watchTimeline(watchPath string) []replayEvent {
-	var evs []replayEvent
-	add := func(apiPath string, wi *capture.WatchIndexEntry) {
-		for i := range wi.Seqs {
-			if i >= len(wi.Times) || i >= len(wi.EventTypes) {
-				break
-			}
-			evs = append(evs, replayEvent{t: wi.Times[i], typ: wi.EventTypes[i], apiPath: apiPath, seq: wi.Seqs[i]})
-		}
-	}
-
-	if wi, ok := s.WatchIndex[watchPath]; ok {
-		add(watchPath, wi)
-	} else if g, v, resource, ns := parseAPIPath(watchPath); ns == "" && resource != "" {
-		var prefix string
-		if g == "" {
-			prefix = "/api/" + v + "/namespaces/"
-		} else {
-			prefix = "/apis/" + g + "/" + v + "/namespaces/"
-		}
-		suffix := "/" + resource
-		for p, wi := range s.WatchIndex {
-			if strings.HasPrefix(p, prefix) && strings.HasSuffix(p, suffix) {
-				add(p, wi)
-			}
-		}
-	}
-
-	// Sort by timestamp, with a deterministic tiebreak (apiPath then seq) so
-	// equal-time events don't flip order across runs — the merged input order
-	// depends on map iteration for the cluster-wide aggregation case.
-	sort.Slice(evs, func(i, j int) bool {
-		if !evs[i].t.Equal(evs[j].t) {
-			return evs[i].t.Before(evs[j].t)
-		}
-		if evs[i].apiPath != evs[j].apiPath {
-			return evs[i].apiPath < evs[j].apiPath
-		}
-		return evs[i].seq < evs[j].seq
-	})
-	return evs
+	body    json.RawMessage // inline body for poll-only events; nil → read lazily
 }
 
 // matchesSelectors reports whether a single object satisfies the label and
@@ -188,31 +144,67 @@ func matchesSelectors(raw json.RawMessage, labelSelector, fieldSelector string) 
 // it stays responsive to pause, seek, speed changes, and loop wraps.
 const replayPollInterval = 200 * time.Millisecond
 
-// streamReplayWatch streams a captured watch as the replay clock advances. It
-// sends the state as-of the clock's current position as an ADDED burst (the
-// informer's initial list), a BOOKMARK, then the captured events in timestamp
-// order — each held until the clock crosses its timestamp. Under --loop the
-// stream re-lists and replays from the window start on each wrap.
+// streamReplayWatch streams a captured watch as the replay clock advances, with
+// informer-grade resourceVersion (RV) semantics:
+//
+//   - No resourceVersion (or "0"): send the state as-of the clock as an ADDED
+//     burst + BOOKMARK, then stream events with rv > rvAsOf(clock).
+//   - resourceVersion=X (X>0): resume — no initial burst; stream events rv > X.
+//     A bogus or below-window X returns 410 Gone so the client relists cleanly.
+//
+// Each streamed event object carries its own monotonic rv; the BOOKMARK carries
+// rvAsOf of its list-as-of time. Under --loop / seek the stream re-lists and
+// resumes from the new position.
 func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path string) {
 	clock := h.clock
 	watchPath := strings.TrimSuffix(path, "/")
 	labelSel := r.URL.Query().Get("labelSelector")
 	fieldSel := r.URL.Query().Get("fieldSelector")
 
+	timeline := h.timelineFor(watchPath)
 	windowStart, _ := clock.Window()
+
+	// Resume vs list+stream, plus stale-RV → 410.
+	resume := false
+	var minRV int64
+	if rvParam := r.URL.Query().Get("resourceVersion"); rvParam != "" && rvParam != "0" {
+		v, err := strconv.ParseInt(rvParam, 10, 64)
+		if err != nil || v < 0 {
+			h.writeGone(w, fmt.Sprintf("resourceVersion %q is not valid; relist", rvParam))
+			return
+		}
+		if v < rvAsOf(timeline, windowStart) {
+			h.writeGone(w, fmt.Sprintf("resourceVersion %d is before the replay window; relist", v))
+			return
+		}
+		resume = true
+		minRV = v
+	}
+
 	startAt, startEpoch, _ := clock.Sample()
 
-	list, ok, err := h.resolveWatchList(watchPath, startAt, labelSel, fieldSel)
-	if err != nil {
-		h.writeStatus(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	if !ok {
-		h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q not found in capture", path))
-		return
+	// Path-derived defaults for the BOOKMARK object kind/apiVersion.
+	g, v, resource, _ := parseAPIPath(watchPath)
+	defKind := resourceToKind(resource)
+	defAPIVersion := v
+	if g != "" {
+		defAPIVersion = g + "/" + v
 	}
 
-	timeline := h.store.watchTimeline(watchPath)
+	var list watchList
+	if !resume {
+		l, ok, err := h.resolveWatchList(watchPath, startAt, labelSel, fieldSel)
+		if err != nil {
+			h.writeStatus(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if !ok {
+			h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q not found in capture", path))
+			return
+		}
+		list = l
+		minRV = rvAsOf(timeline, startAt)
+	}
 
 	// Honor ?timeoutSeconds: nil channel blocks forever (no timeout).
 	timer, stopTimer := watchTimeout(r.URL.Query().Get("timeoutSeconds"))
@@ -238,21 +230,19 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 		}
 		return true
 	}
-	// emitBookmark writes the BOOKMARK marking the end of a (re)list. `at` is the
-	// time the list was reconstructed at, used for the RV fallback so the bookmark
-	// stays coherent with the list-as-of time (rather than drifting to clock.Now()
-	// if the clock advances while a large list streams).
-	emitBookmark := func(l watchList, at time.Time) {
-		// Treat "0" as unspecified — aggregated/synthesized empty lists carry RV
-		// "0", but watch clients expect a non-zero BOOKMARK resourceVersion.
-		rv := l.ResourceVersion
-		if rv == "" || rv == "0" {
-			rv = bookmarkResourceVersion(at, windowStart, h.store.Metadata.CapturedAt, h.store.Metadata.CapturedUntil)
-		}
+	// emitBookmark writes the BOOKMARK marking the end of a (re)list, carrying rv
+	// as the resourceVersion so clients resume from a coherent point.
+	emitBookmark := func(l watchList, rv int64) {
 		bookmarkKind := strings.TrimSuffix(l.Kind, "List")
-		bookmarkAPIVersion := l.APIVersion
+		if bookmarkKind == "" {
+			bookmarkKind = defKind
+		}
 		if bookmarkKind == "" {
 			bookmarkKind = "Status"
+		}
+		bookmarkAPIVersion := l.APIVersion
+		if bookmarkAPIVersion == "" {
+			bookmarkAPIVersion = defAPIVersion
 		}
 		if bookmarkAPIVersion == "" {
 			bookmarkAPIVersion = "v1"
@@ -262,7 +252,7 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 			"object": map[string]any{
 				"apiVersion": bookmarkAPIVersion,
 				"kind":       bookmarkKind,
-				"metadata":   map[string]string{"resourceVersion": rv},
+				"metadata":   map[string]string{"resourceVersion": strconv.FormatInt(rv, 10)},
 			},
 		})
 		_, _ = fmt.Fprintf(w, "%s\n", data)
@@ -273,31 +263,33 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 
 	ctx := r.Context()
 
-	// relistAt re-emits the state as-of `at` as an ADDED burst + BOOKMARK, so a
-	// long-lived watcher sees a fresh, clearly-delimited list after a loop wrap
-	// or a seek — mirroring the initial list behavior.
-	relistAt := func(at time.Time) {
+	// relistAt re-emits the state as-of `at` as an ADDED burst + BOOKMARK and
+	// returns the RV that a subsequent stream should resume above.
+	relistAt := func(at time.Time) int64 {
+		rv := rvAsOf(timeline, at)
 		l, ok, err := h.resolveWatchList(watchPath, at, labelSel, fieldSel)
 		if err != nil || !ok {
-			return
+			return rv
 		}
 		for _, item := range l.Items {
 			emit("ADDED", item)
 		}
-		emitBookmark(l, at)
+		emitBookmark(l, rv)
+		return rv
 	}
 
-	// Initial list burst + bookmark (as-of startAt).
-	for _, item := range list.Items {
-		emit("ADDED", item)
+	// Initial list burst + bookmark, unless resuming from a client-supplied RV.
+	if !resume {
+		for _, item := range list.Items {
+			emit("ADDED", item)
+		}
+		emitBookmark(list, minRV)
 	}
-	emitBookmark(list, startAt)
 
-	after := startAt
 	epoch := startEpoch
 	seekGen := clock.SeekGen()
 	for {
-		res := h.replayPass(ctx, timer, clock, timeline, after, epoch, seekGen, labelSel, fieldSel, emit)
+		res := h.replayPass(ctx, timer, clock, timeline, minRV, epoch, seekGen, labelSel, fieldSel, emit)
 		if res == passCanceled {
 			return
 		}
@@ -314,15 +306,12 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 			}
 		}
 
-		// Re-list and choose the next start point: a loop wrap replays the whole
+		// Re-list and choose the next resume RV: a loop wrap replays the whole
 		// window from the start; a seek resumes from the new clock position.
 		if res == passLooped {
-			relistAt(windowStart)
-			after = windowStart
+			minRV = relistAt(windowStart)
 		} else { // passSeeked
-			pos := clock.Now()
-			relistAt(pos)
-			after = pos
+			minRV = relistAt(clock.Now())
 		}
 		_, epoch, _ = clock.Sample()
 		seekGen = clock.SeekGen()
@@ -397,13 +386,14 @@ func sleepInterruptible(ctx context.Context, timer <-chan time.Time, d time.Dura
 	}
 }
 
-// replayPass streams timeline events with timestamp after `after`, each held
-// until the clock crosses it, until the timeline is exhausted (passDone), the
-// clock loops past `epoch` (passLooped) or is seeked past `seekGen`
-// (passSeeked), or the request is canceled/times out (passCanceled).
-func (h *handler) replayPass(ctx context.Context, timer <-chan time.Time, clock *ReplayClock, timeline []replayEvent, after time.Time, epoch, seekGen int, labelSel, fieldSel string, emit func(string, json.RawMessage) bool) passResult {
+// replayPass streams timeline events with rv > minRV, each held until the clock
+// crosses its timestamp, until the timeline is exhausted (passDone), the clock
+// loops past `epoch` (passLooped) or is seeked past `seekGen` (passSeeked), or
+// the request is canceled/times out (passCanceled). Each emitted object carries
+// its own monotonic rv so clients can resume coherently.
+func (h *handler) replayPass(ctx context.Context, timer <-chan time.Time, clock *ReplayClock, timeline []replayEvent, minRV int64, epoch, seekGen int, labelSel, fieldSel string, emit func(string, json.RawMessage) bool) passResult {
 	for _, ev := range timeline {
-		if !ev.t.After(after) {
+		if ev.rv <= minRV {
 			continue
 		}
 		// Wait until the clock reaches this event's timestamp.
@@ -446,14 +436,21 @@ func (h *handler) replayPass(ctx context.Context, timer <-chan time.Time, clock 
 			}
 		}
 
-		rec, err := h.store.readRecord(ev.apiPath, ev.seq)
-		if err != nil {
+		// Poll-only events carry their body inline; watch events read it lazily.
+		body := ev.body
+		if body == nil {
+			rec, err := h.store.readRecord(ev.apiPath, ev.seq)
+			if err != nil {
+				continue
+			}
+			body = rec.ResponseBody
+		}
+		if !matchesSelectors(body, labelSel, fieldSel) {
 			continue
 		}
-		if !matchesSelectors(rec.ResponseBody, labelSel, fieldSel) {
-			continue
-		}
-		if emit(ev.typ, rec.ResponseBody) {
+		// Stamp the object with its monotonic rv so a reconnecting client resumes
+		// from a coherent resourceVersion.
+		if emit(ev.typ, withResourceVersion(body, ev.rv)) {
 			clock.AddEvents(1)
 		}
 	}

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -161,27 +161,32 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 	labelSel := r.URL.Query().Get("labelSelector")
 	fieldSel := r.URL.Query().Get("fieldSelector")
 
-	timeline := h.timelineFor(watchPath)
-	windowStart, _ := clock.Window()
-
-	// Resume vs list+stream, plus stale-RV → 410. Parse the RV first so any zero
-	// value ("0", "00", …) is treated as unset (list+stream), not resume.
-	resume := false
-	var minRV int64
+	// Validate resourceVersion first — a malformed/negative value returns 410
+	// before we build the (possibly expensive, poll-only) timeline. Any value
+	// that parses to 0 ("0", "00", …) is unset → list+stream.
+	reqRV, hasReqRV := int64(0), false
 	if rvParam := r.URL.Query().Get("resourceVersion"); rvParam != "" {
 		v, err := strconv.ParseInt(rvParam, 10, 64)
 		if err != nil || v < 0 {
 			h.writeGone(w, fmt.Sprintf("resourceVersion %q is not valid; relist", rvParam))
 			return
 		}
-		if v > 0 {
-			if v < rvAsOf(timeline, windowStart) {
-				h.writeGone(w, fmt.Sprintf("resourceVersion %d is before the replay window; relist", v))
-				return
-			}
-			resume = true
-			minRV = v
+		reqRV, hasReqRV = v, v > 0
+	}
+
+	timeline := h.timelineFor(watchPath)
+	windowStart, _ := clock.Window()
+
+	// Resume vs list+stream, plus stale-RV → 410 (window check needs the timeline).
+	resume := false
+	var minRV int64
+	if hasReqRV {
+		if reqRV < rvAsOf(timeline, windowStart) {
+			h.writeGone(w, fmt.Sprintf("resourceVersion %d is before the replay window; relist", reqRV))
+			return
 		}
+		resume = true
+		minRV = reqRV
 	}
 
 	startAt, startEpoch, _ := clock.Sample()

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -177,12 +177,18 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 	timeline := h.timelineFor(watchPath)
 	windowStart, _ := clock.Window()
 
-	// Resume vs list+stream, plus stale-RV → 410 (window check needs the timeline).
+	// Resume vs list+stream, plus stale/unknown-RV → 410 (needs the timeline).
 	resume := false
 	var minRV int64
 	if hasReqRV {
 		if reqRV < rvAsOf(timeline, windowStart) {
 			h.writeGone(w, fmt.Sprintf("resourceVersion %d is before the replay window; relist", reqRV))
+			return
+		}
+		// Too large / unknown (e.g. a raw etcd RV from the original capture):
+		// relist rather than silently streaming nothing.
+		if maxRV := replayRVBase + int64(len(timeline)); reqRV > maxRV {
+			h.writeGone(w, fmt.Sprintf("resourceVersion %d is newer than any replay event (max %d); relist", reqRV, maxRV))
 			return
 		}
 		resume = true

--- a/internal/server/watch_replay_test.go
+++ b/internal/server/watch_replay_test.go
@@ -211,13 +211,16 @@ func TestWatchTimeline_AggregatesAcrossNamespaces(t *testing.T) {
 		},
 	)
 
-	timeline := store.watchTimeline("/api/v1/pods")
+	timeline := store.buildReplayTimeline("/api/v1/pods")
 	if len(timeline) != 3 {
 		t.Fatalf("timeline length = %d, want 3", len(timeline))
 	}
 	for i := 1; i < len(timeline); i++ {
 		if timeline[i].t.Before(timeline[i-1].t) {
 			t.Errorf("timeline not sorted at %d: %s before %s", i, timeline[i].t, timeline[i-1].t)
+		}
+		if timeline[i].rv <= timeline[i-1].rv {
+			t.Errorf("rv not monotonic at %d: %d <= %d", i, timeline[i].rv, timeline[i-1].rv)
 		}
 	}
 	if timeline[0].apiPath != ns1 || timeline[1].apiPath != ns2 {

--- a/internal/transitions/transitions.go
+++ b/internal/transitions/transitions.go
@@ -96,6 +96,16 @@ func LoadTransitions(archivePath string, opts FilterOpts) ([]Transition, error) 
 	return all, nil
 }
 
+// InferPollTransitions synthesizes ADDED/MODIFIED/DELETED transitions for a
+// single poll-only API path by diffing its consecutive snapshots in an
+// already-open archive. It is used by replay mode to build an event stream for
+// captures taken without watch: true. The returned transitions are sorted by
+// time.
+func InferPollTransitions(ar *archive.Archive, apiPath string, entry *capture.IndexEntry) ([]Transition, error) {
+	g, v, r, ns := parseAPIPath(apiPath)
+	return pollTransitions(ar, apiPath, entry, g, v, r, ns, FilterOpts{})
+}
+
 // watchTransitions emits transitions for a watch-captured API path by walking
 // the watch-index entries in chronological order. Per-object state is tracked
 // so that Before is populated accurately for MODIFIED and DELETED events.

--- a/internal/transitions/transitions.go
+++ b/internal/transitions/transitions.go
@@ -102,7 +102,13 @@ func LoadTransitions(archivePath string, opts FilterOpts) ([]Transition, error) 
 // captures taken without watch: true. The returned transitions are sorted by
 // time.
 func InferPollTransitions(ar *archive.Archive, apiPath string, entry *capture.IndexEntry) ([]Transition, error) {
-	g, v, r, ns := parseAPIPath(apiPath)
+	// Strip any query (e.g. pagination) before parsing so the resource metadata
+	// stays correct even if the record is keyed with query params.
+	base := apiPath
+	if i := strings.IndexByte(base, '?'); i >= 0 {
+		base = base[:i]
+	}
+	g, v, r, ns := parseAPIPath(base)
 	return pollTransitions(ar, apiPath, entry, g, v, r, ns, FilterOpts{})
 }
 


### PR DESCRIPTION
Implements **phase 2** of time-based replay (#121, part of #119) — informer-grade robustness.

Builds on the phase-1 replay engine (#140) to make replay reliable for real Kubernetes controllers/informers, and to work for captures taken without `watch: true`.

## resourceVersion coherence (the hard core)
A single time-sorted event timeline per watch path assigns every object a **monotonic RV**:
- `rv(event i) = base + i` (base 1, so window-start/empty RV is never the special `"0"`)
- `rvAsOf(T) = base + count(events with t ≤ T)` — the RV of the state as-of clock time `T`

Because `rv` is a strict sequence rather than a raw timestamp, events that share a timestamp (common for poll-only snapshot diffs) still get **distinct, ordered** RVs — so reconnects never drop or duplicate.

- **LIST** returns `metadata.resourceVersion = rvAsOf(clock)` (overridden in replay mode).
- Each streamed **WATCH event object** is stamped with its own `rv`; **BOOKMARKs** carry `rvAsOf` of their list-as-of time.
- **WATCH honors `resourceVersion`**: absent/`0` → list-then-stream; `X>0` → resume with no initial burst, streaming only `rv > X`.

## Reconnect / relist
A bogus or below-window `resourceVersion` returns **`410 Gone`** (reason `Expired`) so a client-go informer relists cleanly. A client resuming from its last RV continues with no missing/duplicated events.

## Poll-only captures
When a path has no watch index, the timeline is **synthesized by diffing consecutive snapshots** (reusing `internal/transitions`); inferred events carry their body inline. The CLI note and docs now describe inference instead of "nothing streams". Per-path timelines are memoized on the handler so LIST/WATCH don't rebuild them (important for poll-only, which diffs every snapshot).

## Acceptance criteria
- [x] Informer-style LIST→WATCH runs with monotonic RVs; no relist loops (LIST RV, event RVs, and resume filter all aligned; covered by tests).
- [x] Poll-only captures produce a sensible event stream via transition inference.
- [x] Forced reconnect (resume from last RV) → no missing/duplicated events; stale RV → clean 410 relist.
- [x] Tests: RV monotonicity, LIST RV tracking the clock, resume-from-RV, reconnect-without-duplicates, 410 on stale/bogus RV, poll-only end-to-end.

## Testing
`go test -race ./...`, `go vet`, `gofmt`, `go mod tidy`, and pinned `golangci-lint` all clean. Smoke-tested the binary against a poll-only capture: boots with the inference note and LIST returns the coherent RV scheme (`1`) rather than the captured etcd RV.

## Notes
"Multiple concurrent watchers share one clock" is satisfied by construction — a single global `ReplayClock`, with deterministic per-path RVs. Writable overlay remains phase 4 (#123); UI transport controls remain phase 3 (#122).

🤖 Generated with [Claude Code](https://claude.com/claude-code)