### PR TITLE
feat(replay): KWOK convenience — --with-kwok, --schedule-pods, eager node synthesis

### DIFF
--- a/cmd/kwok.go
+++ b/cmd/kwok.go
@@ -33,7 +33,12 @@ func startKwok(kubeconfigPath string) (cleanup func(), err error) {
 		_ = os.Remove(tmp.Name())
 		return nil, fmt.Errorf("--with-kwok: writing stages: %w", err)
 	}
-	_ = tmp.Close()
+	// Check Close: it flushes the write, so a failure here means the stages file
+	// may be incomplete — which would surface later as a confusing kwok parse error.
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return nil, fmt.Errorf("--with-kwok: writing stages: %w", err)
+	}
 
 	kc := exec.Command(kwokBin, "--kubeconfig", kubeconfigPath, "--manage-all-nodes", "--config", tmp.Name())
 	kc.Stdout = os.Stdout

--- a/cmd/kwok.go
+++ b/cmd/kwok.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// KwokStages holds the bundled KWOK Stages config (set from main via go:embed).
+// It is written to a temp file and passed to `kwok --config` by --with-kwok.
+var KwokStages []byte
+
+// startKwok launches a detected `kwok` binary against the mock server's
+// kubeconfig, managing all nodes and using the bundled Stages. It returns a
+// cleanup func that stops kwok and removes the temp stages file. An error is
+// returned (with an install hint) when the kwok binary isn't on PATH.
+func startKwok(kubeconfigPath string) (cleanup func(), err error) {
+	kwokBin, lookErr := exec.LookPath("kwok")
+	if lookErr != nil {
+		return nil, fmt.Errorf("--with-kwok: 'kwok' not found in PATH; install it from " +
+			"https://kwok.sigs.k8s.io/docs/user/install/ (or drop --with-kwok and run kwok yourself)")
+	}
+	if len(KwokStages) == 0 {
+		return nil, fmt.Errorf("--with-kwok: bundled KWOK stages are unavailable in this build")
+	}
+
+	tmp, err := os.CreateTemp("", "kshrk-kwok-stages-*.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("--with-kwok: writing stages: %w", err)
+	}
+	if _, err := tmp.Write(KwokStages); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+		return nil, fmt.Errorf("--with-kwok: writing stages: %w", err)
+	}
+	_ = tmp.Close()
+
+	kc := exec.Command(kwokBin, "--kubeconfig", kubeconfigPath, "--manage-all-nodes", "--config", tmp.Name())
+	kc.Stdout = os.Stdout
+	kc.Stderr = os.Stderr
+	if err := kc.Start(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return nil, fmt.Errorf("--with-kwok: starting kwok: %w", err)
+	}
+
+	cleanup = func() {
+		if kc.Process != nil {
+			_ = kc.Process.Kill()
+		}
+		_ = kc.Wait()
+		_ = os.Remove(tmp.Name())
+	}
+	return cleanup, nil
+}

--- a/cmd/kwok.go
+++ b/cmd/kwok.go
@@ -10,6 +10,18 @@ import (
 // It is written to a temp file and passed to `kwok --config` by --with-kwok.
 var KwokStages []byte
 
+// validateKwokFlags rejects flag combinations that would make --with-kwok fail
+// silently. KWOK only advances pods that are bound to a node, so the scheduling
+// shim must be on; --schedule-pods=false with --with-kwok would leave pods
+// unscheduled and the Pending→Running loop would never fire.
+func validateKwokFlags(withKwok, schedulePods bool) error {
+	if withKwok && !schedulePods {
+		return fmt.Errorf("--with-kwok requires the pod-scheduling shim; remove --schedule-pods=false " +
+			"(KWOK only runs pods that are bound to a node)")
+	}
+	return nil
+}
+
 // startKwok launches a detected `kwok` binary against the mock server's
 // kubeconfig, managing all nodes and using the bundled Stages. It returns a
 // cleanup func that stops kwok and removes the temp stages file. An error is

--- a/cmd/kwok_test.go
+++ b/cmd/kwok_test.go
@@ -22,3 +22,23 @@ func TestStartKwok_NotInstalled(t *testing.T) {
 		t.Errorf("error = %q, want an install hint mentioning PATH", err.Error())
 	}
 }
