### PR TITLE
fix(server): known-but-uncaptured kinds behave like empty live collections

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -522,10 +522,11 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 
 	if code == 404 {
 		// If the path parses as a list-level resource (not an item GET), return
-		// an empty list with a Warning header so kubectl shows
-		// "No resources found" rather than "Error from server: not found".
-		// Item-level GETs (path has more segments than parseAPIPath handles)
-		// still get a proper 404.
+		// an empty list — a known kind (in a captured discovery document or the
+		// index, even with zero captured objects) behaves like a real cluster's
+		// empty live collection: no warning, since a client may well create
+		// objects of it next (especially in writable mode). Reserve the warning
+		// for a genuinely unknown/misconfigured kind (#177).
 		g, v, resource, _ := parseAPIPath(path)
 		if resource != "" {
 			av := v
@@ -538,10 +539,20 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 				"metadata":   map[string]string{"resourceVersion": "0"},
 				"items":      []any{},
 			})
-			w.Header().Set("Warning", fmt.Sprintf(`299 k8shark %q`,
-				resource+" not found in capture; was it included in the capture config?"))
+			if !h.store.isKnownResource(g, v, resource) {
+				w.Header().Set("Warning", fmt.Sprintf(`299 k8shark %q`,
+					resource+" not found in capture; was it included in the capture config?"))
+			}
 			body, code = emptyList, 200
 		} else {
+			// Item-level GET (path has more segments than parseAPIPath handles):
+			// a standard NotFound Status, matching a live cluster, so
+			// apierrors.IsNotFound() recognizes it (#177).
+			ig, _, iresource, _, iname, _ := parseWritePath(strings.TrimSuffix(path, "/"))
+			if iresource != "" && iname != "" {
+				writeJSON(w, http.StatusNotFound, notFoundStatus(ig, iresource, iname))
+				return
+			}
 			h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q not found in capture", path))
 			return
 		}
