### PR TITLE
fix(server): avoid nil-map panic in rewriteListResourceVersion

### DIFF
--- a/internal/server/replay_rv.go
+++ b/internal/server/replay_rv.go
@@ -176,7 +176,7 @@ func rvAsOf(timeline []replayEvent, at time.Time) int64 {
 // preserving all other fields. On any parse error it returns obj unchanged.
 func withResourceVersion(obj json.RawMessage, rv int64) json.RawMessage {
 	var m map[string]json.RawMessage
-	if err := json.Unmarshal(obj, &m); err != nil {
+	if err := json.Unmarshal(obj, &m); err != nil || m == nil {
 		return obj
 	}
 	meta := map[string]json.RawMessage{}

--- a/internal/server/replay_rv.go
+++ b/internal/server/replay_rv.go
@@ -181,7 +181,7 @@ func withResourceVersion(obj json.RawMessage, rv int64) json.RawMessage {
 	}
 	meta := map[string]json.RawMessage{}
 	if raw, ok := m["metadata"]; ok {
-		if err := json.Unmarshal(raw, &meta); err != nil {
+		if err := json.Unmarshal(raw, &meta); err != nil || meta == nil {
 			meta = map[string]json.RawMessage{}
 		}
 	}
@@ -210,7 +210,7 @@ func rewriteListResourceVersion(body []byte, rvFn func() int64) []byte {
 	rv := rvFn()
 	meta := map[string]json.RawMessage{}
 	if raw, ok := m["metadata"]; ok {
-		if err := json.Unmarshal(raw, &meta); err != nil {
+		if err := json.Unmarshal(raw, &meta); err != nil || meta == nil {
 			meta = map[string]json.RawMessage{}
 		}
 	}

--- a/internal/server/replay_rv_test.go
+++ b/internal/server/replay_rv_test.go
@@ -336,3 +336,14 @@ func TestWithResourceVersion_NilMetadata(t *testing.T) {
 		})
 	}
 }
+
+// TestWithResourceVersion_NullObject verifies withResourceVersion doesn't panic
+// when the entire object body is the JSON literal null: json.Unmarshal("null",
+// &m) succeeds but leaves m itself nil (not an empty map), so the later
+// m["metadata"] = ... assignment would panic without the m == nil guard.
+func TestWithResourceVersion_NullObject(t *testing.T) {
+	out := withResourceVersion(json.RawMessage("null"), 7)
+	if string(out) != "null" {
+		t.Errorf("out = %q, want unchanged %q", out, "null")
+	}
+}

--- a/internal/server/replay_rv_test.go
+++ b/internal/server/replay_rv_test.go
@@ -275,3 +275,64 @@ func TestReplayWatch_PollOnly(t *testing.T) {
 		t.Fatalf("frame = %s, want pod-b", e.Object.Metadata.Name)
 	}
 }
+
+// TestRewriteListResourceVersion_NilMetadata verifies rewriteListResourceVersion
+// doesn't panic when the captured list body's "metadata" field unmarshals to a
+// nil map — e.g. an explicit "metadata":null, or a non-object metadata value
+// (both of which leave the reused map variable nil rather than the empty map
+// literal it started as; see withResourceVersion for the identical pattern).
+func TestRewriteListResourceVersion_NilMetadata(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"no metadata field", `{"apiVersion":"v1","kind":"PodList","items":[]}`},
+		{"metadata is null", `{"apiVersion":"v1","kind":"PodList","items":[],"metadata":null}`},
+		{"metadata is wrong type", `{"apiVersion":"v1","kind":"PodList","items":[],"metadata":[]}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := rewriteListResourceVersion([]byte(tc.body), func() int64 { return 42 })
+			var got struct {
+				Metadata struct {
+					ResourceVersion string `json:"resourceVersion"`
+				} `json:"metadata"`
+			}
+			if err := json.Unmarshal(out, &got); err != nil {
+				t.Fatalf("Unmarshal(out): %v (out=%s)", err, out)
+			}
+			if got.Metadata.ResourceVersion != "42" {
+				t.Errorf("resourceVersion = %q, want %q", got.Metadata.ResourceVersion, "42")
+			}
+		})
+	}
+}
+
+// TestWithResourceVersion_NilMetadata verifies withResourceVersion (used for
+// every watch event body) doesn't panic on the same nil-map cases.
+func TestWithResourceVersion_NilMetadata(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"no metadata field", `{"apiVersion":"v1","kind":"Pod"}`},
+		{"metadata is null", `{"apiVersion":"v1","kind":"Pod","metadata":null}`},
+		{"metadata is wrong type", `{"apiVersion":"v1","kind":"Pod","metadata":[]}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := withResourceVersion(json.RawMessage(tc.body), 7)
+			var got struct {
+				Metadata struct {
+					ResourceVersion string `json:"resourceVersion"`
+				} `json:"metadata"`
+			}
+			if err := json.Unmarshal(out, &got); err != nil {
+				t.Fatalf("Unmarshal(out): %v (out=%s)", err, out)
+			}
+			if got.Metadata.ResourceVersion != "7" {
+				t.Errorf("resourceVersion = %q, want %q", got.Metadata.ResourceVersion, "7")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fix a panic in `rewriteListResourceVersion` (and the same bug in `withResourceVersion`) when a captured object's `metadata` field is JSON `null` or a non-object value: unmarshaling `null` into the reused `map[string]json.RawMessage` variable resets it to `nil` instead of leaving the initialized empty map, so the subsequent `meta["resourceVersion"] = ...` assignment panics and crashes the whole replay server.
- Guard by treating a post-unmarshal `nil` map the same as an unmarshal error, re-initializing it to an empty map before assigning into it.

Confirmed reproducible on `main` (92cc58c) by unit-testing both functions directly with a `"metadata":null` body — panics before this fix, passes after. Also spot-checked via `kshrk replay` + `kubectl get pods`, which is the reported real-world path (crashes when a captured list body happens to carry `metadata: null`).

## Test plan
- [x] Added `TestRewriteListResourceVersion_NilMetadata` and `TestWithResourceVersion_NilMetadata` covering: no `metadata` field, `metadata: null`, and `metadata` as a non-object (`[]`)
- [x] Verified the new tests panic on the pre-fix code and pass on the post-fix code
- [x] `make test`
- [x] `make lint`
- [x] `make fmt` (no diff) and `go mod tidy` (no diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)