### PR TITLE
feat(server): protobuf response encoding for a uniform apiserver surface

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -88,6 +88,18 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("  --> %s %s\n", r.Method, path)
 	}
 
+	// Response content negotiation: when the client prefers protobuf, buffer the
+	// (non-watch) response and re-encode JSON bodies of built-in types as
+	// protobuf on the way out. Installed before the early POST/compat shims so
+	// their Status/object responses are negotiated too; watch streams are never
+	// buffered.
+	watchParam := r.URL.Query().Get("watch")
+	if wantsProtobuf(r) && watchParam != "1" && watchParam != "true" {
+		pw := newProtobufResponseWriter(w)
+		defer pw.flush()
+		w = pw
+	}
+
 	// Replay transport controls live under a reserved prefix that can't collide
 	// with the Kubernetes API (which is served under /api, /apis, …). They accept
 	// POST, so intercept before the read-only method check below. Match the exact
@@ -160,17 +172,6 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-	}
-
-	// Response content negotiation: when the client prefers protobuf, buffer the
-	// (non-watch) response and re-encode JSON bodies of built-in types as
-	// protobuf on the way out. Watch streams must never be buffered.
-	watchParam := r.URL.Query().Get("watch")
-	isWatch := watchParam == "1" || watchParam == "true"
-	if wantsProtobuf(r) && !isWatch {
-		pw := newProtobufResponseWriter(w)
-		defer pw.flush()
-		w = pw
 	}
 
 	// Writes: accepted into the overlay in writable replay; otherwise 405.

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -91,10 +91,11 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Response content negotiation: when the client prefers protobuf, buffer the
 	// (non-watch) response and re-encode JSON bodies of built-in types as
 	// protobuf on the way out. Installed before the early POST/compat shims so
-	// their Status/object responses are negotiated too; watch streams are never
-	// buffered.
+	// their Status/object responses are negotiated too. Skipped for watch streams
+	// and for endpoints that never return a protobuf object and may be large or
+	// streamed (OpenAPI docs, pod logs), to avoid buffering them pointlessly.
 	watchParam := r.URL.Query().Get("watch")