+
+// TestValidateKwokFlags: --with-kwok with the scheduling shim disabled is
+// rejected (it would leave pods unscheduled and never reach Running).
+func TestValidateKwokFlags(t *testing.T) {
+	cases := []struct {
+		withKwok, schedulePods, wantErr bool
+	}{
+		{false, true, false},  // no kwok, shim on
+		{false, false, false}, // no kwok, shim off — fine
+		{true, true, false},   // kwok + shim on — the supported combo
+		{true, false, true},   // kwok + shim off — contradictory, rejected
+	}
+	for _, c := range cases {
+		err := validateKwokFlags(c.withKwok, c.schedulePods)
+		if (err != nil) != c.wantErr {
+			t.Errorf("validateKwokFlags(withKwok=%v, schedulePods=%v) err=%v, wantErr=%v",
+				c.withKwok, c.schedulePods, err, c.wantErr)
+		}
+	}
+}

--- a/cmd/kwok_test.go
+++ b/cmd/kwok_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStartKwok_NotInstalled: with no kwok on PATH, startKwok fails with an
+// actionable install hint rather than launching anything.
+func TestStartKwok_NotInstalled(t *testing.T) {
+	t.Setenv("PATH", "") // ensure exec.LookPath("kwok") fails
+	KwokStages = []byte("dummy")
+
+	cleanup, err := startKwok("/tmp/does-not-matter.yaml")
+	if err == nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		t.Fatal("expected an error when kwok is not on PATH")
+	}
+	if !strings.Contains(err.Error(), "not found in PATH") {
+		t.Errorf("error = %q, want an install hint mentioning PATH", err.Error())
+	}
+}

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -66,6 +66,9 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	withKwok, _ := cmd.Flags().GetBool("with-kwok")
 	verbose, _ := cmd.Root().PersistentFlags().GetBool("verbose")
 
