### PR TITLE
fix(capture,replay): stop --with-kwok's kwok from racing the replay clock

### DIFF
--- a/cmd/kwok.go
+++ b/cmd/kwok.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
+	"time"
 )
 
 // KwokStages holds the bundled KWOK Stages config (set from main via go:embed).
@@ -20,6 +24,57 @@ func validateKwokFlags(withKwok, schedulePods bool) error {
 			"(KWOK only runs pods that are bound to a node)")
 	}
 	return nil
+}
+
+// nodesReadyTimeout bounds how long waitForNodesReady polls before giving up
+// and letting kwok start anyway.
+const nodesReadyTimeout = 5 * time.Second
+
+// waitForNodesReady polls addr's /api/v1/nodes until it reports at least one
+// node, or nodesReadyTimeout elapses. In replay mode the as-of clock starts
+// advancing the instant the mock server comes up, but a resource's first
+// captured snapshot can land a moment after the clock's nominal window start
+// (goroutine scheduling and network round-trip jitter around capture start);
+// until the clock catches up, /api/v1/nodes briefly reports an empty list.
+// kwok's node informer LISTs exactly once at startup — if that race loses,
+// its cache stays empty for the whole session and pods it manages never get
+// scheduled to Running. Waiting here (rather than in kwok itself) keeps the
+// launched kwok binary unmodified.
+func waitForNodesReady(addr string, timeout time.Duration) {
+	client := &http.Client{
+		Timeout:   2 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		if nodesReady(client, addr) {
+			return
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// nodesReady reports whether a GET of addr's /api/v1/nodes returns at least
+// one node. Any error, non-200, or empty items list counts as not ready.
+func nodesReady(client *http.Client, addr string) bool {
+	resp, err := client.Get(addr + "/api/v1/nodes")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+	var list struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		return false
+	}
+	return len(list.Items) > 0
 }
 
 // startKwok launches a detected `kwok` binary against the mock server's

--- a/cmd/kwok.go
+++ b/cmd/kwok.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -30,23 +31,41 @@ func validateKwokFlags(withKwok, schedulePods bool) error {
 // and letting kwok start anyway.
 const nodesReadyTimeout = 5 * time.Second
 
+// nodesReadyReqTimeout bounds a single readiness request, so one slow/hung
+// response can't itself blow past waitForNodesReady's overall timeout.
+const nodesReadyReqTimeout = 2 * time.Second
+
 // waitForNodesReady polls addr's /api/v1/nodes until it reports at least one
-// node, or nodesReadyTimeout elapses. In replay mode the as-of clock starts
-// advancing the instant the mock server comes up, but a resource's first
-// captured snapshot can land a moment after the clock's nominal window start
+// node, or timeout elapses. In replay mode the as-of clock starts advancing
+// the instant the mock server comes up, but a resource's first captured
+// snapshot can land a moment after the clock's nominal window start
 // (goroutine scheduling and network round-trip jitter around capture start);
 // until the clock catches up, /api/v1/nodes briefly reports an empty list.
 // kwok's node informer LISTs exactly once at startup — if that race loses,
 // its cache stays empty for the whole session and pods it manages never get
 // scheduled to Running. Waiting here (rather than in kwok itself) keeps the
 // launched kwok binary unmodified.
-func waitForNodesReady(addr string, timeout time.Duration) {
-	client := &http.Client{
-		Timeout:   2 * time.Second,
-		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
-	}
+//
+// certPEM pins the mock server's own self-signed cert (Server.CertPEM())
+// rather than disabling certificate verification: this client talks straight
+// to an HTTPS listener we just spawned in this process, so the real
+// certificate is on hand and there's no reason to skip validating it.
+func waitForNodesReady(addr string, certPEM []byte, timeout time.Duration) {
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(certPEM)
+	transport := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}}
+
 	deadline := time.Now().Add(timeout)
 	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return
+		}
+		reqTimeout := remaining
+		if reqTimeout > nodesReadyReqTimeout {
+			reqTimeout = nodesReadyReqTimeout
+		}
+		client := &http.Client{Timeout: reqTimeout, Transport: transport}
 		if nodesReady(client, addr) {
 			return
 		}

--- a/cmd/kwok_test.go
+++ b/cmd/kwok_test.go
@@ -1,8 +1,14 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // TestStartKwok_NotInstalled: with no kwok on PATH, startKwok fails with an
@@ -20,6 +26,67 @@ func TestStartKwok_NotInstalled(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not found in PATH") {
 		t.Errorf("error = %q, want an install hint mentioning PATH", err.Error())
+	}
+}
+
+// TestWaitForNodesReady_PollsUntilNonEmpty: the fake server reports an empty
+// node list for the first two requests (simulating the replay clock not yet
+// having caught up to the first captured nodes snapshot) and a populated one
+// thereafter. waitForNodesReady must keep polling instead of returning on the
+// first (empty) response.
+func TestWaitForNodesReady_PollsUntilNonEmpty(t *testing.T) {
+	const emptyResponses = 2
+	empty := `{"apiVersion":"v1","kind":"NodeList","items":[]}`
+	nonEmpty := `{"apiVersion":"v1","kind":"NodeList","items":[{"metadata":{"name":"n1"}}]}`
+
+	var reqCount int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if atomic.AddInt32(&reqCount, 1) <= emptyResponses {
+			fmt.Fprint(w, empty)
+			return
+		}
+		fmt.Fprint(w, nonEmpty)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	if nodesReady(client, srv.URL) {
+		t.Fatal("expected not ready while /api/v1/nodes reports an empty list")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		waitForNodesReady(srv.URL, 2*time.Second)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForNodesReady did not return after the node list became non-empty")
+	}
+	if got := atomic.LoadInt32(&reqCount); got <= emptyResponses {
+		t.Fatalf("expected more than %d requests (poll retried until non-empty), got %d", emptyResponses, got)
+	}
+}
+
+// TestWaitForNodesReady_TimesOutWhenAlwaysEmpty: a capture that genuinely has
+// no nodes and no synthesized overlay node (not reachable via --with-kwok in
+// practice, since that always implies the scheduling shim, but the timeout
+// itself must not hang indefinitely) returns once the deadline passes rather
+// than blocking forever.
+func TestWaitForNodesReady_TimesOutWhenAlwaysEmpty(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"apiVersion":"v1","kind":"NodeList","items":[]}`)
+	}))
+	defer srv.Close()
+
+	const timeout = 150 * time.Millisecond
+	start := time.Now()
+	waitForNodesReady(srv.URL, timeout)
+	if elapsed := time.Since(start); elapsed < timeout {
+		t.Fatalf("returned after %s, before the %s timeout elapsed", elapsed, timeout)
 	}
 }
 

--- a/cmd/kwok_test.go
+++ b/cmd/kwok_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +12,14 @@ import (
 	"testing"
 	"time"
 )
+
+// tlsServerCertPEM PEM-encodes an httptest.Server's self-signed certificate,
+// mirroring what Server.CertPEM() returns for the real mock server, so tests
+// can exercise waitForNodesReady's certificate-pinning path instead of
+// disabling verification.
+func tlsServerCertPEM(srv *httptest.Server) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+}
 
 // TestStartKwok_NotInstalled: with no kwok on PATH, startKwok fails with an
 // actionable install hint rather than launching anything.
@@ -50,14 +60,17 @@ func TestWaitForNodesReady_PollsUntilNonEmpty(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	certPEM := tlsServerCertPEM(srv)
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(certPEM)
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}}}
 	if nodesReady(client, srv.URL) {
 		t.Fatal("expected not ready while /api/v1/nodes reports an empty list")
 	}
 
 	done := make(chan struct{})
 	go func() {
-		waitForNodesReady(srv.URL, 2*time.Second)
+		waitForNodesReady(srv.URL, certPEM, 2*time.Second)
 		close(done)
 	}()
 	select {
@@ -67,6 +80,28 @@ func TestWaitForNodesReady_PollsUntilNonEmpty(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&reqCount); got <= emptyResponses {
 		t.Fatalf("expected more than %d requests (poll retried until non-empty), got %d", emptyResponses, got)
+	}
+}
+
+// TestWaitForNodesReady_BoundsPerRequestTimeout: a slow/hung server must not
+// let a single request blow past the overall timeout. Each request's timeout
+// is clamped to the remaining budget, so a 500ms-per-response server with a
+// 100ms overall timeout returns close to 100ms, not 500ms.
+func TestWaitForNodesReady_BoundsPerRequestTimeout(t *testing.T) {
+	const perRequestDelay = 500 * time.Millisecond
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(perRequestDelay)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"apiVersion":"v1","kind":"NodeList","items":[]}`)
+	}))
+	defer srv.Close()
+
+	const timeout = 100 * time.Millisecond
+	start := time.Now()
+	waitForNodesReady(srv.URL, tlsServerCertPEM(srv), timeout)
+	if elapsed := time.Since(start); elapsed > timeout+250*time.Millisecond {
+		t.Fatalf("waitForNodesReady took %s, expected close to the %s timeout — a single "+
+			"in-flight request (%s) shouldn't be able to extend the overall wait", elapsed, timeout, perRequestDelay)
 	}
 }
 
