### PR TITLE
feat(server): support deletecollection in the writable overlay

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -671,15 +671,7 @@ func (h *handler) mergeOverlayList(path string, body []byte) ([]byte, int64) {
 	list.Items, skipRV = h.overlay.applyToList(group, version, resource, namespace, list.Items)
 	// Cascade: drop items whose namespace was deleted in the overlay (covers both
 	// overlay-created and captured items, in namespaced and cluster-wide/-A lists).
-	if dns := h.overlay.deletedNamespaces(); len(dns) > 0 {
-		kept := list.Items[:0]
-		for _, it := range list.Items {
-			if _, gone := dns[metaString(it, "namespace")]; !gone {
-				kept = append(kept, it)
-			}
-		}
-		list.Items = kept
-	}
+	list.Items = dropDeletedNamespaceItems(list.Items, h.overlay.deletedNamespaces())
 	out, err := json.Marshal(list)
 	if err != nil {
 		return body, skipRV

--- a/internal/server/selector.go
+++ b/internal/server/selector.go
@@ -181,24 +181,77 @@ type fieldSelectorReq struct {
 	value string
 }
 
-// parseFieldSelector parses a comma-separated fieldSelector.
-// Supported fields: metadata.name, metadata.namespace.
+// parseFieldSelectorSegment parses one fieldSelector segment ("key=val",
+// "key==val", or "key!=val") into a requirement. ok is false if the segment
+// matches none of those forms.
+func parseFieldSelectorSegment(seg string) (fieldSelectorReq, bool) {
+	if i := strings.Index(seg, "!="); i >= 0 {
+		return fieldSelectorReq{strings.TrimSpace(seg[:i]), "!=", seg[i+2:]}, true
+	}
+	if i := strings.Index(seg, "=="); i >= 0 {
+		return fieldSelectorReq{strings.TrimSpace(seg[:i]), "=", seg[i+2:]}, true
+	}
+	if i := strings.Index(seg, "="); i >= 0 {
+		return fieldSelectorReq{strings.TrimSpace(seg[:i]), "=", seg[i+1:]}, true
+	}
+	return fieldSelectorReq{}, false
+}
+
+// parseFieldSelector parses a comma-separated fieldSelector for reads.
+// Supported fields: metadata.name, metadata.namespace. An unparseable segment
+// is silently skipped — best-effort, matching matchesFields' generous
+// handling of unsupported keys — safe for a read, where "matches more than
+// intended" only affects display fidelity. deletecollection uses the stricter
+// validateSelectorsStrict instead (see below), where the same leniency would
+// risk deleting more than the caller asked for.
 func parseFieldSelector(selector string) []fieldSelectorReq {
 	if selector == "" {
 		return nil
 	}
 	var reqs []fieldSelectorReq
 	for _, seg := range strings.Split(selector, ",") {
-		seg = strings.TrimSpace(seg)
-		if i := strings.Index(seg, "!="); i >= 0 {
-			reqs = append(reqs, fieldSelectorReq{seg[:i], "!=", seg[i+2:]})
-		} else if i := strings.Index(seg, "=="); i >= 0 {
-			reqs = append(reqs, fieldSelectorReq{seg[:i], "=", seg[i+2:]})
-		} else if i := strings.Index(seg, "="); i >= 0 {
-			reqs = append(reqs, fieldSelectorReq{seg[:i], "=", seg[i+1:]})
+		if req, ok := parseFieldSelectorSegment(strings.TrimSpace(seg)); ok {
+			reqs = append(reqs, req)
 		}
 	}
 	return reqs
+}
+
+// supportedFieldSelectorKeys are the metadata fields matchesFields actually
+// filters on; validateSelectorsStrict rejects any other key.
+var supportedFieldSelectorKeys = map[string]bool{
+	"metadata.name":      true,
+	"metadata.namespace": true,
+}
+
+// validateSelectorsStrict validates labelSelector/fieldSelector the way a real
+// apiserver rejects a malformed one — for callers where the best-effort
+// leniency applySelectors/filterItems/parseFieldSelector use for reads would
+// be unsafe. deletecollection is the motivating case: silently treating an
+// unparseable labelSelector or an unsupported fieldSelector key as "matches
+// everything" would delete more than the caller asked for, not just display
+// more than intended. Returns a message suitable for a 400 response, or ""
+// when both selectors are well-formed and reference only supported keys.
+func validateSelectorsStrict(labelSelector, fieldSelector string) string {
+	if labelSelector != "" {
+		if _, err := parseRequirements(labelSelector); err != nil {
+			return "invalid labelSelector: " + err.Error()
+		}
+	}
+	for _, seg := range strings.Split(fieldSelector, ",") {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		req, ok := parseFieldSelectorSegment(seg)
+		if !ok {
+			return fmt.Sprintf("invalid fieldSelector segment %q", seg)
+		}
+		if !supportedFieldSelectorKeys[req.field] {
+			return fmt.Sprintf("unsupported fieldSelector key %q", req.field)
+		}
+	}
+	return ""
 }
 
 // matchesFields returns true if the object satisfies all field selector requirements.

--- a/internal/server/selector.go
+++ b/internal/server/selector.go
@@ -272,6 +272,37 @@ func filterTableRows(tableBody []byte, labelSelector, fieldSelector string) ([]b
 	return json.Marshal(table)
 }
 
+// filterItems returns the subset of items matching both labelSelector and
+// fieldSelector. Best-effort, matching applySelectors: a malformed
+// labelSelector returns items unfiltered rather than erroring, and an item
+// that fails to unmarshal is kept (never silently hidden). Shared by
+// applySelectors (list-body reads) and the writable overlay's deletecollection
+// (which deletes matching items directly — there's no list body to build).
+func filterItems(items []json.RawMessage, labelSelector, fieldSelector string) []json.RawMessage {
+	if labelSelector == "" && fieldSelector == "" {
+		return items
+	}
+	labelReqs, err := parseRequirements(labelSelector)
+	if err != nil {
+		return items // malformed selector — best-effort, same as applySelectors
+	}
+	fieldReqs := parseFieldSelector(fieldSelector)
+
+	filtered := items[:0]
+	for _, raw := range items {
+		var obj k8sObject
+		if err := json.Unmarshal(raw, &obj); err != nil {
+			// Can't parse this item; include it to avoid hiding data.
+			filtered = append(filtered, raw)
+			continue
+		}
+		if matchesLabels(&obj, labelReqs) && matchesFields(&obj, fieldReqs) {
+			filtered = append(filtered, raw)
+		}
+	}
+	return filtered
+}
+
 // applySelectors filters a JSON list body keeping only items that match both
 // labelSelector and fieldSelector. Returns the original body unchanged if
 // both selectors are empty or if the body is not a list.
@@ -279,13 +310,10 @@ func applySelectors(body []byte, labelSelector, fieldSelector string) ([]byte, e
 	if labelSelector == "" && fieldSelector == "" {
 		return body, nil
 	}
-
-	labelReqs, err := parseRequirements(labelSelector)
-	if err != nil {
+	if _, err := parseRequirements(labelSelector); err != nil {
 		// Malformed selector — return body unfiltered (best-effort).
 		return body, nil
 	}
-	fieldReqs := parseFieldSelector(fieldSelector)
 
 	// Unmarshal as a generic list so we preserve all top-level fields.
 	var list struct {
@@ -299,19 +327,6 @@ func applySelectors(body []byte, labelSelector, fieldSelector string) ([]byte, e
 		return body, nil
 	}
 
-	filtered := list.Items[:0]
-	for _, raw := range list.Items {
-		var obj k8sObject
-		if err := json.Unmarshal(raw, &obj); err != nil {
-			// Can't parse this item; include it to avoid hiding data.
-			filtered = append(filtered, raw)
-			continue
-		}
-		if matchesLabels(&obj, labelReqs) && matchesFields(&obj, fieldReqs) {
-			filtered = append(filtered, raw)
-		}
-	}
-
-	list.Items = filtered
+	list.Items = filterItems(list.Items, labelSelector, fieldSelector)
 	return json.Marshal(list)
 }

--- a/internal/server/selector.go
+++ b/internal/server/selector.go
@@ -204,9 +204,10 @@ func parseFieldSelectorSegment(seg string) (fieldSelectorReq, bool) {
 // Supported fields: metadata.name, metadata.namespace. An unparseable segment
 // is silently skipped — best-effort, matching matchesFields' generous
 // handling of unsupported keys — safe for a read, where "matches more than
-// intended" only affects display fidelity. deletecollection uses the stricter
-// validateSelectorsStrict instead (see below), where the same leniency would
-// risk deleting more than the caller asked for.
+// intended" only affects display fidelity. deletecollection uses
+// filterItemsStrict instead (see below), which parses with apimachinery's
+// real selector grammar rather than this lenient one, since the same
+// leniency there would risk deleting more than the caller asked for.
 func parseFieldSelector(selector string) []fieldSelectorReq {
 	if selector == "" {
 		return nil
@@ -392,11 +393,13 @@ func filterTableRows(tableBody []byte, labelSelector, fieldSelector string) ([]b
 }
 
 // filterItems returns the subset of items matching both labelSelector and
-// fieldSelector. Best-effort, matching applySelectors: a malformed
-// labelSelector returns items unfiltered rather than erroring, and an item
-// that fails to unmarshal is kept (never silently hidden). Shared by
-// applySelectors (list-body reads) and the writable overlay's deletecollection
-// (which deletes matching items directly — there's no list body to build).
+// fieldSelector. Best-effort, matching applySelectors (the only caller): a
+// malformed labelSelector returns items unfiltered rather than erroring, and
+// an item that fails to unmarshal is kept (never silently hidden) — safe for
+// a read, where "matches more than intended" only affects display fidelity.
+// The writable overlay's deletecollection uses the stricter filterItemsStrict
+// instead (below), where the same leniency would risk deleting more than the
+// caller asked for.
 func filterItems(items []json.RawMessage, labelSelector, fieldSelector string) []json.RawMessage {
 	if labelSelector == "" && fieldSelector == "" {
 		return items

--- a/internal/server/selector.go
+++ b/internal/server/selector.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // k8s object shape we inspect for filtering.
@@ -249,14 +251,16 @@ func validateSelectorsStrict(labelSelector, fieldSelector string) string {
 			return "invalid labelSelector: " + err.Error()
 		}
 		for _, r := range reqs {
-			if r.key == "" {
-				// parseOneRequirement doesn't itself reject this: e.g. a bare "!" or
-				// "=foo" segment parses to a "doesnotexist"/"="-with-empty-key
-				// requirement rather than an error. An empty key never legitimately
-				// exists on a real object's labels, so "doesnotexist" (and similar)
-				// against it matches every item — exactly the "delete everything"
-				// failure mode this validation exists to catch.
-				return "invalid labelSelector: empty label key"
+			// parseOneRequirement doesn't itself validate the key: a bare "!" or
+			// "a b" or "!)" segment parses to a "doesnotexist"/"="-style
+			// requirement on a key that could never legitimately appear on a real
+			// object's labels (empty, containing spaces, unbalanced parens, …).
+			// Such a requirement (especially doesnotexist/notin) then matches
+			// every item — exactly the "delete everything" failure mode this
+			// validation exists to catch. IsQualifiedName is the same format
+			// check the real apiserver applies to label keys.
+			if errs := validation.IsQualifiedName(r.key); len(errs) > 0 {
+				return fmt.Sprintf("invalid labelSelector: invalid label key %q: %s", r.key, strings.Join(errs, "; "))
 			}
 		}
 	}

--- a/internal/server/selector.go
+++ b/internal/server/selector.go
@@ -219,6 +219,45 @@ func parseFieldSelector(selector string) []fieldSelectorReq {
 	return reqs
 }
 
+// setSyntaxRest returns the text after " in " or " notin " in a label
+// requirement segment, and whether the segment is set-based at all (ok is
+// false, rest "" for a plain key/key=val/key!=val segment).
+func setSyntaxRest(seg string) (rest string, ok bool) {
+	if i := strings.Index(seg, " notin "); i >= 0 {
+		return seg[i+len(" notin "):], true
+	}
+	if i := strings.Index(seg, " in "); i >= 0 {
+		return seg[i+len(" in "):], true
+	}
+	return "", false
+}
+
+// validateSetSyntax checks an "in"/"notin" segment's value list is
+// well-formed "(v1,v2,...)" syntax with at least one non-empty value.
+// parseParenList (used by the lenient parseOneRequirement) doesn't enforce
+// this: it silently tolerates a missing "(" or ")" (e.g. "app notin (") or an
+// empty/blank value list, and for "notin" either of those vacuously matches
+// every item — the same "delete everything" failure mode the rest of
+// validateSelectorsStrict exists to close off. A segment that isn't set-based
+// is reported ok (nothing for this check to do).
+func validateSetSyntax(seg string) (ok bool, msg string) {
+	rest, isSetBased := setSyntaxRest(seg)
+	if !isSetBased {
+		return true, ""
+	}
+	rest = strings.TrimSpace(rest)
+	if len(rest) < 2 || rest[0] != '(' || rest[len(rest)-1] != ')' ||
+		strings.ContainsAny(rest[1:len(rest)-1], "()") {
+		return false, fmt.Sprintf("invalid labelSelector: malformed set syntax in %q", seg)
+	}
+	for _, v := range strings.Split(rest[1:len(rest)-1], ",") {
+		if strings.TrimSpace(v) == "" {
+			return false, fmt.Sprintf("invalid labelSelector: empty value in set syntax %q", seg)
+		}
+	}
+	return true, ""
+}
+
 // supportedFieldSelectorKeys are the metadata fields matchesFields actually
 // filters on; validateSelectorsStrict rejects any other key.
 var supportedFieldSelectorKeys = map[string]bool{
@@ -236,14 +275,19 @@ var supportedFieldSelectorKeys = map[string]bool{
 // when both selectors are well-formed and reference only supported keys.
 func validateSelectorsStrict(labelSelector, fieldSelector string) string {
 	if labelSelector != "" {
-		// parseRequirements silently skips an empty comma-separated segment
-		// (e.g. from "," or "a,,b") rather than erroring, so a selector of just
-		// "," parses to zero requirements — which matchesLabels treats as
-		// "matches everything" (an empty requirement list vacuously passes).
-		// Reject any empty segment explicitly before that leniency can apply.
 		for _, seg := range splitRespectingParens(labelSelector) {
-			if strings.TrimSpace(seg) == "" {
+			seg = strings.TrimSpace(seg)
+			// parseRequirements silently skips an empty comma-separated segment
+			// (e.g. from "," or "a,,b") rather than erroring, so a selector of
+			// just "," parses to zero requirements — which matchesLabels treats
+			// as "matches everything" (an empty requirement list vacuously
+			// passes). Reject any empty segment explicitly before that leniency
+			// can apply.
+			if seg == "" {
 				return "invalid labelSelector: empty selector segment"
+			}
+			if ok, msg := validateSetSyntax(seg); !ok {
+				return msg
 			}
 		}
 		reqs, err := parseRequirements(labelSelector)

--- a/internal/server/selector.go
+++ b/internal/server/selector.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // k8s object shape we inspect for filtering.
@@ -219,115 +220,104 @@ func parseFieldSelector(selector string) []fieldSelectorReq {
 	return reqs
 }
 
-// setSyntaxRest returns the text after " in " or " notin " in a label
-// requirement segment, and whether the segment is set-based at all (ok is
-// false, rest "" for a plain key/key=val/key!=val segment).
-func setSyntaxRest(seg string) (rest string, ok bool) {
-	if i := strings.Index(seg, " notin "); i >= 0 {
-		return seg[i+len(" notin "):], true
-	}
-	if i := strings.Index(seg, " in "); i >= 0 {
-		return seg[i+len(" in "):], true
-	}
-	return "", false
-}
-
-// validateSetSyntax checks an "in"/"notin" segment's value list is
-// well-formed "(v1,v2,...)" syntax with at least one non-empty value.
-// parseParenList (used by the lenient parseOneRequirement) doesn't enforce
-// this: it silently tolerates a missing "(" or ")" (e.g. "app notin (") or an
-// empty/blank value list, and for "notin" either of those vacuously matches
-// every item — the same "delete everything" failure mode the rest of
-// validateSelectorsStrict exists to close off. A segment that isn't set-based
-// is reported ok (nothing for this check to do).
-func validateSetSyntax(seg string) (ok bool, msg string) {
-	rest, isSetBased := setSyntaxRest(seg)
-	if !isSetBased {
-		return true, ""
-	}
-	rest = strings.TrimSpace(rest)
-	if len(rest) < 2 || rest[0] != '(' || rest[len(rest)-1] != ')' ||
-		strings.ContainsAny(rest[1:len(rest)-1], "()") {
-		return false, fmt.Sprintf("invalid labelSelector: malformed set syntax in %q", seg)
-	}
-	for _, v := range strings.Split(rest[1:len(rest)-1], ",") {
-		if strings.TrimSpace(v) == "" {
-			return false, fmt.Sprintf("invalid labelSelector: empty value in set syntax %q", seg)
-		}
-	}
-	return true, ""
-}
-
-// supportedFieldSelectorKeys are the metadata fields matchesFields actually
-// filters on; validateSelectorsStrict rejects any other key.
+// supportedFieldSelectorKeys are the metadata fields matchesFields (and
+// fieldsAdapter, below) actually filter on; filterItemsStrict rejects any
+// other key.
 var supportedFieldSelectorKeys = map[string]bool{
 	"metadata.name":      true,
 	"metadata.namespace": true,
 }
 
-// validateSelectorsStrict validates labelSelector/fieldSelector the way a real
-// apiserver rejects a malformed one — for callers where the best-effort
-// leniency applySelectors/filterItems/parseFieldSelector use for reads would
-// be unsafe. deletecollection is the motivating case: silently treating an
-// unparseable labelSelector or an unsupported fieldSelector key as "matches
-// everything" would delete more than the caller asked for, not just display
-// more than intended. Returns a message suitable for a 400 response, or ""
-// when both selectors are well-formed and reference only supported keys.
-func validateSelectorsStrict(labelSelector, fieldSelector string) string {
+// fieldsAdapter exposes a k8sObject's supported field-selector keys through
+// k8s.io/apimachinery/pkg/fields.Fields, so fields.Selector.Matches can
+// evaluate it directly.
+type fieldsAdapter struct{ obj *k8sObject }
+
+func (f fieldsAdapter) Has(field string) bool { return supportedFieldSelectorKeys[field] }
+
+func (f fieldsAdapter) Get(field string) string {
+	switch field {
+	case "metadata.name":
+		return f.obj.Metadata.Name
+	case "metadata.namespace":
+		return f.obj.Metadata.Namespace
+	default:
+		return ""
+	}
+}
+
+// filterItemsStrict filters items for deletecollection using
+// k8s.io/apimachinery's own label/field selector grammar and matching
+// (labels.Parse, fields.ParseSelector) instead of filterItems' best-effort,
+// hand-rolled parser. Multiple rounds of review turned up ever-more-specific
+// ways the hand-rolled parser leniently accepted a malformed selector as
+// "matches everything" (empty keys, empty segments, unbalanced set syntax,
+// invalid key characters, ...) — using the real, exhaustively-validated
+// parser closes off that entire class of gaps at once rather than patching
+// one shape of malformed input at a time. The read path (applySelectors,
+// filterTableRows) is unaffected — it keeps its existing best-effort
+// filterItems, where "matches more than intended" only affects display
+// fidelity, not what gets deleted.
+//
+// Returns an error message suitable for a 400 response (with items nil), or
+// ("", filtered) on success — filtered is items unchanged if both selectors
+// are empty.
+func filterItemsStrict(items []json.RawMessage, labelSelector, fieldSelector string) (string, []json.RawMessage) {
+	var labelSel labels.Selector
 	if labelSelector != "" {
-		for _, seg := range splitRespectingParens(labelSelector) {
-			seg = strings.TrimSpace(seg)
-			// parseRequirements silently skips an empty comma-separated segment
-			// (e.g. from "," or "a,,b") rather than erroring, so a selector of
-			// just "," parses to zero requirements — which matchesLabels treats
-			// as "matches everything" (an empty requirement list vacuously
-			// passes). Reject any empty segment explicitly before that leniency
-			// can apply.
-			if seg == "" {
-				return "invalid labelSelector: empty selector segment"
-			}
-			if ok, msg := validateSetSyntax(seg); !ok {
-				return msg
-			}
-		}
-		reqs, err := parseRequirements(labelSelector)
+		sel, err := labels.Parse(labelSelector)
 		if err != nil {
-			return "invalid labelSelector: " + err.Error()
+			return "invalid labelSelector: " + err.Error(), nil
 		}
-		for _, r := range reqs {
-			// parseOneRequirement doesn't itself validate the key: a bare "!" or
-			// "a b" or "!)" segment parses to a "doesnotexist"/"="-style
-			// requirement on a key that could never legitimately appear on a real
-			// object's labels (empty, containing spaces, unbalanced parens, …).
-			// Such a requirement (especially doesnotexist/notin) then matches
-			// every item — exactly the "delete everything" failure mode this
-			// validation exists to catch. IsQualifiedName is the same format
-			// check the real apiserver applies to label keys.
-			if errs := validation.IsQualifiedName(r.key); len(errs) > 0 {
-				return fmt.Sprintf("invalid labelSelector: invalid label key %q: %s", r.key, strings.Join(errs, "; "))
-			}
+		// A non-empty input string that parses to a selector with zero
+		// requirements (e.g. all-whitespace) restricts nothing — apimachinery's
+		// parser treats that the same as "no selector supplied" rather than
+		// erroring, which would otherwise let it slip through as "matches
+		// everything".
+		if sel.Empty() {
+			return fmt.Sprintf("invalid labelSelector %q: does not restrict the selection", labelSelector), nil
 		}
+		labelSel = sel
 	}
+	var fieldSel fields.Selector
 	if fieldSelector != "" {
-		for _, seg := range strings.Split(fieldSelector, ",") {
-			seg = strings.TrimSpace(seg)
-			// As with the labelSelector empty-segment check above: parseFieldSelector
-			// silently skips an empty segment (e.g. from "," or "a,,b") rather than
-			// erroring, so a fieldSelector of just "," parses to zero requirements —
-			// which matchesFields treats as "matches everything". Reject it instead.
-			if seg == "" {
-				return "invalid fieldSelector: empty selector segment"
-			}
-			req, ok := parseFieldSelectorSegment(seg)
-			if !ok {
-				return fmt.Sprintf("invalid fieldSelector segment %q", seg)
-			}
-			if !supportedFieldSelectorKeys[req.field] {
-				return fmt.Sprintf("unsupported fieldSelector key %q", req.field)
+		sel, err := fields.ParseSelector(fieldSelector)
+		if err != nil {
+			return "invalid fieldSelector: " + err.Error(), nil
+		}
+		// fields.ParseSelector is, unlike labels.Parse, lenient about a stray
+		// comma (e.g. "," or "a,,b" parses to zero requirements rather than
+		// erroring) — same vacuous "matches everything" risk as above.
+		if sel.Empty() {
+			return fmt.Sprintf("invalid fieldSelector %q: does not restrict the selection", fieldSelector), nil
+		}
+		for _, r := range sel.Requirements() {
+			if !supportedFieldSelectorKeys[r.Field] {
+				return fmt.Sprintf("unsupported fieldSelector key %q", r.Field), nil
 			}
 		}
+		fieldSel = sel
 	}
-	return ""
+	if labelSel == nil && fieldSel == nil {
+		return "", items
+	}
+
+	filtered := items[:0]
+	for _, raw := range items {
+		var obj k8sObject
+		if err := json.Unmarshal(raw, &obj); err != nil {
+			filtered = append(filtered, raw) // can't parse — keep, don't hide (matches filterItems' convention)
+			continue
+		}
+		if labelSel != nil && !labelSel.Matches(labels.Set(obj.Metadata.Labels)) {
+			continue
+		}
+		if fieldSel != nil && !fieldSel.Matches(fieldsAdapter{&obj}) {
+			continue
+		}
+		filtered = append(filtered, raw)
+	}
+	return "", filtered
 }
 
 // matchesFields returns true if the object satisfies all field selector requirements.

--- a/internal/server/selector.go
+++ b/internal/server/selector.go
@@ -234,6 +234,16 @@ var supportedFieldSelectorKeys = map[string]bool{
 // when both selectors are well-formed and reference only supported keys.
 func validateSelectorsStrict(labelSelector, fieldSelector string) string {
 	if labelSelector != "" {
+		// parseRequirements silently skips an empty comma-separated segment
+		// (e.g. from "," or "a,,b") rather than erroring, so a selector of just
+		// "," parses to zero requirements — which matchesLabels treats as
+		// "matches everything" (an empty requirement list vacuously passes).
+		// Reject any empty segment explicitly before that leniency can apply.
+		for _, seg := range splitRespectingParens(labelSelector) {
+			if strings.TrimSpace(seg) == "" {
+				return "invalid labelSelector: empty selector segment"
+			}
+		}
 		reqs, err := parseRequirements(labelSelector)
 		if err != nil {
 			return "invalid labelSelector: " + err.Error()

--- a/internal/server/selector.go
+++ b/internal/server/selector.go
@@ -234,8 +234,20 @@ var supportedFieldSelectorKeys = map[string]bool{
 // when both selectors are well-formed and reference only supported keys.
 func validateSelectorsStrict(labelSelector, fieldSelector string) string {
 	if labelSelector != "" {
-		if _, err := parseRequirements(labelSelector); err != nil {
+		reqs, err := parseRequirements(labelSelector)
+		if err != nil {
 			return "invalid labelSelector: " + err.Error()
+		}
+		for _, r := range reqs {
+			if r.key == "" {
+				// parseOneRequirement doesn't itself reject this: e.g. a bare "!" or
+				// "=foo" segment parses to a "doesnotexist"/"="-with-empty-key
+				// requirement rather than an error. An empty key never legitimately
+				// exists on a real object's labels, so "doesnotexist" (and similar)
+				// against it matches every item — exactly the "delete everything"
+				// failure mode this validation exists to catch.
+				return "invalid labelSelector: empty label key"
+			}
 		}
 	}
 	for _, seg := range strings.Split(fieldSelector, ",") {

--- a/internal/server/selector.go
+++ b/internal/server/selector.go
@@ -308,17 +308,23 @@ func validateSelectorsStrict(labelSelector, fieldSelector string) string {
 			}
 		}
 	}
-	for _, seg := range strings.Split(fieldSelector, ",") {
-		seg = strings.TrimSpace(seg)
-		if seg == "" {
-			continue
-		}
-		req, ok := parseFieldSelectorSegment(seg)
-		if !ok {
-			return fmt.Sprintf("invalid fieldSelector segment %q", seg)
-		}
-		if !supportedFieldSelectorKeys[req.field] {
-			return fmt.Sprintf("unsupported fieldSelector key %q", req.field)
+	if fieldSelector != "" {
+		for _, seg := range strings.Split(fieldSelector, ",") {
+			seg = strings.TrimSpace(seg)
+			// As with the labelSelector empty-segment check above: parseFieldSelector
+			// silently skips an empty segment (e.g. from "," or "a,,b") rather than
+			// erroring, so a fieldSelector of just "," parses to zero requirements —
+			// which matchesFields treats as "matches everything". Reject it instead.
+			if seg == "" {
+				return "invalid fieldSelector: empty selector segment"
+			}
+			req, ok := parseFieldSelectorSegment(seg)
+			if !ok {
+				return fmt.Sprintf("invalid fieldSelector segment %q", seg)
+			}
+			if !supportedFieldSelectorKeys[req.field] {
+				return fmt.Sprintf("unsupported fieldSelector key %q", req.field)
+			}
 		}
 	}
 	return ""

--- a/internal/server/selector.go
+++ b/internal/server/selector.go
@@ -189,13 +189,13 @@ type fieldSelectorReq struct {
 // matches none of those forms.
 func parseFieldSelectorSegment(seg string) (fieldSelectorReq, bool) {
 	if i := strings.Index(seg, "!="); i >= 0 {
-		return fieldSelectorReq{strings.TrimSpace(seg[:i]), "!=", seg[i+2:]}, true
+		return fieldSelectorReq{strings.TrimSpace(seg[:i]), "!=", strings.TrimSpace(seg[i+2:])}, true
 	}
 	if i := strings.Index(seg, "=="); i >= 0 {
-		return fieldSelectorReq{strings.TrimSpace(seg[:i]), "=", seg[i+2:]}, true
+		return fieldSelectorReq{strings.TrimSpace(seg[:i]), "=", strings.TrimSpace(seg[i+2:])}, true
 	}
 	if i := strings.Index(seg, "="); i >= 0 {
-		return fieldSelectorReq{strings.TrimSpace(seg[:i]), "=", seg[i+1:]}, true
+		return fieldSelectorReq{strings.TrimSpace(seg[:i]), "=", strings.TrimSpace(seg[i+1:])}, true
 	}
 	return fieldSelectorReq{}, false
 }
@@ -427,10 +427,6 @@ func filterItems(items []json.RawMessage, labelSelector, fieldSelector string) [
 // both selectors are empty or if the body is not a list.
 func applySelectors(body []byte, labelSelector, fieldSelector string) ([]byte, error) {
 	if labelSelector == "" && fieldSelector == "" {
-		return body, nil
-	}
-	if _, err := parseRequirements(labelSelector); err != nil {
-		// Malformed selector — return body unfiltered (best-effort).
 		return body, nil
 	}
 

--- a/internal/server/selector_test.go
+++ b/internal/server/selector_test.go
@@ -116,6 +116,10 @@ func TestApplySelectors_FieldFilter(t *testing.T) {
 		{"metadata.name!=nginx", []string{"redis"}},
 		{"metadata.namespace=kube-system", []string{"redis"}},
 		{"metadata.namespace!=kube-system", []string{"nginx"}},
+		// Whitespace around the operator must be trimmed from both sides, not
+		// just the key — "= nginx" (with a leading space in the value) should
+		// still match "nginx".
+		{"metadata.name = nginx", []string{"nginx"}},
 	}
 
 	for _, tc := range cases {

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -499,16 +499,30 @@ func (h *handler) overlayDeleteCollection(w http.ResponseWriter, r *http.Request
 	}
 	items = filterItems(items, r.URL.Query().Get("labelSelector"), r.URL.Query().Get("fieldSelector"))
 
-	floor := h.replayFloorRV(group, version, resource, namespace)
+	// floors caches replayFloorRV per namespace: almost always one namespace (the
+	// request's), but a cluster-wide request against a namespaced resource (see
+	// the fallback below `namespace == ""`) can span several — each needs its own
+	// floor so a delete's RV exceeds that specific namespace's watchers, not just
+	// the request scope's.
+	floors := map[string]int64{}
 	for _, it := range items {
 		name := metaString(it, "name")
 		if name == "" {
 			continue // malformed/nameless item — nothing to key a delete on
 		}
+		ns := namespace
+		if ns == "" {
+			ns = metaString(it, "namespace") // cluster-scoped resource, or a cluster-wide request spanning namespaces
+		}
+		floor, ok := floors[ns]
+		if !ok {
+			floor = h.replayFloorRV(group, version, resource, ns)
+			floors[ns] = floor
+		}
 		// deleteOneObject's return is deliberately ignored: an item already gone
 		// (e.g. concurrently deleted) is a silent no-op, matching deletecollection's
 		// best-effort-over-a-listed-set semantics rather than a transaction.
-		h.deleteOneObject(group, version, resource, metaString(it, "namespace"), name, floor)
+		h.deleteOneObject(group, version, resource, ns, name, floor)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"apiVersion": "v1", "kind": "Status", "status": "Success",
@@ -528,23 +542,50 @@ func (h *handler) currentListItems(group, version, resource, namespace string) (
 	if h.clock != nil {
 		at = h.clock.Now()
 	}
-	body, code, err := h.store.ReconstructAt(listPathFor(group, version, resource, namespace), at)
+	items, err := h.reconstructListItems(listPathFor(group, version, resource, namespace), at)
 	if err != nil {
 		return nil, err
 	}
-	var items []json.RawMessage
-	if code == 200 {
-		var list struct {
-			Items []json.RawMessage `json:"items"`
+	if items == nil && namespace != "" {
+		// The namespaced list was never captured on its own path (e.g. only the
+		// cluster-scoped path was captured) — fall back to it and filter by
+		// namespace, mirroring serveResource's read-path fallback (handler.go) so
+		// deletecollection sees the same items a GET/LIST would, rather than
+		// silently no-oping on captured data it can't see.
+		clusterItems, cerr := h.reconstructListItems(listPathFor(group, version, resource, ""), at)
+		if cerr != nil {
+			return nil, cerr
 		}
-		if err := json.Unmarshal(body, &list); err != nil {
-			return nil, err
+		for _, it := range clusterItems {
+			if metaString(it, "namespace") == namespace {
+				items = append(items, it)
+			}
 		}
-		items = list.Items
-	} // code == 404 (or anything else not-200): zero captured items, not an error
+	}
 
 	items, _ = h.overlay.applyToList(group, version, resource, namespace, items)
 	return dropDeletedNamespaceItems(items, h.overlay.deletedNamespaces()), nil
+}
+
+// reconstructListItems reconstructs a captured list at `at` and returns its
+// items. Returns nil (not an error) when nothing was captured at that exact
+// path (a non-200 reconstruction) — distinct from a captured-but-empty list,
+// which unmarshals to a non-nil empty slice and is trusted as-is.
+func (h *handler) reconstructListItems(path string, at time.Time) ([]json.RawMessage, error) {
+	body, code, err := h.store.ReconstructAt(path, at)
+	if err != nil {
+		return nil, err
+	}
+	if code != 200 {
+		return nil, nil
+	}
+	var list struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(body, &list); err != nil {
+		return nil, err
+	}
+	return list.Items, nil
 }
 
 // identityMismatch writes a 400 and returns true when an object body's

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -497,18 +497,18 @@ func (h *handler) overlayDeleteCollection(w http.ResponseWriter, r *http.Request
 		writeJSON(w, http.StatusInternalServerError, statusObj(http.StatusInternalServerError, err.Error()))
 		return
 	}
-	labelSel := r.URL.Query().Get("labelSelector")
-	fieldSel := r.URL.Query().Get("fieldSelector")
 	// Unlike a read (applySelectors/filterItems, deliberately best-effort — a
 	// malformed selector there just means "show more than intended"), a
 	// malformed or unsupported selector here would mean "delete more than
-	// intended" — validate strictly and 400 rather than silently matching
+	// intended" — filterItemsStrict parses with apimachinery's real selector
+	// grammar and 400s on anything malformed, rather than silently matching
 	// everything.
-	if msg := validateSelectorsStrict(labelSel, fieldSel); msg != "" {
+	msg, filtered := filterItemsStrict(items, r.URL.Query().Get("labelSelector"), r.URL.Query().Get("fieldSelector"))
+	if msg != "" {
 		h.writeStatus(w, http.StatusBadRequest, msg)
 		return
 	}
-	items = filterItems(items, labelSel, fieldSel)
+	items = filtered
 
 	// floors caches replayFloorRV per namespace: almost always one namespace (the
 	// request's), but a cluster-wide request against a namespaced resource (see

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -497,7 +497,18 @@ func (h *handler) overlayDeleteCollection(w http.ResponseWriter, r *http.Request
 		writeJSON(w, http.StatusInternalServerError, statusObj(http.StatusInternalServerError, err.Error()))
 		return
 	}
-	items = filterItems(items, r.URL.Query().Get("labelSelector"), r.URL.Query().Get("fieldSelector"))
+	labelSel := r.URL.Query().Get("labelSelector")
+	fieldSel := r.URL.Query().Get("fieldSelector")
+	// Unlike a read (applySelectors/filterItems, deliberately best-effort — a
+	// malformed selector there just means "show more than intended"), a
+	// malformed or unsupported selector here would mean "delete more than
+	// intended" — validate strictly and 400 rather than silently matching
+	// everything.
+	if msg := validateSelectorsStrict(labelSel, fieldSel); msg != "" {
+		h.writeStatus(w, http.StatusBadRequest, msg)
+		return
+	}
+	items = filterItems(items, labelSel, fieldSel)
 
 	// floors caches replayFloorRV per namespace: almost always one namespace (the
 	// request's), but a cluster-wide request against a namespaced resource (see
@@ -546,7 +557,8 @@ func (h *handler) currentListItems(group, version, resource, namespace string) (
 	if err != nil {
 		return nil, err
 	}
-	if items == nil && namespace != "" {
+	switch {
+	case items == nil && namespace != "":
 		// The namespaced list was never captured on its own path (e.g. only the
 		// cluster-scoped path was captured) — fall back to it and filter by
 		// namespace, mirroring serveResource's read-path fallback (handler.go) so
@@ -561,6 +573,24 @@ func (h *handler) currentListItems(group, version, resource, namespace string) (
 				items = append(items, it)
 			}
 		}
+	case items == nil && namespace == "":
+		// The cluster-wide list was never captured on its own path either — fall
+		// back to aggregating it from per-namespace captures, mirroring
+		// serveResource's AggregateAcrossNamespaces fallback, so a cluster-wide
+		// deletecollection (e.g. DELETE /api/v1/pods) sees the same items a
+		// cluster-wide GET/LIST would.
+		aggBody, aggCode, aerr := h.store.AggregateAcrossNamespaces(listPathFor(group, version, resource, ""), at)
+		if aerr != nil {
+			return nil, aerr
+		}
+		if aggCode == 200 {
+			var list struct {
+				Items []json.RawMessage `json:"items"`
+			}
+			if json.Unmarshal(aggBody, &list) == nil {
+				items = list.Items
+			}
+		}
 	}
 
 	items, _ = h.overlay.applyToList(group, version, resource, namespace, items)
@@ -569,8 +599,12 @@ func (h *handler) currentListItems(group, version, resource, namespace string) (
 
 // reconstructListItems reconstructs a captured list at `at` and returns its
 // items. Returns nil (not an error) when nothing was captured at that exact
-// path (a non-200 reconstruction) — distinct from a captured-but-empty list,
-// which unmarshals to a non-nil empty slice and is trusted as-is.
+// path (a non-200 reconstruction), or when the 200 body isn't list-shaped
+// (e.g. a Table-format or other non-list snapshot — CaptureStore.ReconstructAt
+// is deliberately tolerant of those and returns them unchanged, so failing to
+// decode "items" here is best-effort, not a hard error) — either way,
+// currentListItems' overlay merge still applies on top. A genuine store error
+// (decompression failure, etc.) still propagates.
 func (h *handler) reconstructListItems(path string, at time.Time) ([]json.RawMessage, error) {
 	body, code, err := h.store.ReconstructAt(path, at)
 	if err != nil {
@@ -582,8 +616,8 @@ func (h *handler) reconstructListItems(path string, at time.Time) ([]json.RawMes
 	var list struct {
 		Items []json.RawMessage `json:"items"`
 	}
-	if err := json.Unmarshal(body, &list); err != nil {
-		return nil, err
+	if json.Unmarshal(body, &list) != nil {
+		return nil, nil
 	}
 	return list.Items, nil
 }

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -546,8 +546,8 @@ func (h *handler) overlayDeleteCollection(w http.ResponseWriter, r *http.Request
 // error, just zero items) with the overlay applied (overlay wins; tombstones
 // removed; overlay-only creates appended), with items in an overlay-deleted
 // namespace dropped. This is overlayDeleteCollection's item source — the same
-// merge mergeOverlayList performs for LIST responses, but returning items
-// directly since there's no HTTP list body to build here.
+// merge that mergeOverlayList performs for LIST responses, but returning
+// items directly since there's no HTTP list body to build here.
 func (h *handler) currentListItems(group, version, resource, namespace string) ([]json.RawMessage, error) {
 	at := h.at
 	if h.clock != nil {

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -611,13 +611,19 @@ func (h *handler) reconstructListItems(path string, at time.Time) ([]json.RawMes
 		return nil, err
 	}
 	if code != 200 {
-		return nil, nil
+		return nil, nil // genuinely not captured at this path — callers fall back
 	}
 	var list struct {
 		Items []json.RawMessage `json:"items"`
 	}
-	if json.Unmarshal(body, &list) != nil {
-		return nil, nil
+	if json.Unmarshal(body, &list) != nil || list.Items == nil {
+		// A 200 response that isn't list-shaped (e.g. a captured Table snapshot)
+		// or has no "items" field is a captured empty list, not "not captured" —
+		// a non-nil empty slice, so currentListItems' nil-triggered
+		// cluster/aggregation fallback doesn't kick in here. A GET/LIST on the
+		// same path wouldn't fall back either (serveResource only falls back on
+		// an actual 404), so deletecollection must operate on the same item set.
+		return []json.RawMessage{}, nil
 	}
 	return list.Items, nil
 }

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -61,8 +61,8 @@ func (h *handler) handleWrite(w http.ResponseWriter, r *http.Request, path strin
 		}
 		h.overlayPatch(w, r, group, version, resource, namespace, name, sub)
 	case http.MethodDelete:
-		if name == "" {
-			h.writeStatus(w, http.StatusBadRequest, "DELETE requires an object name")
+		if name == "" { // deletecollection: parseWritePath guarantees sub == "" here
+			h.overlayDeleteCollection(w, r, group, version, resource, namespace)
 			return
 		}
 		if sub != "" {
@@ -448,27 +448,103 @@ func (h *handler) overlayPatch(w http.ResponseWriter, r *http.Request, group, ve
 	writeJSON(w, http.StatusOK, json.RawMessage(next))
 }
 
-func (h *handler) overlayDelete(w http.ResponseWriter, group, version, resource, namespace, name string) {
-	if name == "" {
-		h.writeStatus(w, http.StatusBadRequest, "object name is required")
-		return
-	}
+// deleteOneObject tombstones a single object identity if it currently exists
+// (in the overlay or the replay state as of h.at/h.clock.Now()), cascading a
+// namespace delete if the identity is itself a core Namespace. Returns the
+// deleted object's last-known body, or nil if there was nothing to delete —
+// the identity was already gone (e.g. concurrently deleted between
+// deletecollection's item scan and this call). Re-checking liveness here
+// (rather than trusting an earlier list snapshot) keeps the DELETED watch
+// event's body fresh and makes a repeated call for the same identity a safe
+// no-op instead of a duplicate tombstone.
+func (h *handler) deleteOneObject(group, version, resource, namespace, name string, floorRV int64) json.RawMessage {
 	last := h.currentObject(group, version, resource, namespace, name)
 	if last == nil {
-		h.writeStatus(w, http.StatusNotFound, "object not found: "+name)
-		return
+		return nil
 	}
-	h.overlay.del(group, version, resource, namespace, name, last, h.replayFloorRV(group, version, resource, namespace))
+	h.overlay.del(group, version, resource, namespace, name, last, floorRV)
 	// Deleting a namespace cascades to its contents (no namespace controller runs
 	// against the overlay): tombstone the namespace's overlay objects, and its
 	// captured objects are filtered out of reads while the namespace is deleted.
 	if isCoreNamespace(group, version, resource) {
 		h.overlay.cascadeDeleteNamespace(name)
 	}
+	return last
+}
+
+func (h *handler) overlayDelete(w http.ResponseWriter, group, version, resource, namespace, name string) {
+	if h.deleteOneObject(group, version, resource, namespace, name,
+		h.replayFloorRV(group, version, resource, namespace)) == nil {
+		h.writeStatus(w, http.StatusNotFound, "object not found: "+name)
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"apiVersion": "v1", "kind": "Status", "status": "Success",
 		"details": map[string]any{"name": name, "kind": resourceToKind(resource)},
 	})
+}
+
+// overlayDeleteCollection implements Kubernetes deletecollection: it deletes
+// every object currently visible for a list scope (group/version/resource,
+// and namespace — empty for a cluster-scoped resource) that matches the
+// request's labelSelector/fieldSelector. Always responds 200 with a Status
+// Success, even when zero items matched — an empty deletecollection is not an
+// error, matching the real apiserver. The request body (DeleteOptions) is
+// intentionally ignored, mirroring overlayDelete/deleteOneObject.
+func (h *handler) overlayDeleteCollection(w http.ResponseWriter, r *http.Request, group, version, resource, namespace string) {
+	items, err := h.currentListItems(group, version, resource, namespace)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, statusObj(http.StatusInternalServerError, err.Error()))
+		return
+	}
+	items = filterItems(items, r.URL.Query().Get("labelSelector"), r.URL.Query().Get("fieldSelector"))
+
+	floor := h.replayFloorRV(group, version, resource, namespace)
+	for _, it := range items {
+		name := metaString(it, "name")
+		if name == "" {
+			continue // malformed/nameless item — nothing to key a delete on
+		}
+		// deleteOneObject's return is deliberately ignored: an item already gone
+		// (e.g. concurrently deleted) is a silent no-op, matching deletecollection's
+		// best-effort-over-a-listed-set semantics rather than a transaction.
+		h.deleteOneObject(group, version, resource, metaString(it, "namespace"), name, floor)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"apiVersion": "v1", "kind": "Status", "status": "Success",
+		"details": map[string]any{"kind": resourceToKind(resource)},
+	})
+}
+
+// currentListItems returns the merged items for a list scope as of the
+// replay clock: the captured base (if any — a 404/empty capture is not an
+// error, just zero items) with the overlay applied (overlay wins; tombstones
+// removed; overlay-only creates appended), with items in an overlay-deleted
+// namespace dropped. This is overlayDeleteCollection's item source — the same
+// merge mergeOverlayList performs for LIST responses, but returning items
+// directly since there's no HTTP list body to build here.
+func (h *handler) currentListItems(group, version, resource, namespace string) ([]json.RawMessage, error) {
+	at := h.at
+	if h.clock != nil {
+		at = h.clock.Now()
+	}
+	body, code, err := h.store.ReconstructAt(listPathFor(group, version, resource, namespace), at)
+	if err != nil {
+		return nil, err
+	}
+	var items []json.RawMessage
+	if code == 200 {
+		var list struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		if err := json.Unmarshal(body, &list); err != nil {
+			return nil, err
+		}
+		items = list.Items
+	} // code == 404 (or anything else not-200): zero captured items, not an error
+
+	items, _ = h.overlay.applyToList(group, version, resource, namespace, items)
+	return dropDeletedNamespaceItems(items, h.overlay.deletedNamespaces()), nil
 }
 
 // identityMismatch writes a 400 and returns true when an object body's
@@ -640,7 +716,7 @@ func kindForResource(gv schema.GroupVersion, resource string) (schema.GroupVersi
 func allowedMethods(name, sub string) string {
 	switch {
 	case name == "":
-		return "GET, HEAD, POST"
+		return "GET, HEAD, POST, DELETE"
 	case sub == "":
 		return "GET, HEAD, PUT, PATCH, DELETE"
 	case sub == "status":
@@ -762,6 +838,23 @@ func metaInt(obj json.RawMessage, field string) int64 {
 		return 0
 	}
 	return n
+}
+
+// dropDeletedNamespaceItems removes items whose metadata.namespace is in dns
+// (see overlay.deletedNamespaces) — used to cascade a namespace delete into
+// read results and into deletecollection's item set, for both captured and
+// overlay-created items.
+func dropDeletedNamespaceItems(items []json.RawMessage, dns map[string]struct{}) []json.RawMessage {
+	if len(dns) == 0 {
+		return items
+	}
+	kept := items[:0]
+	for _, it := range items {
+		if _, gone := dns[metaString(it, "namespace")]; !gone {
+			kept = append(kept, it)
+		}
+	}
+	return kept
 }
 
 // isJSONObject reports whether b is a JSON object ("{...}"), rejecting null,

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -1058,6 +1058,9 @@ func TestOverlay_DeleteCollection_InvalidSelectorRejected(t *testing.T) {
 		// produces a single empty-string value, so "notin ('')" vacuously
 		// matches every item regardless of whether "app" is even set.
 		{"unclosed notin paren", "?labelSelector=app+notin+%28"},
+		// A bare "," parses to zero fieldSelector requirements the same way it
+		// does for labelSelector — matchesFields vacuously matches every item.
+		{"empty fieldSelector segment", "?fieldSelector=%2C"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -1102,6 +1102,41 @@ func TestOverlay_DeleteCollection_NonListCaptureBodyIsBestEffort(t *testing.T) {
 	}
 }
 
+// TestOverlay_DeleteCollection_NonListClusterBodyDoesNotAggregate is the
+// cluster-wide counterpart: a cluster-wide deletecollection (no namespace
+// segment) whose own list path was captured as a non-list (e.g. Table) 200
+// response must not fall back to aggregating per-namespace captures — a
+// GET/LIST on the same cluster-wide path wouldn't (serveResource only
+// aggregates on an actual 404), so pods captured only under per-namespace
+// paths must survive.
+func TestOverlay_DeleteCollection_NonListClusterBodyDoesNotAggregate(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	tableBody := `{"kind":"Table","apiVersion":"meta.k8s.io/v1","columnDefinitions":[],"rows":[]}`
+	store := buildTestStoreWithWatch(t, map[string]watchTestRecord{
+		"/api/v1/pods": {id: "t", at: from, body: tableBody},
+		"/api/v1/namespaces/ns-a/pods": {id: "a", at: from, body: `{"apiVersion":"v1","kind":"PodList","metadata":{"resourceVersion":"1"},"items":[` +
+			`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-a","namespace":"ns-a"}}]}`},
+	}, nil)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, store, clock)
+
+	// Sanity: pod-a is independently visible via its own namespaced path.
+	if code, _ := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/ns-a/pods/pod-a", "", ""); code != 200 {
+		t.Fatalf("sanity: pod-a should exist before delete, status %d", code)
+	}
+
+	if code, _ := doReq(t, http.MethodDelete, srv.URL+"/api/v1/pods", "", ""); code != 200 {
+		t.Fatalf("cluster-wide deletecollection over a non-list captured body: status %d", code)
+	}
+	// pod-a lives only under its own namespaced capture, invisible to a plain
+	// GET on the cluster-wide path (which just returns the Table body as-is).
+	// The cluster-wide deletecollection must see the same (empty) item set, not
+	// aggregate across every namespace and delete it too.
+	if code, _ := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/ns-a/pods/pod-a", "", ""); code != 200 {
+		t.Errorf("pod-a should survive the cluster-wide deletecollection, status %d", code)
+	}
+}
+
 func TestOverlay_ReadOnlyRejectsWrites(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -967,6 +967,82 @@ func TestOverlay_DeleteCollection_ClusterPathFallback(t *testing.T) {
 	}
 }
 
+// TestOverlay_DeleteCollection_AggregateAcrossNamespacesFallback verifies a
+// cluster-wide deletecollection (no namespace segment) finds items even when
+// only per-namespace list paths were captured — mirroring serveResource's
+// AggregateAcrossNamespaces read-path fallback (handler.go) — rather than
+// silently no-oping on captured objects it can't see directly.
+func TestOverlay_DeleteCollection_AggregateAcrossNamespacesFallback(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	store := buildTestStoreWithWatch(t, map[string]watchTestRecord{
+		"/api/v1/namespaces/ns-a/pods": {id: "a", at: from, body: `{"apiVersion":"v1","kind":"PodList","metadata":{"resourceVersion":"1"},"items":[` +
+			`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-a","namespace":"ns-a"}}]}`},
+		"/api/v1/namespaces/ns-b/pods": {id: "b", at: from, body: `{"apiVersion":"v1","kind":"PodList","metadata":{"resourceVersion":"1"},"items":[` +
+			`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-b","namespace":"ns-b"}}]}`},
+	}, nil)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, store, clock)
+
+	// Sanity: the cluster-wide GET only sees both pods via aggregation.
+	if _, l := doReq(t, http.MethodGet, srv.URL+"/api/v1/pods", "", ""); !contains(listNames(t, l), "pod-a") || !contains(listNames(t, l), "pod-b") {
+		t.Fatalf("sanity: both pods should be visible via cluster-wide aggregation: %v", listNames(t, l))
+	}
+
+	if code, _ := doReq(t, http.MethodDelete, srv.URL+"/api/v1/pods", "", ""); code != 200 {
+		t.Fatalf("cluster-wide deletecollection via aggregation fallback: status %d", code)
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/ns-a/pods/pod-a", "", ""); code != 404 {
+		t.Errorf("GET pod-a after deletecollection: status %d, want 404", code)
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/ns-b/pods/pod-b", "", ""); code != 404 {
+		t.Errorf("GET pod-b after deletecollection: status %d, want 404", code)
+	}
+}
+
+// TestOverlay_DeleteCollection_InvalidSelectorRejected verifies deletecollection
+// validates fieldSelector strictly (400, no items deleted) rather than the read
+// path's best-effort "silently ignore an unsupported key" (matchesFields'
+// generous default) — a silently-ignored requirement here would otherwise mean
+// "delete more than the caller asked for", not just "display more than
+// intended".
+func TestOverlay_DeleteCollection_InvalidSelectorRejected(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock) // captures pod-base
+
+	code, _ := doReq(t, http.MethodDelete, srv.URL+podsPath+"?fieldSelector=spec.nodeName%3Dnode-1", "", "")
+	if code != http.StatusBadRequest {
+		t.Errorf("deletecollection with unsupported fieldSelector key: status %d, want 400", code)
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-base", "", ""); code != 200 {
+		t.Errorf("pod-base should survive a rejected selector: status %d", code)
+	}
+}
+
+// TestOverlay_DeleteCollection_NonListCaptureBodyIsBestEffort verifies
+// deletecollection doesn't hard-fail when the captured body at the list path
+// isn't list-shaped (e.g. a Table-format snapshot) — it's treated as zero
+// captured items (best-effort, matching CaptureStore.ReconstructAt's own
+// tolerance of non-list bodies), and overlay-owned items still delete cleanly.
+func TestOverlay_DeleteCollection_NonListCaptureBodyIsBestEffort(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	tableBody := `{"kind":"Table","apiVersion":"meta.k8s.io/v1","columnDefinitions":[],"rows":[]}`
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{podsPath: {id: "t", at: from, body: tableBody}}, nil)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, store, clock)
+
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-overlay"))
+
+	code, body := doReq(t, http.MethodDelete, srv.URL+podsPath, "", "")
+	if code != 200 {
+		t.Fatalf("deletecollection over a non-list captured body: status %d: %s", code, body)
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-overlay", "", ""); code != 404 {
+		t.Errorf("GET pod-overlay after deletecollection: status %d, want 404", code)
+	}
+}
+
 func TestOverlay_ReadOnlyRejectsWrites(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -1017,6 +1017,10 @@ func TestOverlay_DeleteCollection_InvalidSelectorRejected(t *testing.T) {
 		// (since no real object has an empty-string label key) matches every
 		// item — exactly the "delete everything" failure mode this rejects.
 		{"empty labelSelector key", "?labelSelector=%21"},
+		// A bare "," parses to zero requirements (parseRequirements silently
+		// skips empty segments), and zero requirements vacuously matches every
+		// item — the same "delete everything" failure mode from a different angle.
+		{"empty labelSelector segment", "?labelSelector=%2C"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -768,6 +768,154 @@ func TestOverlay_NamespaceDeleteCascadeCaptured(t *testing.T) {
 	}
 }
 
+// TestOverlay_DeleteCollection_Mixed covers issue #176: a DELETE at a
+// collection path (deletecollection) must remove every matching object,
+// whether it's a captured-only, overlay-created, or overlay-over-captured
+// identity, in a single call.
+func TestOverlay_DeleteCollection_Mixed(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock) // captures pod-base
+
+	// Overlay-created pod.
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-new"))
+	// Overlay-over-captured: overwrite pod-base.
+	doReq(t, http.MethodPut, srv.URL+podsPath+"/pod-base", "application/json", podBody("pod-base"))
+
+	_, before := doReq(t, http.MethodGet, srv.URL+podsPath, "", "")
+	names := listNames(t, before)
+	if !contains(names, "pod-base") || !contains(names, "pod-new") {
+		t.Fatalf("sanity: list before delete = %v, want both pod-base and pod-new", names)
+	}
+
+	code, body := doReq(t, http.MethodDelete, srv.URL+podsPath, "", "")
+	if code != 200 {
+		t.Fatalf("deletecollection: status %d: %s", code, body)
+	}
+	var status struct {
+		Kind   string `json:"kind"`
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(body, &status); err != nil || status.Kind != "Status" || status.Status != "Success" {
+		t.Errorf("deletecollection response = %s, want kind:Status status:Success", body)
+	}
+
+	if code, _ := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-base", "", ""); code != 404 {
+		t.Errorf("GET pod-base after deletecollection: status %d, want 404", code)
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-new", "", ""); code != 404 {
+		t.Errorf("GET pod-new after deletecollection: status %d, want 404", code)
+	}
+	_, after := doReq(t, http.MethodGet, srv.URL+podsPath, "", "")
+	if names := listNames(t, after); len(names) != 0 {
+		t.Errorf("list after deletecollection = %v, want empty", names)
+	}
+}
+
+// TestOverlay_DeleteCollection_LabelSelectorFilters verifies deletecollection
+// honors labelSelector: only matching items are removed.
+func TestOverlay_DeleteCollection_LabelSelectorFilters(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock) // captures pod-base
+
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json",
+		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-la","namespace":"default","labels":{"app":"x"}}}`)
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json",
+		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-lb","namespace":"default","labels":{"app":"y"}}}`)
+
+	code, _ := doReq(t, http.MethodDelete, srv.URL+podsPath+"?labelSelector=app%3Dx", "", "")
+	if code != 200 {
+		t.Fatalf("deletecollection with selector: status %d", code)
+	}
+
+	_, list := doReq(t, http.MethodGet, srv.URL+podsPath, "", "")
+	names := listNames(t, list)
+	if contains(names, "pod-la") {
+		t.Errorf("pod-la (matched selector) should have been deleted: %v", names)
+	}
+	if !contains(names, "pod-lb") || !contains(names, "pod-base") {
+		t.Errorf("non-matching items should survive: %v", names)
+	}
+}
+
+// TestOverlay_DeleteCollection_EmptyIsStillSuccess verifies a deletecollection
+// that matches nothing still returns 200 Success, not a 404 — matching the
+// real apiserver's behavior for an empty collection.
+func TestOverlay_DeleteCollection_EmptyIsStillSuccess(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	// A resource with nothing captured or overlaid at all.
+	code, body := doReq(t, http.MethodDelete, srv.URL+"/api/v1/namespaces/default/secrets", "", "")
+	if code != 200 {
+		t.Fatalf("deletecollection on empty resource: status %d: %s", code, body)
+	}
+
+	// A selector that excludes every existing item.
+	code, body = doReq(t, http.MethodDelete, srv.URL+podsPath+"?labelSelector=nope%3Dnever", "", "")
+	if code != 200 {
+		t.Fatalf("deletecollection with non-matching selector: status %d: %s", code, body)
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-base", "", ""); code != 200 {
+		t.Errorf("pod-base should survive a non-matching selector delete: status %d", code)
+	}
+}
+
+// TestOverlay_DeleteCollection_ClusterScoped mirrors
+// TestOverlay_ClusterScopedDeleteTombstone but for a collection delete: all
+// captured items at a cluster-scoped path are removed in one call.
+func TestOverlay_DeleteCollection_ClusterScoped(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	nsList := `{"apiVersion":"v1","kind":"NamespaceList","metadata":{"resourceVersion":"1"},"items":[` +
+		`{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"default"}},` +
+		`{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"kube-system"}}]}`
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{"/api/v1/namespaces": {id: "ns", at: from, body: nsList}}, nil)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, store, clock)
+
+	if code, _ := doReq(t, http.MethodDelete, srv.URL+"/api/v1/namespaces", "", ""); code != 200 {
+		t.Fatalf("cluster-scoped deletecollection: status %d", code)
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/default", "", ""); code != 404 {
+		t.Errorf("GET default namespace after deletecollection: status %d, want 404", code)
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/kube-system", "", ""); code != 404 {
+		t.Errorf("GET kube-system namespace after deletecollection: status %d, want 404", code)
+	}
+	_, list := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces", "", "")
+	if names := listNames(t, list); len(names) != 0 {
+		t.Errorf("namespace list after deletecollection = %v, want empty", names)
+	}
+}
+
+// TestOverlay_DeleteCollection_NamespaceCascade verifies a namespace
+// deletecollection cascades into each deleted namespace's contents, exactly
+// like a single namespace delete does (TestOverlay_NamespaceDeleteCascade).
+func TestOverlay_DeleteCollection_NamespaceCascade(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	doReq(t, http.MethodPost, srv.URL+"/api/v1/namespaces", "application/json",
+		`{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"joe-test"}}`)
+	deployColl := "/apis/apps/v1/namespaces/joe-test/deployments"
+	doReq(t, http.MethodPost, srv.URL+deployColl, "application/json",
+		`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"web","namespace":"joe-test"}}`)
+
+	if code, _ := doReq(t, http.MethodDelete, srv.URL+"/api/v1/namespaces", "", ""); code != 200 {
+		t.Fatalf("namespace deletecollection: status %d", code)
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/joe-test", "", ""); code != 404 {
+		t.Errorf("GET joe-test namespace after deletecollection: status %d, want 404", code)
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+deployColl+"/web", "", ""); code != 404 {
+		t.Errorf("deployment in cascade-deleted namespace: status %d, want 404", code)
+	}
+}
+
 func TestOverlay_ReadOnlyRejectsWrites(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -1021,6 +1021,10 @@ func TestOverlay_DeleteCollection_InvalidSelectorRejected(t *testing.T) {
 		// skips empty segments), and zero requirements vacuously matches every
 		// item — the same "delete everything" failure mode from a different angle.
 		{"empty labelSelector segment", "?labelSelector=%2C"},
+		// "!)" parses to a doesnotexist requirement on the key ")" — a key no
+		// real object could ever have (invalid label-key syntax) — so it also
+		// matches every item.
+		{"invalid labelSelector key syntax", "?labelSelector=%21%29"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -839,6 +839,35 @@ func TestOverlay_DeleteCollection_LabelSelectorFilters(t *testing.T) {
 	}
 }
 
+// TestOverlay_DeleteCollection_SetBasedSelectorFilters verifies well-formed
+// set-based ("in"/"notin") labelSelectors still work for deletecollection —
+// validateSelectorsStrict's set-syntax check must reject malformed set syntax
+// without breaking legitimate use.
+func TestOverlay_DeleteCollection_SetBasedSelectorFilters(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock) // captures pod-base
+
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json",
+		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-la","namespace":"default","labels":{"app":"x"}}}`)
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json",
+		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-lb","namespace":"default","labels":{"app":"y"}}}`)
+
+	code, _ := doReq(t, http.MethodDelete, srv.URL+podsPath+"?labelSelector=app+in+%28x%29", "", "") // app in (x)
+	if code != 200 {
+		t.Fatalf("deletecollection with set-based selector: status %d", code)
+	}
+
+	_, list := doReq(t, http.MethodGet, srv.URL+podsPath, "", "")
+	names := listNames(t, list)
+	if contains(names, "pod-la") {
+		t.Errorf("pod-la (matched \"app in (x)\") should have been deleted: %v", names)
+	}
+	if !contains(names, "pod-lb") || !contains(names, "pod-base") {
+		t.Errorf("non-matching items should survive: %v", names)
+	}
+}
+
 // TestOverlay_DeleteCollection_EmptyIsStillSuccess verifies a deletecollection
 // that matches nothing still returns 200 Success, not a 404 — matching the
 // real apiserver's behavior for an empty collection.
@@ -1025,6 +1054,10 @@ func TestOverlay_DeleteCollection_InvalidSelectorRejected(t *testing.T) {
 		// real object could ever have (invalid label-key syntax) — so it also
 		// matches every item.
 		{"invalid labelSelector key syntax", "?labelSelector=%21%29"},
+		// "app notin (" has an unclosed paren; parseParenList tolerates it and
+		// produces a single empty-string value, so "notin ('')" vacuously
+		// matches every item regardless of whether "app" is even set.
+		{"unclosed notin paren", "?labelSelector=app+notin+%28"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -916,6 +916,57 @@ func TestOverlay_DeleteCollection_NamespaceCascade(t *testing.T) {
 	}
 }
 
+// TestOverlay_DeleteCollection_ClusterWideSpansNamespaces covers a
+// deletecollection issued at a cluster-wide path (no namespace segment)
+// against a namespaced resource — items span multiple actual namespaces, so
+// each must be deleted (and its RV floor computed) using its own
+// metadata.namespace rather than the request's empty namespace.
+func TestOverlay_DeleteCollection_ClusterWideSpansNamespaces(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	podsAcrossNS := `{"apiVersion":"v1","kind":"PodList","metadata":{"resourceVersion":"1"},"items":[` +
+		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-a","namespace":"ns-a"}},` +
+		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-b","namespace":"ns-b"}}]}`
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{"/api/v1/pods": {id: "p", at: from, body: podsAcrossNS}}, nil)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, store, clock)
+
+	if code, _ := doReq(t, http.MethodDelete, srv.URL+"/api/v1/pods", "", ""); code != 200 {
+		t.Fatalf("cluster-wide deletecollection: status %d", code)
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/ns-a/pods/pod-a", "", ""); code != 404 {
+		t.Errorf("GET pod-a after cluster-wide deletecollection: status %d, want 404", code)
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/ns-b/pods/pod-b", "", ""); code != 404 {
+		t.Errorf("GET pod-b after cluster-wide deletecollection: status %d, want 404", code)
+	}
+}
+
+// TestOverlay_DeleteCollection_ClusterPathFallback verifies a namespaced
+// deletecollection still finds and deletes captured items when only the
+// cluster-scoped list path was captured (no per-namespace list snapshot),
+// mirroring the same fallback GET/LIST already has (handler.go's
+// serveResource cluster-scoped fallback).
+func TestOverlay_DeleteCollection_ClusterPathFallback(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{"/api/v1/pods": {id: "p", at: from, body: podList("pod-x")}}, nil)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, store, clock)
+
+	// Sanity: the namespaced list only sees pod-x via the cluster-path fallback.
+	if _, l := doReq(t, http.MethodGet, srv.URL+podsPath, "", ""); !contains(listNames(t, l), "pod-x") {
+		t.Fatalf("sanity: pod-x should be visible via the namespaced list's cluster-path fallback")
+	}
+
+	if code, _ := doReq(t, http.MethodDelete, srv.URL+podsPath, "", ""); code != 200 {
+		t.Fatalf("namespaced deletecollection via cluster-path fallback: status %d", code)
+	}
+	if code, _ := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-x", "", ""); code != 404 {
+		t.Errorf("GET pod-x after deletecollection: status %d, want 404", code)
+	}
+}
+
 func TestOverlay_ReadOnlyRejectsWrites(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -841,8 +841,8 @@ func TestOverlay_DeleteCollection_LabelSelectorFilters(t *testing.T) {
 
 // TestOverlay_DeleteCollection_SetBasedSelectorFilters verifies well-formed
 // set-based ("in"/"notin") labelSelectors still work for deletecollection —
-// validateSelectorsStrict's set-syntax check must reject malformed set syntax
-// without breaking legitimate use.
+// filterItemsStrict's strict parsing must reject malformed set syntax without
+// breaking legitimate use.
 func TestOverlay_DeleteCollection_SetBasedSelectorFilters(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
@@ -1029,11 +1029,12 @@ func TestOverlay_DeleteCollection_AggregateAcrossNamespacesFallback(t *testing.T
 }
 
 // TestOverlay_DeleteCollection_InvalidSelectorRejected verifies deletecollection
-// validates fieldSelector strictly (400, no items deleted) rather than the read
-// path's best-effort "silently ignore an unsupported key" (matchesFields'
-// generous default) — a silently-ignored requirement here would otherwise mean
-// "delete more than the caller asked for", not just "display more than
-// intended".
+// rejects a malformed or unsupported labelSelector/fieldSelector with 400
+// (filterItemsStrict, backed by k8s.io/apimachinery's labels.Parse and
+// fields.ParseSelector) rather than the read path's best-effort leniency
+// (filterItems/applySelectors) — which for a mutating deletecollection would
+// mean "delete more than the caller asked for," not just "display more than
+// intended."
 func TestOverlay_DeleteCollection_InvalidSelectorRejected(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 
@@ -1042,25 +1043,24 @@ func TestOverlay_DeleteCollection_InvalidSelectorRejected(t *testing.T) {
 		query string
 	}{
 		{"unsupported fieldSelector key", "?fieldSelector=spec.nodeName%3Dnode-1"},
-		// "!" parses to a doesnotexist requirement with an empty label key, which
-		// (since no real object has an empty-string label key) matches every
-		// item — exactly the "delete everything" failure mode this rejects.
-		{"empty labelSelector key", "?labelSelector=%21"},
-		// A bare "," parses to zero requirements (parseRequirements silently
-		// skips empty segments), and zero requirements vacuously matches every
-		// item — the same "delete everything" failure mode from a different angle.
+		// A bare "!" isn't a valid requirement (! must be followed by a key).
+		{"bare negation, no key", "?labelSelector=%21"},
+		// labels.Parse rejects a stray comma outright.
 		{"empty labelSelector segment", "?labelSelector=%2C"},
-		// "!)" parses to a doesnotexist requirement on the key ")" — a key no
-		// real object could ever have (invalid label-key syntax) — so it also
-		// matches every item.
+		// A key must be a valid qualified name; ")" isn't one.
 		{"invalid labelSelector key syntax", "?labelSelector=%21%29"},
-		// "app notin (" has an unclosed paren; parseParenList tolerates it and
-		// produces a single empty-string value, so "notin ('')" vacuously
-		// matches every item regardless of whether "app" is even set.
+		// An unclosed "notin (" is a syntax error in the real grammar.
 		{"unclosed notin paren", "?labelSelector=app+notin+%28"},
-		// A bare "," parses to zero fieldSelector requirements the same way it
-		// does for labelSelector — matchesFields vacuously matches every item.
+		// fields.ParseSelector is lenient about a stray comma (parses to an
+		// Empty selector rather than erroring) — caught by filterItemsStrict's
+		// explicit Empty() check instead.
 		{"empty fieldSelector segment", "?fieldSelector=%2C"},
+		// Whitespace-only selectors parse successfully to an Empty selector in
+		// both labels.Parse and fields.ParseSelector — also caught by the
+		// Empty() check, since the caller supplied a non-empty selector string
+		// that nonetheless restricts nothing.
+		{"whitespace-only labelSelector", "?labelSelector=+"},
+		{"whitespace-only fieldSelector", "?fieldSelector=+"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -1007,15 +1007,30 @@ func TestOverlay_DeleteCollection_AggregateAcrossNamespacesFallback(t *testing.T
 // intended".
 func TestOverlay_DeleteCollection_InvalidSelectorRejected(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
-	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
-	srv := newWritableServer(t, writableTestStore(t, from), clock) // captures pod-base
 
-	code, _ := doReq(t, http.MethodDelete, srv.URL+podsPath+"?fieldSelector=spec.nodeName%3Dnode-1", "", "")
-	if code != http.StatusBadRequest {
-		t.Errorf("deletecollection with unsupported fieldSelector key: status %d, want 400", code)
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"unsupported fieldSelector key", "?fieldSelector=spec.nodeName%3Dnode-1"},
+		// "!" parses to a doesnotexist requirement with an empty label key, which
+		// (since no real object has an empty-string label key) matches every
+		// item — exactly the "delete everything" failure mode this rejects.
+		{"empty labelSelector key", "?labelSelector=%21"},
 	}
-	if code, _ := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-base", "", ""); code != 200 {
-		t.Errorf("pod-base should survive a rejected selector: status %d", code)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+			srv := newWritableServer(t, writableTestStore(t, from), clock) // captures pod-base
+
+			code, _ := doReq(t, http.MethodDelete, srv.URL+podsPath+c.query, "", "")
+			if code != http.StatusBadRequest {
+				t.Errorf("deletecollection with %s: status %d, want 400", c.name, code)
+			}
+			if code, _ := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-base", "", ""); code != 200 {
+				t.Errorf("pod-base should survive a rejected selector: status %d", code)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- `DELETE` on a collection path (no object name — Kubernetes `deletecollection`) was hardcoded to `400 Bad Request` in the writable overlay. Real apiservers support it, and client-go's typed clients call `DeleteCollection` directly against the collection endpoint (`kubectl delete --all` masks the gap via its list-then-delete-by-name fallback, but client-go doesn't). Per the issue, this was the largest failure bucket running the upstream `[Conformance]` suite against `replay --writable`.
- New `overlayDeleteCollection` reconstructs the current item set for the list scope (captured + overlay merged, tombstones removed — via a new `currentListItems` helper), filters by `labelSelector`/`fieldSelector` (reusing a `filterItems` helper extracted from `applySelectors`), and tombstones each match. Always returns 200 `Status Success`, even for zero matches (matching the real apiserver — an empty deletecollection isn't a 404).
- Extracted `deleteOneObject` out of `overlayDelete` so both the single-item and new collection paths re-check an object's liveness at the moment of deletion rather than trusting an earlier list snapshot — avoids a stale `DELETED` watch-event body and a spurious duplicate tombstone if an item is concurrently deleted between the scan and the delete.
- Extracted `dropDeletedNamespaceItems` (the namespace-delete-cascade filter used by `mergeOverlayList` for reads) so it's shared with `currentListItems` instead of duplicated.
- `allowedMethods`'s collection-path case now includes `DELETE` in its `Allow` header.

## Test plan
- [x] `make fmt && make lint && make lint-ci && make test && make test-race` all pass.
- [x] New tests in `internal/server/writes_test.go`: mixed captured/overlay-created/overlay-updated deletecollection, `labelSelector`-filtered deletecollection, empty-match deletecollection (still 200), cluster-scoped deletecollection (namespaces), and namespace-deletecollection cascading into namespace contents.
- [x] All pre-existing overlay/delete tests pass unmodified — `deleteOneObject`/`dropDeletedNamespaceItems`/`filterItems` are behavior-preserving extractions.
- [x] Confirmed (unrelated to this change) that read-only replay already 405s every DELETE, with or without a name, before reaching this code.

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)