### PR TITLE
feat(server): namespace defaults (SA + kube-root-ca) + WatchList support for the writable overlay

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -865,12 +865,18 @@ func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path strin
 	if bookmarkAPIVersion == "" {
 		bookmarkAPIVersion = "v1"
 	}
+	// WatchList (client-go 1.32+): terminate the initial-list burst with a
+	// BOOKMARK carrying k8s.io/initial-events-end so informers complete sync.
+	meta := map[string]any{"resourceVersion": rv}
+	if r.URL.Query().Get("sendInitialEvents") == "true" {
+		meta["annotations"] = map[string]string{"k8s.io/initial-events-end": "true"}
+	}
 	bookmark := map[string]any{
 		"type": "BOOKMARK",
 		"object": map[string]any{
 			"apiVersion": bookmarkAPIVersion,
 			"kind":       bookmarkKind,
-			"metadata":   map[string]string{"resourceVersion": rv},
+			"metadata":   meta,
 		},
 	}
 	data, _ := json.Marshal(bookmark)

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -83,6 +83,14 @@ func (h *handler) resolveWatchList(watchPath string, at time.Time, labelSelector
 		return watchList{}, false, nil
 	}
 
+	// Merge overlay writes into the watch's initial list, mirroring the LIST
+	// path — otherwise a WatchList informer (sendInitialEvents=true) or a plain
+	// no-RV watch never observes overlay-created objects (e.g. the synthesized
+	// default ServiceAccount) in its initial events.
+	if h.overlay != nil {
+		rawBody = h.mergeOverlayList(watchPath, rawBody)
+	}
+
 	body, serr := applySelectors(rawBody, labelSelector, fieldSelector)
 	if serr != nil {
 		// Best-effort: fall back to the unfiltered list rather than failing the
@@ -160,6 +168,10 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 	watchPath := strings.TrimSuffix(path, "/")
 	labelSel := r.URL.Query().Get("labelSelector")
 	fieldSel := r.URL.Query().Get("fieldSelector")
+	// WatchList (client-go 1.32+): the initial-list burst must be terminated by
+	// a BOOKMARK carrying the k8s.io/initial-events-end annotation, or informers
+	// never complete their initial sync.
+	sendInitialEvents := r.URL.Query().Get("sendInitialEvents") == "true"
 
 	// Apply reset-on-loop before consulting the overlay (below, for the resume
 	// upper bound), so a loop wrap resets it even under watch-only traffic.
@@ -261,8 +273,11 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 		return true
 	}
 	// emitBookmark writes the BOOKMARK marking the end of a (re)list, carrying rv
-	// as the resourceVersion so clients resume from a coherent point.
-	emitBookmark := func(l watchList, rv int64) {
+	// as the resourceVersion so clients resume from a coherent point. When
+	// initialEnd is set (WatchList's sendInitialEvents=true), the bookmark also
+	// carries the k8s.io/initial-events-end annotation that client-go informers
+	// require to consider their initial sync complete.
+	emitBookmark := func(l watchList, rv int64, initialEnd bool) {
 		bookmarkKind := strings.TrimSuffix(l.Kind, "List")
 		if bookmarkKind == "" {
 			bookmarkKind = defKind
@@ -277,12 +292,16 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 		if bookmarkAPIVersion == "" {
 			bookmarkAPIVersion = "v1"
 		}
+		meta := map[string]any{"resourceVersion": strconv.FormatInt(rv, 10)}
+		if initialEnd {
+			meta["annotations"] = map[string]string{"k8s.io/initial-events-end": "true"}
+		}
 		data, _ := json.Marshal(map[string]any{
 			"type": "BOOKMARK",
 			"object": map[string]any{
 				"apiVersion": bookmarkAPIVersion,
 				"kind":       bookmarkKind,
-				"metadata":   map[string]string{"resourceVersion": strconv.FormatInt(rv, 10)},
+				"metadata":   meta,
 			},
 		})
 		_, _ = fmt.Fprintf(w, "%s\n", data)
@@ -306,7 +325,7 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 			// resumes from an observed object RV aligns with the event stream.
 			emit("ADDED", withResourceVersion(item, rv))
 		}
-		emitBookmark(l, rv)
+		emitBookmark(l, rv, false)
 		return rv
 	}
 
@@ -317,7 +336,7 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 		for _, item := range list.Items {
 			emit("ADDED", withResourceVersion(item, minRV))
 		}
-		emitBookmark(list, minRV)
+		emitBookmark(list, minRV, sendInitialEvents)
 	}
 
 	epoch := startEpoch

