### PR TITLE
feat(replay-overlay): cascade namespace deletion to its contents

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -423,9 +423,17 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 	// overlay owns it (created/updated → the overlay copy; deleted → 404).
 	if h.overlay != nil {
 		h.overlay.syncEpoch(h.clock)
+		g, v, res, ns, name, sub := parseWritePath(strings.TrimSuffix(path, "/"))
+		// A single-object GET in a namespace deleted in the overlay is gone
+		// (cascade), even for captured objects.
+		if name != "" && h.overlay.isNamespaceDeleted(ns) {
+			h.writeStatus(w, http.StatusNotFound,
+				fmt.Sprintf("%q not found: namespace %q was deleted in the writable overlay", path, ns))
+			return
+		}
 		// Serve overlay-owned objects for a single-object GET (and GET .../status,
 		// so clients can observe their status updates).
-		if g, v, res, ns, name, sub := parseWritePath(strings.TrimSuffix(path, "/")); name != "" && (sub == "" || sub == "status") {
+		if name != "" && (sub == "" || sub == "status") {
 			if e, ok := h.overlay.get(g, v, res, ns, name); ok {
 				if e.deleted {
 					h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q was deleted in the writable overlay", path))
@@ -632,6 +640,17 @@ func (h *handler) mergeOverlayList(path string, body []byte) []byte {
 		return body // not a list
 	}
 	list.Items = h.overlay.applyToList(group, version, resource, namespace, list.Items)
+	// Cascade: drop items whose namespace was deleted in the overlay (covers both
+	// overlay-created and captured items, in namespaced and cluster-wide/-A lists).
+	if dns := h.overlay.deletedNamespaces(); len(dns) > 0 {
+		kept := list.Items[:0]
+		for _, it := range list.Items {
+			if _, gone := dns[metaString(it, "namespace")]; !gone {
+				kept = append(kept, it)
+			}
+		}
+		list.Items = kept
+	}
 	out, err := json.Marshal(list)
 	if err != nil {
 		return body

--- a/internal/server/overlay.go
+++ b/internal/server/overlay.go
@@ -143,7 +143,7 @@ func (o *overlay) del(group, version, resource, namespace, name string, last jso
 	return rv
 }
 
-// coreNamespacesGVR matches the core cluster-scoped "namespaces" resource.
+// isCoreNamespace matches the core cluster-scoped "namespaces" resource.
 func isCoreNamespace(group, version, resource string) bool {
 	return group == "" && version == "v1" && resource == "namespaces"
 }

--- a/internal/server/overlay.go
+++ b/internal/server/overlay.go
@@ -143,6 +143,61 @@ func (o *overlay) del(group, version, resource, namespace, name string, last jso
 	return rv
 }
 
+// coreNamespacesGVR matches the core cluster-scoped "namespaces" resource.
+func isCoreNamespace(group, version, resource string) bool {
+	return group == "" && version == "v1" && resource == "namespaces"
+}
+
+// cascadeDeleteNamespace tombstones every live overlay object in a namespace,
+// mimicking the namespace controller's cascade so a deleted namespace's
+// overlay-created contents don't linger. Captured objects in the namespace are
+// handled lazily on read (see isNamespaceDeleted / read filtering).
+func (o *overlay) cascadeDeleteNamespace(namespace string) {
+	if namespace == "" {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	for key, e := range o.items {
+		if e.namespace == namespace && !e.deleted {
+			rv := o.bumpRVLocked(0)
+			o.items[key] = &overlayEntry{
+				group: e.group, version: e.version, resource: e.resource,
+				namespace: e.namespace, name: e.name, obj: e.obj, deleted: true, rv: rv,
+			}
+		}
+	}
+}
+
+// isNamespaceDeleted reports whether the given namespace has been deleted in the
+// overlay (a tombstoned core namespaces object).
+func (o *overlay) isNamespaceDeleted(namespace string) bool {
+	if namespace == "" {
+		return false
+	}
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	e, ok := o.items[overlayKey("", "v1", "namespaces", "", namespace)]
+	return ok && e.deleted
+}
+
+// deletedNamespaces returns the set of namespaces deleted in the overlay, used to
+// filter their (possibly captured) contents out of read responses.
+func (o *overlay) deletedNamespaces() map[string]struct{} {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	var out map[string]struct{}
+	for _, e := range o.items {
+		if e.deleted && isCoreNamespace(e.group, e.version, e.resource) {
+			if out == nil {
+				out = map[string]struct{}{}
+			}
+			out[e.name] = struct{}{}
+		}
+	}
+	return out
+}
+
 // get returns the overlay entry for an object identity, if present.
 func (o *overlay) get(group, version, resource, namespace, name string) (*overlayEntry, bool) {
 	o.mu.RLock()

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -26,10 +26,11 @@ func (h *handler) handleWrite(w http.ResponseWriter, r *http.Request, path strin
 		return
 	}
 
-	// Can't create/modify objects in a namespace that was deleted in the overlay
-	// (it and its contents are gone). DELETE is exempt (the object is already
-	// gone, so it will 404 naturally).
-	if r.Method != http.MethodDelete && namespace != "" && h.overlay.isNamespaceDeleted(namespace) {
+	// A namespace deleted in the overlay takes its contents with it: any write to
+	// an object in it (create, update, patch, or delete) is a 404, since the
+	// namespace and everything in it are logically gone. Deleting the namespace
+	// object itself has namespace=="" here, so it isn't caught by this check.
+	if namespace != "" && h.overlay.isNamespaceDeleted(namespace) {
 		h.writeStatus(w, http.StatusNotFound, "namespace "+namespace+" was deleted in the writable overlay")
 		return
 	}

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -26,6 +26,14 @@ func (h *handler) handleWrite(w http.ResponseWriter, r *http.Request, path strin
 		return
 	}
 
+	// Can't create/modify objects in a namespace that was deleted in the overlay
+	// (it and its contents are gone). DELETE is exempt (the object is already
+	// gone, so it will 404 naturally).
+	if r.Method != http.MethodDelete && namespace != "" && h.overlay.isNamespaceDeleted(namespace) {
+		h.writeStatus(w, http.StatusNotFound, "namespace "+namespace+" was deleted in the writable overlay")
+		return
+	}
+
 	switch r.Method {
 	case http.MethodPost:
 		if name != "" { // create is a collection operation
@@ -252,6 +260,12 @@ func (h *handler) overlayDelete(w http.ResponseWriter, group, version, resource,
 		return
 	}
 	h.overlay.del(group, version, resource, namespace, name, last, h.replayFloorRV(group, version, resource, namespace))
+	// Deleting a namespace cascades to its contents (no namespace controller runs
+	// against the overlay): tombstone the namespace's overlay objects, and its
+	// captured objects are filtered out of reads while the namespace is deleted.
+	if isCoreNamespace(group, version, resource) {
+		h.overlay.cascadeDeleteNamespace(name)
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"apiVersion": "v1", "kind": "Status", "status": "Success",
 		"details": map[string]any{"name": name, "kind": resourceToKind(resource)},

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -553,6 +553,83 @@ func TestOverlay_ClusterScopedDeleteTombstone(t *testing.T) {
 	}
 }
 
+// TestOverlay_NamespaceDeleteCascade covers the reported bug: deleting an
+// overlay-created namespace must cascade to objects created in it — they should
+// disappear from namespaced and cluster-wide (-A) lists and single GETs.
+func TestOverlay_NamespaceDeleteCascade(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	// Create a namespace and a deployment in it.
+	doReq(t, http.MethodPost, srv.URL+"/api/v1/namespaces", "application/json",
+		`{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"joe-test"}}`)
+	deployColl := "/apis/apps/v1/namespaces/joe-test/deployments"
+	doReq(t, http.MethodPost, srv.URL+deployColl, "application/json",
+		`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"web","namespace":"joe-test"}}`)
+
+	clusterDeploys := "/apis/apps/v1/deployments"
+	if _, l := doReq(t, http.MethodGet, srv.URL+clusterDeploys, "", ""); !contains(listNames(t, l), "web") {
+		t.Fatalf("deployment 'web' should be visible in -A list before delete: %v", listNames(t, l))
+	}
+
+	// Delete the namespace → cascade.
+	if code, _ := doReq(t, http.MethodDelete, srv.URL+"/api/v1/namespaces/joe-test", "", ""); code != 200 {
+		t.Fatalf("delete namespace: status %d", code)
+	}
+
+	// Deployment gone from the cluster-wide (-A) list…
+	if _, l := doReq(t, http.MethodGet, srv.URL+clusterDeploys, "", ""); contains(listNames(t, l), "web") {
+		t.Errorf("deployment 'web' still in -A list after namespace delete: %v", listNames(t, l))
+	}
+	// …the namespaced list…
+	if _, l := doReq(t, http.MethodGet, srv.URL+deployColl, "", ""); len(listNames(t, l)) != 0 {
+		t.Errorf("namespaced deployment list not empty after namespace delete: %v", listNames(t, l))
+	}
+	// …and single GET.
+	if code, _ := doReq(t, http.MethodGet, srv.URL+deployColl+"/web", "", ""); code != 404 {
+		t.Errorf("GET deployment after namespace delete: status %d, want 404", code)
+	}
+	// The namespace itself is gone.
+	if code, _ := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/joe-test", "", ""); code != 404 {
+		t.Errorf("GET deleted namespace: status %d, want 404", code)
+	}
+	// Creating into the deleted namespace is rejected.
+	if code, _ := doReq(t, http.MethodPost, srv.URL+"/api/v1/namespaces/joe-test/configmaps", "application/json",
+		`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm","namespace":"joe-test"}}`); code != 404 {
+		t.Errorf("create into deleted namespace: status %d, want 404", code)
+	}
+}
+
+// TestOverlay_NamespaceDeleteCascadeCaptured verifies deleting a namespace also
+// hides captured objects that live in it (lazy read filter).
+func TestOverlay_NamespaceDeleteCascadeCaptured(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	nsList := `{"apiVersion":"v1","kind":"NamespaceList","metadata":{"resourceVersion":"1"},"items":[` +
+		`{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"cap-ns"}}]}`
+	cmList := `{"apiVersion":"v1","kind":"ConfigMapList","metadata":{"resourceVersion":"1"},"items":[` +
+		`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cap-cm","namespace":"cap-ns"}}]}`
+	store := buildTestStoreWithWatch(t, map[string]watchTestRecord{
+		"/api/v1/namespaces":                   {id: "ns", at: from, body: nsList},
+		"/api/v1/namespaces/cap-ns/configmaps": {id: "cm", at: from, body: cmList},
+	}, nil)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, store, clock)
+
+	if _, l := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/cap-ns/configmaps", "", ""); !contains(listNames(t, l), "cap-cm") {
+		t.Fatalf("captured configmap should be visible before delete: %v", listNames(t, l))
+	}
+	if code, _ := doReq(t, http.MethodDelete, srv.URL+"/api/v1/namespaces/cap-ns", "", ""); code != 200 {
+		t.Fatalf("delete captured namespace: status %d", code)
+	}
+	if _, l := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/cap-ns/configmaps", "", ""); len(listNames(t, l)) != 0 {
+		t.Errorf("captured configmap list not empty after namespace delete: %v", listNames(t, l))
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/cap-ns/configmaps/cap-cm", "", ""); code != 404 {
+		t.Errorf("GET captured configmap after namespace delete: status %d, want 404", code)
+	}
+}
+
 func TestOverlay_ReadOnlyRejectsWrites(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -599,6 +599,10 @@ func TestOverlay_NamespaceDeleteCascade(t *testing.T) {
 		`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm","namespace":"joe-test"}}`); code != 404 {
 		t.Errorf("create into deleted namespace: status %d, want 404", code)
 	}
+	// So is deleting an object in it — its contents are logically gone.
+	if code, _ := doReq(t, http.MethodDelete, srv.URL+deployColl+"/web", "", ""); code != 404 {
+		t.Errorf("delete object in deleted namespace: status %d, want 404", code)
+	}
 }
 
 // TestOverlay_NamespaceDeleteCascadeCaptured verifies deleting a namespace also


### PR DESCRIPTION
Deleting a namespace in the writable overlay didn't cascade — objects created in it lingered (there's no namespace/GC controller against the overlay). Reported: a deployment created in a namespace still appeared in `kubectl get deploy -A` after the namespace was deleted.

> ⚠️ **Stacked on #156** (fix/overlay-cluster-scoped-get) — that PR's `parseWritePath` fix is needed to route `DELETE /api/v1/namespaces/<name>`. Review/merge #156 first; I'll rebase this onto main once it lands. The diff-of-interest is the last commit.

## Fix
Synthesize the namespace-deletion cascade in the overlay:
- **Eager** — on namespace delete, tombstone every overlay object in that namespace (`cascadeDeleteNamespace`), so overlay-created contents don't linger (and don't resurrect if the namespace is later re-created).
- **Lazy** — a single-object GET in a deleted namespace 404s, and LIST responses (namespaced **and** cluster-wide/`-A`) drop items whose namespace was deleted. This covers **captured** objects in a deleted namespace too, without enumerating the capture.
- **Writes** — create/update into a deleted namespace returns 404 ("namespace … was deleted"), matching "the namespace is gone". Re-creating the namespace un-deletes it (old contents stay tombstoned).

## Tests
- Overlay deployment disappears from `-A`, the namespaced list, and single GET after its namespace is deleted; create-into-deleted-namespace 404s.
- Captured objects in a deleted namespace are hidden from list + GET.

## Scope note
This is overlay-state cascade (the overlay's own bookkeeping), not a simulated namespace controller. Broader controller behaviors (finalizers, GC of owner-referenced children beyond namespace scope, etc.) remain out of scope for the overlay and are better served by the KWOK-integration path discussed on #123.

Part of #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)