### PR TITLE
feat(replay): phase 3 — dashboard transport controls (VCR) (#122)

### DIFF
--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -45,6 +46,8 @@ func init() {
 	replayCmd.Flags().String("to", "", "replay window end: RFC3339 or relative duration like -1m (default: capture end)")
 	replayCmd.Flags().Bool("loop", false, "restart the replay from the window start when it reaches the end")
 	replayCmd.Flags().Bool("start-paused", false, "start paused; press Enter to begin playback")
+	replayCmd.Flags().Bool("ui", false, "also start the web dashboard as a replay transport (VCR)")
+	replayCmd.Flags().String("ui-port", "0", "port for the dashboard when --ui is set (0 = random)")
 }
 
 func runReplay(cmd *cobra.Command, args []string) error {
@@ -75,6 +78,18 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	clock := srv.Clock()
 	winStart, winEnd := clock.Window()
 
+	// Optionally start the dashboard as a replay transport, sharing the clock.
+	uiEnabled, _ := cmd.Flags().GetBool("ui")
+	uiPort, _ := cmd.Flags().GetString("ui-port")
+	var uiSrv *ui.Server
+	if uiEnabled {
+		uiSrv, err = ui.Open(ui.OpenOptions{ArchivePath: args[0], Port: uiPort, Verbose: verbose, Clock: clock})
+		if err != nil {
+			srv.Shutdown()
+			return fmt.Errorf("starting dashboard: %w", err)
+		}
+	}
+
 	fmt.Printf("k8shark replay server running\n")
 	fmt.Printf("  Address:    %s\n", srv.Address())
 	fmt.Printf("  Kubeconfig: %s\n", srv.KubeconfigPath())
@@ -84,6 +99,9 @@ func runReplay(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  Loop:       on\n")
 	}
 	fmt.Printf("  Control:    %s/_k8shark/replay\n", srv.Address())
+	if uiSrv != nil {
+		fmt.Printf("  Dashboard:  %s\n", uiSrv.Address())
+	}
 	fmt.Printf("\nRun: export KUBECONFIG=%s\n", srv.KubeconfigPath())
 	fmt.Printf("Then watch it change, e.g.: kubectl get pods -A --watch\n")
 	fmt.Printf("Drive playback, e.g.: curl -sk -X POST %s/_k8shark/replay/pause\n", srv.Address())
@@ -94,11 +112,14 @@ func runReplay(cmd *cobra.Command, args []string) error {
 		fmt.Printf("      higher-resolution ADDED/MODIFIED/DELETED events.\n")
 	}
 
-	if startPaused {
+	switch {
+	case startPaused && uiEnabled:
+		fmt.Printf("\nStarting paused — use the dashboard to begin playback (Ctrl+C to stop).\n")
+	case startPaused:
 		fmt.Printf("\nPaused. Press Enter to begin playback (Ctrl+C to stop).\n")
 		_, _ = bufio.NewReader(os.Stdin).ReadString('\n')
 		clock.Resume()
-	} else {
+	default:
 		fmt.Printf("\nPress Ctrl+C to stop.\n")
 	}
 
@@ -107,6 +128,9 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	go replayStatusLoop(srv, stop)
 	err = srv.Wait()
 	close(stop)
+	if uiSrv != nil {
+		uiSrv.Shutdown()
+	}
 	fmt.Println()
 	return err
 }

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -78,6 +78,12 @@ func runUI(cmd *cobra.Command, args []string) error {
 	replayMode := cmd.Flags().Changed("speed") || cmd.Flags().Changed("from") ||
 		cmd.Flags().Changed("to") || loop || startPaused
 
+	// --at pins a single instant, which is meaningless once the replay clock is
+	// driving time — reject the combination rather than silently ignoring --at.
+	if replayMode && cmd.Flags().Changed("at") {
+		return fmt.Errorf("--at cannot be combined with replay flags (--speed/--from/--to/--loop/--start-paused); use --from/--to to set the replay window")
+	}
+
 	var mockSrv *server.Server
 	var err error
 	if replayMode {

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -40,6 +40,13 @@ func init() {
 	uiCmd.Flags().String("api-port", "0", "port for the mock API server (0 = random available port)")
 	uiCmd.Flags().String("kubeconfig-out", "", "where to write the generated kubeconfig (default: ~/.kube/k8shark-<id>)")
 	uiCmd.Flags().String("at", "", "pin UI data to a specific timestamp (RFC3339 or relative duration like -5m)")
+	// Replay mode: when any of these is set, the dashboard becomes a VCR driven
+	// by a shared replay clock (kubectl follows the same clock).
+	uiCmd.Flags().String("speed", "", "replay mode: playback speed factor, e.g. 2x, 3x, 0.5x (enables replay)")
+	uiCmd.Flags().String("from", "", "replay window start: RFC3339 or relative duration like -10m")
+	uiCmd.Flags().String("to", "", "replay window end: RFC3339 or relative duration like -1m")
+	uiCmd.Flags().Bool("loop", false, "replay mode: restart from the window start when the end is reached")
+	uiCmd.Flags().Bool("start-paused", false, "replay mode: start paused")
 }
 
 func runUI(cmd *cobra.Command, args []string) error {
@@ -61,13 +68,28 @@ func runUI(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	mockSrv, err := server.Open(server.OpenOptions{
-		ArchivePath:   archivePath,
-		Port:          apiPort,
-		KubeconfigOut: kubeconfigOut,
-		At:            at,
-		Verbose:       verbose,
-	})
+	// Replay mode is enabled when any replay flag is set; the mock server and the
+	// dashboard then share one clock (kubectl and the UI stay coherent).
+	speed, _ := cmd.Flags().GetString("speed")
+	from, _ := cmd.Flags().GetString("from")
+	to, _ := cmd.Flags().GetString("to")
+	loop, _ := cmd.Flags().GetBool("loop")
+	startPaused, _ := cmd.Flags().GetBool("start-paused")
+	replayMode := cmd.Flags().Changed("speed") || cmd.Flags().Changed("from") ||
+		cmd.Flags().Changed("to") || loop || startPaused
+
+	var mockSrv *server.Server
+	var err error
+	if replayMode {
+		mockSrv, err = server.Replay(server.ReplayOptions{
+			ArchivePath: archivePath, Port: apiPort, KubeconfigOut: kubeconfigOut,
+			Speed: speed, From: from, To: to, Loop: loop, StartPaused: startPaused, Verbose: verbose,
+		})
+	} else {
+		mockSrv, err = server.Open(server.OpenOptions{
+			ArchivePath: archivePath, Port: apiPort, KubeconfigOut: kubeconfigOut, At: at, Verbose: verbose,
+		})
+	}
 	if err != nil {
 		return fmt.Errorf("opening mock API: %w", err)
 	}
@@ -77,6 +99,7 @@ func runUI(cmd *cobra.Command, args []string) error {
 		Port:        uiPort,
 		At:          at,
 		Verbose:     verbose,
+		Clock:       mockSrv.Clock(), // nil unless replay mode → shared clock
 	})
 	if err != nil {
 		mockSrv.Shutdown()
@@ -86,12 +109,20 @@ func runUI(cmd *cobra.Command, args []string) error {
 	fmt.Printf("k8shark mock server running\n")
 	fmt.Printf("  Address:    %s\n", mockSrv.Address())
 	fmt.Printf("  Kubeconfig: %s\n", mockSrv.KubeconfigPath())
+	if c := mockSrv.Clock(); c != nil {
+		wf, wt := c.Window()
+		fmt.Printf("  Replay:     %s → %s · %s\n", wf.Format("15:04:05Z07:00"), wt.Format("15:04:05Z07:00"), formatSpeed(c.Speed()))
+	}
 	fmt.Printf("\nRun: export KUBECONFIG=%s\n", mockSrv.KubeconfigPath())
 	fmt.Printf("Then use kubectl normally against the capture.\n\n")
 
 	fmt.Printf("k8shark UI running\n")
 	fmt.Printf("  Address: %s\n", uiSrv.Address())
-	fmt.Printf("\nOpen this URL in your browser. Press Ctrl+C to stop.\n")
+	if replayMode {
+		fmt.Printf("\nOpen this URL to drive replay (play/pause/seek/speed). Press Ctrl+C to stop.\n")
+	} else {
+		fmt.Printf("\nOpen this URL in your browser. Press Ctrl+C to stop.\n")
+	}
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newTestUICommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("port", "0", "")
+	cmd.Flags().String("api-port", "0", "")
+	cmd.Flags().String("kubeconfig-out", "", "")
+	cmd.Flags().String("at", "", "")
+	cmd.Flags().String("speed", "", "")
+	cmd.Flags().String("from", "", "")
+	cmd.Flags().String("to", "", "")
+	cmd.Flags().Bool("loop", false, "")
+	cmd.Flags().Bool("start-paused", false, "")
+	return cmd
+}
+
+func TestRunUI_RejectsAtWithReplayFlags(t *testing.T) {
+	arch := buildDiffArchive(t, healthyPodList)
+	cmd := newTestUICommand()
+	_ = cmd.Flags().Set("at", "-5m")
+	_ = cmd.Flags().Set("speed", "2x")
+
+	err := runUI(cmd, []string{arch})
+	if err == nil {
+		t.Fatal("expected error combining --at with replay flags")
+	}
+	if !strings.Contains(err.Error(), "--at cannot be combined") {
+		t.Errorf("error = %v, want it to explain the --at/replay conflict", err)
+	}
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -402,10 +402,16 @@ The primary use case is **local development and testing of controllers/operators
 | `--from` | capture start | Window start: RFC3339 or relative duration like `-10m` |
 | `--to` | capture end | Window end: RFC3339 or relative duration like `-1m` |
 | `--loop` | false | Restart from the window start when the end is reached |
-| `--start-paused` | false | Start paused; press Enter to begin playback |
+| `--start-paused` | false | Start paused (press Enter to begin, or use the dashboard when `--ui` is set) |
+| `--ui` | false | Also start the web dashboard as a replay transport (VCR), sharing the clock |
+| `--ui-port` | random | Port for the dashboard when `--ui` is set |
 | `--port` | random | Port for the mock API server |
 | `--kubeconfig-out` | `~/.kube/k8shark-<id>.yaml` | Where to write the generated kubeconfig |
 | `--verbose` / `-v` | false | Log every request the server receives |
+
+> **Dashboard transport.** Pass `--ui` to drive replay from the browser (play/pause/seek/speed), or
+> start from the UI side with `kshrk ui capture.kshrk --speed 2x` — both share one clock so `kubectl`
+> and the dashboard stay in lockstep. See [the Replay (VCR) section of the Web UI guide](web-ui.md#replay-vcr).
 
 ### Controlling playback
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -168,7 +168,8 @@ kshrk replay capture.kshrk --speed 2x --ui
 ```
 
 A **transport bar** appears in the header with **play/pause**, **step** (◀ ▶ on the scrubber),
-a **speed selector** (0.5× / 1× / 2× / 3×), and a live **events** counter. Drag the scrubber to seek
+a **speed selector** (0.25× / 0.5× / 1× / 2×; the current speed is added if it isn't a preset), and a
+live **events** counter. Drag the scrubber to seek
 the clock; the views auto-refresh as the clock crosses each snapshot. If a view fails to load
 mid-playback, replay **pauses** and surfaces the error rather than pressing on.
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -153,6 +153,42 @@ The header scrubber pins the entire UI to any point in the capture window — dr
 with the arrows, and every view re-renders as the cluster looked at that moment. Click **latest** to
 jump back to the most recent records. This is the in-browser equivalent of the `--at` flag.
 
+## Replay (VCR)
+
+The dashboard doubles as a **transport for time-based replay**: instead of manually scrubbing, a
+replay clock advances through the capture and every view follows it live. Start it either way — both
+share one clock, so `kubectl` against the mock server and the dashboard stay in lockstep:
+
+```sh
+# dashboard-first
+kshrk ui capture.kshrk --speed 2x
+
+# replay-first (also serves the dashboard)
+kshrk replay capture.kshrk --speed 2x --ui
+```
+
+A **transport bar** appears in the header with **play/pause**, **step** (◀ ▶ on the scrubber),
+a **speed selector** (0.5× / 1× / 2× / 3×), and a live **events** counter. Drag the scrubber to seek
+the clock; the views auto-refresh as the clock crosses each snapshot. If a view fails to load
+mid-playback, replay **pauses** and surfaces the error rather than pressing on.
+
+Replay flags mirror the [`replay` command](usage.md#replay): `--speed`, `--from`, `--to`, `--loop`,
+`--start-paused`. See [docs/usage.md](usage.md#replay) for the full model (resourceVersion coherence,
+poll-only inference, etc.).
+
+The transport is backed by a small same-origin control API the dashboard calls (also useful for
+scripting the UI clock):
+
+| Request | Effect |
+|---------|--------|
+| `GET /v2/api/replay` | Current status (`{enabled:false}` when not in replay mode) |
+| `POST /v2/api/replay/play` · `/pause` | Resume / pause the clock |
+| `POST /v2/api/replay/speed?value=2x` | Change speed |
+| `POST /v2/api/replay/seek?to=<RFC3339>` | Seek to a time (or `?offset=<duration>` from the window start) |
+
+(The headless `kshrk replay` server exposes the equivalent under `/_k8shark/replay` on the mock API —
+see [docs/usage.md](usage.md#controlling-playback).)
+
 ## Light and dark themes
 
 Use the toggle at the far right of the header to switch between dark (default) and light themes; the

--- a/internal/server/clock.go
+++ b/internal/server/clock.go
@@ -213,6 +213,11 @@ func (c *ReplayClock) AddEvents(n int64) { c.events.Add(n) }
 // EventsEmitted returns how many watch events have been streamed so far.
 func (c *ReplayClock) EventsEmitted() int64 { return c.events.Load() }
 
+// ParseSpeed parses a speed factor such as "2x", "0.5x", "3", or "1.5x" for
+// callers outside this package (e.g. the UI transport control endpoint). An
+// empty string means real time (1x).
+func ParseSpeed(raw string) (float64, error) { return parseSpeed(raw) }
+
 // parseSpeed parses a speed factor such as "2x", "0.5x", "3", or "1.5x".
 // An empty string means real time (1x).
 func parseSpeed(raw string) (float64, error) {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -26,6 +26,11 @@ type OpenOptions struct {
 	Port        string
 	At          string
 	Verbose     bool
+	// Clock, when non-nil, puts the dashboard in replay mode: views follow the
+	// shared replay clock and the header exposes transport controls. The same
+	// clock instance also drives the mock API server so kubectl and the UI stay
+	// coherent.
+	Clock *server.ReplayClock
 }
 
 // Server is a running UI HTTP server.
@@ -78,6 +83,7 @@ func Open(opts OpenOptions) (*Server, error) {
 		At:          at,
 		ArchivePath: opts.ArchivePath,
 		Verbose:     opts.Verbose,
+		Clock:       opts.Clock,
 	}
 	v2h.Mount(mux)
 

--- a/internal/ui/v2/overview.go
+++ b/internal/ui/v2/overview.go
@@ -48,17 +48,20 @@ func (h *Handler) serveOverview(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, ov)
 }
 
-// resolveAt reads ?at= from the request, falling back to h.At.
+// resolveAt reads ?at= from the request. An explicit, parseable ?at= always
+// wins (manual scrub / paused inspection). Otherwise, in replay mode the current
+// clock position is used so views follow the advancing clock; failing that,
+// h.At (the fixed --at).
 func (h *Handler) resolveAt(r *http.Request) time.Time {
-	q := r.URL.Query().Get("at")
-	if q == "" {
-		return h.At
+	if q := r.URL.Query().Get("at"); q != "" {
+		if t, err := time.Parse(time.RFC3339, q); err == nil {
+			return t.UTC()
+		}
 	}
-	t, err := time.Parse(time.RFC3339, q)
-	if err != nil {
-		return h.At
+	if h.Clock != nil {
+		return h.Clock.Now()
 	}
-	return t.UTC()
+	return h.At
 }
 
 // buildOverview walks the index + reads pod bodies to compute everything the

--- a/internal/ui/v2/overview.go
+++ b/internal/ui/v2/overview.go
@@ -48,15 +48,17 @@ func (h *Handler) serveOverview(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, ov)
 }
 
-// resolveAt reads ?at= from the request. An explicit, parseable ?at= always
-// wins (manual scrub / paused inspection). Otherwise, in replay mode the current
-// clock position is used so views follow the advancing clock; failing that,
-// h.At (the fixed --at).
+// resolveAt reads ?at= from the request. When ?at= is present it wins (manual
+// scrub / paused inspection); a present-but-unparseable value falls back to h.At
+// rather than the clock, so a typo'd pinned URL doesn't unexpectedly start
+// following live replay. When ?at= is absent, replay mode follows the clock;
+// otherwise h.At (the fixed --at).
 func (h *Handler) resolveAt(r *http.Request) time.Time {
 	if q := r.URL.Query().Get("at"); q != "" {
 		if t, err := time.Parse(time.RFC3339, q); err == nil {
 			return t.UTC()
 		}
+		return h.At
 	}
 	if h.Clock != nil {
 		return h.Clock.Now()

--- a/internal/ui/v2/replay.go
+++ b/internal/ui/v2/replay.go
@@ -29,12 +29,24 @@ func (h *Handler) serveReplay(w http.ResponseWriter, r *http.Request) {
 
 	switch action {
 	case "":
-		// status (GET)
+		// status — read-only, GET only.
+		if !replayRequireMethod(w, r, http.MethodGet) {
+			return
+		}
 	case "pause":
+		if !replayRequireMethod(w, r, http.MethodPost) {
+			return
+		}
 		clock.Pause()
 	case "play", "resume":
+		if !replayRequireMethod(w, r, http.MethodPost) {
+			return
+		}
 		clock.Resume()
 	case "speed":
+		if !replayRequireMethod(w, r, http.MethodPost) {
+			return
+		}
 		s, err := server.ParseSpeed(r.URL.Query().Get("value"))
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
@@ -42,6 +54,9 @@ func (h *Handler) serveReplay(w http.ResponseWriter, r *http.Request) {
 		}
 		clock.SetSpeed(s)
 	case "seek":
+		if !replayRequireMethod(w, r, http.MethodPost) {
+			return
+		}
 		target, err := replaySeekTarget(clock, r.URL.Query())
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
@@ -54,6 +69,17 @@ func (h *Handler) serveReplay(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, replayStatus(clock))
+}
+
+// replayRequireMethod enforces the HTTP method for a control action so that
+// state-changing actions can't be triggered by a GET / link navigation.
+func replayRequireMethod(w http.ResponseWriter, r *http.Request, method string) bool {
+	if r.Method == method {
+		return true
+	}
+	w.Header().Set("Allow", method)
+	writeJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": method + " required"})
+	return false
 }
 
 // replaySeekTarget resolves a seek target from the query: ?to= is an RFC3339

--- a/internal/ui/v2/replay.go
+++ b/internal/ui/v2/replay.go
@@ -1,0 +1,112 @@
+package v2
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/server"
+)
+
+// serveReplay is the dashboard's transport-control API, backed by the shared
+// replay clock. A successful request returns the current status as JSON; when
+// the dashboard is not in replay mode it returns {"enabled": false} so the UI
+// can hide the transport bar.
+//
+//	GET  /v2/api/replay              → status
+//	POST /v2/api/replay/pause        → pause
+//	POST /v2/api/replay/play         → resume
+//	POST /v2/api/replay/speed?value= → set speed (2x, 0.5x, …)
+//	POST /v2/api/replay/seek?to=     → seek to an RFC3339 time
+//	                          ?offset=→   or a duration from the window start
+func (h *Handler) serveReplay(w http.ResponseWriter, r *http.Request) {
+	if h.Clock == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"enabled": false})
+		return
+	}
+	clock := h.Clock
+	action := strings.Trim(strings.TrimPrefix(r.URL.Path, "/v2/api/replay"), "/")
+
+	switch action {
+	case "":
+		// status (GET)
+	case "pause":
+		clock.Pause()
+	case "play", "resume":
+		clock.Resume()
+	case "speed":
+		s, err := server.ParseSpeed(r.URL.Query().Get("value"))
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+			return
+		}
+		clock.SetSpeed(s)
+	case "seek":
+		target, err := replaySeekTarget(clock, r.URL.Query())
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+			return
+		}
+		clock.Seek(target)
+	default:
+		writeJSON(w, http.StatusNotFound, map[string]any{"error": "unknown replay control " + action})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, replayStatus(clock))
+}
+
+// replaySeekTarget resolves a seek target from the query: ?to= is an RFC3339
+// timestamp; ?offset= is a duration from the window start (e.g. 90s). The clock
+// clamps to the window.
+func replaySeekTarget(clock *server.ReplayClock, q map[string][]string) (time.Time, error) {
+	from, _ := clock.Window()
+	if v := firstQuery(q, "to"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return t, nil
+	}
+	if v := firstQuery(q, "offset"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return from.Add(d), nil
+	}
+	return time.Time{}, errSeekTarget
+}
+
+var errSeekTarget = &seekErr{}
+
+type seekErr struct{}
+
+func (*seekErr) Error() string { return "seek requires ?to= (RFC3339) or ?offset= (duration)" }
+
+func firstQuery(q map[string][]string, key string) string {
+	if vs := q[key]; len(vs) > 0 {
+		return vs[0]
+	}
+	return ""
+}
+
+// replayStatus builds the JSON status describing the clock's current position.
+func replayStatus(clock *server.ReplayClock) map[string]any {
+	from, to := clock.Window()
+	pos, epoch, ended := clock.Sample()
+	return map[string]any{
+		"enabled":         true,
+		"position":        pos.Format(time.RFC3339),
+		"from":            from.Format(time.RFC3339),
+		"to":              to.Format(time.RFC3339),
+		"elapsed_seconds": int64(pos.Sub(from).Round(time.Second) / time.Second),
+		"total_seconds":   int64(to.Sub(from).Round(time.Second) / time.Second),
+		"speed":           clock.Speed(),
+		"paused":          clock.Paused(),
+		"loop":            clock.Loop(),
+		"ended":           ended,
+		"epoch":           epoch,
+		"events_emitted":  clock.EventsEmitted(),
+	}
+}

--- a/internal/ui/v2/replay.go
+++ b/internal/ui/v2/replay.go
@@ -20,12 +20,19 @@ import (
 //	POST /v2/api/replay/seek?to=     → seek to an RFC3339 time
 //	                          ?offset=→   or a duration from the window start
 func (h *Handler) serveReplay(w http.ResponseWriter, r *http.Request) {
+	action := strings.Trim(strings.TrimPrefix(r.URL.Path, "/v2/api/replay"), "/")
+
 	if h.Clock == nil {
-		writeJSON(w, http.StatusOK, map[string]any{"enabled": false})
+		// GET status reports "not in replay mode"; any control action is a 404 so
+		// a non-UI client doesn't see a mutating call succeed as a silent no-op.
+		if action == "" && r.Method == http.MethodGet {
+			writeJSON(w, http.StatusOK, map[string]any{"enabled": false})
+			return
+		}
+		writeJSON(w, http.StatusNotFound, map[string]any{"enabled": false, "error": "replay mode is not active"})
 		return
 	}
 	clock := h.Clock
-	action := strings.Trim(strings.TrimPrefix(r.URL.Path, "/v2/api/replay"), "/")
 
 	switch action {
 	case "":

--- a/internal/ui/v2/replay.go
+++ b/internal/ui/v2/replay.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -41,17 +42,17 @@ func (h *Handler) serveReplay(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	case "pause":
-		if !replayRequireMethod(w, r, http.MethodPost) {
+		if !h.allowMutation(w, r) {
 			return
 		}
 		clock.Pause()
 	case "play", "resume":
-		if !replayRequireMethod(w, r, http.MethodPost) {
+		if !h.allowMutation(w, r) {
 			return
 		}
 		clock.Resume()
 	case "speed":
-		if !replayRequireMethod(w, r, http.MethodPost) {
+		if !h.allowMutation(w, r) {
 			return
 		}
 		s, err := server.ParseSpeed(r.URL.Query().Get("value"))
@@ -61,7 +62,7 @@ func (h *Handler) serveReplay(w http.ResponseWriter, r *http.Request) {
 		}
 		clock.SetSpeed(s)
 	case "seek":
-		if !replayRequireMethod(w, r, http.MethodPost) {
+		if !h.allowMutation(w, r) {
 			return
 		}
 		target, err := replaySeekTarget(clock, r.URL.Query())
@@ -87,6 +88,24 @@ func replayRequireMethod(w http.ResponseWriter, r *http.Request, method string) 
 	w.Header().Set("Allow", method)
 	writeJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": method + " required"})
 	return false
+}
+
+// allowMutation gates a state-changing control action: it must be a POST and,
+// when an Origin header is present (a browser), must be same-origin — so an
+// unrelated web page can't POST to the local dashboard and move the clock.
+// Non-browser clients (curl) omit Origin and are allowed.
+func (h *Handler) allowMutation(w http.ResponseWriter, r *http.Request) bool {
+	if !replayRequireMethod(w, r, http.MethodPost) {
+		return false
+	}
+	if origin := r.Header.Get("Origin"); origin != "" {
+		u, err := url.Parse(origin)
+		if err != nil || u.Host != r.Host {
+			writeJSON(w, http.StatusForbidden, map[string]any{"error": "cross-origin request rejected"})
+			return false
+		}
+	}
+	return true
 }
 
 // replaySeekTarget resolves a seek target from the query: ?to= is an RFC3339

--- a/internal/ui/v2/replay_test.go
+++ b/internal/ui/v2/replay_test.go
@@ -96,8 +96,9 @@ func TestServeReplay_Errors(t *testing.T) {
 // replay mode when no explicit ?at= is given.
 func TestResolveAt_FollowsClock(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	fixedAt := from.Add(5 * time.Minute)
 	clock := server.NewReplayClock(from, from.Add(time.Hour), 1, false, true) // paused at from
-	h := &Handler{Clock: clock}
+	h := &Handler{Clock: clock, At: fixedAt}
 
 	got := h.resolveAt(httptest.NewRequest(http.MethodGet, "/v2/api/overview", nil))
 	if !got.Equal(from) {
@@ -108,5 +109,10 @@ func TestResolveAt_FollowsClock(t *testing.T) {
 	got = h.resolveAt(httptest.NewRequest(http.MethodGet, "/v2/api/overview?at="+at, nil))
 	if got.Format(time.RFC3339) != at {
 		t.Errorf("resolveAt (?at=%s) = %s, want the explicit value", at, got.Format(time.RFC3339))
+	}
+	// A present-but-invalid ?at= falls back to h.At, not the clock.
+	got = h.resolveAt(httptest.NewRequest(http.MethodGet, "/v2/api/overview?at=not-a-time", nil))
+	if !got.Equal(fixedAt) {
+		t.Errorf("resolveAt (invalid ?at) = %s, want h.At %s (not the clock)", got, fixedAt)
 	}
 }

--- a/internal/ui/v2/replay_test.go
+++ b/internal/ui/v2/replay_test.go
@@ -1,0 +1,112 @@
+package v2
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/server"
+)
+
+func TestServeReplay_DisabledWithoutClock(t *testing.T) {
+	h := &Handler{}
+	rec := httptest.NewRecorder()
+	h.serveReplay(rec, httptest.NewRequest(http.MethodGet, "/v2/api/replay", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if m["enabled"] != false {
+		t.Errorf("enabled = %v, want false", m["enabled"])
+	}
+}
+
+func TestServeReplay_Control(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	to := from.Add(60 * time.Second)
+	h := &Handler{Clock: server.NewReplayClock(from, to, 1, false, false)}
+
+	call := func(method, path string) map[string]any {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		h.serveReplay(rec, httptest.NewRequest(method, path, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s %s: status %d: %s", method, path, rec.Code, rec.Body)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return m
+	}
+
+	if st := call(http.MethodGet, "/v2/api/replay"); st["enabled"] != true {
+		t.Errorf("enabled = %v, want true", st["enabled"])
+	}
+	if st := call(http.MethodPost, "/v2/api/replay/pause"); st["paused"] != true {
+		t.Errorf("after pause: paused = %v, want true", st["paused"])
+	}
+	if st := call(http.MethodPost, "/v2/api/replay/play"); st["paused"] != false {
+		t.Errorf("after play: paused = %v, want false", st["paused"])
+	}
+	if st := call(http.MethodPost, "/v2/api/replay/speed?value=2.5x"); st["speed"].(float64) != 2.5 {
+		t.Errorf("speed = %v, want 2.5", st["speed"])
+	}
+
+	// Seek (pause first for a deterministic position).
+	call(http.MethodPost, "/v2/api/replay/pause")
+	target := from.Add(30 * time.Second).Format(time.RFC3339)
+	if st := call(http.MethodPost, "/v2/api/replay/seek?to="+target); st["position"] != target {
+		t.Errorf("after seek: position = %v, want %s", st["position"], target)
+	}
+}
+
+func TestServeReplay_Errors(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	h := &Handler{Clock: server.NewReplayClock(from, from.Add(time.Minute), 1, false, false)}
+
+	// Bad speed → 400.
+	rec := httptest.NewRecorder()
+	h.serveReplay(rec, httptest.NewRequest(http.MethodPost, "/v2/api/replay/speed?value=nope", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("bad speed: status = %d, want 400", rec.Code)
+	}
+
+	// Seek with no target → 400.
+	rec = httptest.NewRecorder()
+	h.serveReplay(rec, httptest.NewRequest(http.MethodPost, "/v2/api/replay/seek", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("empty seek: status = %d, want 400", rec.Code)
+	}
+
+	// Unknown action → 404.
+	rec = httptest.NewRecorder()
+	h.serveReplay(rec, httptest.NewRequest(http.MethodPost, "/v2/api/replay/frobnicate", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("unknown action: status = %d, want 404", rec.Code)
+	}
+}
+
+// TestResolveAt_FollowsClock verifies resolveAt returns the clock position in
+// replay mode when no explicit ?at= is given.
+func TestResolveAt_FollowsClock(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock := server.NewReplayClock(from, from.Add(time.Hour), 1, false, true) // paused at from
+	h := &Handler{Clock: clock}
+
+	got := h.resolveAt(httptest.NewRequest(http.MethodGet, "/v2/api/overview", nil))
+	if !got.Equal(from) {
+		t.Errorf("resolveAt (no ?at) = %s, want clock position %s", got, from)
+	}
+	// Explicit ?at= still wins.
+	at := from.Add(10 * time.Minute).Format(time.RFC3339)
+	got = h.resolveAt(httptest.NewRequest(http.MethodGet, "/v2/api/overview?at="+at, nil))
+	if got.Format(time.RFC3339) != at {
+		t.Errorf("resolveAt (?at=%s) = %s, want the explicit value", at, got.Format(time.RFC3339))
+	}
+}

--- a/internal/ui/v2/replay_test.go
+++ b/internal/ui/v2/replay_test.go
@@ -24,6 +24,13 @@ func TestServeReplay_DisabledWithoutClock(t *testing.T) {
 	if m["enabled"] != false {
 		t.Errorf("enabled = %v, want false", m["enabled"])
 	}
+
+	// A control action when replay is off is a 404, not a silent 200 no-op.
+	rec = httptest.NewRecorder()
+	h.serveReplay(rec, httptest.NewRequest(http.MethodPost, "/v2/api/replay/pause", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("POST pause without clock: status = %d, want 404", rec.Code)
+	}
 }
 
 func TestServeReplay_Control(t *testing.T) {

--- a/internal/ui/v2/replay_test.go
+++ b/internal/ui/v2/replay_test.go
@@ -97,6 +97,24 @@ func TestServeReplay_Errors(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("unknown action: status = %d, want 404", rec.Code)
 	}
+
+	// Cross-origin POST (Origin host != request host) → 403.
+	rec = httptest.NewRecorder()
+	crossReq := httptest.NewRequest(http.MethodPost, "/v2/api/replay/pause", nil) // Host = example.com
+	crossReq.Header.Set("Origin", "http://evil.example.net")
+	h.serveReplay(rec, crossReq)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("cross-origin pause: status = %d, want 403", rec.Code)
+	}
+
+	// Same-origin POST is allowed.
+	rec = httptest.NewRecorder()
+	sameReq := httptest.NewRequest(http.MethodPost, "/v2/api/replay/pause", nil)
+	sameReq.Header.Set("Origin", "http://"+sameReq.Host)
+	h.serveReplay(rec, sameReq)
+	if rec.Code != http.StatusOK {
+		t.Errorf("same-origin pause: status = %d, want 200", rec.Code)
+	}
 }
 
 // TestResolveAt_FollowsClock verifies resolveAt returns the clock position in

--- a/internal/ui/v2/static/app.css
+++ b/internal/ui/v2/static/app.css
@@ -96,6 +96,22 @@ a { color: inherit; }
 .btn:hover { border-color: var(--accent); }
 .btn.primary { background: var(--accent); color: #0b0f17; border-color: var(--accent); font-weight: 600; }
 
+/* Replay transport (header, replay mode only) */
+.transport {
+  display: flex; align-items: center; gap: 8px; padding: 4px 10px; margin-right: 8px;
+  background: var(--bg-row); border: 1px solid var(--border); border-radius: 6px;
+}
+.transport-play { min-width: 78px; text-align: center; }
+.transport-play.playing { border-color: var(--accent); color: var(--accent); }
+.transport-speed {
+  background: var(--bg-row); color: var(--fg); border: 1px solid var(--border-strong);
+  padding: 3px 6px; border-radius: 5px; font-size: 12px; cursor: pointer;
+}
+.transport-events { font: 11px var(--mono); color: var(--fg-dim); min-width: 70px; }
+.transport-ended {
+  font: 11px var(--mono); color: var(--warn, #d08770); text-transform: uppercase; letter-spacing: .5px;
+}
+
 #content { flex: 1; overflow: auto; padding: 18px 20px 28px; }
 
 .section-title {

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -252,7 +252,8 @@
       const url = new URL('/v2/api/replay/' + action, location.href);
       for (const k in (params || {})) url.searchParams.set(k, params[k]);
       const res = await fetch(url.toString(), { method: 'POST' });
-      const data = await res.json();
+      let data = null;
+      try { data = await res.json(); } catch (_) { /* non-JSON error body */ }
       if (!res.ok) throw new Error((data && data.error) || `${res.status} ${res.statusText}`);
       applyReplayStatus(data, true);
     } catch (e) {

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -288,14 +288,19 @@
     const crossed = idx !== rp.lastRenderedIdx;
     if (force || (!rp.paused && crossed)) {
       rp.lastRenderedIdx = idx;
-      try {
-        render();
-      } catch (e) {
-        // Pause-on-error: stop advancing and surface the failure.
-        replayControl('pause');
-        toast('error', 'Replay paused — view failed to load: ' + e.message);
-      }
+      // render() usually returns a Promise (view renderers are async), so guard
+      // both sync throws and async rejections and pause on failure.
+      Promise.resolve().then(render).catch((e) => replayPauseOnError(e && e.message));
     }
+  }
+
+  // replayPauseOnError stops playback and surfaces the failure. Idempotent while
+  // already paused so a burst of failed loads doesn't spam toasts.
+  function replayPauseOnError(msg) {
+    if (!state.replay.enabled || state.replay.paused) return;
+    state.replay.paused = true; // optimistic; server status confirms on next poll
+    toast('error', 'Replay paused — load failed: ' + (msg || 'unknown error'));
+    replayControl('pause');
   }
 
   async function pollReplay() {
@@ -333,6 +338,9 @@
     try { data = await res.json(); } catch (_) { /* not JSON */ }
     if (!res.ok) {
       const msg = (data && data.error) || `${res.status} ${res.statusText}`;
+      // A data load failing while replay is advancing pauses playback (view
+      // catch blocks otherwise swallow the error into an error panel).
+      if (state.replay.enabled && !state.replay.paused) replayPauseOnError(msg);
       throw new Error(msg);
     }
     return data;

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -161,7 +161,7 @@
     const maxIdx = Math.max(0, state.snapshots.length - 1);
     // In replay mode the thumb tracks the live clock position; otherwise it
     // tracks the manually-selected snapshot.
-    const idxNow = replay ? nearestSnapshotIndex(state.replay.position) : currentSnapshotIndex();
+    const idxNow = replay ? replaySnapshotIndex(state.replay.position) : currentSnapshotIndex();
     const prev = el('button', { class: 'btn', onclick: () => (replay ? seekSnapshot(-1) : stepSnapshot(-1)), title: 'Step back' }, '◀');
     const next = el('button', { class: 'btn', onclick: () => (replay ? seekSnapshot(+1) : stepSnapshot(+1)), title: 'Step forward' }, '▶');
     const range = el('input', { type: 'range', min: '0', max: String(maxIdx), value: String(idxNow) });
@@ -192,15 +192,19 @@
   // ── Replay transport ───────────────────────────────────────────────────────
   const REPLAY_SPEEDS = [0.5, 1, 2, 3];
 
-  function nearestSnapshotIndex(rfc3339) {
+  // replaySnapshotIndex returns the index of the latest snapshot at or before
+  // the given time (floor). Using the floor (not the nearest) means the view
+  // re-renders exactly when the clock crosses a snapshot, rather than at the
+  // midpoint between two snapshots.
+  function replaySnapshotIndex(rfc3339) {
     if (!rfc3339 || state.snapshots.length === 0) return Math.max(0, state.snapshots.length - 1);
     const t = Date.parse(rfc3339);
-    let best = 0, bestDelta = Infinity;
+    let idx = 0;
     for (let i = 0; i < state.snapshots.length; i++) {
-      const d = Math.abs(Date.parse(state.snapshots[i]) - t);
-      if (d < bestDelta) { bestDelta = d; best = i; }
+      if (Date.parse(state.snapshots[i]) <= t) idx = i;
+      else break;
     }
-    return best;
+    return idx;
   }
 
   // renderTransport builds the play/pause + speed controls in the header. It is
@@ -226,7 +230,14 @@
       class: 'transport-speed', title: 'Playback speed',
       onchange: (e) => replayControl('speed', { value: e.target.value + 'x' }),
     });
-    for (const sp of REPLAY_SPEEDS) {
+    // Include the current speed even if it's not one of the presets (e.g. a
+    // server started with --speed 5x), so the control reflects real state.
+    const speeds = REPLAY_SPEEDS.slice();
+    if (!speeds.some((s) => Math.abs(s - rp.speed) < 1e-9)) {
+      speeds.push(rp.speed);
+      speeds.sort((a, b) => a - b);
+    }
+    for (const sp of speeds) {
       const o = el('option', { value: String(sp) }, sp + '×');
       if (Math.abs(sp - rp.speed) < 1e-9) o.selected = true;
       speedSel.appendChild(o);
@@ -241,7 +252,7 @@
 
   // seekSnapshot seeks the clock to the neighbouring snapshot (step buttons).
   function seekSnapshot(delta) {
-    const idx = Math.max(0, Math.min(state.snapshots.length - 1, nearestSnapshotIndex(state.replay.position) + delta));
+    const idx = Math.max(0, Math.min(state.snapshots.length - 1, replaySnapshotIndex(state.replay.position) + delta));
     const to = state.snapshots[idx];
     if (to) replayControl('seek', { to });
   }
@@ -279,7 +290,7 @@
     // Live-update the scrubber thumb + label without a full re-render.
     const s = $('scrubber');
     const range = s && s.querySelector('input[type=range]');
-    const idx = nearestSnapshotIndex(rp.position);
+    const idx = replaySnapshotIndex(rp.position);
     if (range) range.value = String(idx);
     const tsEl = s && s.querySelector('.ts');
     if (tsEl) tsEl.textContent = formatTS(rp.position);

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -315,13 +315,17 @@
     replayControl('pause');
   }
 
+  let replayPollInFlight = false;
   async function pollReplay() {
-    if (!state.replay.enabled) return;
+    if (!state.replay.enabled || replayPollInFlight) return; // avoid overlapping polls
+    replayPollInFlight = true;
     try {
       const res = await fetch(new URL('/v2/api/replay', location.href).toString());
       const data = await res.json();
       applyReplayStatus(data, false);
-    } catch (_) { /* transient; next tick retries */ }
+    } catch (_) { /* transient; next tick retries */ } finally {
+      replayPollInFlight = false;
+    }
   }
 
   function currentSnapshotIndex() {

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -190,7 +190,7 @@
   }
 
   // ── Replay transport ───────────────────────────────────────────────────────
-  const REPLAY_SPEEDS = [0.5, 1, 2, 3];
+  const REPLAY_SPEEDS = [0.25, 0.5, 1, 2];
 
   // replaySnapshotIndex returns the index of the latest snapshot at or before
   // the given time (floor). Using the floor (not the nearest) means the view
@@ -207,47 +207,69 @@
     return idx;
   }
 
-  // renderTransport builds the play/pause + speed controls in the header. It is
-  // only shown in replay mode; the container is created lazily.
+  // transportEls caches the header transport elements. They are built once and
+  // then updated in place — crucially, the poll loop must NOT recreate the
+  // <select> every tick or it would close the native dropdown mid-interaction.
+  let transportEls = null;
+
+  // renderTransport shows the play/pause + speed controls in the header (replay
+  // mode only) and updates their state in place.
   function renderTransport() {
     if (!state.replay.enabled) return;
-    let box = $('transport');
-    if (!box) {
-      box = el('div', { class: 'transport', id: 'transport' });
+    const rp = state.replay;
+
+    if (!transportEls) {
+      const box = el('div', { class: 'transport', id: 'transport' });
       const bar = $('topbar');
       const scrub = $('scrubber');
       if (bar && scrub) bar.insertBefore(box, scrub);
       else if (bar) bar.appendChild(box);
+      const playBtn = el('button', {
+        class: 'btn transport-play',
+        onclick: () => replayControl(state.replay.paused ? 'play' : 'pause'),
+      });
+      const speedSel = el('select', {
+        class: 'transport-speed', title: 'Playback speed',
+        onchange: (e) => replayControl('speed', { value: e.target.value + 'x' }),
+      });
+      const evts = el('span', { class: 'transport-events', title: 'Watch events emitted' });
+      const ended = el('span', { class: 'transport-ended' }, 'ended');
+      box.appendChild(playBtn);
+      box.appendChild(speedSel);
+      box.appendChild(evts);
+      transportEls = { box, playBtn, speedSel, evts, ended, speedKey: '' };
     }
-    box.innerHTML = '';
-    const rp = state.replay;
-    const playBtn = el('button', {
-      class: 'btn transport-play' + (rp.paused ? '' : ' playing'),
-      title: rp.paused ? 'Play' : 'Pause',
-      onclick: () => replayControl(rp.paused ? 'play' : 'pause'),
-    }, rp.paused ? '▶ Play' : '❚❚ Pause');
-    const speedSel = el('select', {
-      class: 'transport-speed', title: 'Playback speed',
-      onchange: (e) => replayControl('speed', { value: e.target.value + 'x' }),
-    });
-    // Include the current speed even if it's not one of the presets (e.g. a
-    // server started with --speed 5x), so the control reflects real state.
+    const t = transportEls;
+
+    // Play / pause.
+    t.playBtn.textContent = rp.paused ? '▶ Play' : '❚❚ Pause';
+    t.playBtn.title = rp.paused ? 'Play' : 'Pause';
+    t.playBtn.classList.toggle('playing', !rp.paused);
+
+    // Speed options — include the current speed even if it isn't a preset (e.g. a
+    // server started with --speed 5x). Rebuild the <option>s only when the set
+    // changes, so polling never recreates the select and closes the dropdown.
     const speeds = REPLAY_SPEEDS.slice();
     if (!speeds.some((s) => Math.abs(s - rp.speed) < 1e-9)) {
       speeds.push(rp.speed);
       speeds.sort((a, b) => a - b);
     }
-    for (const sp of speeds) {
-      const o = el('option', { value: String(sp) }, sp + '×');
-      if (Math.abs(sp - rp.speed) < 1e-9) o.selected = true;
-      speedSel.appendChild(o);
+    const key = speeds.join(',');
+    if (t.speedKey !== key) {
+      t.speedSel.innerHTML = '';
+      for (const sp of speeds) t.speedSel.appendChild(el('option', { value: String(sp) }, sp + '×'));
+      t.speedKey = key;
     }
-    const evts = el('span', { class: 'transport-events', title: 'Watch events emitted' },
-      rp.events + ' event' + (rp.events === 1 ? '' : 's'));
-    box.appendChild(playBtn);
-    box.appendChild(speedSel);
-    box.appendChild(evts);
-    if (rp.ended && !rp.loop) box.appendChild(el('span', { class: 'transport-ended' }, 'ended'));
+    // Reflect the current speed unless the user is interacting with the select.
+    if (document.activeElement !== t.speedSel) t.speedSel.value = String(rp.speed);
+
+    // Events counter and ended badge.
+    t.evts.textContent = rp.events + ' event' + (rp.events === 1 ? '' : 's');
+    if (rp.ended && !rp.loop) {
+      if (!t.ended.parentNode) t.box.appendChild(t.ended);
+    } else if (t.ended.parentNode) {
+      t.ended.remove();
+    }
   }
 
   // seekSnapshot seeks the clock to the neighbouring snapshot (step buttons).

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -74,8 +74,19 @@
   const state = {
     captureMeta: null,
     snapshots: [],   // RFC3339 strings
-    at: '',          // selected snapshot timestamp ('' = latest)
+    at: '',          // selected snapshot timestamp ('' = latest / follow clock in replay)
     route: { name: 'overview' },
+    // Replay transport (populated from /v2/api/replay when replay mode is on).
+    replay: {
+      enabled: false,
+      position: '',  // live clock position (RFC3339)
+      paused: true,
+      speed: 1,
+      loop: false,
+      ended: false,
+      events: 0,
+      lastRenderedIdx: -1, // scrubber index last re-rendered, to throttle auto-follow
+    },
   };
 
   // ── Router ───────────────────────────────────────────────────────────────
@@ -146,24 +157,154 @@
   function renderScrubber() {
     const s = $('scrubber');
     s.innerHTML = '';
-    const prev = el('button', { class: 'btn', onclick: stepSnapshot.bind(null, -1) }, '◀');
-    const next = el('button', { class: 'btn', onclick: stepSnapshot.bind(null, +1) }, '▶');
-    const range = el('input', { type: 'range', min: '0', max: String(Math.max(0, state.snapshots.length - 1)), value: String(currentSnapshotIndex()) });
-    range.addEventListener('input', () => {
-      const idx = Number(range.value);
-      state.at = state.snapshots[idx] || '';
-      ts.textContent = formatTS(state.at);
-    });
-    range.addEventListener('change', () => {
-      const idx = Number(range.value);
-      state.at = state.snapshots[idx] || '';
-      render();
-    });
-    const ts = el('span', { class: 'ts' }, formatTS(state.at));
+    const replay = state.replay.enabled;
+    const maxIdx = Math.max(0, state.snapshots.length - 1);
+    // In replay mode the thumb tracks the live clock position; otherwise it
+    // tracks the manually-selected snapshot.
+    const idxNow = replay ? nearestSnapshotIndex(state.replay.position) : currentSnapshotIndex();
+    const prev = el('button', { class: 'btn', onclick: () => (replay ? seekSnapshot(-1) : stepSnapshot(-1)), title: 'Step back' }, '◀');
+    const next = el('button', { class: 'btn', onclick: () => (replay ? seekSnapshot(+1) : stepSnapshot(+1)), title: 'Step forward' }, '▶');
+    const range = el('input', { type: 'range', min: '0', max: String(maxIdx), value: String(idxNow) });
+    const ts = el('span', { class: 'ts' }, formatTS(replay ? state.replay.position : state.at));
+    if (replay) {
+      // Drag = seek the clock; update label live, commit the seek on release.
+      range.addEventListener('input', () => { ts.textContent = formatTS(state.snapshots[Number(range.value)] || ''); });
+      range.addEventListener('change', () => {
+        const to = state.snapshots[Number(range.value)];
+        if (to) replayControl('seek', { to });
+      });
+    } else {
+      range.addEventListener('input', () => {
+        state.at = state.snapshots[Number(range.value)] || '';
+        ts.textContent = formatTS(state.at);
+      });
+      range.addEventListener('change', () => {
+        state.at = state.snapshots[Number(range.value)] || '';
+        render();
+      });
+    }
     s.appendChild(prev);
     s.appendChild(range);
     s.appendChild(next);
     s.appendChild(ts);
+  }
+
+  // ── Replay transport ───────────────────────────────────────────────────────
+  const REPLAY_SPEEDS = [0.5, 1, 2, 3];
+
+  function nearestSnapshotIndex(rfc3339) {
+    if (!rfc3339 || state.snapshots.length === 0) return Math.max(0, state.snapshots.length - 1);
+    const t = Date.parse(rfc3339);
+    let best = 0, bestDelta = Infinity;
+    for (let i = 0; i < state.snapshots.length; i++) {
+      const d = Math.abs(Date.parse(state.snapshots[i]) - t);
+      if (d < bestDelta) { bestDelta = d; best = i; }
+    }
+    return best;
+  }
+
+  // renderTransport builds the play/pause + speed controls in the header. It is
+  // only shown in replay mode; the container is created lazily.
+  function renderTransport() {
+    if (!state.replay.enabled) return;
+    let box = $('transport');
+    if (!box) {
+      box = el('div', { class: 'transport', id: 'transport' });
+      const bar = $('topbar');
+      const scrub = $('scrubber');
+      if (bar && scrub) bar.insertBefore(box, scrub);
+      else if (bar) bar.appendChild(box);
+    }
+    box.innerHTML = '';
+    const rp = state.replay;
+    const playBtn = el('button', {
+      class: 'btn transport-play' + (rp.paused ? '' : ' playing'),
+      title: rp.paused ? 'Play' : 'Pause',
+      onclick: () => replayControl(rp.paused ? 'play' : 'pause'),
+    }, rp.paused ? '▶ Play' : '❚❚ Pause');
+    const speedSel = el('select', {
+      class: 'transport-speed', title: 'Playback speed',
+      onchange: (e) => replayControl('speed', { value: e.target.value + 'x' }),
+    });
+    for (const sp of REPLAY_SPEEDS) {
+      const o = el('option', { value: String(sp) }, sp + '×');
+      if (Math.abs(sp - rp.speed) < 1e-9) o.selected = true;
+      speedSel.appendChild(o);
+    }
+    const evts = el('span', { class: 'transport-events', title: 'Watch events emitted' },
+      rp.events + ' event' + (rp.events === 1 ? '' : 's'));
+    box.appendChild(playBtn);
+    box.appendChild(speedSel);
+    box.appendChild(evts);
+    if (rp.ended && !rp.loop) box.appendChild(el('span', { class: 'transport-ended' }, 'ended'));
+  }
+
+  // seekSnapshot seeks the clock to the neighbouring snapshot (step buttons).
+  function seekSnapshot(delta) {
+    const idx = Math.max(0, Math.min(state.snapshots.length - 1, nearestSnapshotIndex(state.replay.position) + delta));
+    const to = state.snapshots[idx];
+    if (to) replayControl('seek', { to });
+  }
+
+  // replayControl POSTs a transport action and applies the returned status.
+  async function replayControl(action, params) {
+    try {
+      const url = new URL('/v2/api/replay/' + action, location.href);
+      for (const k in (params || {})) url.searchParams.set(k, params[k]);
+      const res = await fetch(url.toString(), { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok) throw new Error((data && data.error) || `${res.status} ${res.statusText}`);
+      applyReplayStatus(data, true);
+    } catch (e) {
+      toast('error', 'Replay control failed: ' + e.message);
+    }
+  }
+
+  // applyReplayStatus updates replay state from a status payload. When force is
+  // true (an explicit control action) it always re-renders; during polling it
+  // only re-renders the heavy view when the scrubber crosses a new snapshot.
+  function applyReplayStatus(st, force) {
+    if (!st || !st.enabled) return;
+    const rp = state.replay;
+    rp.enabled = true;
+    rp.position = st.position || '';
+    rp.paused = !!st.paused;
+    rp.speed = st.speed || 1;
+    rp.loop = !!st.loop;
+    rp.ended = !!st.ended;
+    rp.events = st.events_emitted || 0;
+
+    renderTransport();
+    // Live-update the scrubber thumb + label without a full re-render.
+    const s = $('scrubber');
+    const range = s && s.querySelector('input[type=range]');
+    const idx = nearestSnapshotIndex(rp.position);
+    if (range) range.value = String(idx);
+    const tsEl = s && s.querySelector('.ts');
+    if (tsEl) tsEl.textContent = formatTS(rp.position);
+
+    // Auto-follow: re-render the current view when the clock crosses into a new
+    // snapshot (throttles the expensive view rebuild to snapshot granularity).
+    const crossed = idx !== rp.lastRenderedIdx;
+    if (force || (!rp.paused && crossed)) {
+      rp.lastRenderedIdx = idx;
+      try {
+        render();
+      } catch (e) {
+        // Pause-on-error: stop advancing and surface the failure.
+        replayControl('pause');
+        toast('error', 'Replay paused — view failed to load: ' + e.message);
+      }
+    }
+  }
+
+  async function pollReplay() {
+    if (!state.replay.enabled) return;
+    try {
+      const res = await fetch(new URL('/v2/api/replay', location.href).toString());
+      const data = await res.json();
+      applyReplayStatus(data, false);
+    } catch (_) { /* transient; next tick retries */ }
   }
 
   function currentSnapshotIndex() {
@@ -2104,6 +2245,7 @@
   function render() {
     renderNav();
     renderScrubber();
+    renderTransport();
     const r = state.route;
     if (r.name === 'overview') return renderOverview();
     if (r.name === 'namespaces') return renderNamespacesIndex();
@@ -2167,6 +2309,14 @@
       // Timestamps endpoint not implemented yet — keep going with empty snapshots.
       $('capture-meta').textContent = 'capture loaded';
     }
+    // Detect replay mode and, if on, start the transport poll loop.
+    try {
+      const rp = await getJSON('/v2/api/replay');
+      if (rp && rp.enabled) {
+        applyReplayStatus(rp, false);
+        setInterval(pollReplay, 700);
+      }
+    } catch (_) { /* replay endpoint absent → static explorer */ }
     render();
   }
   document.addEventListener('DOMContentLoaded', init);

--- a/internal/ui/v2/v2.go
+++ b/internal/ui/v2/v2.go
@@ -22,6 +22,9 @@ type Handler struct {
 	At          time.Time
 	ArchivePath string
 	Verbose     bool
+	// Clock, when non-nil, puts the dashboard in replay mode: resolveAt follows
+	// the clock and /v2/api/replay drives it (see replay.go).
+	Clock *server.ReplayClock
 }
 
 // Mount registers all /v2/* routes on mux. The /v2/ HTML shell is served
@@ -49,4 +52,6 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("/v2/api/diff", h.serveDiff)
 	mux.HandleFunc("/v2/api/object-history", h.serveObjectHistory)
 	mux.HandleFunc("/v2/api/timestamps", h.serveTimestamps)
+	mux.HandleFunc("/v2/api/replay", h.serveReplay)
+	mux.HandleFunc("/v2/api/replay/", h.serveReplay)
 }


### PR DESCRIPTION
Implements **phase 3** of time-based replay (#122, part of #119) — turns the v2 dashboard into a transport/VCR for replay, and also closes the deferred playback-controls item from #7.

## What's here
Both entry points share **one** replay clock, so `kubectl` and the dashboard stay in lockstep:

```sh
kshrk ui capture.kshrk --speed 2x            # dashboard-first
kshrk replay capture.kshrk --speed 2x --ui   # replay-first, also serves the dashboard
```

**Server / UI**
- `ui.OpenOptions` and `v2.Handler` carry an optional `*server.ReplayClock`. `resolveAt` follows the clock when no explicit `?at=` is given (an explicit `?at=` still wins for paused inspection).
- New same-origin control API **`/v2/api/replay`** — `GET` status (`{enabled:false}` when not in replay mode); `POST play|pause|speed|seek`. Backed by the shared clock; `server.ParseSpeed` exported for it.
- `cmd/ui.go`: replay flags (`--speed/--from/--to/--loop/--start-paused`) switch `ui` into replay mode via `server.Replay`, passing the clock to the dashboard. `cmd/replay.go`: `--ui`/`--ui-port` also start the dashboard.

**Front-end** (`app.js`/`app.css`)
- Header **transport bar** (play/pause, step ◀▶, 0.5×/1×/2×/3× speed selector, live event counter), shown only in replay mode.
- The scrubber **seeks the clock**; a poll loop updates the thumb/label live and re-renders the current view as the clock crosses each snapshot (throttled to snapshot granularity so heavy views aren't rebuilt every tick).
- **Pause-on-error**: if a view fails to load mid-playback, replay pauses and surfaces the error.

## Acceptance criteria
- [x] From the dashboard you can start/pause, change speed, and seek, and views update as the clock advances.
- [x] Control endpoint documented (Replay (VCR) section of the Web UI guide + usage.md).
- [x] Closes the optional playback/auto-step controls item from #7.

## Testing
`go test -race ./...`, `go vet`, `gofmt`, `go mod tidy`, pinned `golangci-lint` — all clean. Smoke-tested both commands against a real capture: `/v2/api/replay` reports an advancing position (~5× in `--speed 5x`), pause/speed/seek work, and driving playback from the dashboard endpoint is reflected on the mock server's `/_k8shark/replay` — confirming kubectl and the UI share one clock.

## Notes
Depends on phase 1 (#120, clock + control surface) and phase 2 (#121, RV coherence), both merged. Remaining: #123 (optional writable overlay). No screenshots added here (headless environment); the transport bar reuses existing `.btn`/scrubber styling.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update — speed presets:** at the maintainer's request the dashboard speed selector uses **0.25× / 0.5× / 1× / 2×** (adds 0.25×, drops 3×), which intentionally supersedes the original AC's 0.5×/1×/2×/3×. Any non-preset speed (e.g. `--speed 5x`) is still added to the selector so it reflects real state, and arbitrary speeds remain settable via the CLI/control API. Docs match the UI.