-	if wantsProtobuf(r) && watchParam != "1" && watchParam != "true" {
+	if wantsProtobuf(r) && watchParam != "1" && watchParam != "true" && !isNonProtobufPath(path) {
 		pw := newProtobufResponseWriter(w)
 		defer pw.flush()
 		w = pw

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -162,6 +162,17 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Response content negotiation: when the client prefers protobuf, buffer the
+	// (non-watch) response and re-encode JSON bodies of built-in types as
+	// protobuf on the way out. Watch streams must never be buffered.
+	watchParam := r.URL.Query().Get("watch")
+	isWatch := watchParam == "1" || watchParam == "true"
+	if wantsProtobuf(r) && !isWatch {
+		pw := newProtobufResponseWriter(w)
+		defer pw.flush()
+		w = pw
+	}
+
 	// Writes: accepted into the overlay in writable replay; otherwise 405.
 	// RFC 7231 §6.5.5 requires an Allow header with a 405 response.
 	switch r.Method {

--- a/internal/server/responses_codec.go
+++ b/internal/server/responses_codec.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+)
+
+// Response content negotiation for a uniform apiserver surface (issue #150).
+//
+// client-go/kubectl default to protobuf (application/vnd.kubernetes.protobuf)
+// for built-in types. The mock builds every response as JSON; a protobuf client
+// still decodes those (negotiation is by the *response* Content-Type), so reads
+// already work — but a real apiserver replies with protobuf when the client asks
+// for it. To match, we buffer a non-watch response and, if its JSON body is a
+// scheme-known object, re-encode it as protobuf. Bodies that aren't built-in
+// Kubernetes objects (CRDs/unstructured, OpenAPI docs, health text) fail the
+// scheme decode and pass through as JSON — exactly as a real apiserver does
+// (CRDs have no protobuf).
+
+const protobufMediaType = "application/vnd.kubernetes.protobuf"
+
+// wantsProtobuf reports whether the request's Accept header prefers Kubernetes
+// protobuf. Table requests (kubectl's human output) never include it.
+func wantsProtobuf(r *http.Request) bool {
+	return strings.Contains(r.Header.Get("Accept"), protobufMediaType)
+}
+
+// jsonToProtobuf re-encodes a JSON-encoded built-in Kubernetes object as
+// protobuf. ok is false when the body isn't a scheme-known object, so the caller
+// leaves it as JSON.
+func jsonToProtobuf(body []byte) ([]byte, bool) {
+	obj, _, err := jsonSerializer.Decode(body, nil, nil)
+	if err != nil {
+		return nil, false
+	}
+	var buf bytes.Buffer
+	if err := protobufSerializer.Encode(obj, &buf); err != nil {
+		return nil, false
+	}
+	return buf.Bytes(), true
+}
+
+// protobufResponseWriter buffers a response so a JSON body of a built-in type
+// can be re-encoded as protobuf on flush. It is only used for non-watch requests
+// whose client prefers protobuf.
+type protobufResponseWriter struct {
+	http.ResponseWriter
+	status int
+	buf    bytes.Buffer
+}
+
+func newProtobufResponseWriter(w http.ResponseWriter) *protobufResponseWriter {
+	return &protobufResponseWriter{ResponseWriter: w}
+}
+
+func (p *protobufResponseWriter) WriteHeader(code int) { p.status = code }
+
+func (p *protobufResponseWriter) Write(b []byte) (int, error) { return p.buf.Write(b) }
+
+// flush writes the buffered response, transcoding a JSON built-in-object body to
+// protobuf when possible; otherwise it passes the JSON through unchanged.
+func (p *protobufResponseWriter) flush() {
+	status := p.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	body := p.buf.Bytes()
+
+	ct := p.Header().Get("Content-Type")
+	if strings.HasPrefix(ct, "application/json") {
+		if pb, ok := jsonToProtobuf(body); ok {
+			p.Header().Set("Content-Type", protobufMediaType)
+			p.Header().Del("Content-Length") // length changed; let net/http recompute
+			p.ResponseWriter.WriteHeader(status)
+			_, _ = p.ResponseWriter.Write(pb)
+			return
+		}
+	}
+	p.ResponseWriter.WriteHeader(status)
+	_, _ = p.ResponseWriter.Write(body)
+}

--- a/internal/server/responses_codec.go
+++ b/internal/server/responses_codec.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"bytes"
+	"mime"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -21,9 +23,41 @@ import (
 const protobufMediaType = "application/vnd.kubernetes.protobuf"
 
 // wantsProtobuf reports whether the request's Accept header prefers Kubernetes
-// protobuf. Table requests (kubectl's human output) never include it.
+// protobuf: it must be acceptable (q>0) and at least as preferred as any JSON
+// alternative. This honors q-values, so `…protobuf;q=0` or a higher-q JSON
+// (e.g. kubectl's Table requests) correctly yields JSON.
 func wantsProtobuf(r *http.Request) bool {
-	return strings.Contains(r.Header.Get("Accept"), protobufMediaType)
+	accept := r.Header.Get("Accept")
+	if accept == "" {
+		return false
+	}
+	qProto, qJSON := -1.0, -1.0
+	for _, part := range strings.Split(accept, ",") {
+		mt, params, err := mime.ParseMediaType(strings.TrimSpace(part))
+		if err != nil {
+			continue
+		}
+		q := 1.0
+		if qs, ok := params["q"]; ok {
+			if v, perr := strconv.ParseFloat(qs, 64); perr == nil {
+				q = v
+			}
+		}
+		switch mt {
+		case protobufMediaType:
+			if q > qProto {
+				qProto = q
+			}
+		case "application/json", "application/*", "*/*":
+			if q > qJSON {
+				qJSON = q
+			}
+		}
+	}
+	if qProto <= 0 {
+		return false // protobuf not offered, or explicitly q=0
+	}
+	return qJSON < 0 || qProto >= qJSON // at least as preferred as JSON
 }
 
 // jsonToProtobuf re-encodes a JSON-encoded built-in Kubernetes object as

--- a/internal/server/responses_codec.go
+++ b/internal/server/responses_codec.go
@@ -22,6 +22,14 @@ import (
 
 const protobufMediaType = "application/vnd.kubernetes.protobuf"
 
+// isNonProtobufPath reports request paths that never return a Kubernetes
+// protobuf object and may be large or streamed — OpenAPI documents (multi-MB
+// JSON) and pod log subresources (text/plain). The protobuf response wrapper
+// skips these so they aren't buffered in memory only to pass through unchanged.
+func isNonProtobufPath(path string) bool {
+	return strings.HasPrefix(path, "/openapi") || strings.HasSuffix(path, "/log")
+}
+
 // wantsProtobuf reports whether the client's Accept header selects Kubernetes
 // protobuf over JSON. It mirrors apiserver negotiation: among acceptable (q>0)
 // media types, the highest q wins, and header order breaks ties. So

--- a/internal/server/responses_codec.go
+++ b/internal/server/responses_codec.go
@@ -22,19 +22,34 @@ import (
 
 const protobufMediaType = "application/vnd.kubernetes.protobuf"
 
-// wantsProtobuf reports whether the request's Accept header prefers Kubernetes
-// protobuf: it must be acceptable (q>0) and at least as preferred as any JSON
-// alternative. This honors q-values, so `…protobuf;q=0` or a higher-q JSON
-// (e.g. kubectl's Table requests) correctly yields JSON.
+// wantsProtobuf reports whether the client's Accept header selects Kubernetes
+// protobuf over JSON. It mirrors apiserver negotiation: among acceptable (q>0)
+// media types, the highest q wins, and header order breaks ties. So
+// `protobuf,json` (both q=1) picks protobuf, `json,protobuf` picks JSON, a
+// higher-q entry always wins, and `…protobuf;q=0` / Table requests yield JSON.
 func wantsProtobuf(r *http.Request) bool {
 	accept := r.Header.Get("Accept")
 	if accept == "" {
 		return false
 	}
-	qProto, qJSON := -1.0, -1.0
+	// Walk clauses in header order, keeping the first with the maximum q among
+	// the types we can serve (protobuf, or JSON/wildcard). "First with max q"
+	// makes header order the tie-breaker for equal q-values.
+	bestQ := 0.0
+	bestIsProto := false
 	for _, part := range strings.Split(accept, ",") {
 		mt, params, err := mime.ParseMediaType(strings.TrimSpace(part))
 		if err != nil {
+			continue
+		}
+		var isProto, isJSON bool
+		switch mt {
+		case protobufMediaType:
+			isProto = true
+		case "application/json", "application/*", "*/*":
+			isJSON = true
+		}
+		if !isProto && !isJSON {
 			continue
 		}
 		q := 1.0
@@ -43,21 +58,15 @@ func wantsProtobuf(r *http.Request) bool {
 				q = v
 			}
 		}
-		switch mt {
-		case protobufMediaType:
-			if q > qProto {
-				qProto = q
-			}
-		case "application/json", "application/*", "*/*":
-			if q > qJSON {
-				qJSON = q
-			}
+		if q <= 0 {
+			continue
+		}
+		if q > bestQ { // strictly greater; equal q keeps the earlier clause
+			bestQ = q
+			bestIsProto = isProto
 		}
 	}
-	if qProto <= 0 {
-		return false // protobuf not offered, or explicitly q=0
-	}
-	return qJSON < 0 || qProto >= qJSON // at least as preferred as JSON
+	return bestIsProto
 }
 
 // jsonToProtobuf re-encodes a JSON-encoded built-in Kubernetes object as
@@ -100,6 +109,10 @@ func (p *protobufResponseWriter) flush() {
 		status = http.StatusOK
 	}
 	body := p.buf.Bytes()
+
+	// The chosen representation depends on Accept, so caches/intermediaries must
+	// not reuse it across differing Accept headers.
+	p.Header().Add("Vary", "Accept")
 
 	ct := p.Header().Get("Content-Type")
 	if strings.HasPrefix(ct, "application/json") {

--- a/internal/server/responses_codec_test.go
+++ b/internal/server/responses_codec_test.go
@@ -104,3 +104,20 @@ func TestProtobufResponseNegotiation(t *testing.T) {
 		t.Errorf("Content-Type = %q, want application/json", ct)
 	}
 }
+
+func TestIsNonProtobufPath(t *testing.T) {
+	cases := map[string]bool{
+		"/openapi/v2":                                  true,
+		"/openapi/v3":                                  true,
+		"/openapi/v3/apis/apps/v1":                     true,
+		"/api/v1/namespaces/default/pods/p/log":        true,
+		"/api/v1/namespaces/default/pods":              false,
+		"/api/v1/namespaces/default/pods/p":            false,
+		"/apis/apps/v1/namespaces/default/deployments": false,
+	}
+	for path, want := range cases {
+		if got := isNonProtobufPath(path); got != want {
+			t.Errorf("isNonProtobufPath(%q) = %v, want %v", path, got, want)
+		}
+	}
+}

--- a/internal/server/responses_codec_test.go
+++ b/internal/server/responses_codec_test.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestWantsProtobuf(t *testing.T) {
+	cases := map[string]bool{
+		"application/vnd.kubernetes.protobuf,application/json": true,
+		"application/vnd.kubernetes.protobuf":                  true,
+		"application/json":                                     false,
+		"":                                                     false,
+		"application/json;as=Table;v=v1;g=meta.k8s.io": false,
+	}
+	for accept, want := range cases {
+		r, _ := http.NewRequest(http.MethodGet, "/api/v1/pods", nil)
+		if accept != "" {
+			r.Header.Set("Accept", accept)
+		}
+		if got := wantsProtobuf(r); got != want {
+			t.Errorf("wantsProtobuf(Accept=%q) = %v, want %v", accept, got, want)
+		}
+	}
+}
+
+func TestJSONToProtobuf(t *testing.T) {
+	// A built-in type round-trips to protobuf (k8s\x00-framed).
+	pb, ok := jsonToProtobuf([]byte(`{"apiVersion":"v1","kind":"ConfigMapList","metadata":{},"items":[]}`))
+	if !ok {
+		t.Fatal("jsonToProtobuf(ConfigMapList) ok=false, want true")
+	}
+	if len(pb) < 4 || string(pb[:4]) != "k8s\x00" {
+		t.Errorf("protobuf framing missing, got %q", pb[:min(4, len(pb))])
+	}
+	// A non-scheme body (e.g. an OpenAPI doc) is left alone.
+	if _, ok := jsonToProtobuf([]byte(`{"swagger":"2.0","info":{}}`)); ok {
+		t.Error("jsonToProtobuf(swagger doc) ok=true, want false (should pass through as JSON)")
+	}
+}
+
+// getWithAccept issues a GET with an Accept header and returns status, the
+// response Content-Type, and the raw body.
+func getWithAccept(t *testing.T, url, accept string) (int, string, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Accept", accept)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	return resp.StatusCode, resp.Header.Get("Content-Type"), b
+}
+
+// A protobuf-preferring client gets a protobuf response for a built-in list; a
+// JSON client still gets JSON. (issue #150)
+func TestProtobufResponseNegotiation(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{podsPath: {id: "s", at: from, body: podList("pod-base")}}, nil)
+	h := newHandler(store, from, false)
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	// Protobuf-preferring client: protobuf response that decodes back to a List.
+	code, ct, body := getWithAccept(t, srv.URL+podsPath, "application/vnd.kubernetes.protobuf,application/json")
+	if code != http.StatusOK {
+		t.Fatalf("protobuf GET: status %d, want 200", code)
+	}
+	if ct != protobufMediaType {
+		t.Errorf("Content-Type = %q, want %q", ct, protobufMediaType)
+	}
+	if len(body) < 4 || string(body[:4]) != "k8s\x00" {
+		t.Errorf("protobuf framing missing, got %q", body[:min(4, len(body))])
+	}
+	if obj, _, err := protobufSerializer.Decode(body, nil, nil); err != nil || obj == nil {
+		t.Errorf("protobuf body did not decode: %v", err)
+	}
+
+	// JSON client: unchanged JSON response.
+	code, ct, _ = getWithAccept(t, srv.URL+podsPath, "application/json")
+	if code != http.StatusOK {
+		t.Fatalf("json GET: status %d, want 200", code)
+	}
+	if ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+}

--- a/internal/server/responses_codec_test.go
+++ b/internal/server/responses_codec_test.go
@@ -14,7 +14,11 @@ func TestWantsProtobuf(t *testing.T) {
 		"application/vnd.kubernetes.protobuf":                  true,
 		"application/json":                                     false,
 		"":                                                     false,
-		"application/json;as=Table;v=v1;g=meta.k8s.io": false,
+		"application/json;as=Table;v=v1;g=meta.k8s.io":                      false,
+		"application/vnd.kubernetes.protobuf;q=0,application/json":          false, // protobuf explicitly refused
+		"application/json;q=0.9,application/vnd.kubernetes.protobuf;q=1":    true,  // protobuf preferred
+		"application/json,application/vnd.kubernetes.protobuf;q=0.8":        false, // json preferred (q=1 > 0.8)
+		"application/vnd.kubernetes.protobuf;stream=watch,application/json": true,  // params ignored for the base type
 	}
 	for accept, want := range cases {
 		r, _ := http.NewRequest(http.MethodGet, "/api/v1/pods", nil)

--- a/internal/server/responses_codec_test.go
+++ b/internal/server/responses_codec_test.go
@@ -19,6 +19,9 @@ func TestWantsProtobuf(t *testing.T) {
 		"application/json;q=0.9,application/vnd.kubernetes.protobuf;q=1":    true,  // protobuf preferred
 		"application/json,application/vnd.kubernetes.protobuf;q=0.8":        false, // json preferred (q=1 > 0.8)
 		"application/vnd.kubernetes.protobuf;stream=watch,application/json": true,  // params ignored for the base type
+		"application/json,application/vnd.kubernetes.protobuf":              false, // equal q → header order wins (json first)
+		"application/vnd.kubernetes.protobuf,application/json;q=0.9":        true,  // protobuf first and higher q
+		"application/json;as=Table;v=v1;g=meta.k8s.io,application/json":     false, // Table-first, no protobuf offered
 	}
 	for accept, want := range cases {
 		r, _ := http.NewRequest(http.MethodGet, "/api/v1/pods", nil)


### PR DESCRIPTION
Closes #150. Follow-up to #148 (protobuf request decoding) — the response side, for a uniform protobuf surface.

## Why
client-go/kubectl default to `Accept: application/vnd.kubernetes.protobuf` for built-in types. The mock builds every response as JSON, which those clients accept (negotiation is by the *response* Content-Type), so reads already worked — but a real apiserver replies with protobuf when asked. This matches that.

## How
A small response-transcoding wrapper in `ServeHTTP`: when a **non-watch** request's `Accept` prefers protobuf, buffer the response and, if the JSON body is a scheme-known built-in object, re-encode it as protobuf (the reverse of #148, reusing the same `client-go/kubernetes/scheme` + serializers). Bodies that aren't built-in Kubernetes objects — CRDs/unstructured, OpenAPI docs, health text — fail the scheme decode and **pass through as JSON**, exactly as a real apiserver does (CRDs have no protobuf). Watch streams are never buffered.

Covers GET/LIST, single-object GET, write responses, and Status/error bodies.

## Verification (running server)
```
GET pods (Accept: protobuf)      -> Content-Type: application/vnd.kubernetes.protobuf, body k8s\x00…  (decodes back to PodList)
GET pod  (Accept: protobuf)      -> protobuf
404      (Accept: protobuf)      -> 404 + protobuf Status
GET pods (Accept: json)          -> application/json  (unchanged)
GET /openapi/v2 (Accept: proto)  -> application/json  (not a k8s object; passes through)
```
Tests: `wantsProtobuf`, `jsonToProtobuf` (round-trip + non-object pass-through), and a handler negotiation test (protobuf list decodes; JSON stays JSON). `go test -race ./...`, `go vet`, `gofmt` all clean.

## Scope
- Watch-stream protobuf framing (`;stream=watch`) is a deliberate follow-up (watch already works over JSON; noted in #150).
- No new dependencies.

Together with #148 this gives a uniform protobuf-capable read/write surface for standard client-go tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)