### PR TITLE
fix(replay): stamp apiVersion/kind on watch event objects

### DIFF
--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // watchList is a parsed list body ready to be streamed as watch events.
@@ -156,6 +158,40 @@ func matchesSelectors(raw json.RawMessage, labelSelector, fieldSelector string) 
 	return matchesLabels(&obj, labelReqs) && matchesFields(&obj, fieldReqs)
 }
 
+// withKind stamps apiVersion/kind onto a watch event object when they're absent,
+// preserving everything else. Objects reconstructed from a captured LIST have no
+// TypeMeta (the apiserver strips it from list items), but a typed client-go watch
+// decoder requires the kind on every event object. A no-op when kind is unknown
+// or already present.
+func withKind(obj json.RawMessage, apiVersion, kind string) json.RawMessage {
+	if kind == "" {
+		return obj
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(obj, &m); err != nil || m == nil {
+		return obj
+	}
+	changed := false
+	if _, ok := m["kind"]; !ok {
+		b, _ := json.Marshal(kind)
+		m["kind"] = b
+		changed = true
+	}
+	if _, ok := m["apiVersion"]; !ok {
+		b, _ := json.Marshal(apiVersion)
+		m["apiVersion"] = b
+		changed = true
+	}
+	if !changed {
+		return obj
+	}
+	out, err := json.Marshal(m)
+	if err != nil {
+		return obj
+	}
+	return out
+}
+
 // replayPollInterval bounds how long the streamer sleeps between clock checks so
 // it stays responsive to pause, seek, speed changes, and loop wraps.
 const replayPollInterval = 200 * time.Millisecond
@@ -241,6 +277,16 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 		defAPIVersion = g + "/" + v
 	}
 
+	// apiVersion/kind to stamp onto watch event objects. A typed client-go watcher
+	// (e.g. a controller's or KWOK's reflector) requires every event object to
+	// carry its kind, but objects reconstructed from a captured LIST snapshot have
+	// their TypeMeta stripped. Resolve the exact built-in kind from the scheme,
+	// falling back to the path-derived guess for custom resources.
+	evKind := defKind
+	if gvk, ok := kindForResource(schema.GroupVersion{Group: g, Version: v}, resource); ok {
+		evKind = gvk.Kind
+	}
+
 	// Subscribe to overlay writes before resolving the initial list, so no live
 	// write is lost in the gap between the burst and the pump starting. The skip
 	// floor (overlaySkip) is derived from the burst itself, below — captured
@@ -291,6 +337,9 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 	// emit writes a watch frame and reports whether it was actually written, so
 	// callers only count frames that reached the client.
 	emit := func(typ string, obj json.RawMessage) bool {
+		// Stamp apiVersion/kind so typed client-go watchers can decode the event —
+		// objects from a captured LIST snapshot arrive without TypeMeta.
+		obj = withKind(obj, defAPIVersion, evKind)
 		// Skip malformed frames rather than writing a blank line: a captured
 		// object body could be invalid JSON, which would fail to marshal.
 		data, err := json.Marshal(map[string]any{"type": typ, "object": obj})

--- a/internal/server/watch_replay_test.go
+++ b/internal/server/watch_replay_test.go
@@ -91,6 +91,40 @@ func openWatchStream(t *testing.T, url string) (next func() watchEvent, tryNext 
 	return next, tryNext, cancel
 }
 
+// TestStreamReplayWatch_StampsKindOnEvents guards the fix for typed client-go
+// watchers (controllers, KWOK): a captured event object reconstructed from a LIST
+// snapshot has no apiVersion/kind, but the watch decoder requires kind on every
+// event object. The stream must stamp it from the watch path.
+func TestStreamReplayWatch_StampsKindOnEvents(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	to := from.Add(20 * time.Second)
+	const podsPath = "/api/v1/namespaces/default/pods"
+	// Event object with no apiVersion/kind, as a real LIST-snapshot item.
+	kindlessPod := `{"metadata":{"name":"pod-a","namespace":"default"}}`
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{podsPath: {id: "snap0", at: from, body: emptyPodList}},
+		[]watchTestEvent{
+			{id: "e1", apiPath: podsPath, at: from.Add(2 * time.Second), eventType: "ADDED", objectBody: kindlessPod},
+		})
+	clock, advance := newTestClock(t, from, to, 1, false, false)
+	h := newHandler(store, time.Time{}, false)
+	h.clock = clock
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	next, _, cancel := openWatchStream(t, srv.URL+podsPath+"?watch=1")
+	defer cancel()
+
+	advance(5 * time.Second) // let the event stream past the initial bookmark
+	e := nextNonBookmark(next)
+	if e.Object.Kind != "Pod" {
+		t.Errorf("streamed event Object.Kind = %q, want Pod (typed watchers need it to decode)", e.Object.Kind)
+	}
+	if e.Object.Metadata.Name != "pod-a" {
+		t.Errorf("event name = %q, want pod-a", e.Object.Metadata.Name)
+	}
+}
+
 // TestStreamReplayWatch_EmitsEventsInOrder is the core acceptance test: a watch
 // client receives the captured ADDED/MODIFIED/DELETED events in timestamp order
 // as the replay clock advances.


### PR DESCRIPTION
## Symptom

Running any **typed** client-go watcher — a controller's informer, or `kwok` — against a `kshrk` replay fails and loops:

```
watch ended with error ... unable to decode an event from the watch stream:
unable to decode watch event: Object 'Kind' is missing in '{...}'
```

(Reported while following the KWOK walkthrough; `kwok`'s reflector watches `*v1.Node`/`*v1.Pod`.)

## Cause

kshrk's replay watch reconstructs event objects from captured **LIST snapshots**, whose items have their `apiVersion`/`kind` stripped by the apiserver. A typed client-go watch decoder requires the `kind` on **every** event object to know how to decode it, so the stream is unusable by typed watchers. (Read-only `open`/`replay` are affected too — this isn't specific to the writable overlay.)

This slipped through #158's watch-feedback tests because that informer test uses the **dynamic** (unstructured) client, which tolerates a missing kind; a typed reflector does not.

## Fix

Stamp `apiVersion`/`kind` onto every emitted watch event object when absent, resolved from the watch path (exact built-in kind via the scheme, falling back to the path-derived guess for custom resources). All event sources — the initial burst, replayed timeline events, and live overlay events — flow through the single `emit` choke point, so one stamping point covers them all. Objects that already carry a kind are untouched.

## Tests

`TestStreamReplayWatch_StampsKindOnEvents` — a captured event whose object has no TypeMeta must arrive with `kind: Pod`. `-race` suite + `vet` + `golangci-lint` clean.

## Scope

Standalone fix off `main` — independent of the KWOK scheduling-shim PR (#162), since it affects any typed watcher on replay. It's also a prerequisite for the KWOK walkthrough in #162 to work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)