### PR TITLE
feat(server): compute kubectl Table output for overlay & uncaptured objects

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -653,7 +653,7 @@ The mock server is designed to be a drop-in replacement for `kubectl`'s real ser
 | `kubectl get <resource> -A` | ✅ aggregates across captured namespaces |
 | `kubectl get <resource> <name>` | ✅ extracted from parent list |
 | `kubectl get -o yaml / -o json` | ✅ |
-| `kubectl get -o wide` | ✅ uses captured Table column definitions |
+| `kubectl get -o wide` | ✅ captured Table columns when present, otherwise computed to match a live cluster (see below) |
 | `kubectl describe` | ✅ |
 | `kubectl explain` | ✅ uses captured OpenAPI spec |
 | Short names (`po`, `svc`, `deploy`, `pvc`, `pv`, …) | ✅ |
@@ -664,6 +664,31 @@ The mock server is designed to be a drop-in replacement for `kubectl`'s real ser
 | `kubectl exec` / `kubectl cp` / `kubectl port-forward` / `kubectl attach` | ⛔ returns `405 Method Not Allowed` with a clear error referencing k8shark capture replay |
 | `kubectl logs` | ✅ if captured via `logs: N` in capture config; helpful stub returned when not captured |
 | `kubectl top` | ❌ metrics API not captured |
+
+### How `kubectl get` tables are rendered
+
+`kubectl get` and `-o wide` are driven by server-side **Table** responses
+(`columnDefinitions` + per-object `cells`). k8shark serves the captured Table
+verbatim when it fully covers a request — the most faithful output, using the
+real cluster's exact cells. When a request isn't covered by a captured Table —
+objects created in a writable overlay, or kinds and captures without a stored
+Table — k8shark **computes** a Table so the output still matches a live cluster,
+in this order:
+
+1. a **built-in printer** for core/native kinds (Node, Pod, Deployment,
+   ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob,
+   Service, Endpoints, Ingress, ConfigMap, Secret, PersistentVolumeClaim,
+   PersistentVolume, Namespace, ServiceAccount, Event) — columns mirror upstream
+   kubectl, including `-o wide` columns;
+2. a **CRD printer** built from the captured CRD's
+   `additionalPrinterColumns` (JSONPath), for custom resources;
+3. the **captured `columnDefinitions`** for the kind, with metadata-only cells;
+4. the generic **NAME / (NAMESPACE) / AGE** table.
+
+Reimplementing kubectl's printers is inherently partial: a curated core set is
+covered exactly, and a few computed cells are simplified (e.g. Pod `STATUS`
+approximates kubectl's phase/container-reason logic). Read-only replay of a
+captured object always uses the verbatim captured Table.
 
 ---
 

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -581,7 +581,7 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 
 	// If kubectl requests Table format, try the captured Table response first
 	// (real column defs + pre-computed cell values from the actual cluster).
-	// Fall back to buildTable only for captures predating this feature.
+	// Otherwise fall back to a computed Table (see renderResourceTable).
 	if strings.Contains(r.Header.Get("Accept"), "as=Table") {
 		// Exact-path stored Table (namespace-scoped list). Bypassed in writable
 		// mode so the Table reflects overlay writes (built from the merged body

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -444,6 +444,15 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 					h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q was deleted in the writable overlay", path))
 					return
 				}
+				// Honor Table format (kubectl get <name>) for overlay objects.
+				if strings.Contains(r.Header.Get("Accept"), "as=Table") {
+					if tb, rok := h.renderResourceTable(path, e.obj, at); rok {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write(tb)
+						return
+					}
+				}
 				writeJSON(w, http.StatusOK, json.RawMessage(e.obj))
 				return
 			}
@@ -599,9 +608,12 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 				return
 			}
 		}
-		// Last resort: synthesize a minimal Table from the list body (old captures).
-		// body is already selector-filtered above, so buildTable sees filtered items.
-		if tb, err2 := buildTable(body); err2 == nil {
+		// Compute a Table for objects not covered by a captured Table (writable
+		// overlay, or kinds/captures without a stored Table): built-in per-kind
+		// printers, else CRD additionalPrinterColumns, else captured
+		// columnDefinitions, else the generic buildTable. body is the merged,
+		// selector-filtered list (or a single object).
+		if tb, ok := h.renderResourceTable(path, body, at); ok {
 			body = tb
 		}
 	}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -619,8 +619,8 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		// Compute a Table for objects not covered by a captured Table (writable
 		// overlay, or kinds/captures without a stored Table): built-in per-kind
 		// printers, else CRD additionalPrinterColumns, else captured
-		// columnDefinitions, else the generic buildTable. body is the merged,
-		// selector-filtered list (or a single object).
+		// columnDefinitions, else a computed generic NAME/(NAMESPACE)/AGE table.
+		// body is the merged, selector-filtered list (or a single object).
 		if tb, ok := h.renderResourceTable(path, body, at); ok {
 			body = tb
 		}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -35,6 +35,14 @@ type handler struct {
 	// captures, whose timeline requires diffing every snapshot.
 	timelineMu    sync.Mutex
 	timelineCache map[string][]replayEvent
+
+	// crdColsCache memoizes CRD-derived Table columns per "group/version/resource".
+	// A CRD's additionalPrinterColumns are effectively static, so resolving them
+	// once avoids reconstructing+parsing the whole CRD list on every Table render
+	// (ReconstructAt caches by exact clock time, so an advancing replay clock would
+	// otherwise defeat that cache). Negative results are cached too. Trade-off: a
+	// CRD created/changed mid-replay isn't reflected — acceptable for a mock.
+	crdColsCache sync.Map // map["group/version/resource"] -> []tableCol (may be nil)
 }
 
 func newHandler(store *CaptureStore, at time.Time, verbose bool) *handler {
@@ -716,78 +724,6 @@ func extractTableRow(tableBody []byte, name string) ([]byte, error) {
 		}
 	}
 	return nil, fmt.Errorf("row %q not found in table", name)
-}
-
-// buildTable synthesizes a minimal meta.k8s.io/v1 Table from raw list or
-// single-object JSON. This is a last-resort fallback only reached for captures
-// made before Table responses were stored during capture. New captures always
-// serve the real Table response captured from the live cluster, so no
-// resource-specific logic is needed here.
-func buildTable(body []byte) ([]byte, error) {
-	var envelope struct {
-		Items []json.RawMessage `json:"items"`
-	}
-	_ = json.Unmarshal(body, &envelope)
-	rawItems := envelope.Items
-	if rawItems == nil {
-		rawItems = []json.RawMessage{body}
-	}
-
-	type colDef struct {
-		Name        string `json:"name"`
-		Type        string `json:"type"`
-		Format      string `json:"format,omitempty"`
-		Description string `json:"description"`
-	}
-
-	hasNS := false
-	type objMeta struct {
-		Metadata struct {
-			Name              string `json:"name"`
-			Namespace         string `json:"namespace"`
-			CreationTimestamp string `json:"creationTimestamp"`
-		} `json:"metadata"`
-	}
-	metas := make([]objMeta, len(rawItems))
-	for i, raw := range rawItems {
-		_ = json.Unmarshal(raw, &metas[i])
-		if metas[i].Metadata.Namespace != "" {
-			hasNS = true
-		}
-	}
-
-	cols := []colDef{{Name: "Name", Type: "string", Format: "name", Description: "Name"}}
-	if hasNS {
-		cols = append(cols, colDef{Name: "Namespace", Type: "string", Description: "Namespace"})
-	}
-	cols = append(cols, colDef{Name: "Age", Type: "date", Description: "CreationTimestamp"})
-
-	rows := make([]map[string]any, 0, len(metas))
-	for _, m := range metas {
-		cells := []any{m.Metadata.Name}
-		if hasNS {
-			cells = append(cells, m.Metadata.Namespace)
-		}
-		cells = append(cells, m.Metadata.CreationTimestamp)
-		rows = append(rows, map[string]any{
-			"cells": cells,
-			"object": map[string]any{
-				"kind": "PartialObjectMetadata", "apiVersion": "meta.k8s.io/v1",
-				"metadata": map[string]any{
-					"name": m.Metadata.Name, "namespace": m.Metadata.Namespace,
-					"creationTimestamp": m.Metadata.CreationTimestamp,
-				},
-			},
-		})
-	}
-
-	return json.Marshal(map[string]any{
-		"apiVersion":        "meta.k8s.io/v1",
-		"kind":              "Table",
-		"metadata":          map[string]string{"resourceVersion": "0"},
-		"columnDefinitions": cols,
-		"rows":              rows,
-	})
 }
 
 // trySingleItemGet handles GET .../resource/{name} by finding the parent list

