### PR TITLE
fix(server): cluster-scoped overlay objects 404 on single-object GET (#149)

### DIFF
--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -415,8 +415,10 @@ func listPathFor(group, version, resource, namespace string) string {
 // is guaranteed to start with "namespaces" and have >= 2 elements.
 func namespacesIsScope(group string, rest []string) bool {
 	if group != "" {
-		// Non-core groups have no core "namespaces" resource, so it can only be
-		// the scoping keyword — and only when a resource follows.
+		// Non-core groups have no core "namespaces" resource. Treat a leading
+		// "namespaces" as the scoping keyword only when a namespaced resource
+		// follows (.../namespaces/<ns>/<resource>); a bare .../namespaces/<name>
+		// is left as an item of a (hypothetical) grouped "namespaces" resource.
 		return len(rest) >= 3
 	}
 	switch len(rest) {

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -409,6 +409,27 @@ func listPathFor(group, version, resource, namespace string) string {
 	return base + "/" + resource
 }
 
+// namespacesIsScope reports whether a leading "namespaces" segment is the
+// namespace-scoping keyword (/namespaces/<ns>/<resource>/…) rather than the core
+// cluster-scoped "namespaces" resource itself (/api/v1/namespaces/<name>). rest
+// is guaranteed to start with "namespaces" and have >= 2 elements.
+func namespacesIsScope(group string, rest []string) bool {
+	if group != "" {
+		// Non-core groups have no core "namespaces" resource, so it can only be
+		// the scoping keyword — and only when a resource follows.
+		return len(rest) >= 3
+	}
+	switch len(rest) {
+	case 2: // /api/v1/namespaces/<name> → the namespace object
+		return false
+	case 3: // /api/v1/namespaces/<name>/{status,finalize} → object subresource;
+		//        /api/v1/namespaces/<ns>/<resource>       → namespaced list
+		return rest[2] != "status" && rest[2] != "finalize"
+	default: // 4+: /api/v1/namespaces/<ns>/<resource>/<name>[/<sub>]
+		return true
+	}
+}
+
 // parseWritePath parses a write target into GVR + namespace + name + subresource.
 // name is empty for list-level (create) paths.
 func parseWritePath(path string) (group, version, resource, namespace, name, subresource string) {
@@ -428,7 +449,12 @@ func parseWritePath(path string) (group, version, resource, namespace, name, sub
 	// rest is one of:
 	//   [resource] | [resource name] | [resource name sub]
 	//   [namespaces ns resource] | [... name] | [... name sub]
-	if len(rest) >= 2 && rest[0] == "namespaces" {
+	//
+	// A leading "namespaces" is the namespace-scoping keyword only when a real
+	// namespaced resource follows. In the core group "namespaces" is ALSO a
+	// cluster-scoped resource, so /api/v1/namespaces/<name>[/status|/finalize]
+	// targets a namespace object — not a namespaced path (see namespacesIsScope).
+	if len(rest) >= 2 && rest[0] == "namespaces" && namespacesIsScope(group, rest) {
 		namespace = rest[1]
 		rest = rest[2:]
 	}

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -494,6 +494,65 @@ func TestOverlay_ApplyPatchYAML(t *testing.T) {
 	}
 }
 
+// TestOverlay_ClusterScopedSingleGet covers #149: an overlay-created
+// cluster-scoped object must be returned by a single-object GET (not just LIST),
+// for core (namespaces, nodes) and grouped (clusterroles) resources.
+func TestOverlay_ClusterScopedSingleGet(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	cases := []struct{ createPath, getPath, body, name string }{
+		{"/api/v1/namespaces", "/api/v1/namespaces/ov-ns",
+			`{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"ov-ns"}}`, "ov-ns"},
+		{"/api/v1/nodes", "/api/v1/nodes/ov-node",
+			`{"apiVersion":"v1","kind":"Node","metadata":{"name":"ov-node"}}`, "ov-node"},
+		{"/apis/rbac.authorization.k8s.io/v1/clusterroles", "/apis/rbac.authorization.k8s.io/v1/clusterroles/ov-cr",
+			`{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"name":"ov-cr"}}`, "ov-cr"},
+	}
+	for _, c := range cases {
+		if code, b := doReq(t, http.MethodPost, srv.URL+c.createPath, "application/json", c.body); code != http.StatusCreated {
+			t.Fatalf("create %s: status %d: %s", c.name, code, b)
+		}
+		code, got := doReq(t, http.MethodGet, srv.URL+c.getPath, "", "")
+		if code != 200 {
+			t.Errorf("GET %s: status %d, want 200", c.getPath, code)
+			continue
+		}
+		if n := metaString(got, "name"); n != c.name {
+			t.Errorf("GET %s: name %q, want %q", c.getPath, n, c.name)
+		}
+	}
+}
+
+// TestOverlay_ClusterScopedDeleteTombstone verifies deleting a captured
+// cluster-scoped object (a namespace) returns 404 on GET (not the captured copy)
+// and drops it from LIST.
+func TestOverlay_ClusterScopedDeleteTombstone(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	nsList := `{"apiVersion":"v1","kind":"NamespaceList","metadata":{"resourceVersion":"1"},"items":[` +
+		`{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"default"}}]}`
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{"/api/v1/namespaces": {id: "ns", at: from, body: nsList}}, nil)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, store, clock)
+
+	// Sanity: the captured namespace is visible before deletion.
+	if code, _ := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/default", "", ""); code != 200 {
+		t.Fatalf("GET captured namespace before delete: status %d, want 200", code)
+	}
+	if code, _ := doReq(t, http.MethodDelete, srv.URL+"/api/v1/namespaces/default", "", ""); code != 200 {
+		t.Fatalf("delete namespace: status %d, want 200", code)
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/default", "", ""); code != 404 {
+		t.Errorf("GET deleted namespace: status %d, want 404 (not the captured copy)", code)
+	}
+	_, list := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces", "", "")
+	if contains(listNames(t, list), "default") {
+		t.Errorf("LIST still contains deleted namespace: %v", listNames(t, list))
+	}
+}
+
 func TestOverlay_ReadOnlyRejectsWrites(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)


### PR DESCRIPTION
Fixes #149 — in writable-overlay mode, an overlay-created **cluster-scoped** object was merged into LIST but 404'd on a single-object GET (e.g. `k create ns joe-test` then `k get ns joe-test`).

## Root cause
`parseWritePath` (`internal/server/writes.go`) greedily treated a leading `namespaces` segment as the namespace-scoping keyword, so `/api/v1/namespaces/<name>` parsed as `namespace=<name>` with an **empty resource**. The overlay single-object-GET branch in `serveResource` then keyed `overlay.get(...)` wrong and missed → fell through to `ReconstructAt` → 404. LIST was unaffected (it keys by `(group,version,resource,namespace)`). PUT/PATCH/DELETE on a namespace object were mis-parsed the same way.

## Fix
In the core group, `namespaces` is itself a cluster-scoped resource, so `namespacesIsScope` only treats it as the scoping keyword when a real namespaced resource follows:
- `/api/v1/namespaces/<name>` and `/api/v1/namespaces/<name>/{status,finalize}` → the **namespace object**
- `/api/v1/namespaces/<ns>/<resource>[/<name>[/<sub>]]` → **namespaced**

Fixing the parser (rather than the single-GET branch alone) also repairs PUT/PATCH/DELETE on namespace objects. Other cluster-scoped resources (`nodes`, grouped `clusterroles`) already parsed correctly — verified by tests.

## Tests
- Overlay-created **namespace / node / clusterrole** are returned by single-object GET (the bug).
- A deleted **captured** namespace 404s on GET (not the captured copy) and drops from LIST.
- Namespaced single-GET behavior unchanged (existing tests).

Smoke-tested against a real capture: `POST /api/v1/namespaces {name: joe-test}` → 201, `GET /api/v1/namespaces/joe-test` → **200** (was 404), captured `default` still 200.

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)