### PR TITLE
feat(server): accept protobuf request bodies for writable-overlay writes

### DIFF
--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -80,13 +80,8 @@ func (h *handler) replayFloorRV(group, version, resource, namespace string) int6
 }
 
 func (h *handler) overlayCreate(w http.ResponseWriter, r *http.Request, group, version, resource, namespace string) {
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxWriteBytes))
-	if err != nil {
-		h.writeStatus(w, http.StatusBadRequest, "reading body: "+err.Error())
-		return
-	}
-	if !isJSONObject(body) {
-		h.writeStatus(w, http.StatusBadRequest, "request body must be a JSON object")
+	body, ok := h.readObjectBody(w, r)
+	if !ok {
 		return
 	}
 	name := metaString(body, "name")
@@ -139,13 +134,8 @@ func (h *handler) overlayReplace(w http.ResponseWriter, r *http.Request, group, 
 		h.writeStatus(w, http.StatusMethodNotAllowed, "unsupported subresource: "+sub)
 		return
 	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxWriteBytes))
-	if err != nil {
-		h.writeStatus(w, http.StatusBadRequest, "reading body: "+err.Error())
-		return
-	}
-	if !isJSONObject(body) {
-		h.writeStatus(w, http.StatusBadRequest, "request body must be a JSON object")
+	body, ok := h.readObjectBody(w, r)
+	if !ok {
 		return
 	}
 	if h.identityMismatch(w, body, name, namespace) {

--- a/internal/server/writes_codec.go
+++ b/internal/server/writes_codec.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/runtime/serializer/protobuf"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// Write bodies arrive as JSON or, from client-go/kubectl/controllers by default,
+// as Kubernetes protobuf (application/vnd.kubernetes.protobuf). The overlay
+// stores objects as JSON, so protobuf bodies are decoded to a typed object via
+// the built-in scheme and re-encoded to JSON at the write ingress; everything
+// downstream stays JSON. (See issue #148.)
+var (
+	// scheme.Scheme registers all built-in Kubernetes types; both serializers
+	// are stateless over it and safe for concurrent use.
+	protobufSerializer = protobuf.NewSerializer(scheme.Scheme, scheme.Scheme)
+	jsonSerializer     = kjson.NewSerializerWithOptions(
+		kjson.DefaultMetaFactory, scheme.Scheme, scheme.Scheme, kjson.SerializerOptions{})
+)
+
+// isProtobufContentType reports whether ct is the Kubernetes protobuf media type
+// (ignoring any parameters, e.g. a charset).
+func isProtobufContentType(ct string) bool {
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	return strings.EqualFold(strings.TrimSpace(ct), "application/vnd.kubernetes.protobuf")
+}
+
+// protobufToJSON decodes a Kubernetes protobuf (k8s\x00-framed) body into a
+// typed object using the built-in scheme, then re-encodes it as JSON. It only
+// handles types registered in the scheme (i.e. built-in Kubernetes kinds);
+// CRDs/unstructured are sent by clients as JSON, not protobuf.
+func protobufToJSON(raw []byte) (json.RawMessage, error) {
+	obj, _, err := protobufSerializer.Decode(raw, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := jsonSerializer.Encode(obj, &buf); err != nil {
+		return nil, err
+	}
+	return json.RawMessage(buf.Bytes()), nil
+}
+
+// readObjectBody reads a create/replace request body and returns it as JSON,
+// transparently decoding a Kubernetes protobuf body first. On any error it
+// writes the appropriate Status response and returns ok=false.
+func (h *handler) readObjectBody(w http.ResponseWriter, r *http.Request) (json.RawMessage, bool) {
+	raw, err := io.ReadAll(io.LimitReader(r.Body, maxWriteBytes))
+	if err != nil {
+		h.writeStatus(w, http.StatusBadRequest, "reading body: "+err.Error())
+		return nil, false
+	}
+	if isProtobufContentType(r.Header.Get("Content-Type")) {
+		body, err := protobufToJSON(raw)
+		if err != nil {
+			h.writeStatus(w, http.StatusBadRequest, "decoding protobuf body: "+err.Error())
+			return nil, false
+		}
+		return body, true
+	}
+	// JSON (or unspecified content type): require a JSON object, as before.
+	if !isJSONObject(raw) {
+		h.writeStatus(w, http.StatusBadRequest, "request body must be a JSON object")
+		return nil, false
+	}
+	return raw, true
+}

--- a/internal/server/writes_codec_test.go
+++ b/internal/server/writes_codec_test.go
@@ -41,7 +41,10 @@ func doReqBytes(t *testing.T, method, url, ctype string, body []byte) (int, []by
 		t.Fatalf("%s %s: %v", method, url, err)
 	}
 	defer resp.Body.Close()
-	b, _ := io.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading response body: %v", err)
+	}
 	return resp.StatusCode, b
 }
 

--- a/internal/server/writes_codec_test.go
+++ b/internal/server/writes_codec_test.go
@@ -99,3 +99,29 @@ func TestOverlay_ProtobufCreate(t *testing.T) {
 		t.Errorf("garbage protobuf: status %d, want 400", code)
 	}
 }
+
+// readObjectBody also serves replace (PUT); cover the protobuf overlayReplace
+// path, not just create. (issue #148)
+func TestOverlay_ProtobufReplace(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	// "pod-base" exists in the replayed state; replace it via a protobuf PUT.
+	pb := protobufPod(t, "pod-base")
+	code, got := doReqBytes(t, http.MethodPut, srv.URL+podsPath+"/pod-base",
+		"application/vnd.kubernetes.protobuf", pb)
+	if code != http.StatusOK {
+		t.Fatalf("protobuf replace: status %d, want 200\n%s", code, got)
+	}
+	if n := metaString(got, "name"); n != "pod-base" {
+		t.Errorf("replaced name = %q, want pod-base\n%s", n, got)
+	}
+
+	// A malformed protobuf replace body is a clean 400.
+	code, _ = doReqBytes(t, http.MethodPut, srv.URL+podsPath+"/pod-base",
+		"application/vnd.kubernetes.protobuf", []byte("not-protobuf"))
+	if code != http.StatusBadRequest {
+		t.Errorf("garbage protobuf replace: status %d, want 400", code)
+	}
+}