--- a/internal/server/table.go
+++ b/internal/server/table.go
@@ -637,8 +637,8 @@ func eventObject(o map[string]any) any {
 // ── rendering ───────────────────────────────────────────────────────────────
 
 // renderTableFromColumns builds a meta.k8s.io/v1 Table from columns + decoded
-// objects (with their raw bytes for the row.object PartialObjectMetadata). now
-// (the replay clock) is used to compute relative AGE cells.
+// objects; each row's object is a PartialObjectMetadata built from the decoded
+// object's metadata. now (the replay clock) is used to compute relative AGE cells.
 func renderTableFromColumns(cols []tableCol, objs []map[string]any, now time.Time) []byte {
 	colDefs := make([]map[string]any, len(cols))
 	for i, c := range cols {

--- a/internal/server/table.go
+++ b/internal/server/table.go
@@ -430,6 +430,8 @@ func podStatus(o map[string]any) any {
 	return reason
 }
 
+// jobStatus mirrors kubectl's Job STATUS column: a Complete/Failed condition
+// wins, then a suspended job reads Suspended, otherwise Running.
 func jobStatus(o map[string]any) any {
 	for _, c := range marr(o, "status", "conditions") {
 		cm := asMap(c)
@@ -442,8 +444,8 @@ func jobStatus(o map[string]any) any {
 			}
 		}
 	}
-	if mint(o, "status", "active") > 0 || len(marr(o, "status", "active")) > 0 {
-		return "Running"
+	if b, _ := mget(o, "spec", "suspend").(bool); b {
+		return "Suspended"
 	}
 	return "Running"
 }
@@ -769,6 +771,9 @@ func (h *handler) capturedColumns(path string, at time.Time) []tableCol {
 			c.cell = func(o map[string]any) any { return mstr(o, "metadata", "namespace") }
 		case "age":
 			c.age = true
+			// age cells are emitted as a relative string ("5m", "2d"), so the
+			// declared type must be string even if the captured column said "date".
+			c.typ = "string"
 		default:
 			c.cell = func(map[string]any) any { return "" }
 		}

--- a/internal/server/table.go
+++ b/internal/server/table.go
@@ -394,7 +394,13 @@ func podReady(o map[string]any) any {
 			ready++
 		}
 	}
-	return fmt.Sprintf("%d/%d", ready, len(cs))
+	// Denominator is the spec container count (like kubectl), so a just-created
+	// Pending pod with no containerStatuses reads "0/1" rather than "0/0".
+	total := len(marr(o, "spec", "containers"))
+	if total == 0 {
+		total = len(cs)
+	}
+	return fmt.Sprintf("%d/%d", ready, total)
 }
 
 func podRestarts(o map[string]any) any {

--- a/internal/server/table.go
+++ b/internal/server/table.go
@@ -23,7 +23,7 @@ import (
 //	1. a built-in per-kind printer (core/native kinds), else
 //	2. a CRD printer from the captured CRD's additionalPrinterColumns (JSONPath), else
 //	3. the captured columnDefinitions for the kind + metadata-only cells, else
-//	4. the generic buildTable (NAME/(NAMESPACE)/AGE).
+//	4. a computed generic table (NAME/(NAMESPACE)/AGE).
 //
 // `-o wide` needs no special handling: every column carries a `priority`
 // (0 = default, 1 = wide) and kubectl hides priority>0 unless `-o wide`.
@@ -699,7 +699,7 @@ func genericColumns(objs []map[string]any) []tableCol {
 
 // renderResourceTable renders a Table for the given list/single-object JSON body
 // using (in order) a built-in printer, the captured CRD's additionalPrinterColumns,
-// captured columnDefinitions, or the generic buildTable. Returns ok=false when the
+// captured columnDefinitions, or a computed generic table. Returns ok=false when the
 // body isn't decodable (caller falls back).
 func (h *handler) renderResourceTable(path string, body []byte, at time.Time) ([]byte, bool) {
 	trimmed := strings.TrimSuffix(path, "/")

--- a/internal/server/table.go
+++ b/internal/server/table.go
@@ -448,9 +448,19 @@ func jobStatus(o map[string]any) any {
 	return "Running"
 }
 
+// podContainers returns the pod template's containers, handling both the direct
+// template (Deployment/RS/StatefulSet/DaemonSet/Job) and the nested jobTemplate
+// (CronJob).
+func podContainers(o map[string]any) []any {
+	if c := marr(o, "spec", "template", "spec", "containers"); len(c) > 0 {
+		return c
+	}
+	return marr(o, "spec", "jobTemplate", "spec", "template", "spec", "containers")
+}
+
 func containersCol(o map[string]any) any {
 	var names []string
-	for _, c := range marr(o, "spec", "template", "spec", "containers") {
+	for _, c := range podContainers(o) {
 		names = append(names, mstr(asMap(c), "name"))
 	}
 	return strings.Join(names, ",")
@@ -458,14 +468,19 @@ func containersCol(o map[string]any) any {
 
 func imagesCol(o map[string]any) any {
 	var imgs []string
-	for _, c := range marr(o, "spec", "template", "spec", "containers") {
+	for _, c := range podContainers(o) {
 		imgs = append(imgs, mstr(asMap(c), "image"))
 	}
 	return strings.Join(imgs, ",")
 }
 
+// selectorCol handles both apps/v1 label selectors (spec.selector.matchLabels)
+// and the plain map selector used by ReplicationController/Service (spec.selector).
 func selectorCol(o map[string]any) any {
-	return orNone(mapString(mget(o, "spec", "selector", "matchLabels")))
+	if s := mapString(mget(o, "spec", "selector", "matchLabels")); s != "" {
+		return s
+	}
+	return orNone(mapString(mget(o, "spec", "selector")))
 }
 
 // mapString formats a string map as "k=v,k2=v2" (sorted). Non-map / empty → "".
@@ -668,12 +683,14 @@ func renderTableFromColumns(cols []tableCol, objs []map[string]any, now time.Tim
 // body isn't decodable (caller falls back).
 func (h *handler) renderResourceTable(path string, body []byte, at time.Time) ([]byte, bool) {
 	trimmed := strings.TrimSuffix(path, "/")
+	listPath := trimmed
 	group, version, resource, _ := parseAPIPath(trimmed)
 	if resource == "" {
 		// parseAPIPath only resolves list paths; a single-object GET
 		// (.../<resource>/<name>) resolves after dropping the trailing name.
 		if i := strings.LastIndex(trimmed, "/"); i > 0 {
-			group, version, resource, _ = parseAPIPath(trimmed[:i])
+			listPath = trimmed[:i]
+			group, version, resource, _ = parseAPIPath(listPath)
 		}
 	}
 	if resource == "" {
@@ -685,8 +702,9 @@ func (h *handler) renderResourceTable(path string, body []byte, at time.Time) ([
 		Items []json.RawMessage `json:"items"`
 	}
 	_ = json.Unmarshal(body, &env)
+	singleObject := env.Items == nil
 	raws := env.Items
-	if raws == nil {
+	if singleObject {
 		raws = []json.RawMessage{json.RawMessage(body)}
 	}
 	objs := make([]map[string]any, 0, len(raws))
@@ -697,6 +715,11 @@ func (h *handler) renderResourceTable(path string, body []byte, at time.Time) ([
 		}
 		objs = append(objs, m)
 	}
+	// A single-object request whose body didn't decode isn't renderable — let the
+	// caller fall back rather than emit an empty (rows: []) Table.
+	if singleObject && len(objs) == 0 {
+		return nil, false
+	}
 
 	// 1. Built-in printer.
 	if cols, ok := builtinPrinters[printerKey(group, resource)]; ok {
@@ -706,8 +729,9 @@ func (h *handler) renderResourceTable(path string, body []byte, at time.Time) ([
 	if cols := h.crdPrinterColumns(group, version, resource, at); cols != nil {
 		return renderTableFromColumns(cols, objs, at), true
 	}
-	// 3. Captured columnDefinitions for the kind + metadata-only cells.
-	if cols := h.capturedColumns(path, at); cols != nil {
+	// 3. Captured columnDefinitions for the kind + metadata-only cells. Use the
+	// list path so a single-object GET reuses the list's stored columns.
+	if cols := h.capturedColumns(listPath, at); cols != nil {
 		return renderTableFromColumns(cols, objs, at), true
 	}
 	// 4. Generic.

--- a/internal/server/table.go
+++ b/internal/server/table.go
@@ -741,22 +741,32 @@ func (h *handler) renderResourceTable(path string, body []byte, at time.Time) ([
 		return nil, false
 	}
 
+	// Resolve the instant AGE is relative to. In replay/`--at` mode `at` is that
+	// instant. In plain `open` (at == zero, which the store reads as "latest"),
+	// fall back to the capture's end time so AGE reflects the captured cluster's
+	// clock rather than collapsing to "0s". (`at` is still used for the store
+	// lookups below, where zero correctly means "latest".)
+	now := at
+	if now.IsZero() && h.store != nil {
+		now = h.store.Metadata.CapturedUntil
+	}
+
 	// 1. Built-in printer.
 	if cols, ok := builtinPrinters[printerKey(group, resource)]; ok {
-		return renderTableFromColumns(cols, objs, at), true
+		return renderTableFromColumns(cols, objs, now), true
 	}
 	// 2. CRD additionalPrinterColumns (JSONPath).
 	if cols := h.crdPrinterColumns(group, version, resource, at); cols != nil {
-		return renderTableFromColumns(cols, objs, at), true
+		return renderTableFromColumns(cols, objs, now), true
 	}
 	// 3. Captured columnDefinitions for the kind + metadata-only cells. Use the
 	// list path so a single-object GET reuses the list's stored columns.
 	if cols := h.capturedColumns(listPath, at); cols != nil {
-		return renderTableFromColumns(cols, objs, at), true
+		return renderTableFromColumns(cols, objs, now), true
 	}
 	// 4. Generic NAME / (NAMESPACE) / AGE — computed like the other tiers so AGE
 	// is a relative string (not a raw timestamp) and stays consistent.
-	return renderTableFromColumns(genericColumns(objs), objs, at), true
+	return renderTableFromColumns(genericColumns(objs), objs, now), true
 }
 
 // capturedColumns reuses the columnDefinitions from a captured Table for the

--- a/internal/server/table.go
+++ b/internal/server/table.go
@@ -679,6 +679,24 @@ func renderTableFromColumns(cols []tableCol, objs []map[string]any, now time.Tim
 	return out
 }
 
+// genericColumns is the last-resort column set (NAME, NAMESPACE if any object is
+// namespaced, AGE) for kinds with no built-in/CRD/captured columns.
+func genericColumns(objs []map[string]any) []tableCol {
+	namespaced := false
+	for _, o := range objs {
+		if mstr(o, "metadata", "namespace") != "" {
+			namespaced = true
+			break
+		}
+	}
+	cols := []tableCol{nameColumn()}
+	if namespaced {
+		cols = append(cols, col("Namespace", "string", "Namespace",
+			func(o map[string]any) any { return mstr(o, "metadata", "namespace") }))
+	}
+	return append(cols, ageColumn())
+}
+
 // renderResourceTable renders a Table for the given list/single-object JSON body
 // using (in order) a built-in printer, the captured CRD's additionalPrinterColumns,
 // captured columnDefinitions, or the generic buildTable. Returns ok=false when the
@@ -736,11 +754,9 @@ func (h *handler) renderResourceTable(path string, body []byte, at time.Time) ([
 	if cols := h.capturedColumns(listPath, at); cols != nil {
 		return renderTableFromColumns(cols, objs, at), true
 	}
-	// 4. Generic.
-	if tb, err := buildTable(body); err == nil {
-		return tb, true
-	}
-	return nil, false
+	// 4. Generic NAME / (NAMESPACE) / AGE — computed like the other tiers so AGE
+	// is a relative string (not a raw timestamp) and stays consistent.
+	return renderTableFromColumns(genericColumns(objs), objs, at), true
 }
 
 // capturedColumns reuses the columnDefinitions from a captured Table for the
@@ -782,13 +798,27 @@ func (h *handler) capturedColumns(path string, at time.Time) []tableCol {
 	return cols
 }
 
-// crdPrinterColumns builds columns from the captured CRD's
-// spec.versions[version].additionalPrinterColumns (JSONPath cells). Returns nil
-// when the CRD isn't captured or has no additional columns.
+// crdPrinterColumns returns the CRD-derived columns for a kind, memoizing the
+// result (see handler.crdColsCache) so the CRD list isn't reconstructed+parsed
+// on every render.
 func (h *handler) crdPrinterColumns(group, version, resource string, at time.Time) []tableCol {
 	if group == "" {
 		return nil // core kinds are never CRDs
 	}
+	key := group + "/" + version + "/" + resource
+	if v, ok := h.crdColsCache.Load(key); ok {
+		cols, _ := v.([]tableCol)
+		return cols
+	}
+	cols := h.computeCRDPrinterColumns(group, version, resource, at)
+	h.crdColsCache.Store(key, cols)
+	return cols
+}
+
+// computeCRDPrinterColumns builds columns from the captured CRD's
+// spec.versions[version].additionalPrinterColumns (JSONPath cells). Returns nil
+// when the CRD isn't captured or has no additional columns.
+func (h *handler) computeCRDPrinterColumns(group, version, resource string, at time.Time) []tableCol {
 	crd := h.findCRD(group, resource, at)
 	if crd == nil {
 		return nil

--- a/internal/server/table.go
+++ b/internal/server/table.go
@@ -801,7 +801,10 @@ func (h *handler) capturedColumns(path string, at time.Time) []tableCol {
 			// declared type must be string even if the captured column said "date".
 			c.typ = "string"
 		default:
-			c.cell = func(map[string]any) any { return "" }
+			// We can't recompute arbitrary captured columns for a new object, so
+			// return JSON null rather than "" — null is valid for any declared
+			// column type (integer/date/etc.), an empty string is not.
+			c.cell = func(map[string]any) any { return nil }
 		}
 		cols = append(cols, c)
 	}

--- a/internal/server/table.go
+++ b/internal/server/table.go
@@ -1,0 +1,833 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/client-go/util/jsonpath"
+)
+
+// Table rendering
+// ---------------
+// kubectl's `get`/`-o wide` output is driven by server-side Table responses
+// (columnDefinitions + per-object cells). The mock serves the captured Table
+// verbatim when it fully covers a request (most faithful), but that can't cover
+// objects created in the writable overlay or kinds/objects absent from the
+// capture. renderResourceTable computes a Table for an arbitrary set of objects:
+//
+//	1. a built-in per-kind printer (core/native kinds), else
+//	2. a CRD printer from the captured CRD's additionalPrinterColumns (JSONPath), else
+//	3. the captured columnDefinitions for the kind + metadata-only cells, else
+//	4. the generic buildTable (NAME/(NAMESPACE)/AGE).
+//
+// `-o wide` needs no special handling: every column carries a `priority`
+// (0 = default, 1 = wide) and kubectl hides priority>0 unless `-o wide`.
+
+// tableCol is one column: its schema plus a cell computer over a decoded object.
+type tableCol struct {
+	name     string
+	typ      string // "string" | "integer" | "date"
+	priority int    // 0 = shown by default, 1 = wide-only
+	desc     string
+	cell     func(obj map[string]any) any
+	// age marks the CreationTimestamp column: its cell is the relative age
+	// ("5m49s", "2d") computed at render time against the replay clock, matching
+	// how a real apiserver renders the AGE column (a pre-computed string).
+	age bool
+}
+
+// ── decoded-object accessors ────────────────────────────────────────────────
+
+func mget(m map[string]any, path ...string) any {
+	var cur any = m
+	for _, k := range path {
+		mm, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+		cur = mm[k]
+	}
+	return cur
+}
+
+func mstr(m map[string]any, path ...string) string {
+	s, _ := mget(m, path...).(string)
+	return s
+}
+
+func mint(m map[string]any, path ...string) int64 {
+	switch n := mget(m, path...).(type) {
+	case float64:
+		return int64(n)
+	case int64:
+		return n
+	case json.Number:
+		i, _ := n.Int64()
+		return i
+	}
+	return 0
+}
+
+func marr(m map[string]any, path ...string) []any {
+	a, _ := mget(m, path...).([]any)
+	return a
+}
+
+func orNone(s string) any {
+	if s == "" {
+		return "<none>"
+	}
+	return s
+}
+
+// ── common cells ────────────────────────────────────────────────────────────
+
+func nameCell(o map[string]any) any { return mstr(o, "metadata", "name") }
+
+// nameColumn / ageColumn are the framing columns shared by every built-in
+// printer. AGE is a string column carrying the relative age (matching a real
+// apiserver), computed at render time — see the `age` field on tableCol.
+func nameColumn() tableCol {
+	return tableCol{name: "Name", typ: "string", desc: "Name", cell: nameCell}
+}
+func ageColumn() tableCol {
+	return tableCol{name: "Age", typ: "string", desc: "CreationTimestamp", age: true}
+}
+
+// humanAge renders a creationTimestamp as kubectl's relative age string,
+// relative to now (the replay clock). Zero/invalid inputs render "<unknown>".
+func humanAge(created string, now time.Time) any {
+	if created == "" {
+		return "<unknown>"
+	}
+	t, err := time.Parse(time.RFC3339, created)
+	if err != nil {
+		return "<unknown>"
+	}
+	if now.IsZero() {
+		now = t
+	}
+	return duration.HumanDuration(now.Sub(t))
+}
+
+func col(name, typ, desc string, cell func(map[string]any) any) tableCol {
+	return tableCol{name: name, typ: typ, desc: desc, cell: cell}
+}
+func wcol(name, typ, desc string, cell func(map[string]any) any) tableCol {
+	return tableCol{name: name, typ: typ, priority: 1, desc: desc, cell: cell}
+}
+
+// ── built-in printers, keyed by "group/resource" ────────────────────────────
+
+func printerKey(group, resource string) string { return group + "/" + resource }
+
+var builtinPrinters = map[string][]tableCol{}
+
+func registerPrinter(group, resource string, cols ...tableCol) {
+	// NAME is always the first column; callers supply the rest in upstream
+	// kubectl order, including ageColumn() at the right position (usually after
+	// the default columns and before wide columns — but e.g. nodes place it
+	// before VERSION).
+	full := make([]tableCol, 0, len(cols)+1)
+	full = append(full, nameColumn())
+	full = append(full, cols...)
+	builtinPrinters[printerKey(group, resource)] = full
+}
+
+func init() {
+	// Nodes
+	registerPrinter("", "nodes",
+		col("Status", "string", "Node status", nodeStatus),
+		col("Roles", "string", "Node roles", nodeRoles),
+		ageColumn(),
+		col("Version", "string", "Kubelet version", func(o map[string]any) any { return mstr(o, "status", "nodeInfo", "kubeletVersion") }),
+		wcol("Internal-IP", "string", "Internal IP", nodeAddr("InternalIP")),
+		wcol("External-IP", "string", "External IP", nodeAddr("ExternalIP")),
+		wcol("OS-Image", "string", "OS image", func(o map[string]any) any { return mstr(o, "status", "nodeInfo", "osImage") }),
+		wcol("Kernel-Version", "string", "Kernel version", func(o map[string]any) any { return mstr(o, "status", "nodeInfo", "kernelVersion") }),
+		wcol("Container-Runtime", "string", "Container runtime version", func(o map[string]any) any { return mstr(o, "status", "nodeInfo", "containerRuntimeVersion") }),
+	)
+	// Pods
+	registerPrinter("", "pods",
+		col("Ready", "string", "Ready containers", podReady),
+		col("Status", "string", "Pod status", podStatus),
+		col("Restarts", "integer", "Container restarts", podRestarts),
+		ageColumn(),
+		wcol("IP", "string", "Pod IP", func(o map[string]any) any { return orNone(mstr(o, "status", "podIP")) }),
+		wcol("Node", "string", "Node", func(o map[string]any) any { return orNone(mstr(o, "spec", "nodeName")) }),
+		wcol("Nominated Node", "string", "Nominated node", func(o map[string]any) any { return orNone(mstr(o, "status", "nominatedNodeName")) }),
+		wcol("Readiness Gates", "string", "Readiness gates", func(o map[string]any) any {
+			if n := len(marr(o, "spec", "readinessGates")); n > 0 {
+				return strconv.Itoa(n)
+			}
+			return "<none>"
+		}),
+	)
+	// Deployments / ReplicaSets / StatefulSets / DaemonSets / ReplicationControllers
+	registerPrinter("apps", "deployments",
+		col("Ready", "string", "Ready/desired replicas", func(o map[string]any) any {
+			return fmt.Sprintf("%d/%d", mint(o, "status", "readyReplicas"), mint(o, "spec", "replicas"))
+		}),
+		col("Up-To-Date", "integer", "Updated replicas", func(o map[string]any) any { return mint(o, "status", "updatedReplicas") }),
+		col("Available", "integer", "Available replicas", func(o map[string]any) any { return mint(o, "status", "availableReplicas") }),
+		ageColumn(),
+		wcol("Containers", "string", "Container names", containersCol),
+		wcol("Images", "string", "Container images", imagesCol),
+		wcol("Selector", "string", "Selector", selectorCol),
+	)
+	replicaCols := []tableCol{
+		col("Desired", "integer", "Desired replicas", func(o map[string]any) any { return mint(o, "spec", "replicas") }),
+		col("Current", "integer", "Current replicas", func(o map[string]any) any { return mint(o, "status", "replicas") }),
+		col("Ready", "integer", "Ready replicas", func(o map[string]any) any { return mint(o, "status", "readyReplicas") }),
+		ageColumn(),
+		wcol("Containers", "string", "Container names", containersCol),
+		wcol("Images", "string", "Container images", imagesCol),
+		wcol("Selector", "string", "Selector", selectorCol),
+	}
+	registerPrinter("apps", "replicasets", replicaCols...)
+	registerPrinter("", "replicationcontrollers", replicaCols...)
+	registerPrinter("apps", "statefulsets",
+		col("Ready", "string", "Ready/desired replicas", func(o map[string]any) any {
+			return fmt.Sprintf("%d/%d", mint(o, "status", "readyReplicas"), mint(o, "spec", "replicas"))
+		}),
+		ageColumn(),
+		wcol("Containers", "string", "Container names", containersCol),
+		wcol("Images", "string", "Container images", imagesCol),
+	)
+	registerPrinter("apps", "daemonsets",
+		col("Desired", "integer", "Desired", func(o map[string]any) any { return mint(o, "status", "desiredNumberScheduled") }),
+		col("Current", "integer", "Current", func(o map[string]any) any { return mint(o, "status", "currentNumberScheduled") }),
+		col("Ready", "integer", "Ready", func(o map[string]any) any { return mint(o, "status", "numberReady") }),
+		col("Up-To-Date", "integer", "Updated", func(o map[string]any) any { return mint(o, "status", "updatedNumberScheduled") }),
+		col("Available", "integer", "Available", func(o map[string]any) any { return mint(o, "status", "numberAvailable") }),
+		col("Node Selector", "string", "Node selector", func(o map[string]any) any {
+			return orNone(mapString(mget(o, "spec", "template", "spec", "nodeSelector")))
+		}),
+		ageColumn(),
+		wcol("Containers", "string", "Container names", containersCol),
+		wcol("Images", "string", "Container images", imagesCol),
+		wcol("Selector", "string", "Selector", selectorCol),
+	)
+	// Jobs / CronJobs
+	registerPrinter("batch", "jobs",
+		col("Status", "string", "Job status", jobStatus),
+		col("Completions", "string", "Completions", func(o map[string]any) any {
+			comp := mget(o, "spec", "completions")
+			c := "1"
+			if comp != nil {
+				c = strconv.FormatInt(mint(o, "spec", "completions"), 10)
+			}
+			return fmt.Sprintf("%d/%s", mint(o, "status", "succeeded"), c)
+		}),
+		ageColumn(),
+		wcol("Containers", "string", "Container names", containersCol),
+		wcol("Images", "string", "Container images", imagesCol),
+		wcol("Selector", "string", "Selector", selectorCol),
+	)
+	registerPrinter("batch", "cronjobs",
+		col("Schedule", "string", "Schedule", func(o map[string]any) any { return mstr(o, "spec", "schedule") }),
+		col("Suspend", "string", "Suspend", func(o map[string]any) any {
+			if b, _ := mget(o, "spec", "suspend").(bool); b {
+				return "True"
+			}
+			return "False"
+		}),
+		col("Active", "integer", "Active jobs", func(o map[string]any) any { return int64(len(marr(o, "status", "active"))) }),
+		col("Last Schedule", "date", "Last schedule time", func(o map[string]any) any { return orNone(mstr(o, "status", "lastScheduleTime")) }),
+		ageColumn(),
+		wcol("Containers", "string", "Container names", containersCol),
+		wcol("Images", "string", "Container images", imagesCol),
+	)
+	// Services / Endpoints / Ingress
+	registerPrinter("", "services",
+		col("Type", "string", "Service type", func(o map[string]any) any { return orNone(mstr(o, "spec", "type")) }),
+		col("Cluster-IP", "string", "Cluster IP", func(o map[string]any) any { return orNone(mstr(o, "spec", "clusterIP")) }),
+		col("External-IP", "string", "External IP", serviceExternalIP),
+		col("Port(s)", "string", "Ports", servicePorts),
+		ageColumn(),
+		wcol("Selector", "string", "Selector", func(o map[string]any) any { return orNone(mapString(mget(o, "spec", "selector"))) }),
+	)
+	registerPrinter("", "endpoints",
+		col("Endpoints", "string", "Endpoints", endpointsCol),
+		ageColumn(),
+	)
+	registerPrinter("networking.k8s.io", "ingresses",
+		col("Class", "string", "Ingress class", func(o map[string]any) any { return orNone(mstr(o, "spec", "ingressClassName")) }),
+		col("Hosts", "string", "Hosts", ingressHosts),
+		col("Address", "string", "Address", ingressAddress),
+		col("Ports", "string", "Ports", func(o map[string]any) any {
+			if len(marr(o, "spec", "tls")) > 0 {
+				return "80, 443"
+			}
+			return "80"
+		}),
+		ageColumn(),
+	)
+	// Config / storage / identity
+	registerPrinter("", "configmaps",
+		col("Data", "integer", "Data entries", func(o map[string]any) any {
+			return int64(len(asMap(mget(o, "data"))) + len(asMap(mget(o, "binaryData"))))
+		}),
+		ageColumn(),
+	)
+	registerPrinter("", "secrets",
+		col("Type", "string", "Secret type", func(o map[string]any) any { return mstr(o, "type") }),
+		col("Data", "integer", "Data entries", func(o map[string]any) any { return int64(len(asMap(mget(o, "data")))) }),
+		ageColumn(),
+	)
+	registerPrinter("", "persistentvolumeclaims",
+		col("Status", "string", "Phase", func(o map[string]any) any { return mstr(o, "status", "phase") }),
+		col("Volume", "string", "Bound volume", func(o map[string]any) any { return mstr(o, "spec", "volumeName") }),
+		col("Capacity", "string", "Capacity", func(o map[string]any) any { return mstr(o, "status", "capacity", "storage") }),
+		col("Access Modes", "string", "Access modes", accessModesCol),
+		col("Storageclass", "string", "Storage class", func(o map[string]any) any { return mstr(o, "spec", "storageClassName") }),
+		ageColumn(),
+	)
+	registerPrinter("", "persistentvolumes",
+		col("Capacity", "string", "Capacity", func(o map[string]any) any { return mstr(o, "spec", "capacity", "storage") }),
+		col("Access Modes", "string", "Access modes", accessModesCol),
+		col("Reclaim Policy", "string", "Reclaim policy", func(o map[string]any) any { return mstr(o, "spec", "persistentVolumeReclaimPolicy") }),
+		col("Status", "string", "Phase", func(o map[string]any) any { return mstr(o, "status", "phase") }),
+		col("Claim", "string", "Bound claim", func(o map[string]any) any {
+			ns, n := mstr(o, "spec", "claimRef", "namespace"), mstr(o, "spec", "claimRef", "name")
+			if n == "" {
+				return ""
+			}
+			if ns != "" {
+				return ns + "/" + n
+			}
+			return n
+		}),
+		col("Storageclass", "string", "Storage class", func(o map[string]any) any { return mstr(o, "spec", "storageClassName") }),
+		ageColumn(),
+	)
+	registerPrinter("", "namespaces",
+		col("Status", "string", "Phase", func(o map[string]any) any { return mstr(o, "status", "phase") }),
+		ageColumn(),
+	)
+	registerPrinter("", "serviceaccounts",
+		col("Secrets", "integer", "Secrets", func(o map[string]any) any { return int64(len(marr(o, "secrets"))) }),
+		ageColumn(),
+	)
+	// Events (both core and events.k8s.io)
+	eventCols := []tableCol{
+		col("Type", "string", "Event type", func(o map[string]any) any { return mstr(o, "type") }),
+		col("Reason", "string", "Reason", func(o map[string]any) any { return firstNonEmpty(mstr(o, "reason")) }),
+		col("Object", "string", "Involved object", eventObject),
+		col("Message", "string", "Message", func(o map[string]any) any { return firstNonEmpty(mstr(o, "message"), mstr(o, "note")) }),
+		ageColumn(),
+	}
+	registerPrinter("", "events", eventCols...)
+	registerPrinter("events.k8s.io", "events", eventCols...)
+}
+
+// ── cell helpers ────────────────────────────────────────────────────────────
+
+func asMap(v any) map[string]any { m, _ := v.(map[string]any); return m }
+
+func firstNonEmpty(ss ...string) string {
+	for _, s := range ss {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func nodeStatus(o map[string]any) any {
+	status := "Unknown"
+	for _, c := range marr(o, "status", "conditions") {
+		cm := asMap(c)
+		if mstr(cm, "type") == "Ready" {
+			if mstr(cm, "status") == "True" {
+				status = "Ready"
+			} else {
+				status = "NotReady"
+			}
+		}
+	}
+	if b, _ := mget(o, "spec", "unschedulable").(bool); b {
+		status += ",SchedulingDisabled"
+	}
+	return status
+}
+
+func nodeRoles(o map[string]any) any {
+	var roles []string
+	for k := range asMap(mget(o, "metadata", "labels")) {
+		if r := strings.TrimPrefix(k, "node-role.kubernetes.io/"); r != k {
+			if r == "" {
+				continue
+			}
+			roles = append(roles, r)
+		}
+	}
+	sort.Strings(roles)
+	if len(roles) == 0 {
+		return "<none>"
+	}
+	return strings.Join(roles, ",")
+}
+
+func nodeAddr(typ string) func(map[string]any) any {
+	return func(o map[string]any) any {
+		for _, a := range marr(o, "status", "addresses") {
+			am := asMap(a)
+			if mstr(am, "type") == typ {
+				return mstr(am, "address")
+			}
+		}
+		return "<none>"
+	}
+}
+
+func podReady(o map[string]any) any {
+	cs := marr(o, "status", "containerStatuses")
+	ready := 0
+	for _, c := range cs {
+		if b, _ := asMap(c)["ready"].(bool); b {
+			ready++
+		}
+	}
+	return fmt.Sprintf("%d/%d", ready, len(cs))
+}
+
+func podRestarts(o map[string]any) any {
+	var n int64
+	for _, c := range marr(o, "status", "containerStatuses") {
+		n += mint(asMap(c), "restartCount")
+	}
+	return n
+}
+
+// podStatus approximates kubectl's computed pod status: a container waiting/
+// terminated reason wins over phase; a deletionTimestamp shows Terminating.
+// (Full kubectl logic — init containers, signals — is simplified.)
+func podStatus(o map[string]any) any {
+	if mstr(o, "metadata", "deletionTimestamp") != "" {
+		return "Terminating"
+	}
+	reason := mstr(o, "status", "phase")
+	if r := mstr(o, "status", "reason"); r != "" {
+		reason = r
+	}
+	for _, c := range marr(o, "status", "containerStatuses") {
+		st := asMap(asMap(c)["state"])
+		if w := asMap(st["waiting"]); w != nil && mstr(w, "reason") != "" {
+			reason = mstr(w, "reason")
+			break
+		}
+		if t := asMap(st["terminated"]); t != nil && mstr(t, "reason") != "" {
+			reason = mstr(t, "reason")
+			break
+		}
+	}
+	return reason
+}
+
+func jobStatus(o map[string]any) any {
+	for _, c := range marr(o, "status", "conditions") {
+		cm := asMap(c)
+		if mstr(cm, "status") == "True" {
+			switch mstr(cm, "type") {
+			case "Complete":
+				return "Complete"
+			case "Failed":
+				return "Failed"
+			}
+		}
+	}
+	if mint(o, "status", "active") > 0 || len(marr(o, "status", "active")) > 0 {
+		return "Running"
+	}
+	return "Running"
+}
+
+func containersCol(o map[string]any) any {
+	var names []string
+	for _, c := range marr(o, "spec", "template", "spec", "containers") {
+		names = append(names, mstr(asMap(c), "name"))
+	}
+	return strings.Join(names, ",")
+}
+
+func imagesCol(o map[string]any) any {
+	var imgs []string
+	for _, c := range marr(o, "spec", "template", "spec", "containers") {
+		imgs = append(imgs, mstr(asMap(c), "image"))
+	}
+	return strings.Join(imgs, ",")
+}
+
+func selectorCol(o map[string]any) any {
+	return orNone(mapString(mget(o, "spec", "selector", "matchLabels")))
+}
+
+// mapString formats a string map as "k=v,k2=v2" (sorted). Non-map / empty → "".
+func mapString(v any) string {
+	m := asMap(v)
+	if len(m) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if s, ok := m[k].(string); ok {
+			parts = append(parts, k+"="+s)
+		}
+	}
+	return strings.Join(parts, ",")
+}
+
+func serviceExternalIP(o map[string]any) any {
+	switch mstr(o, "spec", "type") {
+	case "LoadBalancer":
+		var ips []string
+		for _, ing := range marr(o, "status", "loadBalancer", "ingress") {
+			im := asMap(ing)
+			if ip := mstr(im, "ip"); ip != "" {
+				ips = append(ips, ip)
+			} else if h := mstr(im, "hostname"); h != "" {
+				ips = append(ips, h)
+			}
+		}
+		if len(ips) > 0 {
+			return strings.Join(ips, ",")
+		}
+		return "<pending>"
+	case "ExternalName":
+		return orNone(mstr(o, "spec", "externalName"))
+	}
+	var ext []string
+	for _, ip := range marr(o, "spec", "externalIPs") {
+		if s, ok := ip.(string); ok {
+			ext = append(ext, s)
+		}
+	}
+	if len(ext) > 0 {
+		return strings.Join(ext, ",")
+	}
+	return "<none>"
+}
+
+func servicePorts(o map[string]any) any {
+	var parts []string
+	for _, p := range marr(o, "spec", "ports") {
+		pm := asMap(p)
+		port := mint(pm, "port")
+		proto := mstr(pm, "protocol")
+		if proto == "" {
+			proto = "TCP"
+		}
+		if np := mint(pm, "nodePort"); np != 0 {
+			parts = append(parts, fmt.Sprintf("%d:%d/%s", port, np, proto))
+		} else {
+			parts = append(parts, fmt.Sprintf("%d/%s", port, proto))
+		}
+	}
+	if len(parts) == 0 {
+		return "<none>"
+	}
+	return strings.Join(parts, ",")
+}
+
+func accessModesCol(o map[string]any) any {
+	short := map[string]string{"ReadWriteOnce": "RWO", "ReadOnlyMany": "ROX", "ReadWriteMany": "RWX", "ReadWriteOncePod": "RWOP"}
+	var modes []string
+	src := marr(o, "spec", "accessModes")
+	if len(src) == 0 {
+		src = marr(o, "status", "accessModes")
+	}
+	for _, m := range src {
+		s, _ := m.(string)
+		if sh, ok := short[s]; ok {
+			modes = append(modes, sh)
+		} else if s != "" {
+			modes = append(modes, s)
+		}
+	}
+	return strings.Join(modes, ",")
+}
+
+func endpointsCol(o map[string]any) any {
+	var eps []string
+	for _, s := range marr(o, "subsets") {
+		sm := asMap(s)
+		for _, a := range marr(sm, "addresses") {
+			ip := mstr(asMap(a), "ip")
+			for _, p := range marr(sm, "ports") {
+				eps = append(eps, fmt.Sprintf("%s:%d", ip, mint(asMap(p), "port")))
+				if len(eps) >= 3 {
+					return strings.Join(eps, ",") + " + more..."
+				}
+			}
+		}
+	}
+	if len(eps) == 0 {
+		return "<none>"
+	}
+	return strings.Join(eps, ",")
+}
+
+func ingressHosts(o map[string]any) any {
+	var hosts []string
+	for _, r := range marr(o, "spec", "rules") {
+		if h := mstr(asMap(r), "host"); h != "" {
+			hosts = append(hosts, h)
+		}
+	}
+	if len(hosts) == 0 {
+		return "*"
+	}
+	return strings.Join(hosts, ",")
+}
+
+func ingressAddress(o map[string]any) any {
+	var addrs []string
+	for _, ing := range marr(o, "status", "loadBalancer", "ingress") {
+		im := asMap(ing)
+		if ip := mstr(im, "ip"); ip != "" {
+			addrs = append(addrs, ip)
+		} else if h := mstr(im, "hostname"); h != "" {
+			addrs = append(addrs, h)
+		}
+	}
+	return strings.Join(addrs, ",")
+}
+
+func eventObject(o map[string]any) any {
+	// core Event uses involvedObject; events.k8s.io uses regarding.
+	io := asMap(mget(o, "involvedObject"))
+	if io == nil {
+		io = asMap(mget(o, "regarding"))
+	}
+	kind, name := mstr(io, "kind"), mstr(io, "name")
+	if kind == "" && name == "" {
+		return ""
+	}
+	return strings.ToLower(kind) + "/" + name
+}
+
+// ── rendering ───────────────────────────────────────────────────────────────
+
+// renderTableFromColumns builds a meta.k8s.io/v1 Table from columns + decoded
+// objects (with their raw bytes for the row.object PartialObjectMetadata). now
+// (the replay clock) is used to compute relative AGE cells.
+func renderTableFromColumns(cols []tableCol, objs []map[string]any, now time.Time) []byte {
+	colDefs := make([]map[string]any, len(cols))
+	for i, c := range cols {
+		cd := map[string]any{"name": c.name, "type": c.typ, "description": c.desc}
+		if c.name == "Name" {
+			cd["format"] = "name"
+		}
+		if c.priority != 0 {
+			cd["priority"] = c.priority
+		}
+		colDefs[i] = cd
+	}
+	rows := make([]map[string]any, 0, len(objs))
+	for _, o := range objs {
+		cells := make([]any, len(cols))
+		for i, c := range cols {
+			switch {
+			case c.age:
+				cells[i] = humanAge(mstr(o, "metadata", "creationTimestamp"), now)
+			case c.cell != nil:
+				cells[i] = c.cell(o)
+			}
+		}
+		rows = append(rows, map[string]any{
+			"cells": cells,
+			"object": map[string]any{
+				"kind": "PartialObjectMetadata", "apiVersion": "meta.k8s.io/v1",
+				"metadata": mget(o, "metadata"),
+			},
+		})
+	}
+	out, _ := json.Marshal(map[string]any{
+		"kind": "Table", "apiVersion": "meta.k8s.io/v1",
+		"metadata":          map[string]any{"resourceVersion": "0"},
+		"columnDefinitions": colDefs,
+		"rows":              rows,
+	})
+	return out
+}
+
+// renderResourceTable renders a Table for the given list/single-object JSON body
+// using (in order) a built-in printer, the captured CRD's additionalPrinterColumns,
+// captured columnDefinitions, or the generic buildTable. Returns ok=false when the
+// body isn't decodable (caller falls back).
+func (h *handler) renderResourceTable(path string, body []byte, at time.Time) ([]byte, bool) {
+	trimmed := strings.TrimSuffix(path, "/")
+	group, version, resource, _ := parseAPIPath(trimmed)
+	if resource == "" {
+		// parseAPIPath only resolves list paths; a single-object GET
+		// (.../<resource>/<name>) resolves after dropping the trailing name.
+		if i := strings.LastIndex(trimmed, "/"); i > 0 {
+			group, version, resource, _ = parseAPIPath(trimmed[:i])
+		}
+	}
+	if resource == "" {
+		return nil, false
+	}
+
+	// Decode items (list) or a single object.
+	var env struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	_ = json.Unmarshal(body, &env)
+	raws := env.Items
+	if raws == nil {
+		raws = []json.RawMessage{json.RawMessage(body)}
+	}
+	objs := make([]map[string]any, 0, len(raws))
+	for _, r := range raws {
+		var m map[string]any
+		if err := json.Unmarshal(r, &m); err != nil || m == nil {
+			continue
+		}
+		objs = append(objs, m)
+	}
+
+	// 1. Built-in printer.
+	if cols, ok := builtinPrinters[printerKey(group, resource)]; ok {
+		return renderTableFromColumns(cols, objs, at), true
+	}
+	// 2. CRD additionalPrinterColumns (JSONPath).
+	if cols := h.crdPrinterColumns(group, version, resource, at); cols != nil {
+		return renderTableFromColumns(cols, objs, at), true
+	}
+	// 3. Captured columnDefinitions for the kind + metadata-only cells.
+	if cols := h.capturedColumns(path, at); cols != nil {
+		return renderTableFromColumns(cols, objs, at), true
+	}
+	// 4. Generic.
+	if tb, err := buildTable(body); err == nil {
+		return tb, true
+	}
+	return nil, false
+}
+
+// capturedColumns reuses the columnDefinitions from a captured Table for the
+// kind, filling only metadata cells (Name/Namespace/Age) — blanks otherwise.
+func (h *handler) capturedColumns(path string, at time.Time) []tableCol {
+	tb, code, _ := h.store.Latest(strings.TrimSuffix(path, "/")+tableIndexKeySuffix, at)
+	if code != 200 {
+		return nil
+	}
+	var t struct {
+		ColumnDefinitions []struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			Priority int    `json:"priority"`
+			Desc     string `json:"description"`
+		} `json:"columnDefinitions"`
+	}
+	if err := json.Unmarshal(tb, &t); err != nil || len(t.ColumnDefinitions) == 0 {
+		return nil
+	}
+	cols := make([]tableCol, 0, len(t.ColumnDefinitions))
+	for _, cd := range t.ColumnDefinitions {
+		c := tableCol{name: cd.Name, typ: cd.Type, priority: cd.Priority, desc: cd.Desc}
+		switch strings.ToLower(cd.Name) {
+		case "name":
+			c.cell = nameCell
+		case "namespace":
+			c.cell = func(o map[string]any) any { return mstr(o, "metadata", "namespace") }
+		case "age":
+			c.age = true
+		default:
+			c.cell = func(map[string]any) any { return "" }
+		}
+		cols = append(cols, c)
+	}
+	return cols
+}
+
+// crdPrinterColumns builds columns from the captured CRD's
+// spec.versions[version].additionalPrinterColumns (JSONPath cells). Returns nil
+// when the CRD isn't captured or has no additional columns.
+func (h *handler) crdPrinterColumns(group, version, resource string, at time.Time) []tableCol {
+	if group == "" {
+		return nil // core kinds are never CRDs
+	}
+	crd := h.findCRD(group, resource, at)
+	if crd == nil {
+		return nil
+	}
+	var extra []any
+	for _, v := range marr(crd, "spec", "versions") {
+		vm := asMap(v)
+		if mstr(vm, "name") == version {
+			extra = marr(vm, "additionalPrinterColumns")
+			break
+		}
+	}
+	if len(extra) == 0 {
+		return nil
+	}
+	cols := []tableCol{nameColumn()}
+	for _, c := range extra {
+		cm := asMap(c)
+		jp := mstr(cm, "jsonPath")
+		prio := int(mint(cm, "priority"))
+		cols = append(cols, tableCol{
+			name: mstr(cm, "name"), typ: mstr(cm, "type"), priority: prio, desc: mstr(cm, "description"),
+			cell: jsonPathCell(jp),
+		})
+	}
+	cols = append(cols, ageColumn())
+	return cols
+}
+
+// findCRD locates the captured CustomResourceDefinition for a group+resource.
+func (h *handler) findCRD(group, resource string, at time.Time) map[string]any {
+	body, code, err := h.store.ReconstructAt("/apis/apiextensions.k8s.io/v1/customresourcedefinitions", at)
+	if err != nil || code != 200 {
+		return nil
+	}
+	var list struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if json.Unmarshal(body, &list) != nil {
+		return nil
+	}
+	for _, raw := range list.Items {
+		var m map[string]any
+		if json.Unmarshal(raw, &m) != nil {
+			continue
+		}
+		if mstr(m, "spec", "group") == group && mstr(m, "spec", "names", "plural") == resource {
+			return m
+		}
+	}
+	return nil
+}
+
+// jsonPathCell compiles a CRD additionalPrinterColumns JSONPath into a cell func.
+func jsonPathCell(expr string) func(map[string]any) any {
+	if expr == "" {
+		return func(map[string]any) any { return "" }
+	}
+	jp := jsonpath.New("col").AllowMissingKeys(true)
+	// k8s CRD JSONPath is a bare path like ".spec.replicas"; jsonpath wants {…}.
+	if err := jp.Parse("{" + expr + "}"); err != nil {
+		return func(map[string]any) any { return "" }
+	}
+	return func(o map[string]any) any {
+		var sb strings.Builder
+		if err := jp.Execute(&sb, o); err != nil {
+			return ""
+		}
+		return sb.String()
+	}
+}

--- a/internal/server/table_test.go
+++ b/internal/server/table_test.go
@@ -190,6 +190,14 @@ func TestPodPrinter(t *testing.T) {
 	}
 }
 
+func TestPodReady_PendingUsesSpecContainers(t *testing.T) {
+	// A Pending pod with no containerStatuses: denominator comes from spec.containers.
+	body := `{"metadata":{"name":"p"},"spec":{"containers":[{"name":"a"},{"name":"b"}]},
+      "status":{"phase":"Pending"}}`
+	vals, _ := renderOne(t, "/api/v1/namespaces/default/pods", body)
+	wantCell(t, vals, "Ready", "0/2")
+}
+
 func TestPodStatus_WaitingReasonWins(t *testing.T) {
 	body := `{"metadata":{"name":"p"},"status":{"phase":"Running",
       "containerStatuses":[{"ready":false,"state":{"waiting":{"reason":"CrashLoopBackOff"}}}]}}`

--- a/internal/server/table_test.go
+++ b/internal/server/table_test.go
@@ -415,6 +415,40 @@ func TestCapturedColumns_AgeTypeIsString(t *testing.T) {
 	}
 }
 
+// TestGenericFallback_RelativeAge verifies the last-resort generic table (no
+// built-in/CRD/captured columns) still emits AGE as a relative string of type
+// string, consistent with the computed tiers — not a raw timestamp.
+func TestGenericFallback_RelativeAge(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	store := buildTestStoreWithWatch(t, map[string]watchTestRecord{
+		podsPath: {id: "s", at: from, body: podList("p")},
+	}, nil)
+	h := newHandler(store, time.Time{}, false)
+
+	// limitranges has no built-in printer, no CRD, and no captured Table here.
+	body := `{"items":[{"metadata":{"name":"lr","namespace":"default","creationTimestamp":"2026-04-09T09:30:00Z"}}]}`
+	now := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	tb, ok := h.renderResourceTable("/api/v1/namespaces/default/limitranges", []byte(body), now)
+	if !ok {
+		t.Fatal("render ok=false")
+	}
+	r := decodeTable(t, tb)
+	var names []string
+	var ageType, ageVal string
+	for i, c := range r.ColumnDefinitions {
+		names = append(names, c.Name)
+		if c.Name == "Age" {
+			ageType, ageVal = c.Type, fmt.Sprint(r.Rows[0].Cells[i])
+		}
+	}
+	if fmt.Sprint(names) != fmt.Sprint([]string{"Name", "Namespace", "Age"}) {
+		t.Errorf("generic columns = %v, want [Name Namespace Age]", names)
+	}
+	if ageType != "string" || ageVal != "30m" {
+		t.Errorf("generic Age = (%q,%q), want (string,30m)", ageType, ageVal)
+	}
+}
+
 // getTable issues a kubectl-style Table request and returns the decoded Table.
 func getTable(t *testing.T, url string) tblResp {
 	t.Helper()

--- a/internal/server/table_test.go
+++ b/internal/server/table_test.go
@@ -203,6 +203,21 @@ func TestDeploymentPrinter(t *testing.T) {
 	}
 }
 
+func TestJobPrinter_Status(t *testing.T) {
+	cases := []struct{ name, body, want string }{
+		{"complete", `{"metadata":{"name":"j"},"status":{"conditions":[{"type":"Complete","status":"True"}]}}`, "Complete"},
+		{"failed", `{"metadata":{"name":"j"},"status":{"conditions":[{"type":"Failed","status":"True"}]}}`, "Failed"},
+		{"suspended", `{"metadata":{"name":"j"},"spec":{"suspend":true}}`, "Suspended"},
+		{"running", `{"metadata":{"name":"j"},"status":{"active":1}}`, "Running"},
+	}
+	for _, c := range cases {
+		vals, _ := renderOne(t, "/apis/batch/v1/namespaces/default/jobs", c.body)
+		if got := fmt.Sprint(vals["Status"]); got != c.want {
+			t.Errorf("%s: Status = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
 func TestCronJobPrinter_ContainersFromJobTemplate(t *testing.T) {
 	body := `{"metadata":{"name":"cj","namespace":"default"},
       "spec":{"schedule":"*/5 * * * *",
@@ -361,6 +376,43 @@ func TestCRDPrinterColumns(t *testing.T) {
 	}
 	wantCell(t, vals, "Replicas", "3")
 	wantCell(t, vals, "Phase", "Ready")
+}
+
+// TestCapturedColumns_AgeTypeIsString verifies the captured-columns fallback
+// emits the Age column as type string (its cell is a relative-age string), even
+// when the captured columnDefinitions declared it as "date".
+func TestCapturedColumns_AgeTypeIsString(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	// A kind with no built-in printer and no CRD → falls to captured columns.
+	listPath := "/apis/policy/v1/namespaces/default/poddisruptionbudgets"
+	capturedTable := `{"kind":"Table","apiVersion":"meta.k8s.io/v1","columnDefinitions":[
+      {"name":"Name","type":"string"},{"name":"Min Available","type":"string"},
+      {"name":"Age","type":"date"}],"rows":[]}`
+	store := buildTestStoreWithWatch(t, map[string]watchTestRecord{
+		listPath + "?as=Table": {id: "pdb", at: from, body: capturedTable},
+	}, nil)
+	h := newHandler(store, time.Time{}, false)
+
+	pdbs := `{"items":[{"metadata":{"name":"pdb1","creationTimestamp":"2026-04-09T09:00:00Z"}}]}`
+	now := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	tb, ok := h.renderResourceTable(listPath, []byte(pdbs), now)
+	if !ok {
+		t.Fatal("render ok=false")
+	}
+	r := decodeTable(t, tb)
+	var ageType, ageVal string
+	for i, c := range r.ColumnDefinitions {
+		if c.Name == "Age" {
+			ageType = c.Type
+			ageVal = fmt.Sprint(r.Rows[0].Cells[i])
+		}
+	}
+	if ageType != "string" {
+		t.Errorf("captured Age column type = %q, want string", ageType)
+	}
+	if ageVal != "60m" {
+		t.Errorf("captured Age cell = %q, want 60m (relative)", ageVal)
+	}
 }
 
 // getTable issues a kubectl-style Table request and returns the decoded Table.

--- a/internal/server/table_test.go
+++ b/internal/server/table_test.go
@@ -420,9 +420,15 @@ func TestCapturedColumns_AgeTypeIsString(t *testing.T) {
 	r := decodeTable(t, tb)
 	var ageType, ageVal string
 	for i, c := range r.ColumnDefinitions {
-		if c.Name == "Age" {
+		switch c.Name {
+		case "Age":
 			ageType = c.Type
 			ageVal = fmt.Sprint(r.Rows[0].Cells[i])
+		case "Min Available":
+			// A non-metadata captured column can't be recomputed → JSON null.
+			if r.Rows[0].Cells[i] != nil {
+				t.Errorf("Min Available cell = %v, want null", r.Rows[0].Cells[i])
+			}
 		}
 	}
 	if ageType != "string" {

--- a/internal/server/table_test.go
+++ b/internal/server/table_test.go
@@ -40,8 +40,13 @@ func decodeTable(t *testing.T, b []byte) tblResp {
 // single resulting row, a name→cell-value map and a name→priority map.
 func renderOne(t *testing.T, path, body string) (map[string]any, map[string]int) {
 	t.Helper()
+	return renderOneAt(t, path, body, time.Time{})
+}
+
+func renderOneAt(t *testing.T, path, body string, at time.Time) (map[string]any, map[string]int) {
+	t.Helper()
 	h := &handler{}
-	tb, ok := h.renderResourceTable(path, []byte(body), time.Time{})
+	tb, ok := h.renderResourceTable(path, []byte(body), at)
 	if !ok {
 		t.Fatalf("renderResourceTable(%s) returned ok=false", path)
 	}
@@ -145,6 +150,19 @@ func TestAgeColumn(t *testing.T) {
 	}
 	if ageVal != "90m" {
 		t.Errorf("Age cell = %q, want 90m", ageVal)
+	}
+}
+
+// TestAgeColumn_FractionalSeconds guards that a creationTimestamp with
+// fractional seconds (RFC3339Nano) still renders a relative age — Go's
+// time.Parse(time.RFC3339, …) accepts a fractional-second field on input.
+func TestAgeColumn_FractionalSeconds(t *testing.T) {
+	obj := `{"metadata":{"name":"n","creationTimestamp":"2026-04-09T10:00:00.123456Z"},
+      "status":{"conditions":[{"type":"Ready","status":"True"}]}}`
+	now := time.Date(2026, 4, 9, 10, 30, 1, 0, time.UTC)
+	vals, _ := renderOneAt(t, "/api/v1/nodes", obj, now)
+	if got := fmt.Sprint(vals["Age"]); got != "30m" {
+		t.Errorf("Age with fractional-second timestamp = %q, want 30m (not <unknown>)", got)
 	}
 }
 

--- a/internal/server/table_test.go
+++ b/internal/server/table_test.go
@@ -467,6 +467,35 @@ func TestGenericFallback_RelativeAge(t *testing.T) {
 	}
 }
 
+// TestRenderTable_ZeroAtUsesCaptureEnd verifies that in plain `open` mode (at ==
+// zero, meaning "latest"), computed-table AGE is relative to the capture's end
+// time rather than collapsing to "0s".
+func TestRenderTable_ZeroAtUsesCaptureEnd(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	store := buildTestStoreWithWatch(t, map[string]watchTestRecord{
+		podsPath: {id: "s", at: from, body: podList("p")},
+	}, nil)
+	store.Metadata.CapturedUntil = time.Date(2026, 4, 9, 11, 0, 0, 0, time.UTC)
+	h := newHandler(store, time.Time{}, false) // open mode, no --at → zero at
+
+	body := `{"items":[{"metadata":{"name":"n1","creationTimestamp":"2026-04-09T10:00:00Z"},
+      "status":{"conditions":[{"type":"Ready","status":"True"}]}}]}`
+	tb, ok := h.renderResourceTable("/api/v1/nodes", []byte(body), h.at)
+	if !ok {
+		t.Fatal("render ok=false")
+	}
+	r := decodeTable(t, tb)
+	var ageVal string
+	for i, c := range r.ColumnDefinitions {
+		if c.Name == "Age" {
+			ageVal = fmt.Sprint(r.Rows[0].Cells[i])
+		}
+	}
+	if ageVal != "60m" {
+		t.Errorf("open-mode zero-at Age = %q, want 60m (relative to CapturedUntil, not 0s)", ageVal)
+	}
+}
+
 // getTable issues a kubectl-style Table request and returns the decoded Table.
 func getTable(t *testing.T, url string) tblResp {
 	t.Helper()

--- a/internal/server/table_test.go
+++ b/internal/server/table_test.go
@@ -203,6 +203,29 @@ func TestDeploymentPrinter(t *testing.T) {
 	}
 }
 
+func TestCronJobPrinter_ContainersFromJobTemplate(t *testing.T) {
+	body := `{"metadata":{"name":"cj","namespace":"default"},
+      "spec":{"schedule":"*/5 * * * *",
+        "jobTemplate":{"spec":{"template":{"spec":{"containers":[
+          {"name":"worker","image":"busybox:1.36"}]}}}}}}`
+	vals, _ := renderOne(t, "/apis/batch/v1/namespaces/default/cronjobs", body)
+	wantCell(t, vals, "Schedule", "*/5 * * * *")
+	// -o wide columns must resolve through the nested jobTemplate.
+	wantCell(t, vals, "Containers", "worker")
+	wantCell(t, vals, "Images", "busybox:1.36")
+}
+
+func TestReplicationControllerPrinter_PlainSelector(t *testing.T) {
+	// ReplicationController uses a plain map selector (no matchLabels).
+	body := `{"metadata":{"name":"rc","namespace":"default"},
+      "spec":{"replicas":2,"selector":{"app":"legacy"},
+        "template":{"spec":{"containers":[{"name":"c","image":"nginx"}]}}},
+      "status":{"replicas":2,"readyReplicas":2}}`
+	vals, _ := renderOne(t, "/api/v1/namespaces/default/replicationcontrollers", body)
+	wantCell(t, vals, "Desired", "2")
+	wantCell(t, vals, "Selector", "app=legacy")
+}
+
 func TestServicePrinter_Ports(t *testing.T) {
 	body := `{"metadata":{"name":"svc","namespace":"default"},
       "spec":{"type":"NodePort","clusterIP":"10.96.0.1",

--- a/internal/server/table_test.go
+++ b/internal/server/table_test.go
@@ -1,0 +1,417 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// tblResp is the subset of a meta.k8s.io/v1 Table we assert on.
+type tblResp struct {
+	Kind              string `json:"kind"`
+	ColumnDefinitions []struct {
+		Name     string `json:"name"`
+		Type     string `json:"type"`
+		Priority int    `json:"priority"`
+		Format   string `json:"format"`
+	} `json:"columnDefinitions"`
+	Rows []struct {
+		Cells  []any           `json:"cells"`
+		Object json.RawMessage `json:"object"`
+	} `json:"rows"`
+}
+
+func decodeTable(t *testing.T, b []byte) tblResp {
+	t.Helper()
+	var r tblResp
+	if err := json.Unmarshal(b, &r); err != nil {
+		t.Fatalf("decode table: %v\n%s", err, b)
+	}
+	if r.Kind != "Table" {
+		t.Fatalf("kind = %q, want Table\n%s", r.Kind, b)
+	}
+	return r
+}
+
+// renderOne renders path/body through renderResourceTable and returns, for the
+// single resulting row, a name→cell-value map and a name→priority map.
+func renderOne(t *testing.T, path, body string) (map[string]any, map[string]int) {
+	t.Helper()
+	h := &handler{}
+	tb, ok := h.renderResourceTable(path, []byte(body), time.Time{})
+	if !ok {
+		t.Fatalf("renderResourceTable(%s) returned ok=false", path)
+	}
+	r := decodeTable(t, tb)
+	if len(r.Rows) != 1 {
+		t.Fatalf("got %d rows, want 1\n%s", len(r.Rows), tb)
+	}
+	vals := map[string]any{}
+	prio := map[string]int{}
+	for i, c := range r.ColumnDefinitions {
+		vals[c.Name] = r.Rows[0].Cells[i]
+		prio[c.Name] = c.Priority
+	}
+	return vals, prio
+}
+
+func wantCell(t *testing.T, vals map[string]any, name, want string) {
+	t.Helper()
+	if got := fmt.Sprint(vals[name]); got != want {
+		t.Errorf("cell %q = %q, want %q", name, got, want)
+	}
+}
+
+const nodeObj = `{
+  "metadata":{"name":"node-1","creationTimestamp":"2026-04-09T10:00:00Z",
+    "labels":{"node-role.kubernetes.io/control-plane":""}},
+  "spec":{"unschedulable":true},
+  "status":{
+    "conditions":[{"type":"Ready","status":"True"}],
+    "nodeInfo":{"kubeletVersion":"v1.29.0","osImage":"Ubuntu 22.04",
+      "kernelVersion":"6.1.0","containerRuntimeVersion":"containerd://1.7.0"},
+    "addresses":[{"type":"InternalIP","address":"10.0.0.1"},
+      {"type":"ExternalIP","address":"1.2.3.4"}]}}`
+
+func TestNodePrinter(t *testing.T) {
+	vals, prio := renderOne(t, "/api/v1/nodes", nodeObj)
+
+	wantCell(t, vals, "Name", "node-1")
+	wantCell(t, vals, "Status", "Ready,SchedulingDisabled")
+	wantCell(t, vals, "Roles", "control-plane")
+	wantCell(t, vals, "Version", "v1.29.0")
+	// Wide columns.
+	wantCell(t, vals, "Internal-IP", "10.0.0.1")
+	wantCell(t, vals, "External-IP", "1.2.3.4")
+	wantCell(t, vals, "OS-Image", "Ubuntu 22.04")
+
+	// Default columns have priority 0; wide columns priority 1.
+	for _, c := range []string{"Name", "Status", "Roles", "Version", "Age"} {
+		if prio[c] != 0 {
+			t.Errorf("column %q priority = %d, want 0 (default)", c, prio[c])
+		}
+	}
+	for _, c := range []string{"Internal-IP", "External-IP", "OS-Image", "Kernel-Version", "Container-Runtime"} {
+		if prio[c] != 1 {
+			t.Errorf("column %q priority = %d, want 1 (wide)", c, prio[c])
+		}
+	}
+}
+
+func TestNodePrinter_ColumnOrder(t *testing.T) {
+	h := &handler{}
+	tb, ok := h.renderResourceTable("/api/v1/nodes", []byte(nodeObj), time.Time{})
+	if !ok {
+		t.Fatal("render ok=false")
+	}
+	r := decodeTable(t, tb)
+	var names []string
+	for _, c := range r.ColumnDefinitions {
+		names = append(names, c.Name)
+	}
+	// Upstream kubectl order: NAME STATUS ROLES AGE VERSION, then wide columns.
+	want := []string{"Name", "Status", "Roles", "Age", "Version",
+		"Internal-IP", "External-IP", "OS-Image", "Kernel-Version", "Container-Runtime"}
+	if fmt.Sprint(names) != fmt.Sprint(want) {
+		t.Errorf("node columns = %v\nwant %v", names, want)
+	}
+}
+
+// TestAgeColumn verifies the AGE cell is a relative string computed against the
+// replay clock (matching a real apiserver), not a raw timestamp.
+func TestAgeColumn(t *testing.T) {
+	h := &handler{}
+	// creationTimestamp 90 minutes before the replay clock → "90m".
+	obj := `{"metadata":{"name":"n","creationTimestamp":"2026-04-09T10:00:00Z"},
+      "status":{"conditions":[{"type":"Ready","status":"True"}]}}`
+	now := time.Date(2026, 4, 9, 11, 30, 0, 0, time.UTC)
+	tb, ok := h.renderResourceTable("/api/v1/nodes", []byte(obj), now)
+	if !ok {
+		t.Fatal("render ok=false")
+	}
+	r := decodeTable(t, tb)
+	var ageType, ageVal string
+	for i, c := range r.ColumnDefinitions {
+		if c.Name == "Age" {
+			ageType = c.Type
+			ageVal = fmt.Sprint(r.Rows[0].Cells[i])
+		}
+	}
+	if ageType != "string" {
+		t.Errorf("Age column type = %q, want string (relative age is pre-computed)", ageType)
+	}
+	if ageVal != "90m" {
+		t.Errorf("Age cell = %q, want 90m", ageVal)
+	}
+}
+
+const podObj = `{
+  "metadata":{"name":"pod-1","namespace":"default","creationTimestamp":"2026-04-09T10:00:00Z"},
+  "spec":{"nodeName":"node-1"},
+  "status":{"phase":"Running","podIP":"10.244.0.5",
+    "containerStatuses":[{"ready":true,"restartCount":2},{"ready":false,"restartCount":0}]}}`
+
+func TestPodPrinter(t *testing.T) {
+	vals, prio := renderOne(t, "/api/v1/namespaces/default/pods", podObj)
+
+	wantCell(t, vals, "Name", "pod-1")
+	wantCell(t, vals, "Ready", "1/2")
+	wantCell(t, vals, "Status", "Running")
+	wantCell(t, vals, "Restarts", "2")
+	wantCell(t, vals, "IP", "10.244.0.5")
+	wantCell(t, vals, "Node", "node-1")
+
+	if prio["IP"] != 1 || prio["Node"] != 1 {
+		t.Errorf("IP/Node should be wide (priority 1); got IP=%d Node=%d", prio["IP"], prio["Node"])
+	}
+	if prio["Ready"] != 0 || prio["Status"] != 0 {
+		t.Errorf("Ready/Status should be default (priority 0)")
+	}
+}
+
+func TestPodStatus_WaitingReasonWins(t *testing.T) {
+	body := `{"metadata":{"name":"p"},"status":{"phase":"Running",
+      "containerStatuses":[{"ready":false,"state":{"waiting":{"reason":"CrashLoopBackOff"}}}]}}`
+	vals, _ := renderOne(t, "/api/v1/namespaces/default/pods", body)
+	wantCell(t, vals, "Status", "CrashLoopBackOff")
+}
+
+func TestPodStatus_Terminating(t *testing.T) {
+	body := `{"metadata":{"name":"p","deletionTimestamp":"2026-04-09T10:05:00Z"},
+      "status":{"phase":"Running"}}`
+	vals, _ := renderOne(t, "/api/v1/namespaces/default/pods", body)
+	wantCell(t, vals, "Status", "Terminating")
+}
+
+func TestDeploymentPrinter(t *testing.T) {
+	body := `{"metadata":{"name":"web","namespace":"default"},
+      "spec":{"replicas":3,"selector":{"matchLabels":{"app":"web"}},
+        "template":{"spec":{"containers":[{"name":"c","image":"nginx:1.25"}]}}},
+      "status":{"readyReplicas":2,"updatedReplicas":3,"availableReplicas":2}}`
+	vals, prio := renderOne(t, "/apis/apps/v1/namespaces/default/deployments", body)
+	wantCell(t, vals, "Ready", "2/3")
+	wantCell(t, vals, "Up-To-Date", "3")
+	wantCell(t, vals, "Available", "2")
+	wantCell(t, vals, "Containers", "c")
+	wantCell(t, vals, "Images", "nginx:1.25")
+	wantCell(t, vals, "Selector", "app=web")
+	if prio["Containers"] != 1 || prio["Selector"] != 1 {
+		t.Errorf("Containers/Selector should be wide (priority 1)")
+	}
+}
+
+func TestServicePrinter_Ports(t *testing.T) {
+	body := `{"metadata":{"name":"svc","namespace":"default"},
+      "spec":{"type":"NodePort","clusterIP":"10.96.0.1",
+        "ports":[{"port":80,"nodePort":30080,"protocol":"TCP"}]}}`
+	vals, _ := renderOne(t, "/api/v1/namespaces/default/services", body)
+	wantCell(t, vals, "Type", "NodePort")
+	wantCell(t, vals, "Cluster-IP", "10.96.0.1")
+	wantCell(t, vals, "Port(s)", "80:30080/TCP")
+	wantCell(t, vals, "External-IP", "<none>")
+}
+
+func TestConfigMapPrinter_DataCount(t *testing.T) {
+	body := `{"metadata":{"name":"cm","namespace":"default"},
+      "data":{"a":"1","b":"2"},"binaryData":{"c":"AA=="}}`
+	vals, _ := renderOne(t, "/api/v1/namespaces/default/configmaps", body)
+	wantCell(t, vals, "Data", "3")
+}
+
+func TestTableStructure_NameFormatAndObject(t *testing.T) {
+	h := &handler{}
+	tb, ok := h.renderResourceTable("/api/v1/nodes", []byte(nodeObj), time.Time{})
+	if !ok {
+		t.Fatal("render returned ok=false")
+	}
+	r := decodeTable(t, tb)
+	if r.ColumnDefinitions[0].Name != "Name" || r.ColumnDefinitions[0].Format != "name" {
+		t.Errorf("first column should be Name with format=name; got %+v", r.ColumnDefinitions[0])
+	}
+	// Each row carries a PartialObjectMetadata object with the source metadata.
+	var obj struct {
+		Kind     string `json:"kind"`
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(r.Rows[0].Object, &obj); err != nil {
+		t.Fatalf("row object: %v", err)
+	}
+	if obj.Kind != "PartialObjectMetadata" || obj.Metadata.Name != "node-1" {
+		t.Errorf("row object = %+v, want PartialObjectMetadata for node-1", obj)
+	}
+}
+
+// TestSingleObjectPathResolvesPrinter covers `kubectl get <resource> <name>`:
+// a single-object path (…/configmaps/demo, …/nodes/n1) must resolve to the same
+// built-in printer as the list path, not fall back to generic NAME/AGE.
+func TestSingleObjectPathResolvesPrinter(t *testing.T) {
+	cases := []struct {
+		path string
+		body string
+		want string // a column that only the built-in printer produces
+	}{
+		{"/api/v1/namespaces/default/configmaps/demo",
+			`{"metadata":{"name":"demo"},"data":{"a":"1"}}`, "Data"},
+		{"/api/v1/nodes/n1", nodeObj, "Version"},
+		{"/apis/apps/v1/namespaces/default/deployments/web",
+			`{"metadata":{"name":"web"},"spec":{"replicas":1},"status":{"readyReplicas":1}}`, "Ready"},
+	}
+	for _, c := range cases {
+		h := &handler{}
+		tb, ok := h.renderResourceTable(c.path, []byte(c.body), time.Time{})
+		if !ok {
+			t.Errorf("%s: ok=false", c.path)
+			continue
+		}
+		r := decodeTable(t, tb)
+		found := false
+		for _, cd := range r.ColumnDefinitions {
+			if cd.Name == c.want {
+				found = true
+			}
+		}
+		if !found {
+			var names []string
+			for _, cd := range r.ColumnDefinitions {
+				names = append(names, cd.Name)
+			}
+			t.Errorf("%s: missing built-in column %q; got %v", c.path, c.want, names)
+		}
+	}
+}
+
+func TestJSONPathCell(t *testing.T) {
+	cell := jsonPathCell(".spec.replicas")
+	obj := map[string]any{"spec": map[string]any{"replicas": float64(3)}}
+	if got := fmt.Sprint(cell(obj)); got != "3" {
+		t.Errorf("jsonpath .spec.replicas = %q, want 3", got)
+	}
+	// Missing key yields empty, not an error/panic.
+	if got := fmt.Sprint(jsonPathCell(".status.phase")(obj)); got != "" {
+		t.Errorf("missing key should render empty, got %q", got)
+	}
+}
+
+// TestCRDPrinterColumns renders a custom resource via its CRD's
+// additionalPrinterColumns (JSONPath), including a wide (priority 1) column.
+func TestCRDPrinterColumns(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	crdList := `{"apiVersion":"apiextensions.k8s.io/v1","kind":"CustomResourceDefinitionList","items":[
+      {"spec":{"group":"example.com","names":{"plural":"widgets"},
+        "versions":[{"name":"v1","additionalPrinterColumns":[
+          {"name":"Replicas","type":"integer","jsonPath":".spec.replicas"},
+          {"name":"Phase","type":"string","jsonPath":".status.phase","priority":1}]}]}}]}`
+	store := buildTestStoreWithWatch(t, map[string]watchTestRecord{
+		"/apis/apiextensions.k8s.io/v1/customresourcedefinitions": {id: "crd", at: from, body: crdList},
+	}, nil)
+	h := newHandler(store, time.Time{}, false)
+
+	widgets := `{"items":[{"metadata":{"name":"w1","creationTimestamp":"2026-04-09T10:00:00Z"},
+      "spec":{"replicas":3},"status":{"phase":"Ready"}}]}`
+	tb, ok := h.renderResourceTable("/apis/example.com/v1/widgets", []byte(widgets), from)
+	if !ok {
+		t.Fatal("renderResourceTable(widgets) ok=false")
+	}
+	r := decodeTable(t, tb)
+
+	var names []string
+	prio := map[string]int{}
+	for _, c := range r.ColumnDefinitions {
+		names = append(names, c.Name)
+		prio[c.Name] = c.Priority
+	}
+	// NAME prepended, AGE appended, CRD columns in between.
+	if names[0] != "Name" || names[len(names)-1] != "Age" {
+		t.Errorf("columns = %v, want Name…Age framing", names)
+	}
+	if prio["Phase"] != 1 {
+		t.Errorf("Phase should be a wide column (priority 1); got %d", prio["Phase"])
+	}
+	vals := map[string]any{}
+	for i, c := range r.ColumnDefinitions {
+		vals[c.Name] = r.Rows[0].Cells[i]
+	}
+	wantCell(t, vals, "Replicas", "3")
+	wantCell(t, vals, "Phase", "Ready")
+}
+
+// getTable issues a kubectl-style Table request and returns the decoded Table.
+func getTable(t *testing.T, url string) tblResp {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("Accept", "application/json;as=Table;v=v1;g=meta.k8s.io")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("table request: %v", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		t.Fatalf("table request status %d: %s", resp.StatusCode, b)
+	}
+	return decodeTable(t, b)
+}
+
+// TestOverlayTable_PodColumns verifies an overlay-created Pod renders the full
+// built-in Pod columns (incl. wide priority) via the writable path — not the
+// generic NAME/AGE fallback.
+func TestOverlayTable_PodColumns(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-ov"))
+
+	r := getTable(t, srv.URL+podsPath)
+	prio := map[string]int{}
+	for _, c := range r.ColumnDefinitions {
+		prio[c.Name] = c.Priority
+	}
+	for _, c := range []string{"Name", "Ready", "Status", "Restarts", "Age"} {
+		if _, ok := prio[c]; !ok {
+			t.Errorf("Table missing default column %q; got %v", c, prio)
+		}
+	}
+	if prio["IP"] != 1 || prio["Node"] != 1 {
+		t.Errorf("wide columns IP/Node missing or wrong priority: %v", prio)
+	}
+	// The overlay-created object must appear.
+	found := false
+	for _, row := range r.Rows {
+		if len(row.Cells) > 0 && fmt.Sprint(row.Cells[0]) == "pod-ov" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("overlay pod pod-ov not present in Table rows")
+	}
+}
+
+// TestOverlayTable_NeverCapturedKind renders a kind absent from the capture
+// (nodes) through the built-in printer after an overlay create.
+func TestOverlayTable_NeverCapturedKind(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	doReq(t, http.MethodPost, srv.URL+"/api/v1/nodes", "application/json",
+		`{"apiVersion":"v1","kind":"Node","metadata":{"name":"n-ov"},
+          "status":{"conditions":[{"type":"Ready","status":"True"}],
+            "nodeInfo":{"kubeletVersion":"v1.29.0"}}}`)
+
+	r := getTable(t, srv.URL+"/api/v1/nodes")
+	names := map[string]bool{}
+	for _, c := range r.ColumnDefinitions {
+		names[c.Name] = true
+	}
+	for _, c := range []string{"Status", "Roles", "Version"} {
+		if !names[c] {
+			t.Errorf("nodes Table missing built-in column %q; got %v", c, names)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`kubectl get <resource>` and `-o wide` against the k8shark mock didn't always match a live cluster. The mock serves the captured server-side **Table** verbatim when present (faithful), but otherwise fell back to a generic **NAME / (NAMESPACE) / AGE** table that ignored `-o wide`. That fallback fired:

- for kinds/captures without a stored Table, **and**
- in **writable mode** for every overlay object (the captured-Table fast paths are bypassed there), including objects created after capture.

So `kubectl get` on overlay-created or never-captured resources rendered generic columns instead of the real ones. This is the wider applicability called out in #166.

## What changed

New `internal/server/table.go` — a Table renderer + a per-GVK printer registry. `renderResourceTable` computes `columnDefinitions` + per-object `cells` for an arbitrary set of objects, by precedence:

1. **Built-in printer** for ~19 core/native kinds (Node, Pod, Deployment, ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob, Service, Endpoints, Ingress, ConfigMap, Secret, PVC, PV, Namespace, ServiceAccount, Event). Columns mirror upstream kubectl, including `-o wide` columns via per-column `priority`.
2. **CRD printer** built from the captured CRD's `additionalPrinterColumns` (JSONPath cells).
3. **Captured `columnDefinitions`** for the kind + metadata-only cells.
4. The generic `buildTable`.

Details that make output match a live cluster:
- **AGE** is a pre-computed relative string (`5m49s`, `2d`) against the replay clock — matching how a real apiserver emits the column (type `string`), not a raw timestamp.
- **Column order** matches upstream (e.g. nodes: `NAME STATUS ROLES AGE VERSION`, then wide columns).
- **Single-object GET** (`kubectl get <resource> <name>`) resolves to the same printer as the list path.

Wiring in `serveResource`: read-only fully-captured requests still serve the captured Table verbatim; writable mode / no-stored-Table / single overlay objects render through `renderResourceTable`.

## Testing

- Unit tests per kind (columns + cells, default and `-o wide`), column-order and relative-age assertions, CRD JSONPath printer, single-object path resolution, and integration tests over the writable overlay (`internal/server/table_test.go`).
- `make fmt`, `go vet`, `go test -race ./...`, `golangci-lint run ./...`, `govulncheck ./...` — all clean.
- Manual smoke test with `kshrk replay --writable` + `kubectl`: `get nodes` / `-o wide`, and overlay-created ConfigMap/Deployment now render full columns with relative age.

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)