--- a/internal/server/watch_replay_test.go
+++ b/internal/server/watch_replay_test.go
@@ -21,9 +21,11 @@ func podBody(name string) string {
 type watchEvent struct {
 	Type   string `json:"type"`
 	Object struct {
+		Kind     string `json:"kind"`
 		Metadata struct {
-			Name            string `json:"name"`
-			ResourceVersion string `json:"resourceVersion"`
+			Name            string            `json:"name"`
+			ResourceVersion string            `json:"resourceVersion"`
+			Annotations     map[string]string `json:"annotations"`
 		} `json:"metadata"`
 	} `json:"object"`
 }

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -121,7 +121,34 @@ func (h *handler) overlayCreate(w http.ResponseWriter, r *http.Request, group, v
 		"generation":        1,
 	})
 	h.overlay.store(group, version, resource, namespace, name, obj, rv)
+	// A real cluster's ServiceAccount controller auto-creates a `default`
+	// ServiceAccount in every new namespace. The overlay has no controllers, so
+	// synthesize it — otherwise clients (and the e2e framework) that wait for it
+	// hang. `name` is the new namespace's name (namespaces are cluster-scoped).
+	if group == "" && resource == "namespaces" {
+		h.ensureDefaultServiceAccount(name)
+	}
 	writeJSON(w, http.StatusCreated, json.RawMessage(obj))
+}
+
+// ensureDefaultServiceAccount synthesizes the `default` ServiceAccount that a
+// real cluster's controller creates in each new namespace, so overlay clients
+// that wait for it can proceed. Modern Kubernetes (1.24+) provisions no token
+// Secret for it, so a bare SA object is sufficient. No-op if one already exists.
+func (h *handler) ensureDefaultServiceAccount(namespace string) {
+	const saResource, saName = "serviceaccounts", "default"
+	if h.currentObject("", "v1", saResource, namespace, saName) != nil {
+		return
+	}
+	rv := h.overlay.nextRV(h.replayFloorRV("", "v1", saResource, namespace))
+	sa := mergeMeta(json.RawMessage(`{"apiVersion":"v1","kind":"ServiceAccount"}`), map[string]any{
+		"name":              saName,
+		"namespace":         namespace,
+		"uid":               uuid.New().String(),
+		"resourceVersion":   strconv.FormatInt(rv, 10),
+		"creationTimestamp": h.nowRFC3339(),
+	})
+	h.overlay.store("", "v1", saResource, namespace, saName, sa, rv)
 }
 
 func (h *handler) overlayReplace(w http.ResponseWriter, r *http.Request, group, version, resource, namespace, name, sub string) {

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -121,34 +121,42 @@ func (h *handler) overlayCreate(w http.ResponseWriter, r *http.Request, group, v
 		"generation":        1,
 	})
 	h.overlay.store(group, version, resource, namespace, name, obj, rv)
-	// A real cluster's ServiceAccount controller auto-creates a `default`
-	// ServiceAccount in every new namespace. The overlay has no controllers, so
-	// synthesize it — otherwise clients (and the e2e framework) that wait for it
-	// hang. `name` is the new namespace's name (namespaces are cluster-scoped).
+	// A real cluster's controllers auto-provision a `default` ServiceAccount and
+	// a `kube-root-ca.crt` ConfigMap in every new namespace. The overlay has no
+	// controllers, so synthesize them — otherwise clients (and the e2e framework)
+	// that wait for them hang. `name` is the new namespace (cluster-scoped).
 	if group == "" && resource == "namespaces" {
-		h.ensureDefaultServiceAccount(name)
+		h.ensureNamespaceDefaults(name)
 	}
 	writeJSON(w, http.StatusCreated, json.RawMessage(obj))
 }
 