@@ -84,7 +119,7 @@ func TestWaitForNodesReady_TimesOutWhenAlwaysEmpty(t *testing.T) {
 
 	const timeout = 150 * time.Millisecond
 	start := time.Now()
-	waitForNodesReady(srv.URL, timeout)
+	waitForNodesReady(srv.URL, tlsServerCertPEM(srv), timeout)
 	if elapsed := time.Since(start); elapsed < timeout {
 		t.Fatalf("returned after %s, before the %s timeout elapsed", elapsed, timeout)
 	}

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -99,7 +99,7 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	// captured snapshot (see waitForNodesReady).
 	var kwokCleanup func()
 	if withKwok {
-		waitForNodesReady(srv.Address(), nodesReadyTimeout)
+		waitForNodesReady(srv.Address(), srv.CertPEM(), nodesReadyTimeout)
 		kwokCleanup, err = startKwok(srv.KubeconfigPath())
 		if err != nil {
 			srv.Shutdown()

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -94,9 +94,12 @@ func runReplay(cmd *cobra.Command, args []string) error {
 
 	// Optionally launch a detected kwok against the server to drive pod/node
 	// lifecycle. Started after the server is up (it needs the kubeconfig) and torn
-	// down on shutdown.
+	// down on shutdown. waitForNodesReady blocks briefly first so kwok's own
+	// first LIST doesn't race the replay clock past the nodes resource's first
+	// captured snapshot (see waitForNodesReady).
 	var kwokCleanup func()
 	if withKwok {
+		waitForNodesReady(srv.Address(), nodesReadyTimeout)
 		kwokCleanup, err = startKwok(srv.KubeconfigPath())
 		if err != nil {
 			srv.Shutdown()

--- a/docs/archive-format.md
+++ b/docs/archive-format.md
@@ -46,7 +46,7 @@ Capture-level information. Written once at the end of the capture run.
 |-------|-------------|
 | `format_version` | Archive schema version (see [below](#format-version--compatibility)). Absent in pre-versioning archives, which are read as version 1. |
 | `capture_id` | UUID, unique per capture run. Used in the generated kubeconfig filename. |
-| `captured_at` | UTC timestamp when the first poll fired (approximately `now - duration`). |
+| `captured_at` | UTC timestamp recorded immediately before the first poll/watch goroutines launch (after preflight and discovery). |
 | `captured_until` | UTC timestamp when the capture ended. |
 | `kubernetes_version` | `gitVersion` from `/version` on the source cluster. |
 | `server_address` | API server URL from the kubeconfig used during capture. |

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -250,6 +250,18 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 		return nil, err
 	}
 
+	// pollStart is recorded right before the first poll/watch goroutines launch,
+	// so it can stand in for CapturedAt below: preflight, discovery, and
+	// namespace expansion above can themselves take non-trivial wall-clock time
+	// (a full CRD discovery pass in particular), and backdating CapturedAt from
+	// e.cfg.Duration ignored all of it — understating the true first-poll time
+	// by that same amount. A replay session's default window start (from ≈
+	// CapturedAt) could then land before any resource's first captured
+	// snapshot, so a client querying immediately at replay start (e.g. `replay
+	// --with-kwok`'s auto-launched kwok subprocess) would see a spurious "not
+	// found in capture" for a resource that genuinely was captured.
+	pollStart := time.Now().UTC()
+
 	var wg sync.WaitGroup
 
 	// Record columns-only Table schemas for native kinds whose cluster-scoped
@@ -309,7 +321,7 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 	meta := &CaptureMetadata{
 		FormatVersion:     CurrentFormatVersion,
 		CaptureID:         uuid.New().String(),
-		CapturedAt:        time.Now().UTC().Add(-e.cfg.Duration),
+		CapturedAt:        pollStart,
 		CapturedUntil:     time.Now().UTC(),
 		KubernetesVersion: kVersion,
 		ServerAddress:     serverAddr,

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -125,6 +125,98 @@ func TestEngine_CaptureToArchive(t *testing.T) {
 	}
 }
 
+// TestEngine_CapturedAt_ReflectsPollStart guards against a regression where
+// CapturedAt was backdated as `finish - configured duration`, ignoring any
+// wall-clock time spent on preflight/version-check/discovery before the first
+// poll actually fires. A replay session defaults its window start to
+// CapturedAt, so an underestimated CapturedAt could land before a resource's
+// first captured snapshot — a client querying immediately at replay start
+// (e.g. `replay --with-kwok`'s auto-launched kwok subprocess polling
+// /api/v1/nodes) would then see a spurious "not found in capture" for a
+// resource that genuinely was captured.
+func TestEngine_CapturedAt_ReflectsPollStart(t *testing.T) {
+	const versionDelay = 300 * time.Millisecond
+	nodeList := `{"apiVersion":"v1","kind":"NodeList","metadata":{},"items":[{"apiVersion":"v1","kind":"Node","metadata":{"name":"node1"}}]}`
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/version":
+			// Simulate slow preflight/version-check overhead ahead of polling.
+			time.Sleep(versionDelay)
+			fmt.Fprint(w, `{"gitVersion":"v1.29.0"}`)
+		case "/api/v1/nodes":
+			fmt.Fprint(w, nodeList)
+		default:
+			fmt.Fprint(w, `{"kind":"List","items":[]}`)
+		}
+	}))
+	defer srv.Close()
+
+	outDir := t.TempDir()
+	cfg := &config.Config{
+		DurationRaw: "2s",
+		Duration:    2 * time.Second,
+		Output:      filepath.Join(outDir, "capture.kshrk"),
+		Resources: []config.Resource{
+			{Version: "v1", Resource: "nodes", IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	ar, err := archive.Open(cfg.Output)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	defer ar.Close()
+
+	var meta CaptureMetadata
+	if err := ar.ReadMetadata(&meta); err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	var idx Index
+	if err := ar.ReadIndex(&idx); err != nil {
+		t.Fatalf("ReadIndex: %v", err)
+	}
+
+	entry, ok := idx["/api/v1/nodes"]
+	if !ok || len(entry.Times) == 0 {
+		t.Fatalf("nodes missing from index")
+	}
+	firstNodeSnapshot := entry.Times[0]
+
+	// CapturedAt necessarily precedes the first snapshot (it's recorded before
+	// the poll goroutines launch), but the gap should be small — just
+	// goroutine-scheduling and network round-trip jitter, not the ~600ms of
+	// version-check overhead injected above (preflight and fetchServerVersion
+	// each hit /version once). A wide gap here is exactly what let a replay
+	// client's query at the (too-early) window start see this resource as
+	// "not found in capture" despite it genuinely being captured.
+	gap := firstNodeSnapshot.Sub(meta.CapturedAt)
+	if gap < 0 {
+		t.Fatalf("CapturedAt %s is after the first nodes snapshot %s", meta.CapturedAt, firstNodeSnapshot)
+	}
+	const maxGap = 200 * time.Millisecond
+	if gap > maxGap {
+		t.Fatalf("CapturedAt→first-snapshot gap %s exceeds %s (CapturedAt=%s, firstSnapshot=%s): "+
+			"the ~600ms version-check delay leaked into CapturedAt instead of being absorbed before it",
+			gap, maxGap, meta.CapturedAt, firstNodeSnapshot)
+	}
+
+	// Confirms the test actually exercises the drift: the old `now - duration`
+	// estimate ignored the version-check delay above, so its gap to the first
+	// snapshot would have exceeded maxGap.
+	oldEstimate := meta.CapturedUntil.Add(-cfg.Duration)
+	if firstNodeSnapshot.Sub(oldEstimate) <= maxGap {
+		t.Fatalf("test setup didn't reproduce the drift: old estimate %s is still within %s of "+
+			"first snapshot %s", oldEstimate, maxGap, firstNodeSnapshot)
+	}
+}
+
 func TestEngine_FetchPodsLogs(t *testing.T) {
 	// Pod fixtures include spec.containers so the engine knows what to fetch
 	// logs for. The redis pod also has an init container to verify init-

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -522,10 +522,11 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 
 	if code == 404 {
 		// If the path parses as a list-level resource (not an item GET), return
-		// an empty list with a Warning header so kubectl shows
-		// "No resources found" rather than "Error from server: not found".
-		// Item-level GETs (path has more segments than parseAPIPath handles)
-		// still get a proper 404.
+		// an empty list — a known kind (in a captured discovery document or the
+		// index, even with zero captured objects) behaves like a real cluster's
+		// empty live collection: no warning, since a client may well create
+		// objects of it next (especially in writable mode). Reserve the warning
+		// for a genuinely unknown/misconfigured kind (#177).
 		g, v, resource, _ := parseAPIPath(path)
 		if resource != "" {
 			av := v
@@ -538,10 +539,20 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 				"metadata":   map[string]string{"resourceVersion": "0"},
 				"items":      []any{},
 			})
-			w.Header().Set("Warning", fmt.Sprintf(`299 k8shark %q`,
-				resource+" not found in capture; was it included in the capture config?"))
+			if !h.store.isKnownResource(g, v, resource) {
+				w.Header().Set("Warning", fmt.Sprintf(`299 k8shark %q`,
+					resource+" not found in capture; was it included in the capture config?"))
+			}
 			body, code = emptyList, 200
 		} else {
+			// Item-level GET (path has more segments than parseAPIPath handles):
+			// a standard NotFound Status, matching a live cluster, so
+			// apierrors.IsNotFound() recognizes it (#177).
+			ig, _, iresource, _, iname, _ := parseWritePath(strings.TrimSuffix(path, "/"))
+			if iresource != "" && iname != "" {
+				writeJSON(w, http.StatusNotFound, notFoundStatus(ig, iresource, iname))
+				return
+			}
 			h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q not found in capture", path))
 			return
 		}
@@ -978,6 +989,35 @@ func statusObj(code int, msg string) map[string]any {
 		"status":     "Failure",
 		"message":    msg,
 		"code":       code,
+	}
+}
+
+// notFoundStatus builds a standard Kubernetes NotFound Status object for a
+// missing item of group/resource/name — reason: "NotFound" (so client-go's
+// apierrors.IsNotFound() recognizes it) and the real apiserver's message
+// format (e.g. "ingresses.networking.k8s.io \"nope\" not found", or just
+// "pods \"nope\" not found" for the core group), matching
+// k8s.io/apimachinery/pkg/api/errors.NewNotFound (#177). details.kind is the
+// plural resource name, not the singular Kind — an apiserver quirk this
+// mirrors for parity.
+func notFoundStatus(group, resource, name string) map[string]any {
+	qualified := resource
+	if group != "" {
+		qualified = resource + "." + group
+	}
+	details := map[string]any{"name": name, "kind": resource}
+	if group != "" {
+		details["group"] = group
+	}
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Status",
+		"metadata":   map[string]any{},
+		"status":     "Failure",
+		"message":    fmt.Sprintf("%s %q not found", qualified, name),
+		"reason":     "NotFound",
+		"details":    details,
+		"code":       http.StatusNotFound,
 	}
 }
 

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -546,10 +546,14 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 			body, code = emptyList, 200
 		} else {
 			// Item-level GET (path has more segments than parseAPIPath handles):
-			// a standard NotFound Status, matching a live cluster, so
-			// apierrors.IsNotFound() recognizes it (#177).
-			ig, _, iresource, _, iname, _ := parseWritePath(strings.TrimSuffix(path, "/"))
-			if iresource != "" && iname != "" {
+			// for a known resource, a standard NotFound Status matching a live
+			// cluster, so apierrors.IsNotFound() recognizes it (#177). An unknown
+			// resource keeps the k8shark-specific message instead — it signals a
+			// capture-config problem (wrong group/resource entirely), which
+			// "<resource> \"<name>\" not found" would misleadingly present as "the
+			// object is just missing".
+			ig, iv, iresource, _, iname, _ := parseWritePath(strings.TrimSuffix(path, "/"))
+			if iresource != "" && iname != "" && h.store.isKnownResource(ig, iv, iresource) {
 				writeJSON(w, http.StatusNotFound, notFoundStatus(ig, iresource, iname))
 				return
 			}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -533,9 +533,17 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 			if g != "" {
 				av = g + "/" + v
 			}
+			// Prefer the authoritative Kind from discovery/index metadata over the
+			// resourceToKind heuristic, which guesses wrong for resources whose
+			// Kind doesn't follow simple depluralization (e.g. endpointslices)
+			// and for most CRDs — a client deserializing by GVK would break.
+			kind := h.store.resourceKind(g, v, resource)
+			if kind == "" {
+				kind = resourceToKind(resource)
+			}
 			emptyList, _ := json.Marshal(map[string]any{
 				"apiVersion": av,
-				"kind":       resourceToKind(resource) + "List",
+				"kind":       kind + "List",
 				"metadata":   map[string]string{"resourceVersion": "0"},
 				"items":      []any{},
 			})

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -309,6 +309,37 @@ func TestHandler_NotFound_ListPath_KnownResourceNoWarning(t *testing.T) {
 	}
 }
 
+// TestHandler_NotFound_ListPath_KnownResourceUsesDiscoveryKind verifies the
+// empty-list fallback uses the authoritative Kind from discovery metadata,
+// not the resourceToKind heuristic — which guesses "Endpointslice" (wrong)
+// rather than the real "EndpointSlice" for "endpointslices", since it doesn't
+// follow simple depluralization. A client deserializing by GVK would break on
+// the heuristic's guess.
+func TestHandler_NotFound_ListPath_KnownResourceUsesDiscoveryKind(t *testing.T) {
+	discoveryBody := `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"discovery.k8s.io/v1","resources":[` +
+		`{"name":"endpointslices","singularName":"endpointslice","namespaced":true,"kind":"EndpointSlice"}]}`
+	store := buildTestStore(t, map[string][]byte{
+		"/apis/discovery.k8s.io/v1": []byte(discoveryBody),
+	})
+	store.discoveryEnrichmentDone.Wait()
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/apis/discovery.k8s.io/v1/namespaces/default/endpointslices", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rw.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rw.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected JSON body: %v", err)
+	}
+	if body["kind"] != "EndpointSliceList" {
+		t.Errorf("expected kind EndpointSliceList, got %v", body["kind"])
+	}
+}
+
 func TestHandler_SingleItemGet(t *testing.T) {
 	podList := `{"apiVersion":"v1","kind":"PodList","items":[{"metadata":{"name":"nginx","namespace":"default"}},{"metadata":{"name":"redis","namespace":"default"}}]}`
 	store := buildTestStore(t, map[string][]byte{

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -157,6 +157,117 @@ func TestHandler_NotFound_ItemPath(t *testing.T) {
 	}
 }
 
+// TestHandler_NotFound_ItemPath_StandardStatus verifies an item-level GET's
+// 404 body is a standard Kubernetes NotFound Status (reason, message,
+// details) rather than the k8shark-specific "not found in capture" message —
+// so client-go's apierrors.IsNotFound() recognizes it (#177).
+func TestHandler_NotFound_ItemPath_StandardStatus(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/apis/networking.k8s.io/v1/namespaces/default/ingresses/nope", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rw.Code)
+	}
+	var status struct {
+		Kind    string `json:"kind"`
+		Status  string `json:"status"`
+		Reason  string `json:"reason"`
+		Message string `json:"message"`
+		Details struct {
+			Name  string `json:"name"`
+			Group string `json:"group"`
+			Kind  string `json:"kind"`
+		} `json:"details"`
+	}
+	if err := json.Unmarshal(rw.Body.Bytes(), &status); err != nil {
+		t.Fatalf("expected JSON body: %v", err)
+	}
+	if status.Kind != "Status" || status.Status != "Failure" || status.Reason != "NotFound" {
+		t.Errorf("status = %+v, want kind=Status status=Failure reason=NotFound", status)
+	}
+	if status.Message != `ingresses.networking.k8s.io "nope" not found` {
+		t.Errorf("message = %q, want %q", status.Message, `ingresses.networking.k8s.io "nope" not found`)
+	}
+	if status.Details.Name != "nope" || status.Details.Group != "networking.k8s.io" || status.Details.Kind != "ingresses" {
+		t.Errorf("details = %+v, want name=nope group=networking.k8s.io kind=ingresses", status.Details)
+	}
+}
+
+// TestHandler_NotFound_ItemPath_CoreGroupStatus verifies the core group
+// (empty group string) omits ".group" from the message and "group" from
+// details, matching the real apiserver's GroupResource.String() format.
+func TestHandler_NotFound_ItemPath_CoreGroupStatus(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/nope", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rw.Code)
+	}
+	var status struct {
+		Reason  string         `json:"reason"`
+		Message string         `json:"message"`
+		Details map[string]any `json:"details"`
+	}
+	if err := json.Unmarshal(rw.Body.Bytes(), &status); err != nil {
+		t.Fatalf("expected JSON body: %v", err)
+	}
+	if status.Reason != "NotFound" {
+		t.Errorf("reason = %q, want NotFound", status.Reason)
+	}
+	if status.Message != `pods "nope" not found` {
+		t.Errorf("message = %q, want %q", status.Message, `pods "nope" not found`)
+	}
+	if _, hasGroup := status.Details["group"]; hasGroup {
+		t.Errorf("details should omit \"group\" for the core group, got %v", status.Details)
+	}
+}
+
+// TestHandler_NotFound_ListPath_KnownResourceNoWarning verifies a resource
+// listed in a captured discovery document, but with zero captured objects,
+// returns an empty 200 list with no Warning header — it behaves like a real
+// cluster's empty live collection, not a misconfigured/unknown capture
+// (#177). Contrast with TestHandler_NotFound_ListPath, where the resource is
+// genuinely absent from discovery too.
+func TestHandler_NotFound_ListPath_KnownResourceNoWarning(t *testing.T) {
+	discoveryBody := `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"networking.k8s.io/v1","resources":[` +
+		`{"name":"ingresses","singularName":"ingress","namespaced":true,"kind":"Ingress"}]}`
+	store := buildTestStore(t, map[string][]byte{
+		"/apis/networking.k8s.io/v1": []byte(discoveryBody),
+	})
+	store.discoveryEnrichmentDone.Wait()
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/apis/networking.k8s.io/v1/namespaces/default/ingresses", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rw.Code)
+	}
+	if w := rw.Header().Get("Warning"); w != "" {
+		t.Errorf("expected no Warning header for a known resource, got %q", w)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rw.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected JSON body: %v", err)
+	}
+	if body["kind"] != "IngressList" {
+		t.Errorf("expected kind IngressList, got %v", body["kind"])
+	}
+	items, _ := body["items"].([]any)
+	if len(items) != 0 {
+		t.Errorf("expected empty items, got %v", items)
+	}
+}
+
 func TestHandler_SingleItemGet(t *testing.T) {
 	podList := `{"apiVersion":"v1","kind":"PodList","items":[{"metadata":{"name":"nginx","namespace":"default"}},{"metadata":{"name":"redis","namespace":"default"}}]}`
 	store := buildTestStore(t, map[string][]byte{

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -162,7 +162,12 @@ func TestHandler_NotFound_ItemPath(t *testing.T) {
 // details) rather than the k8shark-specific "not found in capture" message —
 // so client-go's apierrors.IsNotFound() recognizes it (#177).
 func TestHandler_NotFound_ItemPath_StandardStatus(t *testing.T) {
-	store := buildTestStore(t, map[string][]byte{})
+	discoveryBody := `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"networking.k8s.io/v1","resources":[` +
+		`{"name":"ingresses","singularName":"ingress","namespaced":true,"kind":"Ingress"}]}`
+	store := buildTestStore(t, map[string][]byte{
+		"/apis/networking.k8s.io/v1": []byte(discoveryBody),
+	})
+	store.discoveryEnrichmentDone.Wait()
 	h := newHandler(store, time.Time{}, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/apis/networking.k8s.io/v1/namespaces/default/ingresses/nope", nil)
@@ -201,7 +206,11 @@ func TestHandler_NotFound_ItemPath_StandardStatus(t *testing.T) {
 // (empty group string) omits ".group" from the message and "group" from
 // details, matching the real apiserver's GroupResource.String() format.
 func TestHandler_NotFound_ItemPath_CoreGroupStatus(t *testing.T) {
-	store := buildTestStore(t, map[string][]byte{})
+	// "pods" is known via a captured (unrelated) pod list — "nope" itself was
+	// never captured.
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/pods": []byte(`{"kind":"PodList","items":[{"metadata":{"name":"other"}}]}`),
+	})
 	h := newHandler(store, time.Time{}, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/nope", nil)
@@ -227,6 +236,38 @@ func TestHandler_NotFound_ItemPath_CoreGroupStatus(t *testing.T) {
 	}
 	if _, hasGroup := status.Details["group"]; hasGroup {
 		t.Errorf("details should omit \"group\" for the core group, got %v", status.Details)
+	}
+}
+
+// TestHandler_NotFound_ItemPath_UnknownResourceKeepsGenericMessage verifies an
+// item-level GET for a resource that's genuinely unknown (absent from both
+// discovery and the index) keeps the k8shark-specific "not found in capture"
+// message rather than the standard NotFound Status — that format would
+// otherwise misleadingly present a capture-config problem (wrong
+// group/resource entirely) as "the object is just missing" (#177).
+func TestHandler_NotFound_ItemPath_UnknownResourceKeepsGenericMessage(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/apis/totally.fake/v1/namespaces/default/foos/nope", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rw.Code)
+	}
+	var status struct {
+		Reason  string `json:"reason"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(rw.Body.Bytes(), &status); err != nil {
+		t.Fatalf("expected JSON body: %v", err)
+	}
+	if status.Reason != "" {
+		t.Errorf("reason = %q, want empty (not the standard NotFound Status)", status.Reason)
+	}
+	if !strings.Contains(status.Message, "not found in capture") {
+		t.Errorf("message = %q, want the k8shark-specific \"not found in capture\" message", status.Message)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -47,6 +47,7 @@ type ReplayOptions struct {
 type Server struct {
 	address        string
 	kubeconfigPath string
+	certPEM        []byte // this run's self-signed TLS cert, for callers that need to pin it
 	ar             *archive.Archive
 	httpServer     *http.Server
 	done           chan struct{}
@@ -165,6 +166,7 @@ func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *Replay
 	return &Server{
 		address:        addr,
 		kubeconfigPath: kubeconfigPath,
+		certPEM:        certPEM,
 		ar:             ar,
 		httpServer:     httpSrv,
 		done:           done,
@@ -182,6 +184,11 @@ func (s *Server) Address() string { return s.address }
 
 // KubeconfigPath returns the path to the generated kubeconfig.
 func (s *Server) KubeconfigPath() string { return s.kubeconfigPath }
+
+// CertPEM returns this run's self-signed TLS certificate in PEM form, so an
+// in-process client (one that isn't going through the generated kubeconfig's
+// insecure-skip-tls-verify) can pin it instead of disabling verification.
+func (s *Server) CertPEM() []byte { return s.certPEM }
 
 // Clock returns the replay clock, or nil when the server is not in replay mode.
 func (s *Server) Clock() *ReplayClock { return s.clock }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -185,10 +185,16 @@ func (s *Server) Address() string { return s.address }
 // KubeconfigPath returns the path to the generated kubeconfig.
 func (s *Server) KubeconfigPath() string { return s.kubeconfigPath }
 
-// CertPEM returns this run's self-signed TLS certificate in PEM form, so an
-// in-process client (one that isn't going through the generated kubeconfig's
-// insecure-skip-tls-verify) can pin it instead of disabling verification.
-func (s *Server) CertPEM() []byte { return s.certPEM }
+// CertPEM returns a copy of this run's self-signed TLS certificate in PEM
+// form, so an in-process client (one that isn't going through the generated
+// kubeconfig's insecure-skip-tls-verify) can pin it instead of disabling
+// verification. A copy is returned so a caller can't mutate the server's
+// stored cert bytes.
+func (s *Server) CertPEM() []byte {
+	out := make([]byte, len(s.certPEM))
+	copy(out, s.certPEM)
+	return out
+}
 
 // Clock returns the replay clock, or nil when the server is not in replay mode.
 func (s *Server) Clock() *ReplayClock { return s.clock }

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -294,6 +294,23 @@ func (s *CaptureStore) isKnownResource(group, version, resource string) bool {
 	return ok
 }
 
+// resourceKind returns the authoritative Kind for a known group/version/
+// resource (from captured discovery, or resourceToKind's heuristic if only
+// seen in the index — see buildResourceInfo/mergeResourceInfo), or "" if the
+// resource isn't known at all. Prefer this over calling resourceToKind
+// directly when a resource might be known: the heuristic guesses wrong for
+// built-in types whose Kind doesn't follow simple depluralization (e.g.
+// "endpointslices" -> "Endpointslice", not the real "EndpointSlice") and for
+// most CRDs.
+func (s *CaptureStore) resourceKind(group, version, resource string) string {
+	s.resourceInfoMu.RLock()
+	defer s.resourceInfoMu.RUnlock()
+	if ri, ok := s.resourceInfo[group+"/"+version+"/"+resource]; ok {
+		return ri.Kind
+	}
+	return ""
+}
+
 // Latest returns the ResponseBody of the most recent record for apiPath.
 // If at is non-zero, it returns the latest record whose timestamp is <= at.
 func (s *CaptureStore) Latest(apiPath string, at time.Time) ([]byte, int, error) {

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -165,7 +165,13 @@ func (s *CaptureStore) buildResourceInfo() {
 // mergeResourceInfo inserts or enriches the ResourceInfo for group/version/
 // resource from a captured discovery document, creating a new entry (zero
 // captured objects) if one doesn't already exist from the index. Safe for
-// concurrent use.
+// concurrent use. namespaced always overwrites: discovery is the authoritative
+// source for a resource's scope, more reliable than buildResourceInfo's
+// index-derived guess (whether any captured path happened to include a
+// namespace segment) — e.g. a capture with only a cluster-wide list
+// (/api/v1/pods, no namespaces: in config) would otherwise report a
+// namespaced resource as cluster-scoped in the regenerated discovery
+// document.
 func (s *CaptureStore) mergeResourceInfo(group, version, resource string, namespaced bool, kind, singularName string, shortNames []string) {
 	s.resourceInfoMu.Lock()
 	defer s.resourceInfoMu.Unlock()
@@ -175,6 +181,7 @@ func (s *CaptureStore) mergeResourceInfo(group, version, resource string, namesp
 		ri = &ResourceInfo{Group: group, Version: version, Resource: resource, Namespaced: namespaced}
 		s.resourceInfo[key] = ri
 	}
+	ri.Namespaced = namespaced
 	if kind != "" {
 		ri.Kind = kind
 	} else if ri.Kind == "" {
@@ -251,13 +258,19 @@ func (s *CaptureStore) enrichResourceInfoFromDiscovery() {
 	}
 }
 
-// Resources returns all distinct ResourceInfo entries.
-func (s *CaptureStore) Resources() []*ResourceInfo {
+// Resources returns a snapshot of all distinct ResourceInfo entries. Each
+// element is a value copy taken under the lock, not the pointer stored in the
+// map — mergeResourceInfo can mutate an existing entry's fields
+// (Kind/SingularName/ShortNames/Namespaced) from the background discovery
+// enrichment goroutine at any time, so returning the original pointers would
+// let a caller observe a struct being concurrently written after the lock is
+// released.
+func (s *CaptureStore) Resources() []ResourceInfo {
 	s.resourceInfoMu.RLock()
 	defer s.resourceInfoMu.RUnlock()
-	out := make([]*ResourceInfo, 0, len(s.resourceInfo))
+	out := make([]ResourceInfo, 0, len(s.resourceInfo))
 	for _, ri := range s.resourceInfo {
-		out = append(out, ri)
+		out = append(out, *ri)
 	}
 	return out
 }

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -16,11 +16,18 @@ import (
 // CaptureStore holds the in-memory index and provides record lookups against
 // a ZIP+Zstd archive opened without extraction to disk.
 type CaptureStore struct {
-	ar           *archive.Archive
-	Metadata     capture.CaptureMetadata
-	Index        capture.Index
-	WatchIndex   capture.WatchIndex
-	resourceInfo map[string]*ResourceInfo
+	ar         *archive.Archive
+	Metadata   capture.CaptureMetadata
+	Index      capture.Index
+	WatchIndex capture.WatchIndex
+
+	resourceInfoMu sync.RWMutex
+	resourceInfo   map[string]*ResourceInfo
+	// discoveryEnrichmentDone lets tests deterministically wait for
+	// enrichResourceInfoFromDiscovery's background pass (see LoadStore) instead
+	// of racing it. Production code intentionally does not wait — the store is
+	// documented as usable before this completes.
+	discoveryEnrichmentDone sync.WaitGroup
 
 	// Record LRU cache (bounded by recordCacheMaxBytes total body bytes).
 	recordCacheMu    sync.Mutex
@@ -115,7 +122,11 @@ func LoadStore(ar *archive.Archive) (*CaptureStore, error) {
 	// Derive ResourceInfo from index keys synchronously (fast — no I/O).
 	s.buildResourceInfo()
 
-	// Enrich ResourceInfo from discovery records asynchronously.
+	// Enrich ResourceInfo from discovery records asynchronously — this also
+	// creates entries for resources listed in a captured discovery document
+	// that have zero captured objects (see mergeResourceInfo), so a known kind
+	// with nothing captured is distinguishable from a genuinely unknown one.
+	s.discoveryEnrichmentDone.Add(1)
 	go s.enrichResourceInfoFromDiscovery()
 
 	return s, nil
@@ -124,6 +135,8 @@ func LoadStore(ar *archive.Archive) (*CaptureStore, error) {
 // buildResourceInfo derives ResourceInfo for each distinct resource type in
 // the index. It does not read any record data.
 func (s *CaptureStore) buildResourceInfo() {
+	s.resourceInfoMu.Lock()
+	defer s.resourceInfoMu.Unlock()
 	for path := range s.Index {
 		if strings.Contains(path, "?") {
 			continue
@@ -149,14 +162,45 @@ func (s *CaptureStore) buildResourceInfo() {
 	}
 }
 
+// mergeResourceInfo inserts or enriches the ResourceInfo for group/version/
+// resource from a captured discovery document, creating a new entry (zero
+// captured objects) if one doesn't already exist from the index. Safe for
+// concurrent use.
+func (s *CaptureStore) mergeResourceInfo(group, version, resource string, namespaced bool, kind, singularName string, shortNames []string) {
+	s.resourceInfoMu.Lock()
+	defer s.resourceInfoMu.Unlock()
+	key := group + "/" + version + "/" + resource
+	ri, ok := s.resourceInfo[key]
+	if !ok {
+		ri = &ResourceInfo{Group: group, Version: version, Resource: resource, Namespaced: namespaced}
+		s.resourceInfo[key] = ri
+	}
+	if kind != "" {
+		ri.Kind = kind
+	} else if ri.Kind == "" {
+		ri.Kind = resourceToKind(resource)
+	}
+	if singularName != "" {
+		ri.SingularName = singularName
+	}
+	if len(shortNames) > 0 {
+		ri.ShortNames = shortNames
+	}
+}
+
 // enrichResourceInfoFromDiscovery reads captured APIResourceList bodies from
-// the archive and back-fills Kind, ShortNames, SingularName into resourceInfo.
-// Runs in a background goroutine; store is usable before this completes.
+// the archive and back-fills Kind, ShortNames, SingularName into resourceInfo
+// — creating a new entry (via mergeResourceInfo) for a resource the discovery
+// document lists but that has zero captured objects, so it's still reported
+// as a known kind rather than "not found in capture" (#177). Runs in a
+// background goroutine; store is usable before this completes.
 func (s *CaptureStore) enrichResourceInfoFromDiscovery() {
+	defer s.discoveryEnrichmentDone.Done()
 	type apiResourceEntry struct {
 		Name         string   `json:"name"`
 		SingularName string   `json:"singularName"`
 		Kind         string   `json:"kind"`
+		Namespaced   bool     `json:"namespaced"`
 		ShortNames   []string `json:"shortNames"`
 	}
 	type apiResourceList struct {
@@ -200,33 +244,34 @@ func (s *CaptureStore) enrichResourceInfoFromDiscovery() {
 		}
 		for _, res := range resList.Resources {
 			if strings.Contains(res.Name, "/") {
-				continue
+				continue // a subresource entry (e.g. "pods/status"), not a top-level resource
 			}
-			key := g + "/" + v + "/" + res.Name
-			ri, ok := s.resourceInfo[key]
-			if !ok {
-				continue
-			}
-			if res.Kind != "" {
-				ri.Kind = res.Kind
-			}
-			if res.SingularName != "" {
-				ri.SingularName = res.SingularName
-			}
-			if len(res.ShortNames) > 0 {
-				ri.ShortNames = res.ShortNames
-			}
+			s.mergeResourceInfo(g, v, res.Name, res.Namespaced, res.Kind, res.SingularName, res.ShortNames)
 		}
 	}
 }
 
 // Resources returns all distinct ResourceInfo entries.
 func (s *CaptureStore) Resources() []*ResourceInfo {
+	s.resourceInfoMu.RLock()
+	defer s.resourceInfoMu.RUnlock()
 	out := make([]*ResourceInfo, 0, len(s.resourceInfo))
 	for _, ri := range s.resourceInfo {
 		out = append(out, ri)
 	}
 	return out
+}
+
+// isKnownResource reports whether group/version/resource is a real API type
+// the captured cluster exposed — present in a captured discovery document or
+// the archive index — even if zero objects of it were ever captured. Used to
+// distinguish "known kind, nothing captured" (should read like an empty live
+// collection) from a genuinely unknown/misconfigured kind (#177).
+func (s *CaptureStore) isKnownResource(group, version, resource string) bool {
+	s.resourceInfoMu.RLock()
+	defer s.resourceInfoMu.RUnlock()
+	_, ok := s.resourceInfo[group+"/"+version+"/"+resource]
+	return ok
 }
 
 // Latest returns the ResponseBody of the most recent record for apiPath.

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -258,19 +258,26 @@ func (s *CaptureStore) enrichResourceInfoFromDiscovery() {
 	}
 }
 
-// Resources returns a snapshot of all distinct ResourceInfo entries. Each
-// element is a value copy taken under the lock, not the pointer stored in the
-// map — mergeResourceInfo can mutate an existing entry's fields
-// (Kind/SingularName/ShortNames/Namespaced) from the background discovery
-// enrichment goroutine at any time, so returning the original pointers would
-// let a caller observe a struct being concurrently written after the lock is
-// released.
+// Resources returns a snapshot of all distinct ResourceInfo entries, fully
+// decoupled from internal storage. Each element is a value copy taken under
+// the lock, not the pointer stored in the map — mergeResourceInfo can mutate
+// an existing entry's fields (Kind/SingularName/ShortNames/Namespaced) from
+// the background discovery enrichment goroutine at any time, so returning the
+// original pointers would let a caller observe a struct being concurrently
+// written after the lock is released. ShortNames is copied too: a struct copy
+// alone still shares the slice's backing array with the stored entry, so a
+// caller mutating the returned ShortNames (even by accident) would corrupt
+// internal state without holding the lock.
 func (s *CaptureStore) Resources() []ResourceInfo {
 	s.resourceInfoMu.RLock()
 	defer s.resourceInfoMu.RUnlock()
 	out := make([]ResourceInfo, 0, len(s.resourceInfo))
 	for _, ri := range s.resourceInfo {
-		out = append(out, *ri)
+		cp := *ri
+		if len(ri.ShortNames) > 0 {
+			cp.ShortNames = append([]string(nil), ri.ShortNames...)
+		}
+		out = append(out, cp)
 	}
 	return out
 }

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -68,10 +68,11 @@ func TestEnrichResourceInfoFromDiscovery_KnownButUncaptured(t *testing.T) {
 	if !store.isKnownResource("networking.k8s.io", "v1", "ingresses") {
 		t.Fatal("ingresses should be a known resource after discovery enrichment")
 	}
+	resources := store.Resources()
 	var found *ResourceInfo
-	for _, ri := range store.Resources() {
-		if ri.Group == "networking.k8s.io" && ri.Resource == "ingresses" {
-			found = ri
+	for i := range resources {
+		if resources[i].Group == "networking.k8s.io" && resources[i].Resource == "ingresses" {
+			found = &resources[i]
 		}
 	}
 	if found == nil {
@@ -82,6 +83,36 @@ func TestEnrichResourceInfoFromDiscovery_KnownButUncaptured(t *testing.T) {
 	}
 	if len(found.ShortNames) != 1 || found.ShortNames[0] != "ing" {
 		t.Errorf("ingresses ShortNames = %v, want [ing]", found.ShortNames)
+	}
+}
+
+// TestEnrichResourceInfoFromDiscovery_CorrectsNamespacedFromIndex verifies
+// discovery's "namespaced" field overwrites buildResourceInfo's index-derived
+// guess on an existing entry, not just at creation — a capture with only a
+// cluster-wide list (no namespaces: in config) would otherwise report a
+// namespaced resource as cluster-scoped in the regenerated discovery
+// document.
+func TestEnrichResourceInfoFromDiscovery_CorrectsNamespacedFromIndex(t *testing.T) {
+	discoveryBody := `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"v1","resources":[` +
+		`{"name":"pods","singularName":"pod","namespaced":true,"kind":"Pod"}]}`
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1":      []byte(discoveryBody),
+		"/api/v1/pods": []byte(`{"kind":"PodList","items":[]}`), // cluster-wide only — buildResourceInfo infers Namespaced=false
+	})
+	store.discoveryEnrichmentDone.Wait()
+
+	resources := store.Resources()
+	var found *ResourceInfo
+	for i := range resources {
+		if resources[i].Group == "" && resources[i].Resource == "pods" {
+			found = &resources[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("pods missing from Resources()")
+	}
+	if !found.Namespaced {
+		t.Error("discovery says pods is namespaced; enrichment should have corrected the index-derived guess")
 	}
 }
 

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -84,6 +84,19 @@ func TestEnrichResourceInfoFromDiscovery_KnownButUncaptured(t *testing.T) {
 	if len(found.ShortNames) != 1 || found.ShortNames[0] != "ing" {
 		t.Errorf("ingresses ShortNames = %v, want [ing]", found.ShortNames)
 	}
+
+	// Mutating the returned ShortNames must not corrupt the store's internal
+	// state — Resources() should be a fully decoupled snapshot, not just a
+	// copy of the outer struct sharing the slice's backing array.
+	found.ShortNames[0] = "mutated"
+	resources2 := store.Resources()
+	for i := range resources2 {
+		if resources2[i].Group == "networking.k8s.io" && resources2[i].Resource == "ingresses" {
+			if resources2[i].ShortNames[0] != "ing" {
+				t.Errorf("mutating a returned ShortNames slice corrupted internal state: got %v", resources2[i].ShortNames)
+			}
+		}
+	}
 }
 
 // TestEnrichResourceInfoFromDiscovery_CorrectsNamespacedFromIndex verifies

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -52,6 +52,39 @@ func TestResourceToKind(t *testing.T) {
 	}
 }
 
+// TestEnrichResourceInfoFromDiscovery_KnownButUncaptured verifies a resource
+// listed in a captured discovery document, but with zero captured objects of
+// its own, still gets a ResourceInfo entry — the root fix for #177 ("known
+// kind, nothing captured" must be distinguishable from "genuinely unknown
+// kind").
+func TestEnrichResourceInfoFromDiscovery_KnownButUncaptured(t *testing.T) {
+	discoveryBody := `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"networking.k8s.io/v1","resources":[` +
+		`{"name":"ingresses","singularName":"ingress","namespaced":true,"kind":"Ingress","shortNames":["ing"]}]}`
+	store := buildTestStore(t, map[string][]byte{
+		"/apis/networking.k8s.io/v1": []byte(discoveryBody),
+	})
+	store.discoveryEnrichmentDone.Wait()
+
+	if !store.isKnownResource("networking.k8s.io", "v1", "ingresses") {
+		t.Fatal("ingresses should be a known resource after discovery enrichment")
+	}
+	var found *ResourceInfo
+	for _, ri := range store.Resources() {
+		if ri.Group == "networking.k8s.io" && ri.Resource == "ingresses" {
+			found = ri
+		}
+	}
+	if found == nil {
+		t.Fatal("ingresses missing from Resources()")
+	}
+	if found.Kind != "Ingress" || found.SingularName != "ingress" || !found.Namespaced {
+		t.Errorf("ingresses ResourceInfo = %+v, want Kind=Ingress SingularName=ingress Namespaced=true", found)
+	}
+	if len(found.ShortNames) != 1 || found.ShortNames[0] != "ing" {
+		t.Errorf("ingresses ShortNames = %v, want [ing]", found.ShortNames)
+	}
+}
+
 // buildTestStore creates a CaptureStore with the given per-path response bodies.
 func buildTestStore(t *testing.T, records map[string][]byte) *CaptureStore {
 	t.Helper()


### PR DESCRIPTION
## Summary

- **Root cause:** `CaptureMetadata.CapturedAt` was computed as `finish - configured duration`, which silently absorbs any wall-clock time spent on preflight/version-check/discovery/namespace-expansion before the first poll actually fires. A replay session defaults its window start (`from`) to `CapturedAt`, so an underestimated `CapturedAt` can land *before* a resource's first captured snapshot.
- A client querying the mock replay server right at startup — most notably `kshrk replay --with-kwok`'s auto-launched `kwok` subprocess, whose node informer issues its very first LIST almost immediately — could hit this gap and see `Latest`/`SnapshotAt` 404 for a resource that genuinely was captured. The handler's known-kind fallback then serves a "real" empty `NodeList` instead of surfacing an error, so kwok's node cache stays empty for the entire session and pods it manages never reach `Running`.
- **Fix 1 (root cause):** `internal/capture/engine.go` now records `CapturedAt` right before the poll/watch goroutines launch, instead of back-computing an estimate from the configured duration. This closes the multi-second gap that discovery/preflight overhead could introduce.
- **Fix 2 (defense in depth):** `cmd/kwok.go`/`cmd/replay.go` now poll the mock server's `/api/v1/nodes` until it reports at least one node (or a bounded timeout elapses) before launching the `kwok` subprocess, closing the much smaller residual race from goroutine-scheduling/network jitter that timestamp bookkeeping alone can't eliminate.
- Updated `docs/archive-format.md` to describe `captured_at`'s corrected semantics.

## Test plan

- [x] Added `TestEngine_CapturedAt_ReflectsPollStart` (`internal/capture/engine_test.go`), which injects an artificial ~600ms version-check delay and asserts the `CapturedAt`→first-snapshot gap stays small — fails against the old `now - duration` computation, passes with the fix.
- [x] Added `TestWaitForNodesReady_PollsUntilNonEmpty` and `TestWaitForNodesReady_TimesOutWhenAlwaysEmpty` (`cmd/kwok_test.go`) covering the new readiness gate.
- [x] `make fmt` — no diff
- [x] `make test` — all packages pass
- [x] `make test-race` — all packages pass
- [x] `make lint` (`go vet`) — clean
- [x] `golangci-lint run` (CI-equivalent) — clean
- [x] `go mod tidy` — no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)