### PR TITLE
fix(replay): don't synthesize kwok-node-0 for captures that have nodes

### DIFF
--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -208,12 +208,22 @@ func (h *handler) syncEpoch() {
 	}
 }
 
-// ensureSchedulableNode synthesizes a node when the capture (as-of the clock) has
-// none, so a scheduling target — and a node for KWOK to manage — exists from
-// startup rather than only appearing when the first Pod is created. Idempotent:
-// storeIfAbsent is a no-op when the node already exists.
+// ensureSchedulableNode synthesizes a node when the capture has none, so a
+// scheduling target — and a node for KWOK to manage — exists from startup rather
+// than only appearing when the first Pod is created. Idempotent: synthesizeNode
+// is a no-op when the node already exists.
+//
+// Node presence is evaluated at the window END, not the current clock instant.
+// A capture's first /api/v1/nodes snapshot commonly lands a few seconds after
+// the window start (from ≈ metadata.CapturedAt, an approximation), so checking
+// at `from` would wrongly see "no nodes" at startup and synthesize kwok-node-0
+// for a capture that actually contains nodes (#172).
 func (h *handler) ensureSchedulableNode() {
-	if len(h.knownNodeNames()) == 0 {
+	at := h.at
+	if h.clock != nil {
+		_, at = h.clock.Window()
+	}
+	if len(h.knownNodeNamesAt(at)) == 0 {
 		h.synthesizeNode(defaultSyntheticNode)
 	}
 }
@@ -241,6 +251,12 @@ func (h *handler) knownNodeNames() []string {
 	if h.clock != nil {
 		at = h.clock.Now()
 	}
+	return h.knownNodeNamesAt(at)
+}
+
+// knownNodeNamesAt returns the sorted node names visible as-of the given instant
+// (captured nodes reconstructed at `at`, merged with overlay writes).
+func (h *handler) knownNodeNamesAt(at time.Time) []string {
 	var items []json.RawMessage
 	if body, code, err := h.store.ReconstructAt("/api/v1/nodes", at); err == nil && code == 200 {
 		var l struct {

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -858,3 +858,58 @@ func TestOverlay_WatchListInitialEvents(t *testing.T) {
 		t.Error("WatchList did not emit a BOOKMARK with the k8s.io/initial-events-end annotation")
 	}
 }
+
+// TestEnsureSchedulableNode_NodeSnapshotAfterWindowStart reproduces the bug where
+// a capture that contains a node still got a synthetic kwok-node-0 because the
+// node's first snapshot lands after the window start, so a check at `from` sees
+// "no nodes". Eager synthesis must evaluate node presence across the window.
+func TestEnsureSchedulableNode_NodeSnapshotAfterWindowStart(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	nodeAt := from.Add(30 * time.Second) // first /api/v1/nodes snapshot after `from`
+	to := from.Add(60 * time.Second)
+	store := buildTestStoreWithWatch(t, map[string]watchTestRecord{
+		"/api/v1/nodes": {id: "n", at: nodeAt,
+			body: `{"apiVersion":"v1","kind":"NodeList","items":[{"metadata":{"name":"node-real"}}]}`},
+	}, nil)
+	clock, _ := newTestClock(t, from, to, 1, false, true) // paused at from
+	h := newHandler(store, time.Time{}, false)
+	h.clock = clock
+	h.overlay = newOverlay()
+	h.schedulePods = true
+
+	// Precondition: at the window start the node snapshot isn't visible yet.
+	if got := h.knownNodeNamesAt(from); len(got) != 0 {
+		t.Fatalf("precondition: expected no nodes at window start, got %v", got)
+	}
+
+	h.ensureSchedulableNode()
+
+	names := h.knownNodeNamesAt(to)
+	if contains(names, defaultSyntheticNode) {
+		t.Errorf("synthesized %s for a capture that already has a node: %v", defaultSyntheticNode, names)
+	}
+	if !contains(names, "node-real") {
+		t.Errorf("expected captured node-real at window end, got %v", names)
+	}
+}
+
+// TestEnsureSchedulableNode_NodelessCaptureSynthesizes verifies the intended KWOK
+// behavior is preserved: a capture with no nodes still gets kwok-node-0.
+func TestEnsureSchedulableNode_NodelessCaptureSynthesizes(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	to := from.Add(60 * time.Second)
+	store := buildTestStoreWithWatch(t, map[string]watchTestRecord{
+		podsPath: {id: "p", at: from, body: podList("p")},
+	}, nil)
+	clock, _ := newTestClock(t, from, to, 1, false, true)
+	h := newHandler(store, time.Time{}, false)
+	h.clock = clock
+	h.overlay = newOverlay()
+	h.schedulePods = true
+
+	h.ensureSchedulableNode()
+
+	if !contains(h.knownNodeNamesAt(to), defaultSyntheticNode) {
+		t.Errorf("nodeless capture should synthesize %s", defaultSyntheticNode)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #172. `kshrk ui --writable` (and `replay --writable`) injected a synthetic `kwok-node-0` even for captures that already contain real nodes.

## Root cause

Eager node synthesis runs once at startup and decided "the capture has no nodes" via `knownNodeNames()`, which evaluates at the replay clock's **current** instant — at startup that's the window start `from` (≈ `metadata.CapturedAt`, an approximation). A capture's first `/api/v1/nodes` snapshot commonly lands a few seconds **after** `from`, so `ReconstructAt("/api/v1/nodes", from)` returned nothing and synthesis fired.

Verified against a capture with a node: at `from` the node list is empty; at `from+5s` the real node appears. `ui --writable` surfaces it most because it sits at `from` (especially `--start-paused`).

## Fix

`ensureSchedulableNode` now evaluates node presence at the window **end** (`clock.Window()`) rather than the current clock instant, so a node whose first snapshot post-dates `from` still counts. `knownNodeNames` is refactored into `knownNodeNamesAt(at)`; the scheduling shim (`schedulePod`) keeps using the clock instant, since it needs a target *now*.

Nodeless captures still synthesize `kwok-node-0` (intended KWOK behavior), and the lazy on-first-pod synthesis path is unchanged.

## Testing

- `TestEnsureSchedulableNode_NodeSnapshotAfterWindowStart` — reproduces the bug (asserts the precondition that nodes are invisible at `from`) and verifies no `kwok-node-0` is synthesized while the real node is present at the window end.
- `TestEnsureSchedulableNode_NodelessCaptureSynthesizes` — the nodeless case still gets `kwok-node-0`.
- Full server suite green under `-race`; lint clean.
- Manual: `ui --writable --start-paused` against a capture with a node now shows no synthetic node (and the real node once the clock advances); a nodeless capture still gets `kwok-node-0`.

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)