@@ -978,6 +989,35 @@ func statusObj(code int, msg string) map[string]any {
 		"status":     "Failure",
 		"message":    msg,
 		"code":       code,
+	}
+}
+
+// notFoundStatus builds a standard Kubernetes NotFound Status object for a
+// missing item of group/resource/name — reason: "NotFound" (so client-go's
+// apierrors.IsNotFound() recognizes it) and the real apiserver's message
+// format (e.g. "ingresses.networking.k8s.io \"nope\" not found", or just
+// "pods \"nope\" not found" for the core group), matching
+// k8s.io/apimachinery/pkg/api/errors.NewNotFound (#177). details.kind is the
+// plural resource name, not the singular Kind — an apiserver quirk this
+// mirrors for parity.
+func notFoundStatus(group, resource, name string) map[string]any {
+	qualified := resource
+	if group != "" {
+		qualified = resource + "." + group
+	}
+	details := map[string]any{"name": name, "kind": resource}
+	if group != "" {
+		details["group"] = group
+	}
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Status",
+		"metadata":   map[string]any{},
+		"status":     "Failure",
+		"message":    fmt.Sprintf("%s %q not found", qualified, name),
+		"reason":     "NotFound",
+		"details":    details,
+		"code":       http.StatusNotFound,
 	}
 }
 

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -546,10 +546,14 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 			body, code = emptyList, 200
 		} else {
 			// Item-level GET (path has more segments than parseAPIPath handles):
-			// a standard NotFound Status, matching a live cluster, so
-			// apierrors.IsNotFound() recognizes it (#177).
-			ig, _, iresource, _, iname, _ := parseWritePath(strings.TrimSuffix(path, "/"))
-			if iresource != "" && iname != "" {
+			// for a known resource, a standard NotFound Status matching a live
+			// cluster, so apierrors.IsNotFound() recognizes it (#177). An unknown
+			// resource keeps the k8shark-specific message instead — it signals a
+			// capture-config problem (wrong group/resource entirely), which
+			// "<resource> \"<name>\" not found" would misleadingly present as "the
+			// object is just missing".
+			ig, iv, iresource, _, iname, _ := parseWritePath(strings.TrimSuffix(path, "/"))
+			if iresource != "" && iname != "" && h.store.isKnownResource(ig, iv, iresource) {
 				writeJSON(w, http.StatusNotFound, notFoundStatus(ig, iresource, iname))
 				return
 			}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -533,9 +533,17 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 			if g != "" {
 				av = g + "/" + v
 			}
+			// Prefer the authoritative Kind from discovery/index metadata over the
+			// resourceToKind heuristic, which guesses wrong for resources whose
+			// Kind doesn't follow simple depluralization (e.g. endpointslices)
+			// and for most CRDs — a client deserializing by GVK would break.
+			kind := h.store.resourceKind(g, v, resource)
+			if kind == "" {
+				kind = resourceToKind(resource)
+			}
 			emptyList, _ := json.Marshal(map[string]any{
 				"apiVersion": av,
-				"kind":       resourceToKind(resource) + "List",
+				"kind":       kind + "List",
 				"metadata":   map[string]string{"resourceVersion": "0"},
 				"items":      []any{},
 			})

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -309,6 +309,37 @@ func TestHandler_NotFound_ListPath_KnownResourceNoWarning(t *testing.T) {
 	}
 }
 
+// TestHandler_NotFound_ListPath_KnownResourceUsesDiscoveryKind verifies the
+// empty-list fallback uses the authoritative Kind from discovery metadata,
+// not the resourceToKind heuristic — which guesses "Endpointslice" (wrong)
+// rather than the real "EndpointSlice" for "endpointslices", since it doesn't
+// follow simple depluralization. A client deserializing by GVK would break on
+// the heuristic's guess.
+func TestHandler_NotFound_ListPath_KnownResourceUsesDiscoveryKind(t *testing.T) {
+	discoveryBody := `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"discovery.k8s.io/v1","resources":[` +
+		`{"name":"endpointslices","singularName":"endpointslice","namespaced":true,"kind":"EndpointSlice"}]}`
+	store := buildTestStore(t, map[string][]byte{
+		"/apis/discovery.k8s.io/v1": []byte(discoveryBody),
+	})
+	store.discoveryEnrichmentDone.Wait()
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/apis/discovery.k8s.io/v1/namespaces/default/endpointslices", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rw.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rw.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected JSON body: %v", err)
+	}
+	if body["kind"] != "EndpointSliceList" {
+		t.Errorf("expected kind EndpointSliceList, got %v", body["kind"])
+	}
+}
+
 func TestHandler_SingleItemGet(t *testing.T) {
 	podList := `{"apiVersion":"v1","kind":"PodList","items":[{"metadata":{"name":"nginx","namespace":"default"}},{"metadata":{"name":"redis","namespace":"default"}}]}`
 	store := buildTestStore(t, map[string][]byte{

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -157,6 +157,117 @@ func TestHandler_NotFound_ItemPath(t *testing.T) {
 	}
 }
 
+// TestHandler_NotFound_ItemPath_StandardStatus verifies an item-level GET's
+// 404 body is a standard Kubernetes NotFound Status (reason, message,
+// details) rather than the k8shark-specific "not found in capture" message —
+// so client-go's apierrors.IsNotFound() recognizes it (#177).
+func TestHandler_NotFound_ItemPath_StandardStatus(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/apis/networking.k8s.io/v1/namespaces/default/ingresses/nope", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rw.Code)
+	}
+	var status struct {
+		Kind    string `json:"kind"`
+		Status  string `json:"status"`
+		Reason  string `json:"reason"`
+		Message string `json:"message"`
+		Details struct {
+			Name  string `json:"name"`
+			Group string `json:"group"`
+			Kind  string `json:"kind"`
+		} `json:"details"`
+	}
+	if err := json.Unmarshal(rw.Body.Bytes(), &status); err != nil {
+		t.Fatalf("expected JSON body: %v", err)
+	}
+	if status.Kind != "Status" || status.Status != "Failure" || status.Reason != "NotFound" {
+		t.Errorf("status = %+v, want kind=Status status=Failure reason=NotFound", status)
+	}
+	if status.Message != `ingresses.networking.k8s.io "nope" not found` {
+		t.Errorf("message = %q, want %q", status.Message, `ingresses.networking.k8s.io "nope" not found`)
+	}
+	if status.Details.Name != "nope" || status.Details.Group != "networking.k8s.io" || status.Details.Kind != "ingresses" {
+		t.Errorf("details = %+v, want name=nope group=networking.k8s.io kind=ingresses", status.Details)
+	}
+}
+
+// TestHandler_NotFound_ItemPath_CoreGroupStatus verifies the core group
+// (empty group string) omits ".group" from the message and "group" from
+// details, matching the real apiserver's GroupResource.String() format.
+func TestHandler_NotFound_ItemPath_CoreGroupStatus(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/nope", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rw.Code)
+	}
+	var status struct {
+		Reason  string         `json:"reason"`
+		Message string         `json:"message"`
+		Details map[string]any `json:"details"`
+	}
+	if err := json.Unmarshal(rw.Body.Bytes(), &status); err != nil {
+		t.Fatalf("expected JSON body: %v", err)
+	}
+	if status.Reason != "NotFound" {
+		t.Errorf("reason = %q, want NotFound", status.Reason)
+	}
+	if status.Message != `pods "nope" not found` {
+		t.Errorf("message = %q, want %q", status.Message, `pods "nope" not found`)
+	}
+	if _, hasGroup := status.Details["group"]; hasGroup {
+		t.Errorf("details should omit \"group\" for the core group, got %v", status.Details)
+	}
+}
+
+// TestHandler_NotFound_ListPath_KnownResourceNoWarning verifies a resource
+// listed in a captured discovery document, but with zero captured objects,
+// returns an empty 200 list with no Warning header — it behaves like a real
+// cluster's empty live collection, not a misconfigured/unknown capture
+// (#177). Contrast with TestHandler_NotFound_ListPath, where the resource is
+// genuinely absent from discovery too.
+func TestHandler_NotFound_ListPath_KnownResourceNoWarning(t *testing.T) {
+	discoveryBody := `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"networking.k8s.io/v1","resources":[` +
+		`{"name":"ingresses","singularName":"ingress","namespaced":true,"kind":"Ingress"}]}`
+	store := buildTestStore(t, map[string][]byte{
+		"/apis/networking.k8s.io/v1": []byte(discoveryBody),
+	})
+	store.discoveryEnrichmentDone.Wait()
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/apis/networking.k8s.io/v1/namespaces/default/ingresses", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rw.Code)
+	}
+	if w := rw.Header().Get("Warning"); w != "" {
+		t.Errorf("expected no Warning header for a known resource, got %q", w)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rw.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected JSON body: %v", err)
+	}
+	if body["kind"] != "IngressList" {
+		t.Errorf("expected kind IngressList, got %v", body["kind"])
+	}
+	items, _ := body["items"].([]any)
+	if len(items) != 0 {
+		t.Errorf("expected empty items, got %v", items)
+	}
+}
+
 func TestHandler_SingleItemGet(t *testing.T) {
 	podList := `{"apiVersion":"v1","kind":"PodList","items":[{"metadata":{"name":"nginx","namespace":"default"}},{"metadata":{"name":"redis","namespace":"default"}}]}`
 	store := buildTestStore(t, map[string][]byte{

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -162,7 +162,12 @@ func TestHandler_NotFound_ItemPath(t *testing.T) {
 // details) rather than the k8shark-specific "not found in capture" message —
 // so client-go's apierrors.IsNotFound() recognizes it (#177).
 func TestHandler_NotFound_ItemPath_StandardStatus(t *testing.T) {
-	store := buildTestStore(t, map[string][]byte{})
+	discoveryBody := `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"networking.k8s.io/v1","resources":[` +
+		`{"name":"ingresses","singularName":"ingress","namespaced":true,"kind":"Ingress"}]}`
+	store := buildTestStore(t, map[string][]byte{
+		"/apis/networking.k8s.io/v1": []byte(discoveryBody),
+	})
+	store.discoveryEnrichmentDone.Wait()
 	h := newHandler(store, time.Time{}, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/apis/networking.k8s.io/v1/namespaces/default/ingresses/nope", nil)
@@ -201,7 +206,11 @@ func TestHandler_NotFound_ItemPath_StandardStatus(t *testing.T) {
 // (empty group string) omits ".group" from the message and "group" from
 // details, matching the real apiserver's GroupResource.String() format.
 func TestHandler_NotFound_ItemPath_CoreGroupStatus(t *testing.T) {
-	store := buildTestStore(t, map[string][]byte{})
+	// "pods" is known via a captured (unrelated) pod list — "nope" itself was
+	// never captured.
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/pods": []byte(`{"kind":"PodList","items":[{"metadata":{"name":"other"}}]}`),
+	})
 	h := newHandler(store, time.Time{}, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/nope", nil)
@@ -227,6 +236,38 @@ func TestHandler_NotFound_ItemPath_CoreGroupStatus(t *testing.T) {
 	}
 	if _, hasGroup := status.Details["group"]; hasGroup {
 		t.Errorf("details should omit \"group\" for the core group, got %v", status.Details)
+	}
+}
+
+// TestHandler_NotFound_ItemPath_UnknownResourceKeepsGenericMessage verifies an
+// item-level GET for a resource that's genuinely unknown (absent from both
+// discovery and the index) keeps the k8shark-specific "not found in capture"
+// message rather than the standard NotFound Status — that format would
+// otherwise misleadingly present a capture-config problem (wrong
+// group/resource entirely) as "the object is just missing" (#177).
+func TestHandler_NotFound_ItemPath_UnknownResourceKeepsGenericMessage(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/apis/totally.fake/v1/namespaces/default/foos/nope", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rw.Code)
+	}
+	var status struct {
+		Reason  string `json:"reason"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(rw.Body.Bytes(), &status); err != nil {
+		t.Fatalf("expected JSON body: %v", err)
+	}
+	if status.Reason != "" {
+		t.Errorf("reason = %q, want empty (not the standard NotFound Status)", status.Reason)
+	}
+	if !strings.Contains(status.Message, "not found in capture") {
+		t.Errorf("message = %q, want the k8shark-specific \"not found in capture\" message", status.Message)
 	}
 }
 

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -294,6 +294,23 @@ func (s *CaptureStore) isKnownResource(group, version, resource string) bool {
 	return ok
 }
 
+// resourceKind returns the authoritative Kind for a known group/version/
+// resource (from captured discovery, or resourceToKind's heuristic if only
+// seen in the index — see buildResourceInfo/mergeResourceInfo), or "" if the
+// resource isn't known at all. Prefer this over calling resourceToKind
+// directly when a resource might be known: the heuristic guesses wrong for
+// built-in types whose Kind doesn't follow simple depluralization (e.g.
+// "endpointslices" -> "Endpointslice", not the real "EndpointSlice") and for
+// most CRDs.
+func (s *CaptureStore) resourceKind(group, version, resource string) string {
+	s.resourceInfoMu.RLock()
+	defer s.resourceInfoMu.RUnlock()
+	if ri, ok := s.resourceInfo[group+"/"+version+"/"+resource]; ok {
+		return ri.Kind
+	}
+	return ""
+}
+
 // Latest returns the ResponseBody of the most recent record for apiPath.
 // If at is non-zero, it returns the latest record whose timestamp is <= at.
 func (s *CaptureStore) Latest(apiPath string, at time.Time) ([]byte, int, error) {

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -165,7 +165,13 @@ func (s *CaptureStore) buildResourceInfo() {
 // mergeResourceInfo inserts or enriches the ResourceInfo for group/version/
 // resource from a captured discovery document, creating a new entry (zero
 // captured objects) if one doesn't already exist from the index. Safe for
-// concurrent use.
+// concurrent use. namespaced always overwrites: discovery is the authoritative
+// source for a resource's scope, more reliable than buildResourceInfo's
+// index-derived guess (whether any captured path happened to include a
+// namespace segment) — e.g. a capture with only a cluster-wide list
+// (/api/v1/pods, no namespaces: in config) would otherwise report a
+// namespaced resource as cluster-scoped in the regenerated discovery
+// document.
 func (s *CaptureStore) mergeResourceInfo(group, version, resource string, namespaced bool, kind, singularName string, shortNames []string) {
 	s.resourceInfoMu.Lock()
 	defer s.resourceInfoMu.Unlock()
@@ -175,6 +181,7 @@ func (s *CaptureStore) mergeResourceInfo(group, version, resource string, namesp
 		ri = &ResourceInfo{Group: group, Version: version, Resource: resource, Namespaced: namespaced}
 		s.resourceInfo[key] = ri
 	}
+	ri.Namespaced = namespaced
 	if kind != "" {
 		ri.Kind = kind
 	} else if ri.Kind == "" {
@@ -251,13 +258,19 @@ func (s *CaptureStore) enrichResourceInfoFromDiscovery() {
 	}
 }
 
-// Resources returns all distinct ResourceInfo entries.
-func (s *CaptureStore) Resources() []*ResourceInfo {
+// Resources returns a snapshot of all distinct ResourceInfo entries. Each
+// element is a value copy taken under the lock, not the pointer stored in the
+// map — mergeResourceInfo can mutate an existing entry's fields
+// (Kind/SingularName/ShortNames/Namespaced) from the background discovery
+// enrichment goroutine at any time, so returning the original pointers would
+// let a caller observe a struct being concurrently written after the lock is
+// released.
+func (s *CaptureStore) Resources() []ResourceInfo {
 	s.resourceInfoMu.RLock()
 	defer s.resourceInfoMu.RUnlock()
-	out := make([]*ResourceInfo, 0, len(s.resourceInfo))
+	out := make([]ResourceInfo, 0, len(s.resourceInfo))
 	for _, ri := range s.resourceInfo {
-		out = append(out, ri)
+		out = append(out, *ri)
 	}
 	return out
 }

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -16,11 +16,18 @@ import (
 // CaptureStore holds the in-memory index and provides record lookups against
 // a ZIP+Zstd archive opened without extraction to disk.
 type CaptureStore struct {
-	ar           *archive.Archive
-	Metadata     capture.CaptureMetadata
-	Index        capture.Index
-	WatchIndex   capture.WatchIndex
-	resourceInfo map[string]*ResourceInfo
+	ar         *archive.Archive
+	Metadata   capture.CaptureMetadata
+	Index      capture.Index
+	WatchIndex capture.WatchIndex
+
+	resourceInfoMu sync.RWMutex
+	resourceInfo   map[string]*ResourceInfo
+	// discoveryEnrichmentDone lets tests deterministically wait for
+	// enrichResourceInfoFromDiscovery's background pass (see LoadStore) instead
+	// of racing it. Production code intentionally does not wait — the store is
+	// documented as usable before this completes.
+	discoveryEnrichmentDone sync.WaitGroup
 
 	// Record LRU cache (bounded by recordCacheMaxBytes total body bytes).
 	recordCacheMu    sync.Mutex
@@ -115,7 +122,11 @@ func LoadStore(ar *archive.Archive) (*CaptureStore, error) {
 	// Derive ResourceInfo from index keys synchronously (fast — no I/O).
 	s.buildResourceInfo()
 
-	// Enrich ResourceInfo from discovery records asynchronously.
+	// Enrich ResourceInfo from discovery records asynchronously — this also
+	// creates entries for resources listed in a captured discovery document
+	// that have zero captured objects (see mergeResourceInfo), so a known kind
+	// with nothing captured is distinguishable from a genuinely unknown one.
+	s.discoveryEnrichmentDone.Add(1)
 	go s.enrichResourceInfoFromDiscovery()
 
 	return s, nil
@@ -124,6 +135,8 @@ func LoadStore(ar *archive.Archive) (*CaptureStore, error) {
 // buildResourceInfo derives ResourceInfo for each distinct resource type in
 // the index. It does not read any record data.
 func (s *CaptureStore) buildResourceInfo() {
+	s.resourceInfoMu.Lock()
+	defer s.resourceInfoMu.Unlock()
 	for path := range s.Index {
 		if strings.Contains(path, "?") {
 			continue
@@ -149,14 +162,45 @@ func (s *CaptureStore) buildResourceInfo() {
 	}
 }
 
+// mergeResourceInfo inserts or enriches the ResourceInfo for group/version/
+// resource from a captured discovery document, creating a new entry (zero
+// captured objects) if one doesn't already exist from the index. Safe for
+// concurrent use.
+func (s *CaptureStore) mergeResourceInfo(group, version, resource string, namespaced bool, kind, singularName string, shortNames []string) {
+	s.resourceInfoMu.Lock()
+	defer s.resourceInfoMu.Unlock()
+	key := group + "/" + version + "/" + resource
+	ri, ok := s.resourceInfo[key]
+	if !ok {
+		ri = &ResourceInfo{Group: group, Version: version, Resource: resource, Namespaced: namespaced}
+		s.resourceInfo[key] = ri
+	}
+	if kind != "" {
+		ri.Kind = kind
+	} else if ri.Kind == "" {
+		ri.Kind = resourceToKind(resource)
+	}
+	if singularName != "" {
+		ri.SingularName = singularName
+	}
+	if len(shortNames) > 0 {
+		ri.ShortNames = shortNames
+	}
+}
+
 // enrichResourceInfoFromDiscovery reads captured APIResourceList bodies from
-// the archive and back-fills Kind, ShortNames, SingularName into resourceInfo.
-// Runs in a background goroutine; store is usable before this completes.
+// the archive and back-fills Kind, ShortNames, SingularName into resourceInfo
+// — creating a new entry (via mergeResourceInfo) for a resource the discovery
+// document lists but that has zero captured objects, so it's still reported
+// as a known kind rather than "not found in capture" (#177). Runs in a
+// background goroutine; store is usable before this completes.
 func (s *CaptureStore) enrichResourceInfoFromDiscovery() {
+	defer s.discoveryEnrichmentDone.Done()
 	type apiResourceEntry struct {
 		Name         string   `json:"name"`
 		SingularName string   `json:"singularName"`
 		Kind         string   `json:"kind"`
+		Namespaced   bool     `json:"namespaced"`
 		ShortNames   []string `json:"shortNames"`
 	}
 	type apiResourceList struct {
@@ -200,33 +244,34 @@ func (s *CaptureStore) enrichResourceInfoFromDiscovery() {
 		}
 		for _, res := range resList.Resources {
 			if strings.Contains(res.Name, "/") {
-				continue
+				continue // a subresource entry (e.g. "pods/status"), not a top-level resource
 			}
-			key := g + "/" + v + "/" + res.Name
-			ri, ok := s.resourceInfo[key]
-			if !ok {
-				continue
-			}
-			if res.Kind != "" {
-				ri.Kind = res.Kind
-			}
-			if res.SingularName != "" {
-				ri.SingularName = res.SingularName
-			}
-			if len(res.ShortNames) > 0 {
-				ri.ShortNames = res.ShortNames
-			}
+			s.mergeResourceInfo(g, v, res.Name, res.Namespaced, res.Kind, res.SingularName, res.ShortNames)
 		}
 	}
 }
 
 // Resources returns all distinct ResourceInfo entries.
 func (s *CaptureStore) Resources() []*ResourceInfo {
+	s.resourceInfoMu.RLock()
+	defer s.resourceInfoMu.RUnlock()
 	out := make([]*ResourceInfo, 0, len(s.resourceInfo))
 	for _, ri := range s.resourceInfo {
 		out = append(out, ri)
 	}
 	return out
+}
+
+// isKnownResource reports whether group/version/resource is a real API type
+// the captured cluster exposed — present in a captured discovery document or
+// the archive index — even if zero objects of it were ever captured. Used to
+// distinguish "known kind, nothing captured" (should read like an empty live
+// collection) from a genuinely unknown/misconfigured kind (#177).
+func (s *CaptureStore) isKnownResource(group, version, resource string) bool {
+	s.resourceInfoMu.RLock()
+	defer s.resourceInfoMu.RUnlock()
+	_, ok := s.resourceInfo[group+"/"+version+"/"+resource]
+	return ok
 }
 
 // Latest returns the ResponseBody of the most recent record for apiPath.

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -258,19 +258,26 @@ func (s *CaptureStore) enrichResourceInfoFromDiscovery() {
 	}
 }
 
-// Resources returns a snapshot of all distinct ResourceInfo entries. Each
-// element is a value copy taken under the lock, not the pointer stored in the
-// map — mergeResourceInfo can mutate an existing entry's fields
-// (Kind/SingularName/ShortNames/Namespaced) from the background discovery
-// enrichment goroutine at any time, so returning the original pointers would
-// let a caller observe a struct being concurrently written after the lock is
-// released.
+// Resources returns a snapshot of all distinct ResourceInfo entries, fully
+// decoupled from internal storage. Each element is a value copy taken under
+// the lock, not the pointer stored in the map — mergeResourceInfo can mutate
+// an existing entry's fields (Kind/SingularName/ShortNames/Namespaced) from
+// the background discovery enrichment goroutine at any time, so returning the
+// original pointers would let a caller observe a struct being concurrently
+// written after the lock is released. ShortNames is copied too: a struct copy
+// alone still shares the slice's backing array with the stored entry, so a
+// caller mutating the returned ShortNames (even by accident) would corrupt
+// internal state without holding the lock.
 func (s *CaptureStore) Resources() []ResourceInfo {
 	s.resourceInfoMu.RLock()
 	defer s.resourceInfoMu.RUnlock()
 	out := make([]ResourceInfo, 0, len(s.resourceInfo))
 	for _, ri := range s.resourceInfo {
-		out = append(out, *ri)
+		cp := *ri
+		if len(ri.ShortNames) > 0 {
+			cp.ShortNames = append([]string(nil), ri.ShortNames...)
+		}
+		out = append(out, cp)
 	}
 	return out
 }

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -68,10 +68,11 @@ func TestEnrichResourceInfoFromDiscovery_KnownButUncaptured(t *testing.T) {
 	if !store.isKnownResource("networking.k8s.io", "v1", "ingresses") {
 		t.Fatal("ingresses should be a known resource after discovery enrichment")
 	}
+	resources := store.Resources()
 	var found *ResourceInfo
-	for _, ri := range store.Resources() {
-		if ri.Group == "networking.k8s.io" && ri.Resource == "ingresses" {
-			found = ri
+	for i := range resources {
+		if resources[i].Group == "networking.k8s.io" && resources[i].Resource == "ingresses" {
+			found = &resources[i]
 		}
 	}
 	if found == nil {
@@ -82,6 +83,36 @@ func TestEnrichResourceInfoFromDiscovery_KnownButUncaptured(t *testing.T) {
 	}
 	if len(found.ShortNames) != 1 || found.ShortNames[0] != "ing" {
 		t.Errorf("ingresses ShortNames = %v, want [ing]", found.ShortNames)
+	}
+}
+
+// TestEnrichResourceInfoFromDiscovery_CorrectsNamespacedFromIndex verifies
+// discovery's "namespaced" field overwrites buildResourceInfo's index-derived
+// guess on an existing entry, not just at creation — a capture with only a
+// cluster-wide list (no namespaces: in config) would otherwise report a
+// namespaced resource as cluster-scoped in the regenerated discovery
+// document.
+func TestEnrichResourceInfoFromDiscovery_CorrectsNamespacedFromIndex(t *testing.T) {
+	discoveryBody := `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"v1","resources":[` +
+		`{"name":"pods","singularName":"pod","namespaced":true,"kind":"Pod"}]}`
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1":      []byte(discoveryBody),
+		"/api/v1/pods": []byte(`{"kind":"PodList","items":[]}`), // cluster-wide only — buildResourceInfo infers Namespaced=false
+	})
+	store.discoveryEnrichmentDone.Wait()
+
+	resources := store.Resources()
+	var found *ResourceInfo
+	for i := range resources {
+		if resources[i].Group == "" && resources[i].Resource == "pods" {
+			found = &resources[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("pods missing from Resources()")
+	}
+	if !found.Namespaced {
+		t.Error("discovery says pods is namespaced; enrichment should have corrected the index-derived guess")
 	}
 }
 

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -84,6 +84,19 @@ func TestEnrichResourceInfoFromDiscovery_KnownButUncaptured(t *testing.T) {
 	if len(found.ShortNames) != 1 || found.ShortNames[0] != "ing" {
 		t.Errorf("ingresses ShortNames = %v, want [ing]", found.ShortNames)
 	}
+
+	// Mutating the returned ShortNames must not corrupt the store's internal
+	// state — Resources() should be a fully decoupled snapshot, not just a
+	// copy of the outer struct sharing the slice's backing array.
+	found.ShortNames[0] = "mutated"
+	resources2 := store.Resources()
+	for i := range resources2 {
+		if resources2[i].Group == "networking.k8s.io" && resources2[i].Resource == "ingresses" {
+			if resources2[i].ShortNames[0] != "ing" {
+				t.Errorf("mutating a returned ShortNames slice corrupted internal state: got %v", resources2[i].ShortNames)
+			}
+		}
+	}
 }
 
 // TestEnrichResourceInfoFromDiscovery_CorrectsNamespacedFromIndex verifies

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -52,6 +52,39 @@ func TestResourceToKind(t *testing.T) {
 	}
 }
 
+// TestEnrichResourceInfoFromDiscovery_KnownButUncaptured verifies a resource
+// listed in a captured discovery document, but with zero captured objects of
+// its own, still gets a ResourceInfo entry — the root fix for #177 ("known
+// kind, nothing captured" must be distinguishable from "genuinely unknown
+// kind").
+func TestEnrichResourceInfoFromDiscovery_KnownButUncaptured(t *testing.T) {
+	discoveryBody := `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"networking.k8s.io/v1","resources":[` +
+		`{"name":"ingresses","singularName":"ingress","namespaced":true,"kind":"Ingress","shortNames":["ing"]}]}`
+	store := buildTestStore(t, map[string][]byte{
+		"/apis/networking.k8s.io/v1": []byte(discoveryBody),
+	})
+	store.discoveryEnrichmentDone.Wait()
+
+	if !store.isKnownResource("networking.k8s.io", "v1", "ingresses") {
+		t.Fatal("ingresses should be a known resource after discovery enrichment")
+	}
+	var found *ResourceInfo
+	for _, ri := range store.Resources() {
+		if ri.Group == "networking.k8s.io" && ri.Resource == "ingresses" {
+			found = ri
+		}
+	}
+	if found == nil {
+		t.Fatal("ingresses missing from Resources()")
+	}
+	if found.Kind != "Ingress" || found.SingularName != "ingress" || !found.Namespaced {
+		t.Errorf("ingresses ResourceInfo = %+v, want Kind=Ingress SingularName=ingress Namespaced=true", found)
+	}
+	if len(found.ShortNames) != 1 || found.ShortNames[0] != "ing" {
+		t.Errorf("ingresses ShortNames = %v, want [ing]", found.ShortNames)
+	}
+}
+
 // buildTestStore creates a CaptureStore with the given per-path response bodies.
 func buildTestStore(t *testing.T, records map[string][]byte) *CaptureStore {
 	t.Helper()


### PR DESCRIPTION
## Summary
- Root cause: `resourceInfo` was only ever derived from captured index paths (`buildResourceInfo`), and `enrichResourceInfoFromDiscovery` only *enriched* existing entries rather than creating new ones — so a resource type listed in a captured discovery document but never actually captured (zero objects) had no `ResourceInfo` entry at all. That made the mock server's own regenerated discovery response for that group/version omit it too, and LIST/GET treat it as unknown.
- `enrichResourceInfoFromDiscovery` now creates a new entry (`mergeResourceInfo`) for a discovery-listed-but-uncaptured resource. Since this background pass now inserts new map keys (not just mutates existing entries' fields), `resourceInfo` access is now mutex-guarded — a concurrent map insert during `Resources()`'s range would otherwise be unsafe.
- Added `CaptureStore.isKnownResource` and a `discoveryEnrichmentDone` `sync.WaitGroup` so tests can deterministically wait for the background enrichment pass instead of racing it (production code still doesn't wait, as already documented/intended).
- `serveResource`'s LIST 404-fallback now only sets the `"not found in capture"` `Warning` header for a genuinely unknown resource; a known one (in discovery or the index, even with zero objects) gets a plain empty `200`, matching a real cluster's empty live collection.
- `serveResource`'s item-GET 404 now returns a standard Kubernetes `NotFound` `Status` (`reason: "NotFound"`, proper `message`/`details` via a new `notFoundStatus` helper) instead of a k8shark-specific message, so `apierrors.IsNotFound()` recognizes it — matching the real apiserver's `create → delete → confirm-gone-with-IsNotFound` pattern.

Out of scope (flagged separately): the writable overlay's own write-path 404s (`PUT`/`PATCH`/`DELETE` on a missing object in `writes.go`) have the same `IsNotFound()` gap but weren't cited in this issue's "Where" section — spun off as a follow-up task.

## Test plan
- [x] `make fmt && make lint && make lint-ci && make test && make test-race` all pass.
- [x] New tests: `TestEnrichResourceInfoFromDiscovery_KnownButUncaptured` (store-level), `TestHandler_NotFound_ListPath_KnownResourceNoWarning` (LIST, no warning for a known kind), `TestHandler_NotFound_ItemPath_StandardStatus` and `TestHandler_NotFound_ItemPath_CoreGroupStatus` (item GET, standard NotFound Status for both grouped and core resources).
- [x] Existing `TestHandler_NotFound_ListPath` / `TestHandler_NotFound_ItemPath` (genuinely-unknown-resource cases) pass unmodified — confirms the warning/generic-404 path is preserved for resources that truly aren't in discovery or the index.

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)