### PR TITLE
feat(replay-overlay): strategic-merge patch for built-in types

### DIFF
--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -232,7 +232,7 @@ func (h *handler) overlayPatch(w http.ResponseWriter, r *http.Request, group, ve
 		h.writeStatus(w, http.StatusNotFound, "object not found: "+name)
 		return
 	}
-	next, perr := applyPatch(current, patch, r.Header.Get("Content-Type"))
+	next, perr := applyPatch(current, patch, r.Header.Get("Content-Type"), group, version, resource)
 	if perr != nil {
 		h.writeStatus(w, http.StatusUnprocessableEntity, "applying patch: "+perr.Error())
 		return
@@ -378,7 +378,7 @@ func supportedPatchType(contentType string) bool {
 // strategic-merge patch (for built-in types, via their registered schema).
 // Server-side apply still falls back to a JSON merge patch for now (real SSA
 // field management lands in a later PR).
-func applyPatch(current, patch []byte, contentType string) ([]byte, error) {
+func applyPatch(current, patch []byte, contentType, group, version, resource string) ([]byte, error) {
 	switch patchMediaType(contentType) {
 	case "application/json-patch+json":
 		p, err := jsonpatch.DecodePatch(patch)
@@ -387,7 +387,7 @@ func applyPatch(current, patch []byte, contentType string) ([]byte, error) {
 		}
 		return p.Apply(current)
 	case "application/strategic-merge-patch+json":
-		return strategicMergePatch(current, patch)
+		return strategicMergePatch(current, patch, group, version, resource)
 	case "application/apply-patch+yaml":
 		// Server-side apply bodies are YAML; convert to JSON, then merge as an
 		// interim (real SSA field management lands in a later PR).
@@ -405,17 +405,17 @@ func applyPatch(current, patch []byte, contentType string) ([]byte, error) {
 // object's built-in type: lists with a patch merge key (e.g. containers by name)
 // are merged element-wise rather than wholesale-replaced, matching the
 // kube-apiserver. Strategic merge is only defined for built-in types — the real
-// apiserver has no strategy metadata for custom resources — so an object whose
-// GVK isn't in the scheme falls back to a plain JSON merge patch.
-func strategicMergePatch(current, patch []byte) ([]byte, error) {
-	var tm struct {
-		APIVersion string `json:"apiVersion"`
-		Kind       string `json:"kind"`
-	}
-	if err := json.Unmarshal(current, &tm); err == nil && tm.Kind != "" {
-		if obj, nerr := scheme.Scheme.New(schema.FromAPIVersionAndKind(tm.APIVersion, tm.Kind)); nerr == nil {
-			return strategicpatch.StrategicMergePatch(current, patch, obj)
-		}
+// apiserver has no strategy metadata for custom resources — so a GVK that isn't
+// in the scheme falls back to a plain JSON merge patch.
+//
+// The GVK is derived from the request path's group/version/resource, not the
+// stored object body: a replayed object reconstructed from a captured LIST has no
+// apiVersion/kind (the apiserver strips TypeMeta from list items), so the body is
+// not a reliable type source.
+func strategicMergePatch(current, patch []byte, group, version, resource string) ([]byte, error) {
+	gvk := schema.GroupVersionKind{Group: group, Version: version, Kind: resourceToKind(resource)}
+	if obj, err := scheme.Scheme.New(gvk); err == nil {
+		return strategicpatch.StrategicMergePatch(current, patch, obj)
 	}
 	// Unknown/custom type: no strategy metadata, so merge like the apiserver's
 	// fallback for resources without a strategic-merge strategy.

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -413,13 +414,29 @@ func applyPatch(current, patch []byte, contentType, group, version, resource str
 // apiVersion/kind (the apiserver strips TypeMeta from list items), so the body is
 // not a reliable type source.
 func strategicMergePatch(current, patch []byte, group, version, resource string) ([]byte, error) {
-	gvk := schema.GroupVersionKind{Group: group, Version: version, Kind: resourceToKind(resource)}
-	if obj, err := scheme.Scheme.New(gvk); err == nil {
-		return strategicpatch.StrategicMergePatch(current, patch, obj)
+	if gvk, ok := kindForResource(schema.GroupVersion{Group: group, Version: version}, resource); ok {
+		if obj, err := scheme.Scheme.New(gvk); err == nil {
+			return strategicpatch.StrategicMergePatch(current, patch, obj)
+		}
 	}
 	// Unknown/custom type: no strategy metadata, so merge like the apiserver's
 	// fallback for resources without a strategic-merge strategy.
 	return jsonpatch.MergePatch(current, patch)
+}
+
+// kindForResource resolves a plural resource name to its registered built-in Kind
+// by inverting the apiserver's own kind→resource convention over the scheme's
+// known types. This is exact for every registered type (e.g. endpointslices →
+// EndpointSlice), unlike a name-capitalization heuristic. ok is false when no
+// built-in type in the group/version maps to the resource (custom resources).
+func kindForResource(gv schema.GroupVersion, resource string) (schema.GroupVersionKind, bool) {
+	for kind := range scheme.Scheme.KnownTypes(gv) {
+		gvk := gv.WithKind(kind)
+		if plural, _ := meta.UnsafeGuessKindToResource(gvk); plural.Resource == resource {
+			return gvk, true
+		}
+	}
+	return schema.GroupVersionKind{}, false
 }
 
 // allowedMethods returns the Allow-header value for a write path shape, used on

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -11,6 +11,9 @@ import (
 
 	"github.com/google/uuid"
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/yaml"
 )
 
@@ -371,9 +374,10 @@ func supportedPatchType(contentType string) bool {
 }
 
 // applyPatch applies a patch of the given (already-validated) content type to the
-// current object. PR-1 supports JSON merge patch and JSON patch (RFC 6902);
-// strategic-merge and server-side apply fall back to a JSON merge patch for now
-// (schema-driven strategic-merge and SSA land in later PRs).
+// current object. Supports JSON merge patch, JSON patch (RFC 6902), and
+// strategic-merge patch (for built-in types, via their registered schema).
+// Server-side apply still falls back to a JSON merge patch for now (real SSA
+// field management lands in a later PR).
 func applyPatch(current, patch []byte, contentType string) ([]byte, error) {
 	switch patchMediaType(contentType) {
 	case "application/json-patch+json":
@@ -382,6 +386,8 @@ func applyPatch(current, patch []byte, contentType string) ([]byte, error) {
 			return nil, err
 		}
 		return p.Apply(current)
+	case "application/strategic-merge-patch+json":
+		return strategicMergePatch(current, patch)
 	case "application/apply-patch+yaml":
 		// Server-side apply bodies are YAML; convert to JSON, then merge as an
 		// interim (real SSA field management lands in a later PR).
@@ -390,9 +396,30 @@ func applyPatch(current, patch []byte, contentType string) ([]byte, error) {
 			return nil, err
 		}
 		return jsonpatch.MergePatch(current, j)
-	default: // merge-patch, strategic-merge (fallback)
+	default: // merge-patch
 		return jsonpatch.MergePatch(current, patch)
 	}
+}
+
+// strategicMergePatch applies a strategic-merge patch using the schema of the
+// object's built-in type: lists with a patch merge key (e.g. containers by name)
+// are merged element-wise rather than wholesale-replaced, matching the
+// kube-apiserver. Strategic merge is only defined for built-in types — the real
+// apiserver has no strategy metadata for custom resources — so an object whose
+// GVK isn't in the scheme falls back to a plain JSON merge patch.
+func strategicMergePatch(current, patch []byte) ([]byte, error) {
+	var tm struct {
+		APIVersion string `json:"apiVersion"`
+		Kind       string `json:"kind"`
+	}
+	if err := json.Unmarshal(current, &tm); err == nil && tm.Kind != "" {
+		if obj, nerr := scheme.Scheme.New(schema.FromAPIVersionAndKind(tm.APIVersion, tm.Kind)); nerr == nil {
+			return strategicpatch.StrategicMergePatch(current, patch, obj)
+		}
+	}
+	// Unknown/custom type: no strategy metadata, so merge like the apiserver's
+	// fallback for resources without a strategic-merge strategy.
+	return jsonpatch.MergePatch(current, patch)
 }
 
 // allowedMethods returns the Allow-header value for a write path shape, used on

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -148,6 +148,83 @@ func TestOverlay_ReplaceAndPatch(t *testing.T) {
 	}
 }
 
+// containerNamesImages decodes spec.containers into a name→image map.
+func containerNamesImages(t *testing.T, body []byte) map[string]string {
+	t.Helper()
+	var obj struct {
+		Spec struct {
+			Containers []struct {
+				Name  string `json:"name"`
+				Image string `json:"image"`
+			} `json:"containers"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal(body, &obj); err != nil {
+		t.Fatalf("decode containers: %v\n%s", err, body)
+	}
+	m := map[string]string{}
+	for _, c := range obj.Spec.Containers {
+		m[c.Name] = c.Image
+	}
+	return m
+}
+
+// TestOverlay_StrategicMergePatch verifies that a strategic-merge patch of a
+// built-in type merges a keyed list (containers, by name) element-wise instead
+// of replacing it — the behavior a plain JSON merge patch cannot provide.
+func TestOverlay_StrategicMergePatch(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	twoContainers := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-sm","namespace":"default"},` +
+		`"spec":{"containers":[{"name":"app","image":"app:v1"},{"name":"sidecar","image":"sidecar:v1"}]}}`
+	if code, body := doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", twoContainers); code != http.StatusCreated {
+		t.Fatalf("create: status %d: %s", code, body)
+	}
+
+	// Strategic merge: update only the "app" container by its merge key.
+	patch := `{"spec":{"containers":[{"name":"app","image":"app:v2"}]}}`
+	code, got := doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-sm", "application/strategic-merge-patch+json", patch)
+	if code != 200 {
+		t.Fatalf("strategic patch: status %d: %s", code, got)
+	}
+	ci := containerNamesImages(t, got)
+	if ci["app"] != "app:v2" {
+		t.Errorf("app image = %q, want app:v2", ci["app"])
+	}
+	if ci["sidecar"] != "sidecar:v1" {
+		t.Errorf("sidecar container was dropped by strategic merge (got %v), want it preserved", ci)
+	}
+}
+
+// TestOverlay_MergePatchReplacesList is the contrast to strategic merge: a plain
+// JSON merge patch replaces a list wholesale rather than merging by key.
+func TestOverlay_MergePatchReplacesList(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	twoContainers := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-mp","namespace":"default"},` +
+		`"spec":{"containers":[{"name":"app","image":"app:v1"},{"name":"sidecar","image":"sidecar:v1"}]}}`
+	if code, body := doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", twoContainers); code != http.StatusCreated {
+		t.Fatalf("create: status %d: %s", code, body)
+	}
+
+	patch := `{"spec":{"containers":[{"name":"app","image":"app:v2"}]}}`
+	code, got := doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-mp", "application/merge-patch+json", patch)
+	if code != 200 {
+		t.Fatalf("merge patch: status %d: %s", code, got)
+	}
+	ci := containerNamesImages(t, got)
+	if _, ok := ci["sidecar"]; ok {
+		t.Errorf("merge patch should replace the containers list, but sidecar survived: %v", ci)
+	}
+	if ci["app"] != "app:v2" {
+		t.Errorf("app image = %q, want app:v2", ci["app"])
+	}
+}
+
 func TestOverlay_DeleteTombstone(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -225,6 +225,37 @@ func TestOverlay_MergePatchReplacesList(t *testing.T) {
 	}
 }
 
+// TestOverlay_StrategicMergePatch_CapturedNoTypeMeta guards the case where the
+// object being patched comes from a replayed LIST and so has no apiVersion/kind
+// (the apiserver strips TypeMeta from list items). The GVK must still be resolved
+// from the request path, or strategic merge would silently degrade to a JSON
+// merge and drop the sibling container.
+func TestOverlay_StrategicMergePatch_CapturedNoTypeMeta(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	// A captured list whose item carries no apiVersion/kind, as a real apiserver
+	// returns list items.
+	listBody := `{"apiVersion":"v1","kind":"PodList","metadata":{"resourceVersion":"1"},"items":[` +
+		`{"metadata":{"name":"cap-pod","namespace":"default"},` +
+		`"spec":{"containers":[{"name":"app","image":"app:v1"},{"name":"sidecar","image":"sidecar:v1"}]}}]}`
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{podsPath: {id: "s", at: from, body: listBody}}, nil)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, store, clock)
+
+	patch := `{"spec":{"containers":[{"name":"app","image":"app:v2"}]}}`
+	code, got := doReq(t, http.MethodPatch, srv.URL+podsPath+"/cap-pod", "application/strategic-merge-patch+json", patch)
+	if code != 200 {
+		t.Fatalf("strategic patch: status %d: %s", code, got)
+	}
+	ci := containerNamesImages(t, got)
+	if ci["sidecar"] != "sidecar:v1" {
+		t.Errorf("sidecar dropped — GVK was not resolved from the path for a TypeMeta-less object: %v", ci)
+	}
+	if ci["app"] != "app:v2" {
+		t.Errorf("app image = %q, want app:v2", ci["app"])
+	}
+}
+
 func TestOverlay_DeleteTombstone(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const podsPath = "/api/v1/namespaces/default/pods"
@@ -253,6 +255,30 @@ func TestOverlay_StrategicMergePatch_CapturedNoTypeMeta(t *testing.T) {
 	}
 	if ci["app"] != "app:v2" {
 		t.Errorf("app image = %q, want app:v2", ci["app"])
+	}
+}
+
+// TestKindForResource checks the resource→Kind resolver against the scheme,
+// including cases a naive capitalization heuristic gets wrong (endpointslices →
+// EndpointSlice, not Endpointslice), and that custom resources resolve to ok=false.
+func TestKindForResource(t *testing.T) {
+	cases := []struct {
+		group, version, resource, wantKind string
+		wantOK                             bool
+	}{
+		{"", "v1", "pods", "Pod", true},
+		{"", "v1", "configmaps", "ConfigMap", true},
+		{"apps", "v1", "deployments", "Deployment", true},
+		{"discovery.k8s.io", "v1", "endpointslices", "EndpointSlice", true},
+		{"networking.k8s.io", "v1", "networkpolicies", "NetworkPolicy", true},
+		{"example.com", "v1", "widgets", "", false}, // custom resource: not in the scheme
+	}
+	for _, c := range cases {
+		gvk, ok := kindForResource(schema.GroupVersion{Group: c.group, Version: c.version}, c.resource)
+		if ok != c.wantOK || gvk.Kind != c.wantKind {
+			t.Errorf("kindForResource(%s/%s, %s) = (%q, %v), want (%q, %v)",
+				c.group, c.version, c.resource, gvk.Kind, ok, c.wantKind, c.wantOK)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Phase-4 **PR 3** of the writable overlay (#123). `application/strategic-merge-patch+json` previously fell back to a plain JSON merge patch, which replaces keyed lists wholesale — so `kubectl patch` / controller patches that update one list element (e.g. one container by name) would silently **drop the others**.

## Change

Route strategic-merge patches through apimachinery's `strategicpatch`, using the object's registered built-in type (`scheme.Scheme.New` on its GVK). Keyed lists (containers by `name`, volumes, env, …) now merge element-wise, matching the kube-apiserver.

Strategic merge is only defined for built-in types — the real apiserver has no strategy metadata for custom resources (a CRD strategic patch is unsupported there) — so an object whose GVK isn't in the scheme falls back to a JSON merge patch.

**No new module dependencies:** client-go's `kubernetes/scheme` and the typed `k8s.io/api` packages are already in the graph (used by the protobuf codec from #155), so this pulls no new modules.

## Tests

- `TestOverlay_StrategicMergePatch` — patching one container by name preserves the sibling container (element-wise merge).
- `TestOverlay_MergePatchReplacesList` — the contrast: a plain merge patch replaces the list wholesale.

`-race` suite green; `gofmt`/`vet`/`golangci-lint` clean; `go mod tidy` a no-op.

## Scope note

The `/status` subresource endpoint already isolates status correctly (via `replaceField`). Full spec/status isolation on the **main** resource endpoint (an apiserver preserves existing `status` on a spec update when the type has a status subresource) needs subresource-registration data the mock doesn't track, so it's left as a follow-up rather than bundled here.

## Remaining phase-4 work

- PR 4 — server-side apply (managedFields + structured-merge-diff).
- PR 5 — docs + UI writable badge & reset.

Part of #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)