+	if err := validateKwokFlags(withKwok, schedulePods); err != nil {
+		return err
+	}
 	// --with-kwok drives pod/node lifecycle against the overlay, so it implies
 	// --writable (and needs the scheduling shim on to bind pods to nodes).
 	if withKwok {

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -49,6 +49,8 @@ func init() {
 	replayCmd.Flags().Bool("ui", false, "also start the web dashboard as a replay transport (VCR)")
 	replayCmd.Flags().String("ui-port", "0", "port for the dashboard when --ui is set (0 = random)")
 	replayCmd.Flags().Bool("writable", false, "accept client writes into an in-memory overlay (closed-loop controller dev)")
+	replayCmd.Flags().Bool("schedule-pods", true, "bind unscheduled pods to a node on create (the scheduler replay lacks); --writable only")
+	replayCmd.Flags().Bool("with-kwok", false, "also run a detected 'kwok' binary against the server to drive pod/node lifecycle (implies --writable)")
 }
 
 func runReplay(cmd *cobra.Command, args []string) error {
@@ -60,22 +62,44 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	loop, _ := cmd.Flags().GetBool("loop")
 	startPaused, _ := cmd.Flags().GetBool("start-paused")
 	writable, _ := cmd.Flags().GetBool("writable")
+	schedulePods, _ := cmd.Flags().GetBool("schedule-pods")
+	withKwok, _ := cmd.Flags().GetBool("with-kwok")
 	verbose, _ := cmd.Root().PersistentFlags().GetBool("verbose")
 
+	// --with-kwok drives pod/node lifecycle against the overlay, so it implies
+	// --writable (and needs the scheduling shim on to bind pods to nodes).
+	if withKwok {
+		writable = true
+	}
+
 	srv, err := server.Replay(server.ReplayOptions{
-		ArchivePath:   args[0],
-		Port:          port,
-		KubeconfigOut: kubeconfigOut,
-		Speed:         speed,
-		From:          from,
-		To:            to,
-		Loop:          loop,
-		StartPaused:   startPaused,
-		Writable:      writable,
-		Verbose:       verbose,
+		ArchivePath:       args[0],
+		Port:              port,
+		KubeconfigOut:     kubeconfigOut,
+		Speed:             speed,
+		From:              from,
+		To:                to,
+		Loop:              loop,
+		StartPaused:       startPaused,
+		Writable:          writable,
+		DisableScheduling: !schedulePods,
+		Verbose:           verbose,
 	})
 	if err != nil {
 		return fmt.Errorf("starting replay: %w", err)
+	}
+
+	// Optionally launch a detected kwok against the server to drive pod/node
+	// lifecycle. Started after the server is up (it needs the kubeconfig) and torn
+	// down on shutdown.
+	var kwokCleanup func()
+	if withKwok {
+		kwokCleanup, err = startKwok(srv.KubeconfigPath())
+		if err != nil {
+			srv.Shutdown()
+			return err
+		}
+		defer kwokCleanup()
 	}
 
 	clock := srv.Clock()
@@ -103,6 +127,9 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	}
 	if srv.Writable() {
 		fmt.Printf("  Writable:   on (client writes land in an in-memory overlay)\n")
+	}
+	if withKwok {
+		fmt.Printf("  KWOK:       on (driving pod/node lifecycle via bundled stages)\n")
 	}
 	fmt.Printf("  Control:    %s/_k8shark/replay\n", srv.Address())
 	if uiSrv != nil {

--- a/docs/kwok.md
+++ b/docs/kwok.md
@@ -20,12 +20,14 @@ KWOK's "Pod → Running" behavior only fires once a Pod is **bound to a node**
 (`spec.nodeName`) — assigning that is the scheduler's job, which replay has no
 equivalent of. So in writable replay `kshrk` binds an unscheduled Pod on create:
 
-- **On by default** under `--writable`. A Pod that never schedules is more
+- **On by default** under `--writable` (turn it off with `--schedule-pods=false`
+  if you're testing your own scheduler). A Pod that never schedules is more
   surprising than one that does.
 - Binds round-robin over the **known nodes** — those in the capture plus any
   created in the overlay.
 - If the capture has **no nodes**, it synthesizes one (`kwok-node-0`) annotated
-  `kwok.x-k8s.io/node: fake` so a stock `kwok` run manages it.
+  `kwok.x-k8s.io/node: fake` so a stock `kwok` run manages it. This happens at
+  startup, so `kubectl get nodes` shows it before any Pod exists.
 - A Pod that already sets `spec.nodeName` is left alone — the shim is a
   scheduler, not an override.
 
@@ -34,6 +36,21 @@ Beyond binding, the overlay stamps a freshly created Pod with
 what KWOK's `pod-ready` stage selects on. It does **not** drive the Pod to
 `Running` — that's KWOK's job, which is what makes the loop realistic rather than
 faked by `kshrk`.
+
+## Quickstart: `--with-kwok`
+
+If a [`kwok` binary](https://kwok.sigs.k8s.io/docs/user/install/) is on your
+`PATH`, `kshrk` can start and manage it for you — it implies `--writable`, runs
+`kwok --manage-all-nodes` with the bundled stages, and stops it on exit:
+
+```sh
+kshrk replay capture.kshrk --with-kwok
+export KUBECONFIG=/Users/you/.kube/k8shark-<id>.yaml   # path is printed
+kubectl run demo --image=nginx && kubectl get pod demo -w   # Pending → Running
+```
+
+That's the whole loop in one process. The manual walkthrough below is equivalent
+and useful when you want to run (or customize) `kwok` yourself.
 
 ## Walkthrough
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -406,6 +406,8 @@ The primary use case is **local development and testing of controllers/operators
 | `--ui` | false | Also start the web dashboard as a replay transport (VCR), sharing the clock |
 | `--ui-port` | random | Port for the dashboard when `--ui` is set |
 | `--writable` | false | Accept client writes into an in-memory overlay (closed-loop controller dev) |
+| `--schedule-pods` | true | Bind unscheduled pods to a node on create (the scheduler replay lacks); `--writable` only |
+| `--with-kwok` | false | Also run a detected `kwok` binary against the server to drive pod/node lifecycle (implies `--writable`) — see [KWOK](kwok.md) |
 | `--port` | random | Port for the mock API server |
 | `--kubeconfig-out` | `~/.kube/k8shark-<id>.yaml` | Where to write the generated kubeconfig |
 | `--verbose` / `-v` | false | Log every request the server receives |

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -427,7 +427,7 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 	// Writable replay: a single-object GET is served from the overlay when the
 	// overlay owns it (created/updated → the overlay copy; deleted → 404).
 	if h.overlay != nil {
-		h.overlay.syncEpoch(h.clock)
+		h.syncEpoch()
 		g, v, res, ns, name, sub := parseWritePath(strings.TrimSuffix(path, "/"))
 		// A single-object GET in a namespace deleted in the overlay is gone
 		// (cascade), even for captured objects.
@@ -633,7 +633,7 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 // and returns the highest overlay RV merged in (see applyToList) — the watch
 // burst uses it as its overlay-event skip floor. LIST callers ignore the RV.
 func (h *handler) mergeOverlayList(path string, body []byte) ([]byte, int64) {
-	h.overlay.syncEpoch(h.clock) // reset-on-loop before merging into a LIST
+	h.syncEpoch() // reset-on-loop before merging into a LIST
 	group, version, resource, namespace := parseAPIPath(strings.TrimSuffix(path, "/"))
 	if resource == "" {
 		return body, 0

--- a/internal/server/overlay.go
+++ b/internal/server/overlay.go
@@ -152,19 +152,22 @@ func itemNSName(raw json.RawMessage) string {
 }
 
 // syncEpoch clears the overlay when the clock's loop epoch has advanced since the
-// last call, implementing reset-on-loop. The RV counter stays monotonic so RVs
-// are never reused. Safe to call on every read/write.
-func (o *overlay) syncEpoch(clock *ReplayClock) {
+// last call, implementing reset-on-loop, and reports whether it reset. The RV
+// counter stays monotonic so RVs are never reused. Safe to call on every
+// read/write.
+func (o *overlay) syncEpoch(clock *ReplayClock) (didReset bool) {
 	if o == nil || clock == nil {
-		return
+		return false
 	}
 	_, epoch, _ := clock.Sample()
 	o.mu.Lock()
 	if epoch != o.epoch {
 		o.items = map[string]*overlayEntry{}
 		o.epoch = epoch
+		didReset = true
 	}
 	o.mu.Unlock()
+	return didReset
 }
 
 // reset clears all overlay entries (manual reset). The RV counter is preserved.

--- a/internal/server/replay_control.go
+++ b/internal/server/replay_control.go
@@ -75,6 +75,11 @@ func (h *handler) handleReplayControl(w http.ResponseWriter, r *http.Request, pa
 			return
 		}
 		h.overlay.reset()
+		if h.schedulePods {
+			// A manual reset drops the synthetic node too; re-synthesize it so a
+			// nodeless capture keeps a scheduling target after reset.
+			h.ensureSchedulableNode()
+		}
 	default:
 		h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("unknown replay control %q", action))
 		return

--- a/internal/server/schedule_test.go
+++ b/internal/server/schedule_test.go
@@ -202,6 +202,34 @@ func TestSchedule_EagerNodeSynthesis(t *testing.T) {
 	}
 }
 
+// TestSchedule_ReensuresNodeAfterLoopReset: a loop-wrap reset clears the overlay
+// (dropping the synthetic node); syncEpoch must re-synthesize it so a nodeless
+// capture keeps a scheduling target across loops.
+func TestSchedule_ReensuresNodeAfterLoopReset(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, advance := newTestClock(t, from, from.Add(5*time.Second), 1, true, false) // loop
+	h := newHandler(schedStore(t, from), time.Time{}, false)                         // no captured nodes
+	h.clock = clock
+	h.overlay = newOverlay()
+	h.schedulePods = true
+	h.syncEpoch()             // record the starting epoch (no reset on first call)
+	h.ensureSchedulableNode() // synthetic node present
+
+	// A user object, to confirm the loop reset actually cleared overlay state.
+	h.overlay.store("", "v1", "configmaps", "default", "cm",
+		json.RawMessage(`{"metadata":{"name":"cm","namespace":"default"}}`), h.overlay.nextRV(0))
+
+	advance(6 * time.Second) // cross the window end → loop wrap (epoch advances)
+	h.syncEpoch()            // resets the overlay, then re-synthesizes the node
+
+	if _, ok := h.overlay.get("", "v1", "nodes", "", defaultSyntheticNode); !ok {
+		t.Error("synthetic node was not re-ensured after the loop reset")
+	}
+	if _, ok := h.overlay.get("", "v1", "configmaps", "default", "cm"); ok {
+		t.Error("loop reset did not clear the user overlay object")
+	}
+}
+
 // TestSchedule_OffByDefault: without the shim enabled, a pod keeps an empty
 // nodeName (default read-only-ish overlay semantics).
 func TestSchedule_OffByDefault(t *testing.T) {

--- a/internal/server/schedule_test.go
+++ b/internal/server/schedule_test.go
@@ -175,6 +175,33 @@ func TestSchedule_CreatedPodIsPending(t *testing.T) {
 	}
 }
 
+// TestSchedule_EagerNodeSynthesis: ensureSchedulableNode synthesizes a node when
+// the capture has none, and is a no-op when it already has one.
+func TestSchedule_EagerNodeSynthesis(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+
+	// No captured nodes → synthesize.
+	h := newHandler(schedStore(t, from), time.Time{}, false)
+	h.clock = clock
+	h.overlay = newOverlay()
+	h.schedulePods = true
+	h.ensureSchedulableNode()
+	if _, ok := h.overlay.get("", "v1", "nodes", "", defaultSyntheticNode); !ok {
+		t.Error("eager synthesis did not create the synthetic node when the capture had none")
+	}
+
+	// Captured node present → no synthetic node.
+	h2 := newHandler(schedStore(t, from, "node-a"), time.Time{}, false)
+	h2.clock = clock
+	h2.overlay = newOverlay()
+	h2.schedulePods = true
+	h2.ensureSchedulableNode()
+	if _, ok := h2.overlay.get("", "v1", "nodes", "", defaultSyntheticNode); ok {
+		t.Error("synthesized a node despite the capture already having one")
+	}
+}
+
 // TestSchedule_OffByDefault: without the shim enabled, a pod keeps an empty
 // nodeName (default read-only-ish overlay semantics).
 func TestSchedule_OffByDefault(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -36,7 +36,11 @@ type ReplayOptions struct {
 	Loop          bool
 	StartPaused   bool
 	Writable      bool // accept client writes into an in-memory overlay
-	Verbose       bool
+	// DisableScheduling turns off the pod-scheduling shim (which otherwise binds
+	// an unscheduled Pod to a node on create). Zero value keeps the shim on under
+	// --writable; set it to opt out (--schedule-pods=false).
+	DisableScheduling bool
+	Verbose           bool
 }
 
 // Server represents a running mock API server.
@@ -68,7 +72,7 @@ func Open(opts OpenOptions) (*Server, error) {
 		_ = ar.Close()
 		return nil, err
 	}
-	return serve(ar, store, at, nil, false, opts.Port, opts.KubeconfigOut, opts.Verbose)
+	return serve(ar, store, at, nil, false, false, opts.Port, opts.KubeconfigOut, opts.Verbose)
 }
 
 // Replay opens a capture and starts the mock HTTPS server in replay mode: a
@@ -95,13 +99,13 @@ func Replay(opts ReplayOptions) (*Server, error) {
 		return nil, err
 	}
 	clock := NewReplayClock(from, to, speed, opts.Loop, opts.StartPaused)
-	return serve(ar, store, time.Time{}, clock, opts.Writable, opts.Port, opts.KubeconfigOut, opts.Verbose)
+	return serve(ar, store, time.Time{}, clock, opts.Writable, !opts.DisableScheduling, opts.Port, opts.KubeconfigOut, opts.Verbose)
 }
 
 // serve brings up the shared TLS listener, kubeconfig, and HTTP server. When
 // clock is non-nil the handler runs in replay mode; when writable is set (replay
 // only) client writes land in an in-memory overlay.
-func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *ReplayClock, writable bool, port, kubeconfigOut string, verbose bool) (*Server, error) {
+func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *ReplayClock, writable, schedulePods bool, port, kubeconfigOut string, verbose bool) (*Server, error) {
 	certPEM, keyPEM, err := generateSelfSignedCert()
 	if err != nil {
 		_ = ar.Close()
@@ -144,7 +148,12 @@ func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *Replay
 	h.clock = clock
 	if writable && clock != nil { // writable is a replay-only feature
 		h.overlay = newOverlay()
-		h.schedulePods = true // bind unscheduled pods to a node (KWOK integration, #160)
+		h.schedulePods = schedulePods // bind unscheduled pods to a node (KWOK integration, #160)
+		if h.schedulePods {
+			// Eager node synthesis: give KWOK (and `kubectl get nodes`) a node to
+			// manage before any Pod is created, when the capture has none.
+			h.ensureSchedulableNode()
+		}
 	}
 	httpSrv := &http.Server{Handler: h}
 	done := make(chan struct{})

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -220,7 +220,7 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 	// Apply reset-on-loop before consulting the overlay (below, for the resume
 	// upper bound), so a loop wrap resets it even under watch-only traffic.
 	if h.overlay != nil {
-		h.overlay.syncEpoch(clock)
+		h.syncEpoch()
 	}
 
 	// Validate resourceVersion first — a malformed/negative value returns 410

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -194,6 +194,15 @@ func (h *handler) synthesizeOverlayObject(resource, namespace, name, base string
 // contains none.
 const defaultSyntheticNode = "kwok-node-0"
 
+// ensureSchedulableNode synthesizes a node when the capture (as-of the clock) has
+// none, so a scheduling target — and a node for KWOK to manage — exists from
+// startup rather than only appearing when the first Pod is created.
+func (h *handler) ensureSchedulableNode() {
+	if len(h.knownNodeNames()) == 0 {
+		h.synthesizeNode(defaultSyntheticNode)
+	}
+}
+
 // schedulePod binds an unscheduled Pod to a node — the scheduler replay lacks —
 // picking round-robin over the known nodes (captured + overlay) and synthesizing
 // a KWOK-managed node if none exist. Returns the body with spec.nodeName set.

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -23,7 +23,7 @@ import (
 // (writable replay). It is only reached when h.overlay != nil; read-only replay
 // keeps returning 405 for writes.
 func (h *handler) handleWrite(w http.ResponseWriter, r *http.Request, path string) {
-	h.overlay.syncEpoch(h.clock) // reset-on-loop before touching state
+	h.syncEpoch() // reset-on-loop (re-synthesizes the scheduling node if needed)
 
 	group, version, resource, namespace, name, sub := parseWritePath(strings.TrimSuffix(path, "/"))
 	if resource == "" {
@@ -194,9 +194,24 @@ func (h *handler) synthesizeOverlayObject(resource, namespace, name, base string
 // contains none.
 const defaultSyntheticNode = "kwok-node-0"
 
+// syncEpoch applies the overlay's reset-on-loop and, when a reset occurred,
+// re-synthesizes the scheduling node if needed. The synthetic node lives in the
+// overlay, so a loop wrap would otherwise drop it — leaving a nodeless capture
+// with no node for KWOK to manage until the next write. Call this instead of
+// h.overlay.syncEpoch directly on read/write entry points.
+func (h *handler) syncEpoch() {
+	if h.overlay == nil {
+		return
+	}
+	if h.overlay.syncEpoch(h.clock) && h.schedulePods {
+		h.ensureSchedulableNode()
+	}
+}
+
 // ensureSchedulableNode synthesizes a node when the capture (as-of the clock) has
 // none, so a scheduling target — and a node for KWOK to manage — exists from
-// startup rather than only appearing when the first Pod is created.
+// startup rather than only appearing when the first Pod is created. Idempotent:
+// storeIfAbsent is a no-op when the node already exists.
 func (h *handler) ensureSchedulableNode() {
 	if len(h.knownNodeNames()) == 0 {
 		h.synthesizeNode(defaultSyntheticNode)

--- a/main.go
+++ b/main.go
@@ -1,7 +1,20 @@
 package main
 
-import "github.com/phenixblue/k8shark/cmd"
+import (
+	_ "embed"
+
+	"github.com/phenixblue/k8shark/cmd"
+)
+
+// kwokStages is the bundled KWOK "fast" Stages config, embedded so
+// `replay --writable --with-kwok` can run a detected kwok without a checkout.
+// It is the same file documented for the manual walkthrough. Embedded here (the
+// module root) because go:embed cannot reach a sibling directory from cmd/.
+//
+//go:embed examples/kwok-stages.yaml
+var kwokStages []byte
 
 func main() {
+	cmd.KwokStages = kwokStages
 	cmd.Execute()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestKwokStagesEmbedded verifies examples/kwok-stages.yaml embedded into the
+// binary (used by `replay --with-kwok`) — a build/embed regression guard.
+func TestKwokStagesEmbedded(t *testing.T) {
+	if len(kwokStages) == 0 {
+		t.Fatal("examples/kwok-stages.yaml did not embed")
+	}
+	if n := strings.Count(string(kwokStages), "kind: Stage"); n != 4 {
+		t.Errorf("embedded stages: found %d Stage docs, want 4", n)
+	}
+}


### PR DESCRIPTION
The three optional follow-ups tracked on #160 (now closed), bundled into one small PR.

## 1. `--with-kwok`
Implies `--writable`, then starts a detected `kwok` binary against the server (`--manage-all-nodes` + the bundled stages) and tears it down on exit — the whole closed loop in one process:

```sh
kshrk replay capture.kshrk --with-kwok
kubectl run demo --image=nginx && kubectl get pod demo -w   # Pending → Running
```

If `kwok` isn't on `PATH`, it fails with an actionable install hint. The stages come from `examples/kwok-stages.yaml`, **embedded** into the binary (via a `go:embed` in the module-root package, since `go:embed` can't reach a sibling dir from `cmd/`) and injected into `cmd` — single source of truth, works from an installed binary.

## 2. `--schedule-pods` (default true)
Opt out of the pod-scheduling shim (for users testing their own scheduler). Implemented as `ReplayOptions.DisableScheduling` whose **zero value keeps the shim on**, so `ui.go`'s writable mode is unchanged without touching it.

## 3. Eager node synthesis
`serve()` now synthesizes the fake node at **startup** when the capture has none (previously lazy, on first Pod create), so `kubectl get nodes` — and KWOK — sees it before any Pod exists.

## Tests
- `TestSchedule_EagerNodeSynthesis` — synthesizes when no captured nodes, no-op when one exists.
- `TestStartKwok_NotInstalled` — clear error + install hint when `kwok` is absent.
- `TestKwokStagesEmbedded` — embed regression guard (4 Stage docs).

Full `-race` suite + `vet` + `golangci-lint` clean; `go mod tidy` a no-op (no new deps). Docs updated (`docs/kwok.md` quickstart + `docs/usage.md` flag table).

## Follow-up (not here)
An e2e exercising the `--with-kwok` path end-to-end (the existing `e2e-kwok.sh` validates the same loop via a manually-run kwok; `--with-kwok` is thin glue over those unit-tested components).

Closes the optional items from #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)