### PR TITLE
feat(ui): default replay to paused in the Web UI

### DIFF
--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -46,7 +46,7 @@ func init() {
 	uiCmd.Flags().String("from", "", "replay window start: RFC3339 or relative duration like -10m")
 	uiCmd.Flags().String("to", "", "replay window end: RFC3339 or relative duration like -1m")
 	uiCmd.Flags().Bool("loop", false, "replay mode: restart from the window start when the end is reached")
-	uiCmd.Flags().Bool("start-paused", false, "replay mode: start paused")
+	uiCmd.Flags().Bool("start-paused", false, "replay mode: start paused (default; pass --start-paused=false to auto-play)")
 	uiCmd.Flags().Bool("writable", false, "replay mode: accept client writes into an in-memory overlay")
 }
 
@@ -79,6 +79,7 @@ func runUI(cmd *cobra.Command, args []string) error {
 	writable, _ := cmd.Flags().GetBool("writable")
 	replayMode := cmd.Flags().Changed("speed") || cmd.Flags().Changed("from") ||
 		cmd.Flags().Changed("to") || loop || startPaused || writable
+	startPaused = resolveUIStartPaused(replayMode, startPaused, cmd.Flags().Changed("start-paused"))
 
 	// --at pins a single instant, which is meaningless once the replay clock is
 	// driving time — reject the combination rather than silently ignoring --at.
@@ -140,4 +141,16 @@ func runUI(cmd *cobra.Command, args []string) error {
 	mockSrv.Shutdown()
 
 	return nil
+}
+
+// resolveUIStartPaused decides whether the dashboard's replay clock should
+// begin paused. The Web UI is a VCR the user drives by hand, so — unlike the
+// headless `kshrk replay` command, which defaults to auto-play — it defaults
+// to paused whenever replay mode is on. An explicit --start-paused (true or
+// false) always wins.
+func resolveUIStartPaused(replayMode, startPaused, startPausedChanged bool) bool {
+	if replayMode && !startPausedChanged {
+		return true
+	}
+	return startPaused
 }

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -46,7 +46,7 @@ func init() {
 	uiCmd.Flags().String("from", "", "replay window start: RFC3339 or relative duration like -10m")
 	uiCmd.Flags().String("to", "", "replay window end: RFC3339 or relative duration like -1m")
 	uiCmd.Flags().Bool("loop", false, "replay mode: restart from the window start when the end is reached")
-	uiCmd.Flags().Bool("start-paused", false, "replay mode: start paused (default; pass --start-paused=false to auto-play)")
+	uiCmd.Flags().Bool("start-paused", false, "replay mode: start paused (the UI defaults to this; pass --start-paused=false to auto-play)")
 	uiCmd.Flags().Bool("writable", false, "replay mode: accept client writes into an in-memory overlay")
 }
 

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -21,6 +21,31 @@ func newTestUICommand() *cobra.Command {
 	return cmd
 }
 
+func TestResolveUIStartPaused(t *testing.T) {
+	cases := []struct {
+		name               string
+		replayMode         bool
+		startPaused        bool
+		startPausedChanged bool
+		want               bool
+	}{
+		{"no replay mode leaves paused false", false, false, false, false},
+		{"replay mode defaults to paused", true, false, false, true},
+		{"explicit --start-paused=false wins in replay mode", true, false, true, false},
+		{"explicit --start-paused=true still paused", true, true, true, true},
+		{"no replay mode with flag set still honors flag", false, true, true, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := resolveUIStartPaused(c.replayMode, c.startPaused, c.startPausedChanged)
+			if got != c.want {
+				t.Errorf("resolveUIStartPaused(%v, %v, %v) = %v, want %v",
+					c.replayMode, c.startPaused, c.startPausedChanged, got, c.want)
+			}
+		})
+	}
+}
+
 func TestRunUI_RejectsAtWithReplayFlags(t *testing.T) {
 	arch := buildDiffArchive(t, healthyPodList)
 	cmd := newTestUICommand()

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -174,8 +174,8 @@ the clock; the views auto-refresh as the clock crosses each snapshot. If a view 
 mid-playback, replay **pauses** and surfaces the error rather than pressing on.
 
 Replay flags mirror the [`replay` command](usage.md#replay): `--speed`, `--from`, `--to`, `--loop`,
-`--start-paused`. See [docs/usage.md](usage.md#replay) for the full model (resourceVersion coherence,
-poll-only inference, etc.).
+`--start-paused`, `--writable`. See [docs/usage.md](usage.md#replay) for the full model
+(resourceVersion coherence, poll-only inference, etc.).
 
 Unlike the headless `kshrk replay` command (which auto-plays by default), `kshrk ui` starts replay
 **paused** by default — the dashboard renders the window-start state and waits for you to press

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -177,6 +177,10 @@ Replay flags mirror the [`replay` command](usage.md#replay): `--speed`, `--from`
 `--start-paused`. See [docs/usage.md](usage.md#replay) for the full model (resourceVersion coherence,
 poll-only inference, etc.).
 
+Unlike the headless `kshrk replay` command (which auto-plays by default), `kshrk ui` starts replay
+**paused** by default — the dashboard renders the window-start state and waits for you to press
+**Play**. Pass `--start-paused=false` to have it auto-play from launch instead.
+
 The transport is backed by a small same-origin control API the dashboard calls (also useful for
 scripting the UI clock):
 


### PR DESCRIPTION
## Summary
- `kshrk ui` now defaults replay to **paused** when any replay flag is set (`--speed`/`--from`/`--to`/`--loop`/`--writable`), so the dashboard renders the window-start state until the user presses Play. An explicit `--start-paused=false` still forces auto-play.
- Headless `kshrk replay` is unchanged — it still auto-plays by default.
- Plain `kshrk ui` (no replay flags) was confirmed to stay read-only: `/v2/api/replay` reports `{"enabled":false}` and the clock never engages.
- Extracted the paused-decision into a small testable `resolveUIStartPaused` helper in `cmd/ui.go`, with unit tests covering the default/override matrix.
- Documented the new default in `docs/web-ui.md` and updated the `--start-paused` flag help text.

## Test plan
- [x] `make fmt && make lint && make test` all pass.
- [x] `go test ./cmd/... -run TestResolveUIStartPaused -v` covers: no replay mode, replay mode default-paused, explicit `--start-paused=false` override, explicit `--start-paused=true`, and flag set without replay mode.
- [x] Manually ran `kshrk ui <capture> --speed 2x --from ... --to ...` and confirmed `/v2/api/replay` reports `"paused":true` on launch.
- [x] Manually ran with `--start-paused=false` and confirmed `"paused":false` (auto-play).
- [x] Manually ran `kshrk replay <capture> --speed 2x` (headless) and confirmed it still auto-plays (`"paused":false`).
- [x] Manually ran plain `kshrk ui <capture>` (no flags) and confirmed `/v2/api/replay` returns `{"enabled":false}`.

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)