### PR TITLE
fix(ui): "Recent Transitions" name/kind spacing + title casing

### DIFF
--- a/internal/ui/v2/static/app.css
+++ b/internal/ui/v2/static/app.css
@@ -366,7 +366,7 @@ a { color: inherit; }
 .event .kind.bad { color: var(--bad); }
 .event .kind.warn { color: var(--warn); }
 .event .body b { color: var(--fg); }
-.event .body .small { color: var(--fg-dim); font-size: 11px; }
+.event .body .small { color: var(--fg-dim); font-size: 11px; margin-left: 6px; }
 .event .age { font: 11px var(--mono); color: var(--fg-faint); text-align: right; }
 
 /* Timeline rows (history sidebar) */

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -782,7 +782,7 @@
     }
 
     const recentCard = el('div', { class: 'card' },
-      cardHeader('Recent transitions', 'last events'));
+      cardHeader('Recent Transitions', 'last events'));
     const recent = (data.recent || []).filter((t) => resourceEnabled(t.resource));
     if (recent.length === 0) {
       recentCard.appendChild(el('div', { class: 'state', style: 'padding:18px;' },


### PR DESCRIPTION
## Summary
- Add a gap between the object name and its Kind/namespace text in each Recent Transitions row (`internal/ui/v2/static/app.css`).
- Capitalize the card title to "Recent Transitions" (`internal/ui/v2/static/app.js`).

## Test plan
- [x] Ran `kshrk ui` locally against `internal/archive/testdata/golden-v1.kshrk` and confirmed the served `/v2/app.js` and `/v2/app.css` reflect both changes.

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)