### PR TITLE
fix(ci): conformance PR comment silently broken (gh --slurp + --jq)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -81,11 +81,11 @@ jobs:
           [ -f /tmp/conformance.md ] || { echo "no report to post"; exit 0; }
           marker='<!-- conformance-report -->'
           # Find an existing report comment (by marker) and update it, else create.
-          # --slurp collects every page into one array first (add flattens the
-          # page arrays) so the jq runs once over all comments and yields a
-          # single id, rather than per-page (which could emit multiple lines).
-          cid=$(gh api "repos/$REPO/issues/$PR/comments" --paginate --slurp \
-                  --jq "add | map(select(.body | contains(\"$marker\"))) | .[0].id // empty")
+          # gh forbids --slurp together with --jq, so let --paginate+--jq emit the
+          # id of every matching comment across all pages (one per line) and take
+          # the first with head -n1 — a single, deterministic value (or empty).
+          cid=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+                  --jq ".[] | select(.body | contains(\"$marker\")) | .id" | head -n1)
           if [ -n "$cid" ]; then
             gh api -X PATCH "repos/$REPO/issues/comments/$cid" -F body=@/tmp/conformance.md >/dev/null
             echo "updated comment $cid"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -67,8 +67,10 @@ jobs:
 
       - name: Comment results on PR
         # Skip on forked PRs, where GITHUB_TOKEN is read-only and the API call
-        # would 403. continue-on-error keeps a comment hiccup from failing the
-        # gate — the conformance check itself already set the job status.
+        # would 403. This step never fails the gate (the conformance check
+        # already set the job status); a failure is surfaced as a ::warning::
+        # annotation so it can't break silently. continue-on-error stays as a
+        # belt-and-suspenders safety net.
         if: >-
           always() && github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
@@ -78,18 +80,22 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
+          set +e   # surface comment failures as a warning; never fail the gate
           [ -f /tmp/conformance.md ] || { echo "no report to post"; exit 0; }
           marker='<!-- conformance-report -->'
+          warn() { echo "::warning title=conformance-comment::could not post results comment ($1); see step log"; exit 0; }
           # Find an existing report comment (by marker) and update it, else create.
-          # gh forbids --slurp together with --jq, so let --paginate+--jq emit the
-          # id of every matching comment across all pages (one per line) and take
-          # the first with head -n1 — a single, deterministic value (or empty).
-          cid=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
-                  --jq ".[] | select(.body | contains(\"$marker\")) | .id" | head -n1)
+          # gh forbids --slurp with --jq, so let --paginate+--jq emit the id of
+          # every matching comment across all pages; take the first (deterministic).
+          # Capture into a var (not a pipe to head) so gh's exit status is checked
+          # and a closed pipe can't SIGPIPE gh into a false failure.
+          ids=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+                  --jq ".[] | select(.body | contains(\"$marker\")) | .id") || warn lookup
+          cid=$(printf '%s\n' "$ids" | head -n1)
           if [ -n "$cid" ]; then
-            gh api -X PATCH "repos/$REPO/issues/comments/$cid" -F body=@/tmp/conformance.md >/dev/null
+            gh api -X PATCH "repos/$REPO/issues/comments/$cid" -F body=@/tmp/conformance.md >/dev/null || warn update
             echo "updated comment $cid"
           else
-            gh api "repos/$REPO/issues/$PR/comments" -F body=@/tmp/conformance.md >/dev/null
+            gh api "repos/$REPO/issues/$PR/comments" -F body=@/tmp/conformance.md >/dev/null || warn create
             echo "created new comment"
           fi


### PR DESCRIPTION
## Problem

The conformance workflow's **"Comment results on PR"** step never posts a comment. It runs:

```sh
gh api "repos/$REPO/issues/$PR/comments" --paginate --slurp \
  --jq "add | map(select(.body | contains(\"$marker\"))) | .[0].id // empty"
```

but `gh api` **forbids `--slurp` together with `--jq`/`--template`**:

```
the `--slurp` option is not supported with `--jq` or `--template`
```

The step is `continue-on-error: true` (so a comment hiccup can't fail the conformance gate), which meant this failed **silently** — the sticky results comment stopped being posted/updated, with no job failure. Example: [run 29029998935](https://github.com/phenixblue/k8shark/actions/runs/29029998935/job/86159878625?pr=146).

Regression from the earlier "make the lookup deterministic across pages" change — the jq expression was validated in isolation but the `--slurp --jq` combination itself was never actually run.

## Fix

Drop `--slurp`. Let `--paginate` + `--jq` emit the id of each matching comment across all pages (one per line), then take the first with `head -n1`:

```sh
cid=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
        --jq ".[] | select(.body | contains(\"$marker\")) | .id" | head -n1)
```

Still deterministic and multi-page safe (the concern the `--slurp` change was chasing), and it's a supported flag combination.

## Verification

Against a real paginated PR thread (#141, which has the marker comment):
- old `--slurp --jq` form → errors exactly as in CI;
- new `--paginate --jq … | head -n1` form → returns the single correct comment id.

`continue-on-error` is kept intentionally (fork PRs have a read-only token; a comment failure shouldn't fail the gate) — but the underlying error is now gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)