-// ensureDefaultServiceAccount synthesizes the `default` ServiceAccount that a
-// real cluster's controller creates in each new namespace, so overlay clients
-// that wait for it can proceed. Modern Kubernetes (1.24+) provisions no token
-// Secret for it, so a bare SA object is sufficient. No-op if one already exists.
-func (h *handler) ensureDefaultServiceAccount(namespace string) {
-	const saResource, saName = "serviceaccounts", "default"
-	if h.currentObject("", "v1", saResource, namespace, saName) != nil {
+// ensureNamespaceDefaults synthesizes the per-namespace objects a real cluster's
+// controllers create: the `default` ServiceAccount (modern Kubernetes provisions
+// no token Secret for it, so a bare object suffices) and the `kube-root-ca.crt`
+// ConfigMap that the root-CA controller publishes.
+func (h *handler) ensureNamespaceDefaults(namespace string) {
+	h.synthesizeOverlayObject("serviceaccounts", namespace, "default",
+		`{"apiVersion":"v1","kind":"ServiceAccount"}`)
+	h.synthesizeOverlayObject("configmaps", namespace, "kube-root-ca.crt",
+		`{"apiVersion":"v1","kind":"ConfigMap","data":{"ca.crt":"k8shark-replay-placeholder"}}`)
+}
+
+// synthesizeOverlayObject stores a synthetic core/v1 object in the overlay with
+// stamped metadata, unless one already exists at that path.
+func (h *handler) synthesizeOverlayObject(resource, namespace, name, base string) {
+	if h.currentObject("", "v1", resource, namespace, name) != nil {
 		return
 	}
-	rv := h.overlay.nextRV(h.replayFloorRV("", "v1", saResource, namespace))
-	sa := mergeMeta(json.RawMessage(`{"apiVersion":"v1","kind":"ServiceAccount"}`), map[string]any{
-		"name":              saName,
+	rv := h.overlay.nextRV(h.replayFloorRV("", "v1", resource, namespace))
+	obj := mergeMeta(json.RawMessage(base), map[string]any{
+		"name":              name,
 		"namespace":         namespace,
 		"uid":               uuid.New().String(),
 		"resourceVersion":   strconv.FormatInt(rv, 10),
 		"creationTimestamp": h.nowRFC3339(),
 	})
-	h.overlay.store("", "v1", saResource, namespace, saName, sa, rv)
+	h.overlay.store("", "v1", resource, namespace, name, obj, rv)
 }
 
 func (h *handler) overlayReplace(w http.ResponseWriter, r *http.Request, group, version, resource, namespace, name, sub string) {

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -508,3 +508,31 @@ func TestOverlay_ReadOnlyRejectsWrites(t *testing.T) {
 		t.Errorf("read-only POST: status %d, want 405", code)
 	}
 }
+
+func TestOverlay_DefaultServiceAccountOnNamespaceCreate(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	// Creating a namespace synthesizes its `default` ServiceAccount (a real
+	// cluster's controller would); the overlay has none.
+	nsBody := `{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"ns-x"}}`
+	if code, _ := doReq(t, http.MethodPost, srv.URL+"/api/v1/namespaces", "application/json", nsBody); code != http.StatusCreated {
+		t.Fatalf("create namespace: status %d, want 201", code)
+	}
+
+	saPath := "/api/v1/namespaces/ns-x/serviceaccounts"
+	code, got := doReq(t, http.MethodGet, srv.URL+saPath+"/default", "", "")
+	if code != http.StatusOK {
+		t.Fatalf("GET default SA: status %d, want 200\n%s", code, got)
+	}
+	if n := metaString(got, "name"); n != "default" {
+		t.Errorf("SA name = %q, want default", n)
+	}
+	if rv := bodyRV(t, got); rv == "" || rv == "0" {
+		t.Errorf("SA resourceVersion = %q, want non-zero", rv)
+	}
+	if _, list := doReq(t, http.MethodGet, srv.URL+saPath, "", ""); !contains(listNames(t, list), "default") {
+		t.Errorf("SA list missing default: %v", listNames(t, list))
+	}
+}

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -535,4 +535,52 @@ func TestOverlay_DefaultServiceAccountOnNamespaceCreate(t *testing.T) {
 	if _, list := doReq(t, http.MethodGet, srv.URL+saPath, "", ""); !contains(listNames(t, list), "default") {
 		t.Errorf("SA list missing default: %v", listNames(t, list))
 	}
+
+	// The kube-root-ca.crt ConfigMap is synthesized too.
+	code, cm := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/ns-x/configmaps/kube-root-ca.crt", "", "")
+	if code != http.StatusOK {
+		t.Fatalf("GET kube-root-ca.crt: status %d, want 200\n%s", code, cm)
+	}
+	if n := metaString(cm, "name"); n != "kube-root-ca.crt" {
+		t.Errorf("CM name = %q, want kube-root-ca.crt", n)
+	}
+}
+
+// A WatchList informer (sendInitialEvents=true) must see overlay-created objects
+// in the initial burst and receive the k8s.io/initial-events-end BOOKMARK, or it
+// never completes its initial sync. (issues #152/#153)
+func TestOverlay_WatchListInitialEvents(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	nsBody := `{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"wl"}}`
+	if code, _ := doReq(t, http.MethodPost, srv.URL+"/api/v1/namespaces", "application/json", nsBody); code != http.StatusCreated {
+		t.Fatalf("create namespace: status %d, want 201", code)
+	}
+
+	url := srv.URL + "/api/v1/namespaces/wl/serviceaccounts?watch=true&sendInitialEvents=true&timeoutSeconds=2"
+	_, tryNext, cancel := openWatchStream(t, url)
+	defer cancel()
+
+	var sawSA, sawInitialEndBookmark bool
+	for {
+		e, ok := tryNext(3 * time.Second)
+		if !ok {
+			break
+		}
+		if e.Type == "ADDED" && e.Object.Metadata.Name == "default" {
+			sawSA = true
+		}
+		if e.Type == "BOOKMARK" && e.Object.Metadata.Annotations["k8s.io/initial-events-end"] == "true" {
+			sawInitialEndBookmark = true
+			break
+		}
+	}
+	if !sawSA {
+		t.Error("WatchList initial burst did not include the overlay-synthesized default SA")
+	}
+	if !sawInitialEndBookmark {
+		t.Error("WatchList did not emit a BOOKMARK with the k8s.io/initial-events-end annotation")
+	}
 }


### PR DESCRIPTION
Closes #152, closes #153. Combines the Tier-1 conformance-unblock work into one PR (per request) so the writable overlay works with real client-go tooling and the CNCF conformance framework's per-test setup.

## What
1. **Synthesize per-namespace defaults on create** — a real cluster's controllers auto-provision a `default` ServiceAccount and a `kube-root-ca.crt` ConfigMap in every namespace; the overlay has none, so clients that wait for them hang. `ensureNamespaceDefaults` / `synthesizeOverlayObject` create them in the overlay on namespace create.
2. **Merge the overlay into the watch initial burst** — `resolveWatchList` now applies the overlay like the LIST path. Without this, a WatchList informer's watch-only initial events never observed overlay-created objects.
3. **WatchList protocol (client-go 1.32+, `sendInitialEvents=true`)** — terminate the initial burst with a `BOOKMARK` carrying the `k8s.io/initial-events-end` annotation (both replay and plain watch paths), so informers complete their initial sync.

## Verification
Against `kshrk replay --writable` + upstream `e2e.test v1.36.1`, the conformance per-test `BeforeEach` now **fully clears**:
- `Waiting for a default service account to be provisioned` ✅
- `Waiting for kube-root-ca.crt to be provisioned` ✅
- WatchList informer initial sync ✅

Specs now reach their **actual test bodies** (previously they died in setup on `405`/`400`/SA-timeout). They then fail on real conformance content/GC gaps (e.g. aggregated-discovery completeness, namespace deletion) — deeper, separate concerns that need live-cluster behavior and are out of scope here.

Tests: overlay SA + kube-root-ca synthesis; WatchList burst includes the overlay object and emits the annotated bookmark; protobuf create/replace (from the parent work). `go test -race ./internal/server/`, `go vet`, `gofmt` clean.

## Scope note
This unblocks setup/informers; it does **not** make CNCF conformance pass (that needs Tier-3 scheduler/kubelet + discovery completeness — see the #123 gap note). The synthesized defaults and WatchList support are independently useful for controller-dev against the overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)