### PR TITLE
chore(ui): remove dead Legacy UI link + drop active-development warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@
 
 > **Customer cluster is broken. You can't get access. You can't reproduce it. k8shark fixes that.**
 
-> **Important:** `k8shark` is under active development. Performance and architecture work is landing quickly, and some updates can be backward-incompatible until the API and archive format stabilize.
->
-> For production usage, prefer the latest release candidate (`v0.2.0-rc.N`) so you get compatibility fixes and the current capture/replay behavior.
-
 **k8shark** captures a Kubernetes cluster's state over time and packages it into a single portable archive. A built-in mock API server lets support engineers replay that archive exactly like a live cluster — no direct connectivity required.
 
 A customer hands over one file. A support engineer queries the environment interactively, without live cluster access or back-and-forth command output.

--- a/internal/ui/v2/static/app.css
+++ b/internal/ui/v2/static/app.css
@@ -48,11 +48,6 @@
   border-radius: 6px; padding: 5px 9px; font-size: 12px; cursor: pointer;
 }
 .theme-toggle:hover { color: var(--fg); }
-.legacy-link {
-  font-size: 11px; color: var(--fg-faint); text-decoration: none;
-  border: 1px solid var(--border-strong); border-radius: 6px; padding: 5px 9px; white-space: nowrap;
-}
-.legacy-link:hover { color: var(--fg); border-color: var(--accent); }
 * { box-sizing: border-box; }
 html, body { margin: 0; padding: 0; height: 100%; background: var(--bg); color: var(--fg); font: 13px var(--font); }
 a { color: inherit; }

--- a/internal/ui/v2/static/index.html
+++ b/internal/ui/v2/static/index.html
@@ -15,7 +15,6 @@
     <div class="grow"></div>
     <div class="meta" id="capture-meta">loading…</div>
     <div class="scrubber" id="scrubber"></div>
-    <a class="legacy-link" href="/v1/" title="Open the legacy v1 explorer">Legacy UI ↗</a>
   </div>
   <main id="content"></main>
   <div id="toasts"></div>


### PR DESCRIPTION
Two small cleanups now that all the replay/UI PRs have merged.

## 1. Remove the dead "Legacy UI ↗" link
The v1 UI was removed in #91, but the v2 dashboard header still rendered:
```html
<a class="legacy-link" href="/v1/" title="Open the legacy v1 explorer">Legacy UI ↗</a>
```
`/v1/` no longer has a handler — `serveRoot` 404s it (confirmed against a running server: `GET /v1/ → 404`). Removed the anchor from `index.html` and its now-unused `.legacy-link` rules from `app.css`.

## 2. Drop the "under active development" README warning
Removed the `> **Important:** … under active development … prefer the latest release candidate` block from the README, now that the API/archive format have stabilized.

## Verification
- Built and served the v2 dashboard: `/v2/` no longer references `/v1/`/legacy and renders normally (title + topbar intact).
- Remaining `/api/v1/...` strings in `app.js` are Kubernetes API paths, not the UI route.
- `make build` clean.

Docs note: `CLAUDE.md` already says "don't reference `/v1/`" — this removes the last stray reference that contradicted it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)