--- a/internal/server/writes_codec_test.go
+++ b/internal/server/writes_codec_test.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsProtobufContentType(t *testing.T) {
+	cases := map[string]bool{
+		"application/vnd.kubernetes.protobuf":            true,
+		"application/vnd.kubernetes.protobuf; charset=x": true,
+		"Application/VND.Kubernetes.Protobuf":            true,
+		"application/json":                               false,
+		"":                                               false,
+		"application/vnd.kubernetes.protobuf;stream=watch": true,
+	}
+	for ct, want := range cases {
+		if got := isProtobufContentType(ct); got != want {
+			t.Errorf("isProtobufContentType(%q) = %v, want %v", ct, got, want)
+		}
+	}
+}
+
+// doReqBytes issues a request with a raw (binary) body — protobuf can't go
+// through the string-based doReq helper cleanly.
+func doReqBytes(t *testing.T, method, url, ctype string, body []byte) (int, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(method, url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", ctype)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, b
+}
+
+func protobufPod(t *testing.T, name string) []byte {
+	t.Helper()
+	pod := &corev1.Pod{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx"}}},
+	}
+	var buf bytes.Buffer
+	if err := protobufSerializer.Encode(pod, &buf); err != nil {
+		t.Fatalf("encode protobuf pod: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// A client-go/kubectl-style protobuf create body is decoded, stored, and
+// round-trips like a JSON create. (issue #148)
+func TestOverlay_ProtobufCreate(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	pb := protobufPod(t, "pb-pod")
+	if len(pb) < 4 || string(pb[:4]) != "k8s\x00" {
+		t.Fatalf("expected k8s protobuf framing, got %q", pb[:min(4, len(pb))])
+	}
+
+	code, created := doReqBytes(t, http.MethodPost, srv.URL+podsPath,
+		"application/vnd.kubernetes.protobuf", pb)
+	if code != http.StatusCreated {
+		t.Fatalf("protobuf create: status %d, want 201\n%s", code, created)
+	}
+	if n := metaString(created, "name"); n != "pb-pod" {
+		t.Errorf("created name = %q, want pb-pod\n%s", n, created)
+	}
+
+	// It round-trips on a subsequent GET.
+	code, got := doReq(t, http.MethodGet, srv.URL+podsPath+"/pb-pod", "", "")
+	if code != http.StatusOK {
+		t.Fatalf("GET pb-pod: status %d, want 200", code)
+	}
+	if n := metaString(got, "name"); n != "pb-pod" {
+		t.Errorf("GET name = %q, want pb-pod", n)
+	}
+
+	// A malformed protobuf body is a clean 400, not a panic.
+	code, _ = doReqBytes(t, http.MethodPost, srv.URL+podsPath,
+		"application/vnd.kubernetes.protobuf", []byte("not-protobuf"))
+	if code != http.StatusBadRequest {
+		t.Errorf("garbage protobuf: status %d, want 400", code)
+	}
+}


### PR DESCRIPTION
Closes #148.

## Problem
The writable overlay (`kshrk replay --writable` / `kshrk ui --writable`) only accepted **JSON** request bodies. `kubectl`, `client-go`, and controllers default to `Content-Type: application/vnd.kubernetes.protobuf` for built-in types, so their writes were rejected with `400 "request body must be a JSON object"` — unusable with standard tooling.

## Change
Normalize the write body to JSON at ingress (`internal/server/writes_codec.go`):
- New `readObjectBody` used by `overlayCreate`/`overlayReplace`. When `Content-Type` is `application/vnd.kubernetes.protobuf`, decode the `k8s\x00`-framed body into a typed object via `client-go/kubernetes/scheme` + the apimachinery protobuf serializer, then re-encode as JSON and feed the existing path.
- JSON (or unspecified) bodies behave exactly as before; a malformed protobuf body is a clean `400`.
- Everything downstream (overlay store, LIST merge, watch events, responses) stays JSON. Responses remain JSON — client-go decodes them fine (response-side protobuf is the separate #150). **No new dependencies.**

Protobuf only affects create (`POST`) / replace (`PUT`) object bodies; patch/apply have their own JSON/YAML content-types and are untouched.

## Tests
- `writes_codec_test.go`: `isProtobufContentType` cases; a client-go-style protobuf `Pod` create is decoded, stored, and round-trips; malformed protobuf → `400`.
- `go test -race ./internal/server/`, `go vet`, `gofmt`, `go mod tidy` all clean.

## End-to-end verification
Against `kshrk replay --writable` built from this branch:
- `kubectl create namespace` (default protobuf) → **`namespace/... created`** (was `400` before).
- Re-ran the CNCF conformance Discovery slice (`e2e.test v1.36.1`): the per-spec `BeforeEach` now **advances past namespace creation** (previously it died there on the protobuf `400`). It subsequently blocks on `wait for service account "default" ... timed out` — i.e. live-cluster-only control-plane behavior (ServiceAccount controller), which is out of scope for a capture replay. So this delivers the intended goal (default client-go/kubectl writes work against the overlay), independent of full CNCF conformance.

## Follow-ups (already filed)
- #150 — protobuf **response** encoding, for a fully uniform surface.
- #149 — cluster-scoped overlay objects 404 on single-object GET (unrelated bug; that's why `kubectl get namespace <created>` still 404s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)