### PR TITLE
feat(replay): writable overlay — writes + read merge (#123, PR 1)

### DIFF
--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -48,6 +48,7 @@ func init() {
 	replayCmd.Flags().Bool("start-paused", false, "start paused; press Enter to begin playback")
 	replayCmd.Flags().Bool("ui", false, "also start the web dashboard as a replay transport (VCR)")
 	replayCmd.Flags().String("ui-port", "0", "port for the dashboard when --ui is set (0 = random)")
+	replayCmd.Flags().Bool("writable", false, "accept client writes into an in-memory overlay (closed-loop controller dev)")
 }
 
 func runReplay(cmd *cobra.Command, args []string) error {
@@ -58,6 +59,7 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	to, _ := cmd.Flags().GetString("to")
 	loop, _ := cmd.Flags().GetBool("loop")
 	startPaused, _ := cmd.Flags().GetBool("start-paused")
+	writable, _ := cmd.Flags().GetBool("writable")
 	verbose, _ := cmd.Root().PersistentFlags().GetBool("verbose")
 
 	srv, err := server.Replay(server.ReplayOptions{
@@ -69,6 +71,7 @@ func runReplay(cmd *cobra.Command, args []string) error {
 		To:            to,
 		Loop:          loop,
 		StartPaused:   startPaused,
+		Writable:      writable,
 		Verbose:       verbose,
 	})
 	if err != nil {
@@ -97,6 +100,9 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Speed:      %s\n", formatSpeed(clock.Speed()))
 	if loop {
 		fmt.Printf("  Loop:       on\n")
+	}
+	if srv.Writable() {
+		fmt.Printf("  Writable:   on (client writes land in an in-memory overlay)\n")
 	}
 	fmt.Printf("  Control:    %s/_k8shark/replay\n", srv.Address())
 	if uiSrv != nil {

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -47,6 +47,7 @@ func init() {
 	uiCmd.Flags().String("to", "", "replay window end: RFC3339 or relative duration like -1m")
 	uiCmd.Flags().Bool("loop", false, "replay mode: restart from the window start when the end is reached")
 	uiCmd.Flags().Bool("start-paused", false, "replay mode: start paused")
+	uiCmd.Flags().Bool("writable", false, "replay mode: accept client writes into an in-memory overlay")
 }
 
 func runUI(cmd *cobra.Command, args []string) error {
@@ -75,13 +76,14 @@ func runUI(cmd *cobra.Command, args []string) error {
 	to, _ := cmd.Flags().GetString("to")
 	loop, _ := cmd.Flags().GetBool("loop")
 	startPaused, _ := cmd.Flags().GetBool("start-paused")
+	writable, _ := cmd.Flags().GetBool("writable")
 	replayMode := cmd.Flags().Changed("speed") || cmd.Flags().Changed("from") ||
-		cmd.Flags().Changed("to") || loop || startPaused
+		cmd.Flags().Changed("to") || loop || startPaused || writable
 
 	// --at pins a single instant, which is meaningless once the replay clock is
 	// driving time — reject the combination rather than silently ignoring --at.
 	if replayMode && cmd.Flags().Changed("at") {
-		return fmt.Errorf("--at cannot be combined with replay flags (--speed/--from/--to/--loop/--start-paused); use --from/--to to set the replay window")
+		return fmt.Errorf("--at cannot be combined with replay flags (--speed/--from/--to/--loop/--start-paused/--writable); use --from/--to to set the replay window")
 	}
 
 	var mockSrv *server.Server
@@ -89,7 +91,7 @@ func runUI(cmd *cobra.Command, args []string) error {
 	if replayMode {
 		mockSrv, err = server.Replay(server.ReplayOptions{
 			ArchivePath: archivePath, Port: apiPort, KubeconfigOut: kubeconfigOut,
-			Speed: speed, From: from, To: to, Loop: loop, StartPaused: startPaused, Verbose: verbose,
+			Speed: speed, From: from, To: to, Loop: loop, StartPaused: startPaused, Writable: writable, Verbose: verbose,
 		})
 	} else {
 		mockSrv, err = server.Open(server.OpenOptions{

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -405,6 +405,7 @@ The primary use case is **local development and testing of controllers/operators
 | `--start-paused` | false | Start paused (press Enter to begin, or use the dashboard when `--ui` is set) |
 | `--ui` | false | Also start the web dashboard as a replay transport (VCR), sharing the clock |
 | `--ui-port` | random | Port for the dashboard when `--ui` is set |
+| `--writable` | false | Accept client writes into an in-memory overlay (closed-loop controller dev) |
 | `--port` | random | Port for the mock API server |
 | `--kubeconfig-out` | `~/.kube/k8shark-<id>.yaml` | Where to write the generated kubeconfig |
 | `--verbose` / `-v` | false | Log every request the server receives |

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
+	gopkg.in/evanphx/json-patch.v4 v4.13.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -49,5 +50,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -20,6 +20,11 @@ type handler struct {
 	// events over time (see streamReplayWatch). nil for plain `open`/`ui`.
 	clock *ReplayClock
 
+	// overlay, when non-nil, enables writable replay: client writes land in an
+	// in-memory layer merged over the replayed state (see overlay.go, writes.go).
+	// nil for read-only replay (writes return 405).
+	overlay *overlay
+
 	// timelineCache memoizes the (immutable) per-path replay event timeline so
 	// LIST and WATCH don't rebuild it per request — important for poll-only
 	// captures, whose timeline requires diffing every snapshot.
@@ -157,12 +162,16 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Reject all write operations — k8shark replay is read-only.
+	// Writes: accepted into the overlay in writable replay; otherwise 405.
 	// RFC 7231 §6.5.5 requires an Allow header with a 405 response.
 	switch r.Method {
 	case http.MethodGet, http.MethodHead:
 		// allowed
 	default:
+		if h.overlay != nil {
+			h.handleWrite(w, r, path)
+			return
+		}
 		w.Header().Set("Allow", "GET, HEAD")
 		h.writeStatus(w, http.StatusMethodNotAllowed,
 			"k8shark replay server is read-only; write operations are not supported")
@@ -397,6 +406,22 @@ func (h *handler) serveGroupResourceList(w http.ResponseWriter, path string) {
 }
 
 func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path string, at time.Time) {
+	// Writable replay: a single-object GET is served from the overlay when the
+	// overlay owns it (created/updated → the overlay copy; deleted → 404).
+	if h.overlay != nil {
+		h.overlay.syncEpoch(h.clock)
+		if g, v, res, ns, name, sub := parseWritePath(strings.TrimSuffix(path, "/")); name != "" && sub == "" {
+			if e, ok := h.overlay.get(g, v, res, ns, name); ok {
+				if e.deleted {
+					h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q not found in capture", path))
+					return
+				}
+				writeJSON(w, http.StatusOK, json.RawMessage(e.obj))
+				return
+			}
+		}
+	}
+
 	body, code, err := h.store.ReconstructAt(path, at)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, statusObj(500, err.Error()))
@@ -540,18 +565,53 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		}
 	}
 
+	// Writable replay: merge overlay objects into the list (overlay wins).
+	if h.overlay != nil {
+		body = h.mergeOverlayList(path, body)
+	}
+
 	// In replay mode, override a list's resourceVersion with the coherent RV
-	// as-of the clock, so a following WATCH(resourceVersion=RV) aligns with the
-	// event stream's monotonic RVs.
+	// as-of the clock (and, in writable mode, at least the overlay's RV), so a
+	// following WATCH(resourceVersion=RV) aligns with the event stream's RVs.
 	if h.clock != nil {
 		body = rewriteListResourceVersion(body, func() int64 {
-			return rvAsOf(h.timelineFor(path), at)
+			rv := rvAsOf(h.timelineFor(path), at)
+			if h.overlay != nil {
+				if orv := h.overlay.currentRV(); orv > rv {
+					rv = orv
+				}
+			}
+			return rv
 		})
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	_, _ = w.Write(body)
+}
+
+// mergeOverlayList merges overlay objects into a list body for the list's scope.
+// Non-list bodies are returned unchanged.
+func (h *handler) mergeOverlayList(path string, body []byte) []byte {
+	group, version, resource, namespace := parseAPIPath(strings.TrimSuffix(path, "/"))
+	if resource == "" {
+		return body
+	}
+	var list struct {
+		APIVersion string            `json:"apiVersion"`
+		Kind       string            `json:"kind"`
+		Metadata   json.RawMessage   `json:"metadata"`
+		Items      []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(body, &list); err != nil || list.Items == nil {
+		return body // not a list
+	}
+	list.Items = h.overlay.applyToList(group, version, resource, namespace, list.Items)
+	out, err := json.Marshal(list)
+	if err != nil {
+		return body
+	}
+	return out
 }
 
 // extractTableRow finds the row matching name in a Table response and returns

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -595,6 +595,7 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 // mergeOverlayList merges overlay objects into a list body for the list's scope.
 // Non-list bodies are returned unchanged.
 func (h *handler) mergeOverlayList(path string, body []byte) []byte {
+	h.overlay.syncEpoch(h.clock) // reset-on-loop before merging into a LIST
 	group, version, resource, namespace := parseAPIPath(strings.TrimSuffix(path, "/"))
 	if resource == "" {
 		return body

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -587,7 +587,8 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		body = rewriteListResourceVersion(body, func() int64 {
 			rv := rvAsOf(h.timelineFor(path), at)
 			if h.overlay != nil {
-				if orv := h.overlay.currentRV(); orv > rv {
+				g, v, resource, namespace := parseAPIPath(strings.TrimSuffix(path, "/"))
+				if orv := h.overlay.scopeRV(g, v, resource, namespace); orv > rv {
 					rv = orv
 				}
 			}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -513,6 +513,16 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		return
 	}
 
+	// Writable replay: merge overlay objects into the list (overlay wins) before
+	// Table negotiation, then re-apply selectors so overlay items are filtered
+	// consistently with replayed items.
+	if h.overlay != nil {
+		body = h.mergeOverlayList(path, body)
+		if filtered, ferr := applySelectors(body, labelSel, fieldSel); ferr == nil {
+			body = filtered
+		}
+	}
+
 	// tableFiltered applies label/field selectors to a stored Table-format body,
 	// removing rows whose embedded object does not match. Returns tb unchanged
 	// when selectors are empty or if filtering fails (best-effort).
@@ -530,8 +540,10 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 	// (real column defs + pre-computed cell values from the actual cluster).
 	// Fall back to buildTable only for captures predating this feature.
 	if strings.Contains(r.Header.Get("Accept"), "as=Table") {
-		// Exact-path stored Table (namespace-scoped list).
-		if tb, tbCode, _ := h.store.Latest(path+"?as=Table", at); tbCode == 200 {
+		// Exact-path stored Table (namespace-scoped list). Bypassed in writable
+		// mode so the Table reflects overlay writes (built from the merged body
+		// below) rather than the captured-only stored Table.
+		if tb, tbCode, _ := h.store.Latest(path+"?as=Table", at); tbCode == 200 && h.overlay == nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(200)
 			_, _ = w.Write(tableFiltered(tb))
@@ -552,7 +564,8 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 			}
 		}
 		// Aggregated Table across namespaces (for -A / cluster-scoped paths only).
-		if _, _, _, reqNS := parseAPIPath(path); reqNS == "" {
+		// Also bypassed in writable mode (see above).
+		if _, _, _, reqNS := parseAPIPath(path); reqNS == "" && h.overlay == nil {
 			if tb, tbCode, _ := h.store.AggregateTableAcrossNamespaces(path, at); tbCode == 200 {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(200)
@@ -565,11 +578,6 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		if tb, err2 := buildTable(body); err2 == nil {
 			body = tb
 		}
-	}
-
-	// Writable replay: merge overlay objects into the list (overlay wins).
-	if h.overlay != nil {
-		body = h.mergeOverlayList(path, body)
 	}
 
 	// In replay mode, override a list's resourceVersion with the coherent RV

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -410,10 +410,12 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 	// overlay owns it (created/updated → the overlay copy; deleted → 404).
 	if h.overlay != nil {
 		h.overlay.syncEpoch(h.clock)
-		if g, v, res, ns, name, sub := parseWritePath(strings.TrimSuffix(path, "/")); name != "" && sub == "" {
+		// Serve overlay-owned objects for a single-object GET (and GET .../status,
+		// so clients can observe their status updates).
+		if g, v, res, ns, name, sub := parseWritePath(strings.TrimSuffix(path, "/")); name != "" && (sub == "" || sub == "status") {
 			if e, ok := h.overlay.get(g, v, res, ns, name); ok {
 				if e.deleted {
-					h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q not found in capture", path))
+					h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q was deleted in the writable overlay", path))
 					return
 				}
 				writeJSON(w, http.StatusOK, json.RawMessage(e.obj))

--- a/internal/server/overlay.go
+++ b/internal/server/overlay.go
@@ -143,9 +143,11 @@ func (o *overlay) get(group, version, resource, namespace, name string) (*overla
 // Overlay entries replace matching base items (overlay wins), tombstones remove
 // them, and overlay-created items not in the base are appended.
 func (o *overlay) applyToList(group, version, resource, namespace string, base []json.RawMessage) []json.RawMessage {
+	// Snapshot the relevant entries under the lock, then release it before walking
+	// (and JSON-unmarshalling) the base list, so a large LIST doesn't block writes.
+	// Stored entries are immutable (store/del replace the pointer), so the
+	// snapshot is safe to read after unlock.
 	o.mu.RLock()
-	defer o.mu.RUnlock()
-
 	matched := map[string]*overlayEntry{}
 	for _, e := range o.items {
 		if e.group == group && e.version == version && e.resource == resource &&
@@ -153,6 +155,8 @@ func (o *overlay) applyToList(group, version, resource, namespace string, base [
 			matched[nsName(e.namespace, e.name)] = e
 		}
 	}
+	o.mu.RUnlock()
+
 	if len(matched) == 0 {
 		return base
 	}

--- a/internal/server/overlay.go
+++ b/internal/server/overlay.go
@@ -81,11 +81,23 @@ func (o *overlay) reset() {
 	o.mu.Unlock()
 }
 
-// currentRV returns the highest RV the overlay has assigned so far.
-func (o *overlay) currentRV() int64 {
+// scopeRV returns the highest overlay RV among entries in a list scope
+// (group/version/resource, and namespace — empty matches all namespaces). Replay
+// RVs are per watch/list path, so list/watch RV coherence must use the scoped
+// overlay RV, not the global counter (which mixes writes across resources).
+func (o *overlay) scopeRV(group, version, resource, namespace string) int64 {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
-	return o.counter
+	var maxRV int64
+	for _, e := range o.items {
+		if e.group == group && e.version == version && e.resource == resource &&
+			(namespace == "" || e.namespace == namespace) {
+			if e.rv > maxRV {
+				maxRV = e.rv
+			}
+		}
+	}
+	return maxRV
 }
 
 // bumpRV advances the monotonic counter to at least floorRV+1 and returns it.

--- a/internal/server/overlay.go
+++ b/internal/server/overlay.go
@@ -157,7 +157,9 @@ func (o *overlay) applyToList(group, version, resource, namespace string, base [
 		return base
 	}
 
-	out := make([]json.RawMessage, 0, len(base)+len(matched))
+	// Pre-size to the base length; append grows for any overlay-created items.
+	// (Avoids len(base)+len(matched), which CodeQL flags as a possible overflow.)
+	out := make([]json.RawMessage, 0, len(base))
 	seen := map[string]bool{}
 	for _, item := range base {
 		k := itemNSName(item)

--- a/internal/server/overlay.go
+++ b/internal/server/overlay.go
@@ -10,11 +10,12 @@ import (
 // capture state on read, so a controller can observe its own writes (closed-loop
 // dev). It is nil for read-only replay.
 //
-// Conflict policy is "overlay wins (owned)": once an object identity is present
-// in the overlay, replay events for it are suppressed (see owns) and reads use
-// the overlay copy. Reset policy is "on loop wrap only" — syncEpoch clears the
-// overlay when the replay clock's loop epoch advances; a manual reset is also
-// exposed. The overlay persists across seeks.
+// Conflict policy is "overlay wins (owned)": on read, an object present in the
+// overlay shadows the replayed copy (LIST/GET use the overlay). Suppressing
+// replay *watch* events for owned objects lands with watch feedback in a later
+// PR. Reset policy is "on loop wrap only" — syncEpoch clears the overlay when the
+// replay clock's loop epoch advances; a manual reset is also exposed. The overlay
+// persists across seeks.
 type overlay struct {
 	mu      sync.RWMutex
 	items   map[string]*overlayEntry // key: overlayKey(g,v,resource,namespace,name)

--- a/internal/server/overlay.go
+++ b/internal/server/overlay.go
@@ -1,0 +1,181 @@
+package server
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+// overlay is the in-memory write layer for --writable replay. Client writes
+// (create/update/patch/delete) land here and are merged over the replayed
+// capture state on read, so a controller can observe its own writes (closed-loop
+// dev). It is nil for read-only replay.
+//
+// Conflict policy is "overlay wins (owned)": once an object identity is present
+// in the overlay, replay events for it are suppressed (see owns) and reads use
+// the overlay copy. Reset policy is "on loop wrap only" — syncEpoch clears the
+// overlay when the replay clock's loop epoch advances; a manual reset is also
+// exposed. The overlay persists across seeks.
+type overlay struct {
+	mu      sync.RWMutex
+	items   map[string]*overlayEntry // key: overlayKey(g,v,resource,namespace,name)
+	counter int64                    // monotonic RV source (never decreases)
+	epoch   int                      // last-seen clock loop epoch (reset-on-loop)
+}
+
+type overlayEntry struct {
+	group, version, resource string
+	namespace, name          string
+	obj                      json.RawMessage // last-known body (kept even when deleted, for the DELETED event)
+	deleted                  bool            // tombstone
+	rv                       int64
+}
+
+func newOverlay() *overlay {
+	return &overlay{items: map[string]*overlayEntry{}}
+}
+
+// overlayKey identifies an object by GVR + namespace + name.
+func overlayKey(group, version, resource, namespace, name string) string {
+	return group + "/" + version + "/" + resource + "/" + namespace + "/" + name
+}
+
+// nsName is the namespace-qualified name used to match list items ("ns/name",
+// or "/name" for cluster-scoped objects).
+func nsName(namespace, name string) string { return namespace + "/" + name }
+
+// itemNSName extracts the namespace-qualified name from a raw list item.
+func itemNSName(raw json.RawMessage) string {
+	var m struct {
+		Metadata struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return ""
+	}
+	return nsName(m.Metadata.Namespace, m.Metadata.Name)
+}
+
+// syncEpoch clears the overlay when the clock's loop epoch has advanced since the
+// last call, implementing reset-on-loop. The RV counter stays monotonic so RVs
+// are never reused. Safe to call on every read/write.
+func (o *overlay) syncEpoch(clock *ReplayClock) {
+	if o == nil || clock == nil {
+		return
+	}
+	_, epoch, _ := clock.Sample()
+	o.mu.Lock()
+	if epoch != o.epoch {
+		o.items = map[string]*overlayEntry{}
+		o.epoch = epoch
+	}
+	o.mu.Unlock()
+}
+
+// reset clears all overlay entries (manual reset). The RV counter is preserved.
+func (o *overlay) reset() {
+	o.mu.Lock()
+	o.items = map[string]*overlayEntry{}
+	o.mu.Unlock()
+}
+
+// currentRV returns the highest RV the overlay has assigned so far.
+func (o *overlay) currentRV() int64 {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.counter
+}
+
+// bumpRV advances the monotonic counter to at least floorRV+1 and returns it.
+// Callers hold o.mu.
+func (o *overlay) bumpRVLocked(floorRV int64) int64 {
+	rv := o.counter
+	if floorRV > rv {
+		rv = floorRV
+	}
+	rv++
+	o.counter = rv
+	return rv
+}
+
+// nextRV advances the monotonic counter above floorRV and returns the new RV,
+// without storing anything — callers stamp the RV into the object, then store it.
+func (o *overlay) nextRV(floorRV int64) int64 {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.bumpRVLocked(floorRV)
+}
+
+// store upserts a finalized object under a pre-assigned RV.
+func (o *overlay) store(group, version, resource, namespace, name string, obj json.RawMessage, rv int64) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.items[overlayKey(group, version, resource, namespace, name)] = &overlayEntry{
+		group: group, version: version, resource: resource,
+		namespace: namespace, name: name, obj: obj, rv: rv,
+	}
+}
+
+// del marks an object deleted (tombstone) and returns its new RV. last is the
+// object body to carry on the DELETED event (may be nil).
+func (o *overlay) del(group, version, resource, namespace, name string, last json.RawMessage, floorRV int64) int64 {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	rv := o.bumpRVLocked(floorRV)
+	o.items[overlayKey(group, version, resource, namespace, name)] = &overlayEntry{
+		group: group, version: version, resource: resource,
+		namespace: namespace, name: name, obj: last, deleted: true, rv: rv,
+	}
+	return rv
+}
+
+// get returns the overlay entry for an object identity, if present.
+func (o *overlay) get(group, version, resource, namespace, name string) (*overlayEntry, bool) {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	e, ok := o.items[overlayKey(group, version, resource, namespace, name)]
+	return e, ok
+}
+
+// applyToList merges the overlay over a base list's items for a given list scope
+// (group/version/resource, and namespace — empty for a cluster-wide/-A list).
+// Overlay entries replace matching base items (overlay wins), tombstones remove
+// them, and overlay-created items not in the base are appended.
+func (o *overlay) applyToList(group, version, resource, namespace string, base []json.RawMessage) []json.RawMessage {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+
+	matched := map[string]*overlayEntry{}
+	for _, e := range o.items {
+		if e.group == group && e.version == version && e.resource == resource &&
+			(namespace == "" || e.namespace == namespace) {
+			matched[nsName(e.namespace, e.name)] = e
+		}
+	}
+	if len(matched) == 0 {
+		return base
+	}
+
+	out := make([]json.RawMessage, 0, len(base)+len(matched))
+	seen := map[string]bool{}
+	for _, item := range base {
+		k := itemNSName(item)
+		if e, ok := matched[k]; ok {
+			seen[k] = true
+			if e.deleted {
+				continue // removed by overlay
+			}
+			out = append(out, e.obj) // overlay wins
+		} else {
+			out = append(out, item)
+		}
+	}
+	for k, e := range matched {
+		if seen[k] || e.deleted {
+			continue
+		}
+		out = append(out, e.obj)
+	}
+	return out
+}

--- a/internal/server/replay_control.go
+++ b/internal/server/replay_control.go
@@ -63,6 +63,15 @@ func (h *handler) handleReplayControl(w http.ResponseWriter, r *http.Request, pa
 			return
 		}
 		clock.Seek(target)
+	case "reset-overlay":
+		if !h.requireMethod(w, r, http.MethodPost) {
+			return
+		}
+		if h.overlay == nil {
+			h.writeStatus(w, http.StatusConflict, "replay is not writable; nothing to reset")
+			return
+		}
+		h.overlay.reset()
 	default:
 		h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("unknown replay control %q", action))
 		return

--- a/internal/server/replay_control.go
+++ b/internal/server/replay_control.go
@@ -24,6 +24,8 @@ const replayControlPrefix = "/_k8shark/replay"
 //	POST /_k8shark/replay/speed?value= → set speed (e.g. 2x, 0.5x)
 //	POST /_k8shark/replay/seek?to=     → seek to an RFC3339 time or duration
 //	                          ?offset= →   relative to the window end / start
+//	POST /_k8shark/replay/reset-overlay → clear the writable overlay (409 if the
+//	                                       server is read-only)
 func (h *handler) handleReplayControl(w http.ResponseWriter, r *http.Request, path string) {
 	clock := h.clock
 	action := strings.Trim(strings.TrimPrefix(path, replayControlPrefix), "/")
@@ -64,6 +66,7 @@ func (h *handler) handleReplayControl(w http.ResponseWriter, r *http.Request, pa
 		}
 		clock.Seek(target)
 	case "reset-overlay":
+		// Clear the writable overlay (manual reset, in addition to reset-on-loop).
 		if !h.requireMethod(w, r, http.MethodPost) {
 			return
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -35,6 +35,7 @@ type ReplayOptions struct {
 	To            string // window end: RFC3339 or relative like -1m (empty = capture end)
 	Loop          bool
 	StartPaused   bool
+	Writable      bool // accept client writes into an in-memory overlay
 	Verbose       bool
 }
 
@@ -46,6 +47,7 @@ type Server struct {
 	httpServer     *http.Server
 	done           chan struct{}
 	clock          *ReplayClock // non-nil in replay mode
+	writable       bool         // overlay enabled
 	hasWatch       bool         // capture contains watch events
 }
 
@@ -66,7 +68,7 @@ func Open(opts OpenOptions) (*Server, error) {
 		_ = ar.Close()
 		return nil, err
 	}
-	return serve(ar, store, at, nil, opts.Port, opts.KubeconfigOut, opts.Verbose)
+	return serve(ar, store, at, nil, false, opts.Port, opts.KubeconfigOut, opts.Verbose)
 }
 
 // Replay opens a capture and starts the mock HTTPS server in replay mode: a
@@ -93,12 +95,13 @@ func Replay(opts ReplayOptions) (*Server, error) {
 		return nil, err
 	}
 	clock := NewReplayClock(from, to, speed, opts.Loop, opts.StartPaused)
-	return serve(ar, store, time.Time{}, clock, opts.Port, opts.KubeconfigOut, opts.Verbose)
+	return serve(ar, store, time.Time{}, clock, opts.Writable, opts.Port, opts.KubeconfigOut, opts.Verbose)
 }
 
 // serve brings up the shared TLS listener, kubeconfig, and HTTP server. When
-// clock is non-nil the handler runs in replay mode.
-func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *ReplayClock, port, kubeconfigOut string, verbose bool) (*Server, error) {
+// clock is non-nil the handler runs in replay mode; when writable is set (replay
+// only) client writes land in an in-memory overlay.
+func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *ReplayClock, writable bool, port, kubeconfigOut string, verbose bool) (*Server, error) {
 	certPEM, keyPEM, err := generateSelfSignedCert()
 	if err != nil {
 		_ = ar.Close()
@@ -139,6 +142,9 @@ func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *Replay
 
 	h := newHandler(store, at, verbose)
 	h.clock = clock
+	if writable && clock != nil { // writable is a replay-only feature
+		h.overlay = newOverlay()
+	}
 	httpSrv := &http.Server{Handler: h}
 	done := make(chan struct{})
 	go func() {
@@ -153,9 +159,13 @@ func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *Replay
 		httpServer:     httpSrv,
 		done:           done,
 		clock:          clock,
+		writable:       h.overlay != nil,
 		hasWatch:       len(store.WatchIndex) > 0,
 	}, nil
 }
+
+// Writable reports whether the server accepts client writes into the overlay.
+func (s *Server) Writable() bool { return s.writable }
 
 // Address returns the HTTPS listen address (e.g. "https://127.0.0.1:54321").
 func (s *Server) Address() string { return s.address }

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -161,6 +161,12 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 	labelSel := r.URL.Query().Get("labelSelector")
 	fieldSel := r.URL.Query().Get("fieldSelector")
 
+	// Apply reset-on-loop before consulting the overlay (below, for the resume
+	// upper bound), so a loop wrap resets it even under watch-only traffic.
+	if h.overlay != nil {
+		h.overlay.syncEpoch(clock)
+	}
+
 	// Validate resourceVersion first — a malformed/negative value returns 410
 	// before we build the (possibly expensive, poll-only) timeline. Any value
 	// that parses to 0 ("0", "00", …) is unset → list+stream.

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -186,8 +186,16 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 			return
 		}
 		// Too large / unknown (e.g. a raw etcd RV from the original capture):
-		// relist rather than silently streaming nothing.
-		if maxRV := replayRVBase + int64(len(timeline)); reqRV > maxRV {
+		// relist rather than silently streaming nothing. Include the overlay's RV
+		// so a LIST RV bumped by an overlay write is still a valid resume point
+		// (otherwise a LIST→WATCH informer would loop on 410).
+		maxRV := replayRVBase + int64(len(timeline))
+		if h.overlay != nil {
+			if orv := h.overlay.currentRV(); orv > maxRV {
+				maxRV = orv
+			}
+		}
+		if reqRV > maxRV {
 			h.writeGone(w, fmt.Sprintf("resourceVersion %d is newer than any replay event (max %d); relist", reqRV, maxRV))
 			return
 		}

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -191,7 +191,8 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 		// (otherwise a LIST→WATCH informer would loop on 410).
 		maxRV := replayRVBase + int64(len(timeline))
 		if h.overlay != nil {
-			if orv := h.overlay.currentRV(); orv > maxRV {
+			g, v, resource, namespace := parseAPIPath(watchPath)
+			if orv := h.overlay.scopeRV(g, v, resource, namespace); orv > maxRV {
 				maxRV = orv
 			}
 		}

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -57,7 +57,7 @@ func (h *handler) handleWrite(w http.ResponseWriter, r *http.Request, path strin
 		}
 		h.overlayDelete(w, group, version, resource, namespace, name)
 	default:
-		w.Header().Set("Allow", "GET, HEAD, POST, PUT, PATCH, DELETE")
+		w.Header().Set("Allow", allowedMethods(name, sub))
 		h.writeStatus(w, http.StatusMethodNotAllowed, "unsupported method "+r.Method)
 	}
 }

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
+	"sigs.k8s.io/yaml"
 )
 
 // handleWrite services a create/update/patch/delete against the in-memory overlay
@@ -340,7 +341,15 @@ func applyPatch(current, patch []byte, contentType string) ([]byte, error) {
 			return nil, err
 		}
 		return p.Apply(current)
-	default: // merge-patch, strategic-merge (fallback), apply-patch (fallback)
+	case "application/apply-patch+yaml":
+		// Server-side apply bodies are YAML; convert to JSON, then merge as an
+		// interim (real SSA field management lands in a later PR).
+		j, err := yaml.YAMLToJSON(patch)
+		if err != nil {
+			return nil, err
+		}
+		return jsonpatch.MergePatch(current, j)
+	default: // merge-patch, strategic-merge (fallback)
 		return jsonpatch.MergePatch(current, patch)
 	}
 }

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -179,6 +179,11 @@ func (h *handler) overlayPatch(w http.ResponseWriter, r *http.Request, group, ve
 		h.writeStatus(w, http.StatusMethodNotAllowed, "unsupported subresource: "+sub)
 		return
 	}
+	if !supportedPatchType(r.Header.Get("Content-Type")) {
+		h.writeStatus(w, http.StatusUnsupportedMediaType,
+			"unsupported patch Content-Type "+strconv.Quote(r.Header.Get("Content-Type")))
+		return
+	}
 	patch, err := io.ReadAll(io.LimitReader(r.Body, maxWriteBytes))
 	if err != nil {
 		h.writeStatus(w, http.StatusBadRequest, "reading body: "+err.Error())
@@ -303,16 +308,32 @@ func (h *handler) nowRFC3339() string {
 // maxWriteBytes caps request bodies accepted by the overlay.
 const maxWriteBytes = 8 << 20 // 8 MiB
 
-// applyPatch applies a patch of the given content type to the current object.
-// PR-1 supports JSON merge patch and JSON patch (RFC 6902); strategic-merge and
-// server-side apply fall back to a JSON merge patch for now (schema-driven
-// strategic-merge and SSA land in later PRs).
-func applyPatch(current, patch []byte, contentType string) ([]byte, error) {
+// patchMediaType strips any parameters from a PATCH Content-Type.
+func patchMediaType(contentType string) string {
 	ct := contentType
 	if i := strings.IndexByte(ct, ';'); i >= 0 {
 		ct = ct[:i]
 	}
-	switch strings.TrimSpace(ct) {
+	return strings.TrimSpace(ct)
+}
+
+// supportedPatchType reports whether the PATCH Content-Type is one we handle;
+// an unknown or empty type is rejected with 415 rather than silently merged.
+func supportedPatchType(contentType string) bool {
+	switch patchMediaType(contentType) {
+	case "application/merge-patch+json", "application/json-patch+json",
+		"application/strategic-merge-patch+json", "application/apply-patch+yaml":
+		return true
+	}
+	return false
+}
+
+// applyPatch applies a patch of the given (already-validated) content type to the
+// current object. PR-1 supports JSON merge patch and JSON patch (RFC 6902);
+// strategic-merge and server-side apply fall back to a JSON merge patch for now
+// (schema-driven strategic-merge and SSA land in later PRs).
+func applyPatch(current, patch []byte, contentType string) ([]byte, error) {
+	switch patchMediaType(contentType) {
 	case "application/json-patch+json":
 		p, err := jsonpatch.DecodePatch(patch)
 		if err != nil {

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -1,0 +1,339 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	jsonpatch "gopkg.in/evanphx/json-patch.v4"
+)
+
+// handleWrite services a create/update/patch/delete against the in-memory overlay
+// (writable replay). It is only reached when h.overlay != nil; read-only replay
+// keeps returning 405 for writes.
+func (h *handler) handleWrite(w http.ResponseWriter, r *http.Request, path string) {
+	h.overlay.syncEpoch(h.clock) // reset-on-loop before touching state
+
+	group, version, resource, namespace, name, sub := parseWritePath(strings.TrimSuffix(path, "/"))
+	if resource == "" {
+		h.writeStatus(w, http.StatusBadRequest, "unsupported write path: "+path)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPost:
+		h.overlayCreate(w, r, group, version, resource, namespace)
+	case http.MethodPut:
+		h.overlayReplace(w, r, group, version, resource, namespace, name, sub)
+	case http.MethodPatch:
+		h.overlayPatch(w, r, group, version, resource, namespace, name, sub)
+	case http.MethodDelete:
+		h.overlayDelete(w, group, version, resource, namespace, name)
+	default:
+		w.Header().Set("Allow", "GET, HEAD, POST, PUT, PATCH, DELETE")
+		h.writeStatus(w, http.StatusMethodNotAllowed, "unsupported method "+r.Method)
+	}
+}
+
+// replayFloorRV is the replay resourceVersion as-of the clock for the object's
+// list path(s), so an overlay write's RV always exceeds the current replay RV.
+func (h *handler) replayFloorRV(group, version, resource, namespace string) int64 {
+	at := h.at
+	if h.clock != nil {
+		at = h.clock.Now()
+	}
+	floor := rvAsOf(h.timelineFor(listPathFor(group, version, resource, namespace)), at)
+	if namespace != "" { // a cluster-wide watcher of the same resource has its own floor
+		if c := rvAsOf(h.timelineFor(listPathFor(group, version, resource, "")), at); c > floor {
+			floor = c
+		}
+	}
+	return floor
+}
+
+func (h *handler) overlayCreate(w http.ResponseWriter, r *http.Request, group, version, resource, namespace string) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxWriteBytes))
+	if err != nil {
+		h.writeStatus(w, http.StatusBadRequest, "reading body: "+err.Error())
+		return
+	}
+	name := metaString(body, "name")
+	if name == "" {
+		if gn := metaString(body, "generateName"); gn != "" {
+			name = gn + uuid.New().String()[:5]
+		}
+	}
+	if name == "" {
+		h.writeStatus(w, http.StatusBadRequest, "metadata.name or metadata.generateName is required")
+		return
+	}
+	if bodyNS := metaString(body, "namespace"); bodyNS != "" && namespace == "" {
+		namespace = bodyNS
+	}
+
+	rv := h.overlay.nextRV(h.replayFloorRV(group, version, resource, namespace))
+	obj := mergeMeta(body, map[string]any{
+		"name":              name,
+		"namespace":         namespace,
+		"uid":               uuid.New().String(),
+		"resourceVersion":   strconv.FormatInt(rv, 10),
+		"creationTimestamp": h.nowRFC3339(),
+		"generation":        1,
+	})
+	h.overlay.store(group, version, resource, namespace, name, obj, rv)
+	writeJSON(w, http.StatusCreated, json.RawMessage(obj))
+}
+
+func (h *handler) overlayReplace(w http.ResponseWriter, r *http.Request, group, version, resource, namespace, name, sub string) {
+	if name == "" {
+		h.writeStatus(w, http.StatusBadRequest, "object name is required")
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxWriteBytes))
+	if err != nil {
+		h.writeStatus(w, http.StatusBadRequest, "reading body: "+err.Error())
+		return
+	}
+	current := h.currentObject(group, version, resource, namespace, name)
+	var next json.RawMessage
+	if sub == "status" && current != nil {
+		next = replaceField(current, "status", body) // status subresource: only status changes
+	} else {
+		next = body
+	}
+	next = h.stampUpdate(next, current, group, version, resource, namespace, name)
+	writeJSON(w, http.StatusOK, json.RawMessage(next))
+}
+
+func (h *handler) overlayPatch(w http.ResponseWriter, r *http.Request, group, version, resource, namespace, name, sub string) {
+	if name == "" {
+		h.writeStatus(w, http.StatusBadRequest, "object name is required")
+		return
+	}
+	patch, err := io.ReadAll(io.LimitReader(r.Body, maxWriteBytes))
+	if err != nil {
+		h.writeStatus(w, http.StatusBadRequest, "reading body: "+err.Error())
+		return
+	}
+	current := h.currentObject(group, version, resource, namespace, name)
+	if current == nil {
+		h.writeStatus(w, http.StatusNotFound, "object not found: "+name)
+		return
+	}
+	next, perr := applyPatch(current, patch, r.Header.Get("Content-Type"))
+	if perr != nil {
+		h.writeStatus(w, http.StatusUnprocessableEntity, "applying patch: "+perr.Error())
+		return
+	}
+	next = h.stampUpdate(next, current, group, version, resource, namespace, name)
+	writeJSON(w, http.StatusOK, json.RawMessage(next))
+}
+
+func (h *handler) overlayDelete(w http.ResponseWriter, group, version, resource, namespace, name string) {
+	if name == "" {
+		h.writeStatus(w, http.StatusBadRequest, "object name is required")
+		return
+	}
+	last := h.currentObject(group, version, resource, namespace, name)
+	if last == nil {
+		h.writeStatus(w, http.StatusNotFound, "object not found: "+name)
+		return
+	}
+	h.overlay.del(group, version, resource, namespace, name, last, h.replayFloorRV(group, version, resource, namespace))
+	writeJSON(w, http.StatusOK, map[string]any{
+		"apiVersion": "v1", "kind": "Status", "status": "Success",
+		"details": map[string]any{"name": name, "kind": resource},
+	})
+}
+
+// stampUpdate assigns a fresh RV (and preserves uid/creationTimestamp from the
+// current object), stores the object, and returns it.
+func (h *handler) stampUpdate(next, current json.RawMessage, group, version, resource, namespace, name string) json.RawMessage {
+	updates := map[string]any{"name": name, "namespace": namespace}
+	if current != nil {
+		if uid := metaString(current, "uid"); uid != "" {
+			updates["uid"] = uid
+		}
+		if ct := metaString(current, "creationTimestamp"); ct != "" {
+			updates["creationTimestamp"] = ct
+		}
+	}
+	newRV := h.overlay.nextRV(h.replayFloorRV(group, version, resource, namespace))
+	updates["resourceVersion"] = strconv.FormatInt(newRV, 10)
+	obj := mergeMeta(next, updates)
+	h.overlay.store(group, version, resource, namespace, name, obj, newRV)
+	return obj
+}
+
+// currentObject returns the object as merged for reads: the overlay copy if
+// present (nil if tombstoned), else the replay object as-of the clock.
+func (h *handler) currentObject(group, version, resource, namespace, name string) json.RawMessage {
+	if e, ok := h.overlay.get(group, version, resource, namespace, name); ok {
+		if e.deleted {
+			return nil
+		}
+		return e.obj
+	}
+	at := h.at
+	if h.clock != nil {
+		at = h.clock.Now()
+	}
+	body, code := h.trySingleItemGet(listPathFor(group, version, resource, namespace)+"/"+name, at)
+	if code != 200 {
+		return nil
+	}
+	return body
+}
+
+func (h *handler) nowRFC3339() string {
+	if h.clock != nil {
+		return h.clock.Now().UTC().Format(time.RFC3339)
+	}
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+// maxWriteBytes caps request bodies accepted by the overlay.
+const maxWriteBytes = 8 << 20 // 8 MiB
+
+// applyPatch applies a patch of the given content type to the current object.
+// PR-1 supports JSON merge patch and JSON patch (RFC 6902); strategic-merge and
+// server-side apply fall back to a JSON merge patch for now (schema-driven
+// strategic-merge and SSA land in later PRs).
+func applyPatch(current, patch []byte, contentType string) ([]byte, error) {
+	ct := contentType
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	switch strings.TrimSpace(ct) {
+	case "application/json-patch+json":
+		p, err := jsonpatch.DecodePatch(patch)
+		if err != nil {
+			return nil, err
+		}
+		return p.Apply(current)
+	default: // merge-patch, strategic-merge (fallback), apply-patch (fallback)
+		return jsonpatch.MergePatch(current, patch)
+	}
+}
+
+// listPathFor builds the canonical list path for a GVR + namespace.
+func listPathFor(group, version, resource, namespace string) string {
+	base := "/api/" + version
+	if group != "" {
+		base = "/apis/" + group + "/" + version
+	}
+	if namespace != "" {
+		return base + "/namespaces/" + namespace + "/" + resource
+	}
+	return base + "/" + resource
+}
+
+// parseWritePath parses a write target into GVR + namespace + name + subresource.
+// name is empty for list-level (create) paths.
+func parseWritePath(path string) (group, version, resource, namespace, name, subresource string) {
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	var rest []string
+	switch {
+	case len(parts) >= 3 && parts[0] == "api":
+		version = parts[1]
+		rest = parts[2:]
+	case len(parts) >= 4 && parts[0] == "apis":
+		group = parts[1]
+		version = parts[2]
+		rest = parts[3:]
+	default:
+		return
+	}
+	// rest is one of:
+	//   [resource] | [resource name] | [resource name sub]
+	//   [namespaces ns resource] | [... name] | [... name sub]
+	if len(rest) >= 2 && rest[0] == "namespaces" {
+		namespace = rest[1]
+		rest = rest[2:]
+	}
+	switch len(rest) {
+	case 1:
+		resource = rest[0]
+	case 2:
+		resource, name = rest[0], rest[1]
+	case 3:
+		resource, name, subresource = rest[0], rest[1], rest[2]
+	}
+	return
+}
+
+// ── small JSON helpers ──────────────────────────────────────────────────────
+
+// metaString reads metadata.<field> as a string ("" if absent/non-string).
+func metaString(obj json.RawMessage, field string) string {
+	var m struct {
+		Metadata map[string]json.RawMessage `json:"metadata"`
+	}
+	if err := json.Unmarshal(obj, &m); err != nil {
+		return ""
+	}
+	raw, ok := m.Metadata[field]
+	if !ok {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	return s
+}
+
+// mergeMeta returns obj with the given metadata fields set/overwritten.
+func mergeMeta(obj json.RawMessage, updates map[string]any) json.RawMessage {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(obj, &m); err != nil {
+		return obj
+	}
+	meta := map[string]json.RawMessage{}
+	if raw, ok := m["metadata"]; ok {
+		_ = json.Unmarshal(raw, &meta)
+	}
+	for k, v := range updates {
+		if s, ok := v.(string); ok && s == "" {
+			continue // don't write empty namespace/uid/etc.
+		}
+		b, err := json.Marshal(v)
+		if err != nil {
+			continue
+		}
+		meta[k] = b
+	}
+	m["metadata"], _ = json.Marshal(meta)
+	out, err := json.Marshal(m)
+	if err != nil {
+		return obj
+	}
+	return out
+}
+
+// replaceField returns base with top-level field set to the same field taken
+// from src (used for the status subresource: only status changes).
+func replaceField(base json.RawMessage, field string, src json.RawMessage) json.RawMessage {
+	var b map[string]json.RawMessage
+	if err := json.Unmarshal(base, &b); err != nil {
+		return base
+	}
+	var s map[string]json.RawMessage
+	if err := json.Unmarshal(src, &s); err != nil {
+		return base
+	}
+	if v, ok := s[field]; ok {
+		b[field] = v
+	} else {
+		delete(b, field)
+	}
+	out, err := json.Marshal(b)
+	if err != nil {
+		return base
+	}
+	return out
+}

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -26,12 +26,32 @@ func (h *handler) handleWrite(w http.ResponseWriter, r *http.Request, path strin
 
 	switch r.Method {
 	case http.MethodPost:
+		if name != "" { // create is a collection operation
+			h.writeStatus(w, http.StatusMethodNotAllowed, "POST creates at a collection path, not an item path")
+			return
+		}
 		h.overlayCreate(w, r, group, version, resource, namespace)
 	case http.MethodPut:
+		if name == "" {
+			h.writeStatus(w, http.StatusBadRequest, "PUT requires an object name")
+			return
+		}
 		h.overlayReplace(w, r, group, version, resource, namespace, name, sub)
 	case http.MethodPatch:
+		if name == "" {
+			h.writeStatus(w, http.StatusBadRequest, "PATCH requires an object name")
+			return
+		}
 		h.overlayPatch(w, r, group, version, resource, namespace, name, sub)
 	case http.MethodDelete:
+		if name == "" {
+			h.writeStatus(w, http.StatusBadRequest, "DELETE requires an object name")
+			return
+		}
+		if sub != "" {
+			h.writeStatus(w, http.StatusMethodNotAllowed, "cannot DELETE a subresource")
+			return
+		}
 		h.overlayDelete(w, group, version, resource, namespace, name)
 	default:
 		w.Header().Set("Allow", "GET, HEAD, POST, PUT, PATCH, DELETE")
@@ -59,6 +79,10 @@ func (h *handler) overlayCreate(w http.ResponseWriter, r *http.Request, group, v
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxWriteBytes))
 	if err != nil {
 		h.writeStatus(w, http.StatusBadRequest, "reading body: "+err.Error())
+		return
+	}
+	if !json.Valid(body) {
+		h.writeStatus(w, http.StatusBadRequest, "request body is not valid JSON")
 		return
 	}
 	name := metaString(body, "name")
@@ -98,9 +122,20 @@ func (h *handler) overlayReplace(w http.ResponseWriter, r *http.Request, group, 
 		h.writeStatus(w, http.StatusBadRequest, "reading body: "+err.Error())
 		return
 	}
+	if !json.Valid(body) {
+		h.writeStatus(w, http.StatusBadRequest, "request body is not valid JSON")
+		return
+	}
+	// PUT is update, not upsert: the object must already exist (in the overlay or
+	// the replay state). This also keeps status updates on missing objects a 404,
+	// matching the kube-apiserver.
 	current := h.currentObject(group, version, resource, namespace, name)
+	if current == nil {
+		h.writeStatus(w, http.StatusNotFound, "object not found: "+name)
+		return
+	}
 	var next json.RawMessage
-	if sub == "status" && current != nil {
+	if sub == "status" {
 		next = replaceField(current, "status", body) // status subresource: only status changes
 	} else {
 		next = body
@@ -153,13 +188,16 @@ func (h *handler) overlayDelete(w http.ResponseWriter, group, version, resource,
 // stampUpdate assigns a fresh RV (and preserves uid/creationTimestamp from the
 // current object), stores the object, and returns it.
 func (h *handler) stampUpdate(next, current json.RawMessage, group, version, resource, namespace, name string) json.RawMessage {
-	updates := map[string]any{"name": name, "namespace": namespace}
+	updates := map[string]any{"name": name, "namespace": namespace, "generation": int64(1)}
 	if current != nil {
 		if uid := metaString(current, "uid"); uid != "" {
 			updates["uid"] = uid
 		}
 		if ct := metaString(current, "creationTimestamp"); ct != "" {
 			updates["creationTimestamp"] = ct
+		}
+		if g := metaInt(current, "generation"); g > 0 {
+			updates["generation"] = g + 1 // bump on each replace/patch
 		}
 	}
 	newRV := h.overlay.nextRV(h.replayFloorRV(group, version, resource, namespace))
@@ -285,6 +323,25 @@ func metaString(obj json.RawMessage, field string) string {
 		return ""
 	}
 	return s
+}
+
+// metaInt reads metadata.<field> as an int64 (0 if absent/non-number).
+func metaInt(obj json.RawMessage, field string) int64 {
+	var m struct {
+		Metadata map[string]json.RawMessage `json:"metadata"`
+	}
+	if err := json.Unmarshal(obj, &m); err != nil {
+		return 0
+	}
+	raw, ok := m.Metadata[field]
+	if !ok {
+		return 0
+	}
+	var n int64
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return 0
+	}
+	return n
 }
 
 // mergeMeta returns obj with the given metadata fields set/overwritten.

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -81,8 +81,8 @@ func (h *handler) overlayCreate(w http.ResponseWriter, r *http.Request, group, v
 		h.writeStatus(w, http.StatusBadRequest, "reading body: "+err.Error())
 		return
 	}
-	if !json.Valid(body) {
-		h.writeStatus(w, http.StatusBadRequest, "request body is not valid JSON")
+	if !isJSONObject(body) {
+		h.writeStatus(w, http.StatusBadRequest, "request body must be a JSON object")
 		return
 	}
 	name := metaString(body, "name")
@@ -136,8 +136,8 @@ func (h *handler) overlayReplace(w http.ResponseWriter, r *http.Request, group, 
 		h.writeStatus(w, http.StatusBadRequest, "reading body: "+err.Error())
 		return
 	}
-	if !json.Valid(body) {
-		h.writeStatus(w, http.StatusBadRequest, "request body is not valid JSON")
+	if !isJSONObject(body) {
+		h.writeStatus(w, http.StatusBadRequest, "request body must be a JSON object")
 		return
 	}
 	// PUT is update, not upsert: the object must already exist (in the overlay or
@@ -180,6 +180,10 @@ func (h *handler) overlayPatch(w http.ResponseWriter, r *http.Request, group, ve
 	next, perr := applyPatch(current, patch, r.Header.Get("Content-Type"))
 	if perr != nil {
 		h.writeStatus(w, http.StatusUnprocessableEntity, "applying patch: "+perr.Error())
+		return
+	}
+	if !isJSONObject(next) {
+		h.writeStatus(w, http.StatusUnprocessableEntity, "patch did not produce a JSON object")
 		return
 	}
 	next = h.stampUpdate(next, current, group, version, resource, namespace, name)
@@ -362,15 +366,28 @@ func metaInt(obj json.RawMessage, field string) int64 {
 	return n
 }
 
-// mergeMeta returns obj with the given metadata fields set/overwritten.
+// isJSONObject reports whether b is a JSON object ("{...}"), rejecting null,
+// arrays, and scalars — so client write bodies can't be e.g. "null".
+func isJSONObject(b []byte) bool {
+	var m map[string]json.RawMessage
+	return json.Unmarshal(b, &m) == nil && m != nil
+}
+
+// mergeMeta returns obj with the given metadata fields set/overwritten. It is
+// nil-safe: a null object or null metadata is treated as an empty object.
 func mergeMeta(obj json.RawMessage, updates map[string]any) json.RawMessage {
 	var m map[string]json.RawMessage
 	if err := json.Unmarshal(obj, &m); err != nil {
 		return obj
 	}
+	if m == nil {
+		m = map[string]json.RawMessage{}
+	}
 	meta := map[string]json.RawMessage{}
 	if raw, ok := m["metadata"]; ok {
-		_ = json.Unmarshal(raw, &meta)
+		if err := json.Unmarshal(raw, &meta); err != nil || meta == nil {
+			meta = map[string]json.RawMessage{}
+		}
 	}
 	for k, v := range updates {
 		if s, ok := v.(string); ok && s == "" {
@@ -394,11 +411,11 @@ func mergeMeta(obj json.RawMessage, updates map[string]any) json.RawMessage {
 // from src (used for the status subresource: only status changes).
 func replaceField(base json.RawMessage, field string, src json.RawMessage) json.RawMessage {
 	var b map[string]json.RawMessage
-	if err := json.Unmarshal(base, &b); err != nil {
+	if err := json.Unmarshal(base, &b); err != nil || b == nil {
 		return base
 	}
 	var s map[string]json.RawMessage
-	if err := json.Unmarshal(src, &s); err != nil {
+	if err := json.Unmarshal(src, &s); err != nil || s == nil {
 		return base
 	}
 	if v, ok := s[field]; ok {

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -98,11 +98,8 @@ func (h *handler) overlayCreate(w http.ResponseWriter, r *http.Request, group, v
 	}
 	// The effective namespace comes from the request path; a body namespace must
 	// match it (a namespaced resource is created via its namespaced collection
-	// path). This rejects both mismatches and "selecting" a namespace via the body
-	// on a cluster-scoped path.
-	if bodyNS := metaString(body, "namespace"); bodyNS != "" && bodyNS != namespace {
-		h.writeStatus(w, http.StatusBadRequest,
-			fmt.Sprintf("metadata.namespace %q does not match the request path namespace %q", bodyNS, namespace))
+	// path), rejecting "selecting" a namespace via the body on a cluster path.
+	if h.identityMismatch(w, body, name, namespace) {
 		return
 	}
 
@@ -145,6 +142,9 @@ func (h *handler) overlayReplace(w http.ResponseWriter, r *http.Request, group, 
 	}
 	if !isJSONObject(body) {
 		h.writeStatus(w, http.StatusBadRequest, "request body must be a JSON object")
+		return
+	}
+	if h.identityMismatch(w, body, name, namespace) {
 		return
 	}
 	// PUT is update, not upsert: the object must already exist (in the overlay or
@@ -194,6 +194,9 @@ func (h *handler) overlayPatch(w http.ResponseWriter, r *http.Request, group, ve
 		h.writeStatus(w, http.StatusUnprocessableEntity, "patch did not produce a JSON object")
 		return
 	}
+	if h.identityMismatch(w, next, name, namespace) {
+		return
+	}
 	// A status-subresource patch may only change status; keep the rest of the
 	// current object, and don't bump generation.
 	if sub == "status" {
@@ -216,8 +219,25 @@ func (h *handler) overlayDelete(w http.ResponseWriter, group, version, resource,
 	h.overlay.del(group, version, resource, namespace, name, last, h.replayFloorRV(group, version, resource, namespace))
 	writeJSON(w, http.StatusOK, map[string]any{
 		"apiVersion": "v1", "kind": "Status", "status": "Success",
-		"details": map[string]any{"name": name, "kind": resource},
+		"details": map[string]any{"name": name, "kind": resourceToKind(resource)},
 	})
+}
+
+// identityMismatch writes a 400 and returns true when an object body's
+// metadata.name/metadata.namespace (when set) disagrees with the request path,
+// matching the kube-apiserver's rejection of mismatched identities.
+func (h *handler) identityMismatch(w http.ResponseWriter, obj json.RawMessage, name, namespace string) bool {
+	if bn := metaString(obj, "name"); bn != "" && bn != name {
+		h.writeStatus(w, http.StatusBadRequest,
+			fmt.Sprintf("metadata.name %q does not match the request path name %q", bn, name))
+		return true
+	}
+	if bns := metaString(obj, "namespace"); bns != "" && bns != namespace {
+		h.writeStatus(w, http.StatusBadRequest,
+			fmt.Sprintf("metadata.namespace %q does not match the request path namespace %q", bns, namespace))
+		return true
+	}
+	return false
 }
 
 // stampUpdate assigns a fresh RV (and preserves uid/creationTimestamp from the

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -28,7 +28,7 @@ func (h *handler) handleWrite(w http.ResponseWriter, r *http.Request, path strin
 	switch r.Method {
 	case http.MethodPost:
 		if name != "" { // create is a collection operation
-			w.Header().Set("Allow", "GET, HEAD, PUT, PATCH, DELETE")
+			w.Header().Set("Allow", allowedMethods(name, sub))
 			h.writeStatus(w, http.StatusMethodNotAllowed, "POST creates at a collection path, not an item path")
 			return
 		}
@@ -51,7 +51,7 @@ func (h *handler) handleWrite(w http.ResponseWriter, r *http.Request, path strin
 			return
 		}
 		if sub != "" {
-			w.Header().Set("Allow", "GET, HEAD, PUT, PATCH")
+			w.Header().Set("Allow", allowedMethods(name, sub))
 			h.writeStatus(w, http.StatusMethodNotAllowed, "cannot DELETE a subresource")
 			return
 		}
@@ -134,7 +134,7 @@ func (h *handler) overlayReplace(w http.ResponseWriter, r *http.Request, group, 
 		return
 	}
 	if sub != "" && sub != "status" {
-		w.Header().Set("Allow", "GET, HEAD")
+		w.Header().Set("Allow", allowedMethods(name, sub))
 		h.writeStatus(w, http.StatusMethodNotAllowed, "unsupported subresource: "+sub)
 		return
 	}
@@ -175,7 +175,7 @@ func (h *handler) overlayPatch(w http.ResponseWriter, r *http.Request, group, ve
 		return
 	}
 	if sub != "" && sub != "status" {
-		w.Header().Set("Allow", "GET, HEAD")
+		w.Header().Set("Allow", allowedMethods(name, sub))
 		h.writeStatus(w, http.StatusMethodNotAllowed, "unsupported subresource: "+sub)
 		return
 	}
@@ -321,6 +321,23 @@ func applyPatch(current, patch []byte, contentType string) ([]byte, error) {
 		return p.Apply(current)
 	default: // merge-patch, strategic-merge (fallback), apply-patch (fallback)
 		return jsonpatch.MergePatch(current, patch)
+	}
+}
+
+// allowedMethods returns the Allow-header value for a write path shape, used on
+// 405 responses (RFC 7231 §6.5.5): collection paths allow create; item paths
+// allow the full CRUD set; the status subresource is read + update (no delete);
+// any other subresource is read-only.
+func allowedMethods(name, sub string) string {
+	switch {
+	case name == "":
+		return "GET, HEAD, POST"
+	case sub == "":
+		return "GET, HEAD, PUT, PATCH, DELETE"
+	case sub == "status":
+		return "GET, HEAD, PUT, PATCH"
+	default:
+		return "GET, HEAD"
 	}
 }
 

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -99,6 +99,16 @@ func (h *handler) overlayCreate(w http.ResponseWriter, r *http.Request, group, v
 		namespace = bodyNS
 	}
 
+	// Create semantics: fail if the object already exists (in the overlay or the
+	// replayed state), matching the kube-apiserver's 409 AlreadyExists.
+	if h.currentObject(group, version, resource, namespace, name) != nil {
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"apiVersion": "v1", "kind": "Status", "status": "Failure", "reason": "AlreadyExists",
+			"message": resource + " " + name + " already exists", "code": http.StatusConflict,
+		})
+		return
+	}
+
 	rv := h.overlay.nextRV(h.replayFloorRV(group, version, resource, namespace))
 	obj := mergeMeta(body, map[string]any{
 		"name":              name,
@@ -115,6 +125,10 @@ func (h *handler) overlayCreate(w http.ResponseWriter, r *http.Request, group, v
 func (h *handler) overlayReplace(w http.ResponseWriter, r *http.Request, group, version, resource, namespace, name, sub string) {
 	if name == "" {
 		h.writeStatus(w, http.StatusBadRequest, "object name is required")
+		return
+	}
+	if sub != "" && sub != "status" {
+		h.writeStatus(w, http.StatusMethodNotAllowed, "unsupported subresource: "+sub)
 		return
 	}
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxWriteBytes))
@@ -147,6 +161,10 @@ func (h *handler) overlayReplace(w http.ResponseWriter, r *http.Request, group, 
 func (h *handler) overlayPatch(w http.ResponseWriter, r *http.Request, group, version, resource, namespace, name, sub string) {
 	if name == "" {
 		h.writeStatus(w, http.StatusBadRequest, "object name is required")
+		return
+	}
+	if sub != "" && sub != "status" {
+		h.writeStatus(w, http.StatusMethodNotAllowed, "unsupported subresource: "+sub)
 		return
 	}
 	patch, err := io.ReadAll(io.LimitReader(r.Body, maxWriteBytes))

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -95,8 +96,14 @@ func (h *handler) overlayCreate(w http.ResponseWriter, r *http.Request, group, v
 		h.writeStatus(w, http.StatusBadRequest, "metadata.name or metadata.generateName is required")
 		return
 	}
-	if bodyNS := metaString(body, "namespace"); bodyNS != "" && namespace == "" {
-		namespace = bodyNS
+	// The effective namespace comes from the request path; a body namespace must
+	// match it (a namespaced resource is created via its namespaced collection
+	// path). This rejects both mismatches and "selecting" a namespace via the body
+	// on a cluster-scoped path.
+	if bodyNS := metaString(body, "namespace"); bodyNS != "" && bodyNS != namespace {
+		h.writeStatus(w, http.StatusBadRequest,
+			fmt.Sprintf("metadata.namespace %q does not match the request path namespace %q", bodyNS, namespace))
+		return
 	}
 
 	// Create semantics: fail if the object already exists (in the overlay or the
@@ -154,7 +161,8 @@ func (h *handler) overlayReplace(w http.ResponseWriter, r *http.Request, group, 
 	} else {
 		next = body
 	}
-	next = h.stampUpdate(next, current, group, version, resource, namespace, name)
+	// Status updates don't bump generation (which tracks spec changes).
+	next = h.stampUpdate(next, current, group, version, resource, namespace, name, sub != "status")
 	writeJSON(w, http.StatusOK, json.RawMessage(next))
 }
 
@@ -186,7 +194,12 @@ func (h *handler) overlayPatch(w http.ResponseWriter, r *http.Request, group, ve
 		h.writeStatus(w, http.StatusUnprocessableEntity, "patch did not produce a JSON object")
 		return
 	}
-	next = h.stampUpdate(next, current, group, version, resource, namespace, name)
+	// A status-subresource patch may only change status; keep the rest of the
+	// current object, and don't bump generation.
+	if sub == "status" {
+		next = replaceField(current, "status", next)
+	}
+	next = h.stampUpdate(next, current, group, version, resource, namespace, name, sub != "status")
 	writeJSON(w, http.StatusOK, json.RawMessage(next))
 }
 
@@ -208,18 +221,25 @@ func (h *handler) overlayDelete(w http.ResponseWriter, group, version, resource,
 }
 
 // stampUpdate assigns a fresh RV (and preserves uid/creationTimestamp from the
-// current object), stores the object, and returns it.
-func (h *handler) stampUpdate(next, current json.RawMessage, group, version, resource, namespace, name string) json.RawMessage {
-	updates := map[string]any{"name": name, "namespace": namespace, "generation": int64(1)}
+// current object), stores the object, and returns it. bumpGen controls whether
+// metadata.generation advances — a spec change bumps it; a status update does not.
+func (h *handler) stampUpdate(next, current json.RawMessage, group, version, resource, namespace, name string, bumpGen bool) json.RawMessage {
+	updates := map[string]any{"name": name, "namespace": namespace}
+	curGen := metaInt(current, "generation")
+	switch {
+	case bumpGen && curGen > 0:
+		updates["generation"] = curGen + 1
+	case bumpGen:
+		updates["generation"] = int64(1)
+	case curGen > 0:
+		updates["generation"] = curGen // preserve on status updates
+	}
 	if current != nil {
 		if uid := metaString(current, "uid"); uid != "" {
 			updates["uid"] = uid
 		}
 		if ct := metaString(current, "creationTimestamp"); ct != "" {
 			updates["creationTimestamp"] = ct
-		}
-		if g := metaInt(current, "generation"); g > 0 {
-			updates["generation"] = g + 1 // bump on each replace/patch
 		}
 	}
 	newRV := h.overlay.nextRV(h.replayFloorRV(group, version, resource, namespace))

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -28,6 +28,7 @@ func (h *handler) handleWrite(w http.ResponseWriter, r *http.Request, path strin
 	switch r.Method {
 	case http.MethodPost:
 		if name != "" { // create is a collection operation
+			w.Header().Set("Allow", "GET, HEAD, PUT, PATCH, DELETE")
 			h.writeStatus(w, http.StatusMethodNotAllowed, "POST creates at a collection path, not an item path")
 			return
 		}
@@ -50,6 +51,7 @@ func (h *handler) handleWrite(w http.ResponseWriter, r *http.Request, path strin
 			return
 		}
 		if sub != "" {
+			w.Header().Set("Allow", "GET, HEAD, PUT, PATCH")
 			h.writeStatus(w, http.StatusMethodNotAllowed, "cannot DELETE a subresource")
 			return
 		}
@@ -132,6 +134,7 @@ func (h *handler) overlayReplace(w http.ResponseWriter, r *http.Request, group, 
 		return
 	}
 	if sub != "" && sub != "status" {
+		w.Header().Set("Allow", "GET, HEAD")
 		h.writeStatus(w, http.StatusMethodNotAllowed, "unsupported subresource: "+sub)
 		return
 	}
@@ -172,6 +175,7 @@ func (h *handler) overlayPatch(w http.ResponseWriter, r *http.Request, group, ve
 		return
 	}
 	if sub != "" && sub != "status" {
+		w.Header().Set("Allow", "GET, HEAD")
 		h.writeStatus(w, http.StatusMethodNotAllowed, "unsupported subresource: "+sub)
 		return
 	}

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -309,13 +309,14 @@ func (h *handler) nowRFC3339() string {
 // maxWriteBytes caps request bodies accepted by the overlay.
 const maxWriteBytes = 8 << 20 // 8 MiB
 
-// patchMediaType strips any parameters from a PATCH Content-Type.
+// patchMediaType strips any parameters from a PATCH Content-Type and lower-cases
+// it (media types are case-insensitive per RFC 7231).
 func patchMediaType(contentType string) string {
 	ct := contentType
 	if i := strings.IndexByte(ct, ';'); i >= 0 {
 		ct = ct[:i]
 	}
-	return strings.TrimSpace(ct)
+	return strings.ToLower(strings.TrimSpace(ct))
 }
 
 // supportedPatchType reports whether the PATCH Content-Type is one we handle;

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -447,6 +447,24 @@ func TestOverlay_TableReflectsWrite(t *testing.T) {
 	}
 }
 
+// TestOverlay_CrossScopeRVIsolation verifies a write to one resource does not
+// inflate another resource's list resourceVersion (RVs are per path).
+func TestOverlay_CrossScopeRVIsolation(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	// A write to configmaps bumps the global overlay counter.
+	doReq(t, http.MethodPost, srv.URL+"/api/v1/namespaces/default/configmaps", "application/json",
+		`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm","namespace":"default"}}`)
+
+	// The pods LIST RV must be unaffected by the configmap write.
+	_, list := doReq(t, http.MethodGet, srv.URL+podsPath, "", "")
+	if rv := metaString(list, "resourceVersion"); rv != "1" {
+		t.Errorf("pods list RV = %q, want \"1\" (not inflated by the configmap write)", rv)
+	}
+}
+
 func TestOverlay_ReadOnlyRejectsWrites(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -1,0 +1,237 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const podsPath = "/api/v1/namespaces/default/pods"
+
+// newWritableServer builds a writable replay handler over the given store/clock.
+func newWritableServer(t *testing.T, store *CaptureStore, clock *ReplayClock) *httptest.Server {
+	t.Helper()
+	h := newHandler(store, time.Time{}, false)
+	h.clock = clock
+	h.overlay = newOverlay()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func doReq(t *testing.T, method, url, ctype, body string) (int, []byte) {
+	t.Helper()
+	var r io.Reader
+	if body != "" {
+		r = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, r)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if ctype != "" {
+		req.Header.Set("Content-Type", ctype)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, b
+}
+
+func bodyRV(t *testing.T, b []byte) string {
+	t.Helper()
+	return metaString(b, "resourceVersion")
+}
+
+func listNames(t *testing.T, b []byte) []string {
+	t.Helper()
+	var l struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(b, &l); err != nil {
+		t.Fatalf("decode list: %v\n%s", err, b)
+	}
+	var names []string
+	for _, it := range l.Items {
+		names = append(names, metaString(it, "name"))
+	}
+	return names
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func writableTestStore(t *testing.T, from time.Time) *CaptureStore {
+	return buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{podsPath: {id: "s", at: from, body: podList("pod-base")}},
+		nil)
+}
+
+func TestOverlay_CreateGetList(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	// Create pod-new.
+	code, body := doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-new"))
+	if code != http.StatusCreated {
+		t.Fatalf("create: status %d: %s", code, body)
+	}
+	if rv := bodyRV(t, body); rv == "" || rv == "0" {
+		t.Errorf("created object rv = %q, want non-zero", rv)
+	}
+	if metaString(body, "uid") == "" || metaString(body, "creationTimestamp") == "" {
+		t.Errorf("created object missing uid/creationTimestamp: %s", body)
+	}
+
+	// GET the object.
+	code, got := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-new", "", "")
+	if code != 200 || metaString(got, "name") != "pod-new" {
+		t.Fatalf("GET pod-new: status %d name %q", code, metaString(got, "name"))
+	}
+
+	// LIST includes both the replay base and the overlay object.
+	code, list := doReq(t, http.MethodGet, srv.URL+podsPath, "", "")
+	if code != 200 {
+		t.Fatalf("list: status %d", code)
+	}
+	names := listNames(t, list)
+	if !contains(names, "pod-base") || !contains(names, "pod-new") {
+		t.Errorf("list = %v, want both pod-base and pod-new", names)
+	}
+}
+
+func TestOverlay_ReplaceAndPatch(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-x"))
+
+	// PUT replace with a label.
+	replaced := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-x","namespace":"default","labels":{"team":"a"}}}`
+	code, body := doReq(t, http.MethodPut, srv.URL+podsPath+"/pod-x", "application/json", replaced)
+	if code != 200 {
+		t.Fatalf("put: status %d: %s", code, body)
+	}
+
+	// JSON merge patch adds another label.
+	code, patched := doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-x",
+		"application/merge-patch+json", `{"metadata":{"labels":{"tier":"web"}}}`)
+	if code != 200 {
+		t.Fatalf("patch: status %d: %s", code, patched)
+	}
+	var obj struct {
+		Metadata struct {
+			Labels map[string]string `json:"labels"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(patched, &obj); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if obj.Metadata.Labels["team"] != "a" || obj.Metadata.Labels["tier"] != "web" {
+		t.Errorf("merged labels = %v, want team=a tier=web", obj.Metadata.Labels)
+	}
+}
+
+func TestOverlay_DeleteTombstone(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	// Delete a replay-base object → tombstone; GET 404, LIST excludes it.
+	code, _ := doReq(t, http.MethodDelete, srv.URL+podsPath+"/pod-base", "", "")
+	if code != 200 {
+		t.Fatalf("delete: status %d", code)
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-base", "", ""); code != 404 {
+		t.Errorf("GET after delete: status %d, want 404", code)
+	}
+	_, list := doReq(t, http.MethodGet, srv.URL+podsPath, "", "")
+	if contains(listNames(t, list), "pod-base") {
+		t.Errorf("list still contains deleted pod-base: %v", listNames(t, list))
+	}
+}
+
+func TestOverlay_WinsOverReplayAndRVMonotonic(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	// Overwrite the replay-base object; the list must show the overlay copy.
+	_, b1 := doReq(t, http.MethodPut, srv.URL+podsPath+"/pod-base", "application/json",
+		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-base","namespace":"default","labels":{"owned":"yes"}}}`)
+	_, b2 := doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-2"))
+	rv1, rv2 := bodyRV(t, b1), bodyRV(t, b2)
+	if rv1 == "" || rv2 == "" || !(rv2 > rv1) { // string compare ok for equal-width ints here
+		t.Errorf("RVs not monotonic: rv1=%q rv2=%q", rv1, rv2)
+	}
+
+	code, got := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-base", "", "")
+	if code != 200 {
+		t.Fatalf("get pod-base: %d", code)
+	}
+	if !strings.Contains(string(got), `"owned":"yes"`) {
+		t.Errorf("overlay did not win for pod-base: %s", got)
+	}
+}
+
+func TestOverlay_ResetOnLoop(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, advance := newTestClock(t, from, from.Add(10*time.Second), 1, true /*loop*/, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-tmp"))
+	if code, _ := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-tmp", "", ""); code != 200 {
+		t.Fatalf("pod-tmp should exist before loop: %d", code)
+	}
+
+	advance(15 * time.Second) // cross the window end → loop wrap (epoch advances)
+
+	if code, _ := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-tmp", "", ""); code != 404 {
+		t.Errorf("pod-tmp should be cleared after loop wrap, got status %d", code)
+	}
+}
+
+func TestOverlay_ManualReset(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-tmp"))
+	code, _ := doReq(t, http.MethodPost, srv.URL+"/_k8shark/replay/reset-overlay", "", "")
+	if code != 200 {
+		t.Fatalf("reset-overlay: status %d", code)
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-tmp", "", ""); code != 404 {
+		t.Errorf("pod-tmp should be gone after manual reset, got %d", code)
+	}
+}
+
+func TestOverlay_ReadOnlyRejectsWrites(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	// Read-only replay handler (no overlay).
+	h := newHandler(writableTestStore(t, from), time.Time{}, false)
+	h.clock = clock
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	code, _ := doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("nope"))
+	if code != http.StatusMethodNotAllowed {
+		t.Errorf("read-only POST: status %d, want 405", code)
+	}
+}

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -472,6 +472,24 @@ func TestOverlay_CrossScopeRVIsolation(t *testing.T) {
 	}
 }
 
+// TestOverlay_ApplyPatchYAML verifies apply-patch+yaml bodies (YAML) are parsed
+// and merged (interim SSA behavior).
+func TestOverlay_ApplyPatchYAML(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-a"))
+	yamlBody := "apiVersion: v1\nkind: Pod\nmetadata:\n  name: pod-a\n  namespace: default\n  labels:\n    applied: \"yes\"\n"
+	code, got := doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-a", "application/apply-patch+yaml", yamlBody)
+	if code != 200 {
+		t.Fatalf("apply-patch yaml: status %d: %s", code, got)
+	}
+	if !strings.Contains(string(got), `"applied":"yes"`) {
+		t.Errorf("apply-patch did not merge YAML body: %s", got)
+	}
+}
+
 func TestOverlay_ReadOnlyRejectsWrites(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -270,6 +270,66 @@ func TestOverlay_StatusSubresource(t *testing.T) {
 	}
 }
 
+func TestOverlay_CreateConflict(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	// Creating over a replay-base object → 409.
+	if code, _ := doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-base")); code != http.StatusConflict {
+		t.Errorf("create over replay object: status %d, want 409", code)
+	}
+	// Create then create again → 409.
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-dup"))
+	if code, _ := doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-dup")); code != http.StatusConflict {
+		t.Errorf("duplicate create: status %d, want 409", code)
+	}
+}
+
+func TestOverlay_UnknownSubresourceRejected(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-x"))
+
+	if code, _ := doReq(t, http.MethodPut, srv.URL+podsPath+"/pod-x/scale", "application/json", `{"spec":{"replicas":2}}`); code != http.StatusMethodNotAllowed {
+		t.Errorf("PUT unknown subresource: status %d, want 405", code)
+	}
+	if code, _ := doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-x/scale", "application/merge-patch+json", `{"spec":{"replicas":2}}`); code != http.StatusMethodNotAllowed {
+		t.Errorf("PATCH unknown subresource: status %d, want 405", code)
+	}
+}
+
+// TestOverlay_ListThenWatchNoRelistLoop verifies a LIST RV bumped by an overlay
+// write is still a valid WATCH resume point (no 410 relist loop).
+func TestOverlay_ListThenWatchNoRelistLoop(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-x"))
+	_, list := doReq(t, http.MethodGet, srv.URL+podsPath, "", "")
+	listRV := metaString(list, "resourceVersion")
+	if listRV == "" {
+		// list-level RV is in metadata.resourceVersion; metaString reads metadata.*
+		var l struct {
+			Metadata struct {
+				ResourceVersion string `json:"resourceVersion"`
+			} `json:"metadata"`
+		}
+		_ = json.Unmarshal(list, &l)
+		listRV = l.Metadata.ResourceVersion
+	}
+	resp, err := http.Get(srv.URL + podsPath + "?watch=1&resourceVersion=" + listRV + "&timeoutSeconds=1")
+	if err != nil {
+		t.Fatalf("watch: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("WATCH from list RV %s: status %d, want 200 (no 410 relist loop)", listRV, resp.StatusCode)
+	}
+}
+
 func TestOverlay_ReadOnlyRejectsWrites(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -351,6 +351,10 @@ func TestOverlay_NullBodyNoPanic(t *testing.T) {
 	if code, _ := doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-n", "text/plain", `{"x":1}`); code != http.StatusUnsupportedMediaType {
 		t.Errorf("unknown patch content-type: status %d, want 415", code)
 	}
+	// Media types are case-insensitive.
+	if code, _ := doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-n", "Application/Merge-Patch+JSON", `{"metadata":{"labels":{"c":"d"}}}`); code != 200 {
+		t.Errorf("mixed-case patch content-type: status %d, want 200", code)
+	}
 	if code, _ := doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-n", "", `{"x":1}`); code != http.StatusUnsupportedMediaType {
 		t.Errorf("empty patch content-type: status %d, want 415", code)
 	}

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -390,7 +390,13 @@ func TestOverlay_CreateNamespaceMismatch(t *testing.T) {
 
 	body := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-m","namespace":"other"}}`
 	if code, _ := doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", body); code != http.StatusBadRequest {
-		t.Errorf("namespace mismatch: status %d, want 400", code)
+		t.Errorf("create namespace mismatch: status %d, want 400", code)
+	}
+	// PUT with a body name that disagrees with the URL is rejected.
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-ok"))
+	wrong := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"different","namespace":"default"}}`
+	if code, _ := doReq(t, http.MethodPut, srv.URL+podsPath+"/pod-ok", "application/json", wrong); code != http.StatusBadRequest {
+		t.Errorf("PUT name mismatch: status %d, want 400", code)
 	}
 }
 

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -175,9 +176,10 @@ func TestOverlay_WinsOverReplayAndRVMonotonic(t *testing.T) {
 	_, b1 := doReq(t, http.MethodPut, srv.URL+podsPath+"/pod-base", "application/json",
 		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-base","namespace":"default","labels":{"owned":"yes"}}}`)
 	_, b2 := doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-2"))
-	rv1, rv2 := bodyRV(t, b1), bodyRV(t, b2)
-	if rv1 == "" || rv2 == "" || !(rv2 > rv1) { // string compare ok for equal-width ints here
-		t.Errorf("RVs not monotonic: rv1=%q rv2=%q", rv1, rv2)
+	n1, _ := strconv.Atoi(bodyRV(t, b1))
+	n2, _ := strconv.Atoi(bodyRV(t, b2))
+	if n1 <= 0 || n2 <= n1 {
+		t.Errorf("RVs not monotonic: rv1=%d rv2=%d", n1, n2)
 	}
 
 	code, got := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-base", "", "")
@@ -218,6 +220,53 @@ func TestOverlay_ManualReset(t *testing.T) {
 	}
 	if code, _ := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-tmp", "", ""); code != 404 {
 		t.Errorf("pod-tmp should be gone after manual reset, got %d", code)
+	}
+}
+
+func TestOverlay_WriteValidationAndGeneration(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	if code, _ := doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", "{not json"); code != http.StatusBadRequest {
+		t.Errorf("invalid-JSON create: status %d, want 400", code)
+	}
+	if code, _ := doReq(t, http.MethodPost, srv.URL+podsPath+"/pod-x", "application/json", podBody("pod-x")); code != http.StatusMethodNotAllowed {
+		t.Errorf("POST to item path: status %d, want 405", code)
+	}
+	if code, _ := doReq(t, http.MethodPut, srv.URL+podsPath+"/ghost", "application/json", podBody("ghost")); code != http.StatusNotFound {
+		t.Errorf("PUT missing object: status %d, want 404", code)
+	}
+
+	// generation: 1 on create, bumped on replace.
+	_, created := doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-g"))
+	if g := metaInt(created, "generation"); g != 1 {
+		t.Errorf("created generation = %d, want 1", g)
+	}
+	_, updated := doReq(t, http.MethodPut, srv.URL+podsPath+"/pod-g", "application/json",
+		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-g","namespace":"default","labels":{"x":"y"}}}`)
+	if g := metaInt(updated, "generation"); g != 2 {
+		t.Errorf("replaced generation = %d, want 2", g)
+	}
+
+	if code, _ := doReq(t, http.MethodDelete, srv.URL+podsPath+"/pod-g/status", "", ""); code != http.StatusMethodNotAllowed {
+		t.Errorf("DELETE subresource: status %d, want 405", code)
+	}
+}
+
+func TestOverlay_StatusSubresource(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-s"))
+	if code, _ := doReq(t, http.MethodPut, srv.URL+podsPath+"/pod-s/status", "application/json",
+		`{"status":{"phase":"Running"}}`); code != 200 {
+		t.Fatalf("PUT status: %d", code)
+	}
+	code, got := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-s/status", "", "")
+	if code != 200 || !strings.Contains(string(got), `"phase":"Running"`) {
+		t.Errorf("GET status: %d body=%s, want status.phase Running", code, got)
 	}
 }
 

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -400,6 +400,53 @@ func TestOverlay_CreateNamespaceMismatch(t *testing.T) {
 	}
 }
 
+// TestOverlay_ListSelectorFiltersOverlay verifies label selectors filter overlay
+// items consistently with replayed items.
+func TestOverlay_ListSelectorFiltersOverlay(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json",
+		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-la","namespace":"default","labels":{"app":"x"}}}`)
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json",
+		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-lb","namespace":"default","labels":{"app":"y"}}}`)
+
+	_, list := doReq(t, http.MethodGet, srv.URL+podsPath+"?labelSelector=app%3Dx", "", "")
+	names := listNames(t, list)
+	if !contains(names, "pod-la") {
+		t.Errorf("selector app=x should include pod-la; got %v", names)
+	}
+	if contains(names, "pod-lb") || contains(names, "pod-base") {
+		t.Errorf("selector app=x leaked non-matching items: %v", names)
+	}
+}
+
+// TestOverlay_TableReflectsWrite verifies a Table LIST (kubectl's default) shows
+// overlay-created objects.
+func TestOverlay_TableReflectsWrite(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-t"))
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+podsPath, nil)
+	req.Header.Set("Accept", "application/json;as=Table;v=v1;g=meta.k8s.io")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("table list: %v", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(b), `"kind":"Table"`) {
+		t.Fatalf("expected a Table response, got: %s", b)
+	}
+	if !strings.Contains(string(b), "pod-t") {
+		t.Errorf("Table LIST did not reflect overlay write pod-t: %s", b)
+	}
+}
+
 func TestOverlay_ReadOnlyRejectsWrites(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -349,6 +349,51 @@ func TestOverlay_NullBodyNoPanic(t *testing.T) {
 	}
 }
 
+// TestOverlay_StatusPatchIsolated verifies a PATCH to .../status only changes
+// status (not spec/metadata) and does not bump generation, while a spec PATCH
+// does bump it.
+func TestOverlay_StatusPatchIsolated(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-s")) // generation 1
+
+	// Status patch also tries to sneak in a label — the label must be ignored.
+	doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-s/status", "application/merge-patch+json",
+		`{"metadata":{"labels":{"hacked":"x"}},"status":{"phase":"Running"}}`)
+	_, got := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-s", "", "")
+	if !strings.Contains(string(got), `"phase":"Running"`) {
+		t.Errorf("status not applied: %s", got)
+	}
+	if strings.Contains(string(got), `"hacked"`) {
+		t.Errorf("status patch leaked a metadata change: %s", got)
+	}
+	if g := metaInt(got, "generation"); g != 1 {
+		t.Errorf("status patch bumped generation to %d, want 1", g)
+	}
+
+	// A spec patch bumps generation.
+	doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-s", "application/merge-patch+json", `{"spec":{"x":"y"}}`)
+	_, got2 := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-s", "", "")
+	if g := metaInt(got2, "generation"); g != 2 {
+		t.Errorf("spec patch generation = %d, want 2", g)
+	}
+}
+
+// TestOverlay_CreateNamespaceMismatch verifies a body namespace that disagrees
+// with the request-path namespace is rejected.
+func TestOverlay_CreateNamespaceMismatch(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	body := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-m","namespace":"other"}}`
+	if code, _ := doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", body); code != http.StatusBadRequest {
+		t.Errorf("namespace mismatch: status %d, want 400", code)
+	}
+}
+
 func TestOverlay_ReadOnlyRejectsWrites(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -347,6 +347,13 @@ func TestOverlay_NullBodyNoPanic(t *testing.T) {
 	if code, _ := doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-n", "application/merge-patch+json", "null"); code != http.StatusUnprocessableEntity {
 		t.Errorf("merge-patch null: status %d, want 422", code)
 	}
+	// An unknown/empty PATCH Content-Type is rejected with 415, not merge-patched.
+	if code, _ := doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-n", "text/plain", `{"x":1}`); code != http.StatusUnsupportedMediaType {
+		t.Errorf("unknown patch content-type: status %d, want 415", code)
+	}
+	if code, _ := doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-n", "", `{"x":1}`); code != http.StatusUnsupportedMediaType {
+		t.Errorf("empty patch content-type: status %d, want 415", code)
+	}
 }
 
 // TestOverlay_StatusPatchIsolated verifies a PATCH to .../status only changes

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -330,6 +330,25 @@ func TestOverlay_ListThenWatchNoRelistLoop(t *testing.T) {
 	}
 }
 
+// TestOverlay_NullBodyNoPanic ensures client-supplied "null"/non-object write
+// bodies are rejected with 400 rather than crashing the server (nil-map panic).
+func TestOverlay_NullBodyNoPanic(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	for _, body := range []string{"null", `["a"]`, `"scalar"`, `{"metadata":null,"kind":"Pod"}`} {
+		if code, _ := doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", body); code != http.StatusBadRequest {
+			t.Errorf("POST body %q: status %d, want 400", body, code)
+		}
+	}
+	// A merge patch of "null" on an existing object must not panic (422, not 500).
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-n"))
+	if code, _ := doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-n", "application/merge-patch+json", "null"); code != http.StatusUnprocessableEntity {
+		t.Errorf("merge-patch null: status %d, want 422", code)
+	}
+}
+
 func TestOverlay_ReadOnlyRejectsWrites(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)


### PR DESCRIPTION
First of a staged series implementing **phase 4** of time-based replay (#123): an opt-in **writable overlay** so a controller's writes take effect during replay (closed-loop dev) instead of being rejected.

This PR lands the **overlay core + write/read paths**. Watch feedback, strategic-merge patch, and server-side apply follow in later PRs (per the approved design).

## What's here
- **`internal/server/overlay.go`** — in-memory overlay keyed by `GVR + namespace + name`, with tombstones, a monotonic RV counter (`nextRV` keeps overlay RVs above the current replay RV), `reset()`, and `syncEpoch()` (reset-on-loop tied to the clock's loop epoch).
- **`internal/server/writes.go`** — create (POST), replace (PUT), delete (DELETE), and PATCH (JSON-merge + JSON patch; strategic-merge / apply-patch fall back to merge patch for now). Generates `uid`/`resourceVersion`/`creationTimestamp`/`generation`; `status` subresource on PUT.
- **`handler.go`** — route writes to the overlay when writable (else the existing 405); merge the overlay over single-object GET and LIST (**overlay wins**), with the list `resourceVersion` bumped to include overlay writes.
- **`server.go`** — `ReplayOptions.Writable` + `Server.Writable()`; overlay wired in `serve()` (replay-only). **`replay_control.go`** — `POST /_k8shark/replay/reset-overlay`.
- **cmd** — `--writable` on `kshrk replay` and `kshrk ui` (replay mode); **default off** ⇒ read-only replay unchanged.

## Approved design decisions (from #123)
- **Conflict: overlay wins** — once the controller writes object X, reads return the overlay copy; replay drives untouched objects.
- **Reset: on loop wrap only + manual reset**; overlay persists across seeks.
- **Write fidelity:** full is the goal — this PR does create/replace/delete + JSON-merge/JSON patch; **strategic-merge + server-side apply come in follow-up PRs** (they fall back to merge patch here).

## Testing
7 overlay tests (create/get/list merge, replace+merge-patch, delete tombstone, overlay-wins + RV monotonicity, reset-on-loop, manual reset, read-only still 405). `go test -race ./...`, vet, gofmt, tidy, pinned golangci-lint all clean. Smoke-tested the binary: `kshrk replay --writable` create→GET→merge-patch→delete round-trips (rv/uid assigned, delete→404).

## Follow-up PRs (tracked by #123)
2. Watch feedback (overlay events on active watches; overlay-wins suppression in the stream).
3. Strategic-merge patch + status subresource (schema-driven via captured OpenAPI).
4. Server-side apply (managedfields + structured-merge-diff).
5. Docs (conflict/reset/fidelity + limitations) + dashboard writable badge & reset button.

Part of #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)