### PR TITLE
feat(replay,ui): --with-controller-manager for closed-loop reconciliation

### DIFF
--- a/cmd/controllermanager.go
+++ b/cmd/controllermanager.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/phenixblue/k8shark/internal/k8sbin"
+)
+
+// controllerManagerControllers is the curated set of kube-controller-manager
+// controllers --with-controller-manager enables: pure API-object reconcilers
+// that only need the writable overlay's CRUD+watch surface, not a real
+// kubelet, storage provisioner, cloud provider, or node lifecycle. This
+// deliberately excludes controllers like node-lifecycle, persistentvolume
+// (binding needs a real provisioner), and certificate-signing — see
+// docs/kwok.md's non-goals, which apply here too.
+var controllerManagerControllers = []string{
+	"namespace",
+	"serviceaccount",
+	"resourcequota",
+	"garbagecollector",
+	"daemonset",
+	"deployment",
+	"replicaset",
+	"statefulset",
+	"job",
+	"cronjob",
+	"endpoint",
+	"endpointslice",
+	"endpointslicemirroring",
+	"disruption",
+}
+
+// startControllerManager locates or builds a kube-controller-manager binary
+// matching k8sVersion (see internal/k8sbin) and runs it against the mock
+// server's kubeconfig with the curated controller set, no leader election (a
+// single local process needs none), and no delegated authn/authz (there's no
+// real TokenReview/SubjectAccessReview API for it to call — it falls back to
+// always-allow, same as any other out-of-cluster test harness). It returns a
+// cleanup func that stops the subprocess.
+func startControllerManager(kubeconfigPath, k8sVersion string) (cleanup func(), err error) {
+	binPath, err := k8sbin.EnsureControllerManager(k8sVersion, func(msg string) {
+		fmt.Fprintf(os.Stderr, "--with-controller-manager: %s\n", msg)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("--with-controller-manager: %w", err)
+	}
+
+	args := []string{
+		"--kubeconfig", kubeconfigPath,
+		"--leader-elect=false",
+		"--use-service-account-credentials=false",
+		"--controllers=" + strings.Join(controllerManagerControllers, ","),
+	}
+	c := exec.Command(binPath, args...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	if err := c.Start(); err != nil {
+		return nil, fmt.Errorf("--with-controller-manager: starting kube-controller-manager: %w", err)
+	}
+
+	cleanup = func() {
+		if c.Process != nil {
+			_ = c.Process.Kill()
+		}
+		_ = c.Wait()
+	}
+	return cleanup, nil
+}

--- a/cmd/controllermanager.go
+++ b/cmd/controllermanager.go
@@ -33,6 +33,15 @@ var controllerManagerControllers = []string{
 	"disruption",
 }
 
+// controllerManagerFlagHelp is the --with-controller-manager flag description
+// shared by `replay` and `ui`, derived from controllerManagerControllers
+// rather than duplicated as a hand-written list in each cmd/*.go — the two
+// drifted out of sync with the actual set (and each other) when the list was
+// last extended.
+var controllerManagerFlagHelp = "also run kube-controller-manager (downloaded/built to match the capture's " +
+	"Kubernetes version) against the server, reconciling a curated set of controllers (" +
+	strings.Join(controllerManagerControllers, ", ") + ") — see docs/kwok.md (implies --writable)"
+
 // startControllerManager locates or builds a kube-controller-manager binary
 // matching k8sVersion (see internal/k8sbin) and runs it against the mock
 // server's kubeconfig with the curated controller set, no leader election (a

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/phenixblue/k8shark/internal/server"
@@ -51,6 +52,7 @@ func init() {
 	replayCmd.Flags().Bool("writable", false, "accept client writes into an in-memory overlay (closed-loop controller dev)")
 	replayCmd.Flags().Bool("schedule-pods", true, "bind unscheduled pods to a node on create (the scheduler replay lacks); --writable only")
 	replayCmd.Flags().Bool("with-kwok", false, "also run a detected 'kwok' binary against the server to drive pod/node lifecycle (implies --writable)")
+	replayCmd.Flags().Bool("with-controller-manager", false, "also run kube-controller-manager (downloaded/built to match the capture's Kubernetes version) against the server, with a curated controller set, to reconcile Deployments/ReplicaSets/DaemonSets/StatefulSets/Jobs/CronJobs/Endpoints (implies --writable)")
 }
 
 func runReplay(cmd *cobra.Command, args []string) error {
@@ -64,14 +66,16 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	writable, _ := cmd.Flags().GetBool("writable")
 	schedulePods, _ := cmd.Flags().GetBool("schedule-pods")
 	withKwok, _ := cmd.Flags().GetBool("with-kwok")
+	withControllerManager, _ := cmd.Flags().GetBool("with-controller-manager")
 	verbose, _ := cmd.Root().PersistentFlags().GetBool("verbose")
 
 	if err := validateKwokFlags(withKwok, schedulePods); err != nil {
 		return err
 	}
-	// --with-kwok drives pod/node lifecycle against the overlay, so it implies
-	// --writable (and needs the scheduling shim on to bind pods to nodes).
-	if withKwok {
+	// --with-kwok and --with-controller-manager both drive the overlay from a
+	// live process, so either implies --writable (and --with-kwok needs the
+	// scheduling shim on to bind pods to nodes).
+	if withKwok || withControllerManager {
 		writable = true
 	}
 
@@ -92,20 +96,35 @@ func runReplay(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("starting replay: %w", err)
 	}
 
-	// Optionally launch a detected kwok against the server to drive pod/node
-	// lifecycle. Started after the server is up (it needs the kubeconfig) and torn
-	// down on shutdown. waitForNodesReady blocks briefly first so kwok's own
-	// first LIST doesn't race the replay clock past the nodes resource's first
-	// captured snapshot (see waitForNodesReady).
+	// Optionally launch a detected kwok and/or kube-controller-manager against the
+	// server to drive pod/node lifecycle and reconcile the curated controller set
+	// (Deployments/ReplicaSets/Jobs/CronJobs/...). Started after the server is up
+	// (they need the kubeconfig) and torn down on shutdown. waitForNodesReady
+	// blocks briefly first so their informers' first LIST doesn't race the replay
+	// clock past the nodes resource's first captured snapshot (see
+	// waitForNodesReady) — needed at most once even when both are enabled.
+	if withKwok || withControllerManager {
+		waitForNodesReady(srv.Address(), srv.CertPEM(), nodesReadyTimeout)
+	}
+
 	var kwokCleanup func()
 	if withKwok {
-		waitForNodesReady(srv.Address(), srv.CertPEM(), nodesReadyTimeout)
 		kwokCleanup, err = startKwok(srv.KubeconfigPath())
 		if err != nil {
 			srv.Shutdown()
 			return err
 		}
 		defer kwokCleanup()
+	}
+
+	var controllerManagerCleanup func()
+	if withControllerManager {
+		controllerManagerCleanup, err = startControllerManager(srv.KubeconfigPath(), srv.KubernetesVersion())
+		if err != nil {
+			srv.Shutdown()
+			return err
+		}
+		defer controllerManagerCleanup()
 	}
 
 	clock := srv.Clock()
@@ -136,6 +155,9 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	}
 	if withKwok {
 		fmt.Printf("  KWOK:       on (driving pod/node lifecycle via bundled stages)\n")
+	}
+	if withControllerManager {
+		fmt.Printf("  Controller-manager: on (reconciling %s)\n", strings.Join(controllerManagerControllers, ", "))
 	}
 	fmt.Printf("  Control:    %s/_k8shark/replay\n", srv.Address())
 	if uiSrv != nil {

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -52,7 +52,7 @@ func init() {
 	replayCmd.Flags().Bool("writable", false, "accept client writes into an in-memory overlay (closed-loop controller dev)")
 	replayCmd.Flags().Bool("schedule-pods", true, "bind unscheduled pods to a node on create (the scheduler replay lacks); --writable only")
 	replayCmd.Flags().Bool("with-kwok", false, "also run a detected 'kwok' binary against the server to drive pod/node lifecycle (implies --writable)")
-	replayCmd.Flags().Bool("with-controller-manager", false, "also run kube-controller-manager (downloaded/built to match the capture's Kubernetes version) against the server, with a curated controller set, to reconcile Deployments/ReplicaSets/DaemonSets/StatefulSets/Jobs/CronJobs/Endpoints (implies --writable)")
+	replayCmd.Flags().Bool("with-controller-manager", false, controllerManagerFlagHelp)
 }
 
 func runReplay(cmd *cobra.Command, args []string) error {

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/phenixblue/k8shark/internal/config"
@@ -28,7 +29,10 @@ the config file).`,
   kshrk ui capture.kshrk --port 8080 --api-port 8081
 
   # Open the UI pinned to a point in time
-  kshrk ui capture.kshrk --at -5m`,
+  kshrk ui capture.kshrk --at -5m
+
+  # Watch a closed-loop simulation in the dashboard (see docs/kwok.md)
+  kshrk ui capture.kshrk --with-kwok --with-controller-manager`,
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: completeArchiveArg,
 	RunE:              runUI,
@@ -48,6 +52,8 @@ func init() {
 	uiCmd.Flags().Bool("loop", false, "replay mode: restart from the window start when the end is reached")
 	uiCmd.Flags().Bool("start-paused", false, "replay mode: start paused (the UI defaults to this; pass --start-paused=false to auto-play)")
 	uiCmd.Flags().Bool("writable", false, "replay mode: accept client writes into an in-memory overlay")
+	uiCmd.Flags().Bool("with-kwok", false, "replay mode: also run a detected 'kwok' binary against the server to drive pod/node lifecycle (implies --writable)")
+	uiCmd.Flags().Bool("with-controller-manager", false, "replay mode: also run kube-controller-manager against the server, with a curated controller set, to reconcile Deployments/ReplicaSets/Jobs/CronJobs/Endpoints (implies --writable)")
 }
 
 func runUI(cmd *cobra.Command, args []string) error {
@@ -77,14 +83,25 @@ func runUI(cmd *cobra.Command, args []string) error {
 	loop, _ := cmd.Flags().GetBool("loop")
 	startPaused, _ := cmd.Flags().GetBool("start-paused")
 	writable, _ := cmd.Flags().GetBool("writable")
+	withKwok, _ := cmd.Flags().GetBool("with-kwok")
+	withControllerManager, _ := cmd.Flags().GetBool("with-controller-manager")
+	// --with-kwok and --with-controller-manager both drive the overlay from a
+	// live process, so either implies --writable (and replay mode).
+	if withKwok || withControllerManager {
+		writable = true
+	}
 	replayMode := cmd.Flags().Changed("speed") || cmd.Flags().Changed("from") ||
 		cmd.Flags().Changed("to") || loop || startPaused || writable
 	startPaused = resolveUIStartPaused(replayMode, startPaused, cmd.Flags().Changed("start-paused"))
 
+	if err := validateKwokFlags(withKwok, true); err != nil {
+		return err
+	}
+
 	// --at pins a single instant, which is meaningless once the replay clock is
 	// driving time — reject the combination rather than silently ignoring --at.
 	if replayMode && cmd.Flags().Changed("at") {
-		return fmt.Errorf("--at cannot be combined with replay flags (--speed/--from/--to/--loop/--start-paused/--writable); use --from/--to to set the replay window")
+		return fmt.Errorf("--at cannot be combined with replay flags (--speed/--from/--to/--loop/--start-paused/--writable/--with-kwok/--with-controller-manager); use --from/--to to set the replay window")
 	}
 
 	var mockSrv *server.Server
@@ -103,6 +120,33 @@ func runUI(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("opening mock API: %w", err)
 	}
 
+	// Optionally launch a detected kwok and/or kube-controller-manager against the
+	// server, mirroring `kshrk replay`. Started after the server is up (they need
+	// the kubeconfig) and torn down on shutdown. waitForNodesReady guards against
+	// their informers' first LIST racing the replay clock's startup jitter (see
+	// cmd/kwok.go) — needed at most once even when both are enabled.
+	var kwokCleanup, controllerManagerCleanup func()
+	if withKwok || withControllerManager {
+		waitForNodesReady(mockSrv.Address(), mockSrv.CertPEM(), nodesReadyTimeout)
+	}
+	if withKwok {
+		kwokCleanup, err = startKwok(mockSrv.KubeconfigPath())
+		if err != nil {
+			mockSrv.Shutdown()
+			return err
+		}
+	}
+	if withControllerManager {
+		controllerManagerCleanup, err = startControllerManager(mockSrv.KubeconfigPath(), mockSrv.KubernetesVersion())
+		if err != nil {
+			if kwokCleanup != nil {
+				kwokCleanup()
+			}
+			mockSrv.Shutdown()
+			return err
+		}
+	}
+
 	uiSrv, err := ui.Open(ui.OpenOptions{
 		ArchivePath: archivePath,
 		Port:        uiPort,
@@ -111,6 +155,12 @@ func runUI(cmd *cobra.Command, args []string) error {
 		Clock:       mockSrv.Clock(), // nil unless replay mode → shared clock
 	})
 	if err != nil {
+		if controllerManagerCleanup != nil {
+			controllerManagerCleanup()
+		}
+		if kwokCleanup != nil {
+			kwokCleanup()
+		}
 		mockSrv.Shutdown()
 		return fmt.Errorf("opening UI: %w", err)
 	}
@@ -121,6 +171,12 @@ func runUI(cmd *cobra.Command, args []string) error {
 	if c := mockSrv.Clock(); c != nil {
 		wf, wt := c.Window()
 		fmt.Printf("  Replay:     %s → %s · %s\n", wf.Format("15:04:05Z07:00"), wt.Format("15:04:05Z07:00"), formatSpeed(c.Speed()))
+	}
+	if withKwok {
+		fmt.Printf("  KWOK:       on (driving pod/node lifecycle via bundled stages)\n")
+	}
+	if withControllerManager {
+		fmt.Printf("  Controller-manager: on (reconciling %s)\n", strings.Join(controllerManagerControllers, ", "))
 	}
 	fmt.Printf("\nRun: export KUBECONFIG=%s\n", mockSrv.KubeconfigPath())
 	fmt.Printf("Then use kubectl normally against the capture.\n\n")
@@ -138,6 +194,12 @@ func runUI(cmd *cobra.Command, args []string) error {
 	<-sigCh
 
 	uiSrv.Shutdown()
+	if controllerManagerCleanup != nil {
+		controllerManagerCleanup()
+	}
+	if kwokCleanup != nil {
+		kwokCleanup()
+	}
 	mockSrv.Shutdown()
 
 	return nil

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -53,7 +53,7 @@ func init() {
 	uiCmd.Flags().Bool("start-paused", false, "replay mode: start paused (the UI defaults to this; pass --start-paused=false to auto-play)")
 	uiCmd.Flags().Bool("writable", false, "replay mode: accept client writes into an in-memory overlay")
 	uiCmd.Flags().Bool("with-kwok", false, "replay mode: also run a detected 'kwok' binary against the server to drive pod/node lifecycle (implies --writable)")
-	uiCmd.Flags().Bool("with-controller-manager", false, "replay mode: also run kube-controller-manager against the server, with a curated controller set, to reconcile Deployments/ReplicaSets/Jobs/CronJobs/Endpoints (implies --writable)")
+	uiCmd.Flags().Bool("with-controller-manager", false, controllerManagerFlagHelp)
 }
 
 func runUI(cmd *cobra.Command, args []string) error {

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -81,3 +81,21 @@ func TestRunUI_WithKwokImpliesReplayMode(t *testing.T) {
 		t.Errorf("error = %v, want it to explain the --at/replay conflict", err)
 	}
 }
+
+// TestRunUI_WithControllerManagerImpliesReplayMode is the symmetric case for
+// --with-controller-manager: it implies replay mode (and thus --writable)
+// exactly like --with-kwok does, so it must conflict with --at the same way.
+func TestRunUI_WithControllerManagerImpliesReplayMode(t *testing.T) {
+	arch := buildDiffArchive(t, healthyPodList)
+	cmd := newTestUICommand()
+	_ = cmd.Flags().Set("at", "-5m")
+	_ = cmd.Flags().Set("with-controller-manager", "true")
+
+	err := runUI(cmd, []string{arch})
+	if err == nil {
+		t.Fatal("expected error: --with-controller-manager implies replay mode, which conflicts with --at")
+	}
+	if !strings.Contains(err.Error(), "--at cannot be combined") {
+		t.Errorf("error = %v, want it to explain the --at/replay conflict", err)
+	}
+}

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -18,6 +18,9 @@ func newTestUICommand() *cobra.Command {
 	cmd.Flags().String("to", "", "")
 	cmd.Flags().Bool("loop", false, "")
 	cmd.Flags().Bool("start-paused", false, "")
+	cmd.Flags().Bool("writable", false, "")
+	cmd.Flags().Bool("with-kwok", false, "")
+	cmd.Flags().Bool("with-controller-manager", false, "")
 	return cmd
 }
 
@@ -55,6 +58,24 @@ func TestRunUI_RejectsAtWithReplayFlags(t *testing.T) {
 	err := runUI(cmd, []string{arch})
 	if err == nil {
 		t.Fatal("expected error combining --at with replay flags")
+	}
+	if !strings.Contains(err.Error(), "--at cannot be combined") {
+		t.Errorf("error = %v, want it to explain the --at/replay conflict", err)
+	}
+}
+
+// TestRunUI_WithKwokImpliesReplayMode verifies --with-kwok forces replay mode
+// (and thus --writable) the same way --with-controller-manager and --writable
+// do, so it also conflicts with --at.
+func TestRunUI_WithKwokImpliesReplayMode(t *testing.T) {
+	arch := buildDiffArchive(t, healthyPodList)
+	cmd := newTestUICommand()
+	_ = cmd.Flags().Set("at", "-5m")
+	_ = cmd.Flags().Set("with-kwok", "true")
+
+	err := runUI(cmd, []string{arch})
+	if err == nil {
+		t.Fatal("expected error: --with-kwok implies replay mode, which conflicts with --at")
 	}
 	if !strings.Contains(err.Error(), "--at cannot be combined") {
 		t.Errorf("error = %v, want it to explain the --at/replay conflict", err)

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -41,13 +41,21 @@ is updated in place on each run).
 
 ## Why not the CNCF conformance suite?
 
-The upstream CNCF suite (Sonobuoy / hydrophone / `e2e.test`) is a **non-goal**.
-Its runners deploy a test pod *inside* the target cluster, and every
-`[Conformance]` spec's shared `framework.BeforeEach` **creates a namespace**
-before asserting anything. A read-only replay rejects that write by design, so
-the suite fails in setup on all ~446 conformance specs regardless of read
-fidelity — it measures the wrong thing here. The differential comparison above
-is the meaningful signal. (This was verified empirically; see #136.)
+The upstream CNCF suite (Sonobuoy / hydrophone / `e2e.test`) is a **non-goal**
+for this workflow. Its runners deploy a test pod *inside* the target cluster,
+and every `[Conformance]` spec's shared `framework.BeforeEach` **creates a
+namespace** before asserting anything. A read-only replay rejects that write
+by design, so the suite fails in setup on all ~446 conformance specs
+regardless of read fidelity — it measures the wrong thing here. The
+differential comparison above is the meaningful signal. (This was verified
+empirically; see #136.)
+
+Pairing a writable replay with `--with-kwok --with-controller-manager` (see
+[docs/kwok.md](kwok.md#closing-more-of-the-loop-with-controller-manager))
+gets past that specific setup blocker and clears a small slice of the suite —
+the pure CRUD/discovery/pod-static-lifecycle specs that don't need a real
+kubelet — but the bulk of the suite still needs a real container runtime and
+isn't a goal here either; treat it as an exploratory signal, not a gate.
 
 ## Baseline / accepted divergences
 

--- a/docs/kwok.md
+++ b/docs/kwok.md
@@ -108,16 +108,75 @@ runner lacks), so it is not part of `make e2e` or the automatic e2e job. In CI i
 runs from the **e2e-kwok** GitHub Actions workflow (Actions tab → Run workflow),
 which installs `kwok` first.
 
+## Closing more of the loop: `--with-controller-manager`
+
+KWOK plays the kubelet; `--with-controller-manager` adds a real
+`kube-controller-manager` reconciling a curated set of controllers against the
+same writable overlay, so a Deployment you create actually gets a ReplicaSet
+and Pods, a CronJob spawns Jobs on schedule, and a Service gets Endpoints and
+an EndpointSlice — all without a full second cluster:
+
+```sh
+kshrk replay capture.kshrk --with-kwok --with-controller-manager
+export KUBECONFIG=/Users/you/.kube/k8shark-<id>.yaml
+kubectl create deployment demo --image=nginx --replicas=2
+kubectl get pods -w   # ReplicaSet + Pods appear, KWOK takes them to Running
+```
+
+**Curated controller set** (`internal/k8sbin` + `cmd/controllermanager.go`):
+`namespace`, `serviceaccount`, `resourcequota`, `garbagecollector`,
+`daemonset`, `deployment`, `replicaset`, `statefulset`, `job`, `cronjob`,
+`endpoint`, `endpointslice`, `endpointslicemirroring`, `disruption` — pure
+API-object reconcilers that only need CRUD+watch against the overlay, not a
+real kubelet, storage provisioner, cloud provider, or node lifecycle. Started
+with `--leader-elect=false` (a single local process needs no leader election)
+and `--use-service-account-credentials=false`.
+
+**Binary sourcing.** Kubernetes only publishes `kube-controller-manager` for
+`linux/{amd64,arm64}` — there's no macOS or Windows build. On Linux,
+`--with-controller-manager` downloads the official release binary from
+`dl.k8s.io` (matching the capture's Kubernetes version) and verifies it
+against the published SHA-256 checksum. On other platforms it instead
+downloads and verifies the official Kubernetes **source** tarball from the
+same `dl.k8s.io` origin and compiles it with the host's Go toolchain — the
+same approach [KWOK's own docs recommend](https://kwok.sigs.k8s.io/docs/user/kwokctl-platform-specific-binaries/)
+for platforms it doesn't publish binaries for either. Either way, the result is
+cached under the OS cache directory, keyed by version and GOOS/GOARCH, so this
+only runs once per version per machine. `go` must be on `PATH` for the
+source-build path.
+
+**API defaulting.** A real apiserver defaults dozens of fields on every write
+(e.g. an empty `Deployment.spec.strategy.type` becomes `RollingUpdate` with a
+25%/25% `rollingUpdate` struct); the writable overlay has no apiserver behind
+it, so `internal/server/writes.go`'s `applyKnownDefaults` hand-applies the
+specific, long-stable defaults these controllers assume are already
+present — real controller code unconditionally dereferences fields like
+`Spec.Strategy.RollingUpdate.MaxSurge` or `Spec.BackoffLimit`, so a missing
+default panics deep inside the controller (caught by client-go's recover, so
+it doesn't crash the process, but the object never reconciles) rather than
+erroring cleanly.
+
 ## Non-goals
 
-Standalone KWOK + the overlay covers pod/node lifecycle. It intentionally does
-**not** provide the rest of a control plane:
+Even with `--with-controller-manager`, this intentionally does **not** provide
+a full control plane:
 
-- **Scheduling fit** — the shim is round-robin, not a real scheduler (no
-  resource/affinity/taint evaluation).
-- **Endpoints/EndpointSlices and the rest of kube-controller-manager** — only a
-  real control plane (`kwokctl`, a separate throwaway cluster) runs these.
-- **Full CNCF conformance** via replay.
+- **Scheduling fit** — the pod-scheduling shim is round-robin, not a real
+  scheduler (no resource/affinity/taint evaluation).
+- **A real kubelet/container runtime** — KWOK fakes Pod status transitions; it
+  never runs a container, so anything that depends on actual process/exit-code
+  behavior (`kubectl exec`, `kubectl logs`, a Job ever reaching `Succeeded`)
+  doesn't work. See the "exec, cp, port-forward, and proxy are not supported"
+  error for the replay server's own explicit stance on this.
+- **PersistentVolume binding, HorizontalPodAutoscaler, node-lifecycle,
+  certificate-signing, and the other kube-controller-manager controllers**
+  outside the curated set above — they need a real storage provisioner, a real
+  metrics-server, or real node health, which nothing here provides. A full
+  control plane (`kwokctl`, a separate throwaway cluster) is still the answer
+  for those.
+- **Full CNCF conformance** via replay — measured directly; see
+  [docs/conformance.md](conformance.md) and the upstream `[Conformance]` suite
+  results for what this closes and what it doesn't.
 
 See [#160](https://github.com/phenixblue/k8shark/issues/160) for the tracking
 issue and [#123](https://github.com/phenixblue/k8shark/issues/123) for the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -408,6 +408,7 @@ The primary use case is **local development and testing of controllers/operators
 | `--writable` | false | Accept client writes into an in-memory overlay (closed-loop controller dev) |
 | `--schedule-pods` | true | Bind unscheduled pods to a node on create (the scheduler replay lacks); `--writable` only |
 | `--with-kwok` | false | Also run a detected `kwok` binary against the server to drive pod/node lifecycle (implies `--writable`) — see [KWOK](kwok.md) |
+| `--with-controller-manager` | false | Also run kube-controller-manager (downloaded/built to match the capture's Kubernetes version) against the server, with a curated controller set, to reconcile Deployments/ReplicaSets/DaemonSets/StatefulSets/Jobs/CronJobs/Endpoints (implies `--writable`) — see [KWOK](kwok.md#closing-more-of-the-loop-with-controller-manager) |
 | `--port` | random | Port for the mock API server |
 | `--kubeconfig-out` | `~/.kube/k8shark-<id>.yaml` | Where to write the generated kubeconfig |
 | `--verbose` / `-v` | false | Log every request the server receives |

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -174,8 +174,11 @@ the clock; the views auto-refresh as the clock crosses each snapshot. If a view 
 mid-playback, replay **pauses** and surfaces the error rather than pressing on.
 
 Replay flags mirror the [`replay` command](usage.md#replay): `--speed`, `--from`, `--to`, `--loop`,
-`--start-paused`, `--writable`. See [docs/usage.md](usage.md#replay) for the full model
-(resourceVersion coherence, poll-only inference, etc.).
+`--start-paused`, `--writable`, `--with-kwok`, `--with-controller-manager`. See
+[docs/usage.md](usage.md#replay) for the full model (resourceVersion coherence, poll-only inference,
+etc.) and [docs/kwok.md](kwok.md) for the closed-loop KWOK/controller-manager setup — watching a
+Deployment's Pods flip Pending → Running live in the dashboard works the same way it does over
+`kubectl`.
 
 Unlike the headless `kshrk replay` command (which auto-plays by default), `kshrk ui` starts replay
 **paused** by default — the dashboard renders the window-start state and waits for you to press

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -54,7 +55,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect

--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -38,6 +38,23 @@ const (
 	downloadTimeout = 10 * time.Minute
 )
 
+// dlClient is the HTTP client used for every dl.k8s.io fetch (binary,
+// source tarball, and their .sha256 companions). Its CheckRedirect rejects a
+// redirect to a different host than the one originally requested: every
+// artifact this package fetches is served directly by dl.k8s.io with no
+// redirect involved (verified empirically), so this is pure defense in
+// depth against a compromised or malicious intermediate redirecting an
+// otherwise-trusted download to an attacker-controlled host — the checksum
+// fetch and the artifact fetch would otherwise both silently follow it.
+var dlClient = &http.Client{
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		if req.URL.Host != via[0].URL.Host {
+			return fmt.Errorf("refusing to follow redirect from %s to a different host %s", via[0].URL.Host, req.URL.Host)
+		}
+		return nil
+	},
+}
+
 // versionRE matches a dl.k8s.io release version, e.g. "v1.36.1" or
 // "v1.30.0-rc.1". Validated strictly before use in any URL or filesystem
 // path: the version string originates from capture metadata (a field a
@@ -227,12 +244,26 @@ func buildFromSource(version, destPath string, progress func(string)) error {
 	return atomicInstall(tmpBinPath, destPath)
 }
 
+// atomicInstall marks tmpPath executable and renames it into destPath. Go's
+// os.Rename already replaces an existing destPath on every platform this
+// package supports (Windows included: internal/syscall/windows.Rename passes
+// MOVEFILE_REPLACE_EXISTING), so the common case is a single atomic,
+// same-filesystem rename. The remove-then-retry fallback below only matters
+// for edge cases plain rename can't handle regardless of platform (e.g.
+// destPath somehow left behind as a directory from a prior version of this
+// code, or an unwritable/locked leftover) — it isn't a full substitute for
+// atomicity, just a best-effort recovery path.
 func atomicInstall(tmpPath, destPath string) error {
 	if err := os.Chmod(tmpPath, 0o755); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("marking binary executable: %w", err)
 	}
 	if err := os.Rename(tmpPath, destPath); err != nil {
+		if rmErr := os.RemoveAll(destPath); rmErr == nil {
+			if err := os.Rename(tmpPath, destPath); err == nil {
+				return nil
+			}
+		}
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("installing binary: %w", err)
 	}
@@ -257,7 +288,7 @@ func downloadAndVerifyToFile(url, destPath string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := dlClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("GET %s: %w", url, err)
 	}
@@ -301,7 +332,7 @@ func fetchChecksum(ctx context.Context, url string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := dlClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("GET %s: %w", url, err)
 	}
@@ -386,6 +417,13 @@ func extractTarGz(tarGzPath, destDir string) error {
 				return err
 			}
 		case tar.TypeReg:
+			// hdr.Size is attacker-controlled (it comes straight from the
+			// archive); a malformed or hostile header could set it negative,
+			// which would underflow the running extracted total and defeat
+			// the maxExtractedBytes check below for every entry after it.
+			if hdr.Size < 0 {
+				return fmt.Errorf("tar entry %q has a negative size (%d); rejecting as malformed", cleanedName, hdr.Size)
+			}
 			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 				return err
 			}

--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -68,6 +68,10 @@ var dlClient = &http.Client{CheckRedirect: dlCheckRedirect}
 // crafted archive could set arbitrarily), so it must not be trusted as-is.
 var versionRE = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$`)
 
+// baseVersionRE matches just the upstream "vX.Y.Z" portion of a version,
+// with no suffix at all. Used by normalizeVersion's managed-distro fallback.
+var baseVersionRE = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`)
+
 // EnsureControllerManager returns the path to a cached, executable
 // kube-controller-manager binary matching gitVersion (as reported by a
 // cluster's /version endpoint, e.g. "v1.36.1"). progress, if non-nil, is
@@ -126,16 +130,30 @@ func hasPrebuiltBinary(goos, goarch string) bool {
 // normalizeVersion strips any "+build" metadata and validates the result
 // against versionRE, rejecting anything that isn't a plausible dl.k8s.io
 // release version before it's used to build a URL or filesystem path.
+//
+// A managed-distro gitVersion (e.g. GKE/EKS's "v1.29.0-eks-a5c69e0") won't
+// match versionRE, since its suffix has its own internal "-"-separated
+// structure that versionRE's single dash-delimited segment doesn't allow —
+// but dl.k8s.io only ever publishes the plain upstream "vX.Y.Z" release
+// anyway, so when the full string doesn't match, fall back to truncating at
+// the first remaining "-" and using that base version if it's valid on its
+// own. An explicit upstream prerelease like "v1.30.0-rc.1" already matches
+// versionRE in full and is returned as-is, never reaching this fallback.
 func normalizeVersion(raw string) (string, error) {
 	v := raw
 	if i := strings.IndexByte(v, '+'); i >= 0 {
 		v = v[:i]
 	}
-	if !versionRE.MatchString(v) {
-		return "", fmt.Errorf("capture's Kubernetes version %q doesn't look like a dl.k8s.io release version "+
-			"(want vX.Y.Z); can't determine which kube-controller-manager to fetch", raw)
+	if versionRE.MatchString(v) {
+		return v, nil
 	}
-	return v, nil
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		if base := v[:i]; baseVersionRE.MatchString(base) {
+			return base, nil
+		}
+	}
+	return "", fmt.Errorf("capture's Kubernetes version %q doesn't look like a dl.k8s.io release version "+
+		"(want vX.Y.Z); can't determine which kube-controller-manager to fetch", raw)
 }
 
 func binDir(version string) (string, error) {

--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -238,14 +238,28 @@ func buildFromSource(version, destPath string, progress func(string)) error {
 		return fmt.Errorf("extracting Kubernetes source: %w", err)
 	}
 
+	vendorDir := filepath.Join(srcDir, "vendor")
+	if info, err := os.Stat(vendorDir); err != nil || !info.IsDir() {
+		return fmt.Errorf("kubernetes-src.tar.gz for %s has no vendor/ directory at %s; "+
+			"cannot build without fetching dependencies from outside dl.k8s.io", version, vendorDir)
+	}
+
 	progress("compiling kube-controller-manager...")
 	tmpBinPath, err := uniqueTempPath(filepath.Dir(destPath))
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command(goBin, "build", "-o", tmpBinPath, "./cmd/"+binName)
+	cmd := exec.Command(goBin, "build", "-mod=vendor", "-o", tmpBinPath, "./cmd/"+binName)
 	cmd.Dir = srcDir
-	cmd.Env = os.Environ()
+	// Force vendor-only module resolution: the Kubernetes source tarball ships
+	// its full dependency tree under vendor/, and this package's "only fetches
+	// from dl.k8s.io" guarantee depends on go build never reaching out to a
+	// module proxy or VCS host for it. -mod=vendor alone would normally be
+	// enough, but a GOFLAGS already set in the caller's environment could
+	// override it, so GOFLAGS is scrubbed and re-set here, and GOPROXY=off
+	// makes any resolution attempt that slips through fail loudly instead of
+	// silently reaching the network.
+	cmd.Env = withEnvOverride(os.Environ(), "GOFLAGS=-mod=vendor", "GOPROXY=off")
 	var stderr bytes.Buffer
 	cmd.Stdout = &stderr
 	cmd.Stderr = &stderr
@@ -254,6 +268,27 @@ func buildFromSource(version, destPath string, progress func(string)) error {
 		return fmt.Errorf("go build ./cmd/%s: %w\n%s", binName, err, stderr.String())
 	}
 	return atomicInstall(tmpBinPath, destPath)
+}
+
+// withEnvOverride returns a copy of base with any existing entries for the
+// same variable names as overrides removed, then overrides appended — so the
+// override always wins regardless of duplicate-key lookup order, which
+// varies across platforms/libc implementations.
+func withEnvOverride(base []string, overrides ...string) []string {
+	names := make(map[string]bool, len(overrides))
+	for _, o := range overrides {
+		if i := strings.IndexByte(o, '='); i >= 0 {
+			names[o[:i]] = true
+		}
+	}
+	env := make([]string, 0, len(base)+len(overrides))
+	for _, e := range base {
+		if i := strings.IndexByte(e, '='); i >= 0 && names[e[:i]] {
+			continue
+		}
+		env = append(env, e)
+	}
+	return append(env, overrides...)
 }
 
 // atomicInstall marks tmpPath executable and renames it into destPath. Go's

--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -122,10 +122,23 @@ func binDir(version string) (string, error) {
 	return filepath.Join(base, "kshark", "kube-controller-manager", version, runtime.GOOS+"-"+runtime.GOARCH), nil
 }
 
+// isExecutableFile reports whether path is a regular file this package can
+// hand to exec.Command. The Unix execute-bit check (mode&0o111) is
+// meaningless on Windows — os.FileInfo.Mode() there reflects the read-only
+// file attribute, not anything execution-related — so a cached Windows
+// binary would never be recognized as such and EnsureControllerManager would
+// redownload/rebuild on every call. A plain non-empty regular file is
+// sufficient there: CreateProcess doesn't require an execute bit, and
+// buildFromSource/downloadPrebuilt always write to this exact path (no
+// implicit ".exe" is appended — go build's explicit -o path is honored as
+// given even when cross-compiling to GOOS=windows).
 func isExecutableFile(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil || info.IsDir() {
 		return false
+	}
+	if runtime.GOOS == "windows" {
+		return info.Size() > 0
 	}
 	return info.Mode()&0o111 != 0
 }

--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -143,7 +143,7 @@ func binDir(version string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolving cache directory: %w", err)
 	}
-	return filepath.Join(base, "kshark", "kube-controller-manager", version, runtime.GOOS+"-"+runtime.GOARCH), nil
+	return filepath.Join(base, "k8shark", "kube-controller-manager", version, runtime.GOOS+"-"+runtime.GOARCH), nil
 }
 
 // isExecutableFile reports whether path is a regular file this package can
@@ -222,7 +222,7 @@ func buildFromSource(version, destPath string, progress func(string)) error {
 	progress(fmt.Sprintf("no official kube-controller-manager binary for %s/%s; building from official source "+
 		"%s (this can take a minute)", runtime.GOOS, runtime.GOARCH, srcURL))
 
-	tmpDir, err := os.MkdirTemp("", "kshark-k8s-src-*")
+	tmpDir, err := os.MkdirTemp("", "kshrk-k8s-src-*")
 	if err != nil {
 		return fmt.Errorf("creating temp build directory: %w", err)
 	}

--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -190,6 +190,11 @@ func downloadPrebuilt(version, destPath string, progress func(string)) error {
 		return err
 	}
 	if err := downloadAndVerifyToFile(url, tmpPath); err != nil {
+		// uniqueTempPath's file may still be sitting there empty: a failure
+		// before downloadAndVerifyToFile ever opens destPath (e.g. the
+		// checksum fetch, or the artifact GET itself, failing) never reaches
+		// its own cleanup path. Remove is a no-op if that path already did.
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("downloading kube-controller-manager: %w", err)
 	}
 	return atomicInstall(tmpPath, destPath)

--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -443,11 +443,16 @@ func extractTarGz(tarGzPath, destDir string) error {
 
 		// hdr.Name comes from the archive and must never be trusted directly: a
 		// hostile ".."-laden or absolute name could otherwise write outside
-		// destDir ("Zip Slip"). Reject a traversal attempt outright — not
-		// remap it into destDir — so entries never silently collide or land
-		// somewhere surprising. filepath.Rel re-verifies containment on the
-		// joined result as a second, independent check before target is ever
-		// used in a filesystem operation below.
+		// destDir ("Zip Slip"). filepath.Clean first normalizes harmless
+		// internal ".." segments that still resolve inside destDir (e.g.
+		// "foo/../bar" becomes "bar" — see TestExtractTarGz_PathTraversalRejected),
+		// but any name that still escapes destDir after cleaning (a leading
+		// "..", an absolute path) is rejected outright here — not remapped
+		// into destDir — so an escaping entry never silently lands somewhere
+		// surprising inside destDir instead of failing. filepath.Rel
+		// re-verifies containment on the joined result as a second,
+		// independent check before target is ever used in a filesystem
+		// operation below.
 		cleanedName := filepath.Clean(hdr.Name)
 		if cleanedName == ".." || strings.HasPrefix(cleanedName, ".."+string(filepath.Separator)) || filepath.IsAbs(cleanedName) {
 			continue

--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -143,13 +143,35 @@ func isExecutableFile(path string) bool {
 	return info.Mode()&0o111 != 0
 }
 
+// uniqueTempPath returns a path to a new, empty, uniquely-named file in dir
+// (the same directory destPath lives in, so a later os.Rename into destPath
+// is atomic and same-filesystem). Using a random per-call name rather than a
+// fixed "<dest>.download" means two concurrent EnsureControllerManager calls
+// (e.g. two kshrk processes downloading/building the same version at once)
+// can't corrupt each other by writing through the same path.
+func uniqueTempPath(dir string) (string, error) {
+	f, err := os.CreateTemp(dir, binName+"-*.download")
+	if err != nil {
+		return "", fmt.Errorf("creating temp file: %w", err)
+	}
+	path := f.Name()
+	if err := f.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", fmt.Errorf("creating temp file: %w", err)
+	}
+	return path, nil
+}
+
 // downloadPrebuilt fetches the official release binary for linux/GOARCH.
 func downloadPrebuilt(version, destPath string, progress func(string)) error {
 	arch := runtime.GOARCH
 	url := fmt.Sprintf("%s/%s/bin/linux/%s/%s", dlBaseURL, version, arch, binName)
 	progress(fmt.Sprintf("downloading kube-controller-manager %s for linux/%s", version, arch))
 
-	tmpPath := destPath + ".download"
+	tmpPath, err := uniqueTempPath(filepath.Dir(destPath))
+	if err != nil {
+		return err
+	}
 	if err := downloadAndVerifyToFile(url, tmpPath); err != nil {
 		return fmt.Errorf("downloading kube-controller-manager: %w", err)
 	}
@@ -188,7 +210,10 @@ func buildFromSource(version, destPath string, progress func(string)) error {
 	}
 
 	progress("compiling kube-controller-manager...")
-	tmpBinPath := destPath + ".download"
+	tmpBinPath, err := uniqueTempPath(filepath.Dir(destPath))
+	if err != nil {
+		return err
+	}
 	cmd := exec.Command(goBin, "build", "-o", tmpBinPath, "./cmd/"+binName)
 	cmd.Dir = srcDir
 	cmd.Env = os.Environ()
@@ -196,6 +221,7 @@ func buildFromSource(version, destPath string, progress func(string)) error {
 	cmd.Stdout = &stderr
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		_ = os.Remove(tmpBinPath)
 		return fmt.Errorf("go build ./cmd/%s: %w\n%s", binName, err, stderr.String())
 	}
 	return atomicInstall(tmpBinPath, destPath)

--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -1,0 +1,361 @@
+// Package k8sbin locates or produces a kube-controller-manager binary
+// matching a capture's Kubernetes version, for --with-controller-manager.
+//
+// Kubernetes only publishes prebuilt server-component binaries (unlike
+// kubectl) for linux/amd64 and linux/arm64. On other platforms there is no
+// official download, so this package falls back to compiling
+// kube-controller-manager from the official Kubernetes source tarball —
+// the same "self-build" approach documented by the KWOK project for its own
+// non-Linux binary gap
+// (https://kwok.sigs.k8s.io/docs/user/kwokctl-platform-specific-binaries/).
+// Both paths fetch only from dl.k8s.io (the official Kubernetes release CDN)
+// and verify every download against its published SHA-256 checksum before
+// it is executed or fed to a compiler.
+package k8sbin
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	dlBaseURL       = "https://dl.k8s.io"
+	binName         = "kube-controller-manager"
+	downloadTimeout = 10 * time.Minute
+)
+
+// versionRE matches a dl.k8s.io release version, e.g. "v1.36.1" or
+// "v1.30.0-rc.1". Validated strictly before use in any URL or filesystem
+// path: the version string originates from capture metadata (a field a
+// crafted archive could set arbitrarily), so it must not be trusted as-is.
+var versionRE = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$`)
+
+// EnsureControllerManager returns the path to a cached, executable
+// kube-controller-manager binary matching gitVersion (as reported by a
+// cluster's /version endpoint, e.g. "v1.36.1"). progress, if non-nil, is
+// called with human-readable status lines as the binary is located, fetched,
+// or built.
+//
+// On linux/{amd64,arm64} it downloads the official prebuilt release binary.
+// On any other platform (no official binary exists) it downloads and builds
+// the official Kubernetes source tarball via the host's Go toolchain
+// ('go' must be on PATH). Results are cached under the user's cache
+// directory, keyed by version and GOOS/GOARCH, so this only runs once per
+// version per machine.
+func EnsureControllerManager(gitVersion string, progress func(string)) (string, error) {
+	if progress == nil {
+		progress = func(string) {}
+	}
+	version, err := normalizeVersion(gitVersion)
+	if err != nil {
+		return "", err
+	}
+	dir, err := binDir(version)
+	if err != nil {
+		return "", err
+	}
+	destPath := filepath.Join(dir, binName)
+	if isExecutableFile(destPath) {
+		progress(fmt.Sprintf("using cached kube-controller-manager %s (%s)", version, destPath))
+		return destPath, nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("creating cache directory %s: %w", dir, err)
+	}
+
+	if runtime.GOOS == "linux" {
+		if err := downloadPrebuilt(version, destPath, progress); err != nil {
+			return "", err
+		}
+	} else {
+		if err := buildFromSource(version, destPath, progress); err != nil {
+			return "", err
+		}
+	}
+	return destPath, nil
+}
+
+// normalizeVersion strips any "+build" metadata and validates the result
+// against versionRE, rejecting anything that isn't a plausible dl.k8s.io
+// release version before it's used to build a URL or filesystem path.
+func normalizeVersion(raw string) (string, error) {
+	v := raw
+	if i := strings.IndexByte(v, '+'); i >= 0 {
+		v = v[:i]
+	}
+	if !versionRE.MatchString(v) {
+		return "", fmt.Errorf("capture's Kubernetes version %q doesn't look like a dl.k8s.io release version "+
+			"(want vX.Y.Z); can't determine which kube-controller-manager to fetch", raw)
+	}
+	return v, nil
+}
+
+func binDir(version string) (string, error) {
+	base, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving cache directory: %w", err)
+	}
+	return filepath.Join(base, "kshark", "kube-controller-manager", version, runtime.GOOS+"-"+runtime.GOARCH), nil
+}
+
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return info.Mode()&0o111 != 0
+}
+
+// downloadPrebuilt fetches the official release binary for linux/GOARCH.
+func downloadPrebuilt(version, destPath string, progress func(string)) error {
+	arch := runtime.GOARCH
+	url := fmt.Sprintf("%s/%s/bin/linux/%s/%s", dlBaseURL, version, arch, binName)
+	progress(fmt.Sprintf("downloading kube-controller-manager %s for linux/%s", version, arch))
+
+	tmpPath := destPath + ".download"
+	if err := downloadAndVerifyToFile(url, tmpPath); err != nil {
+		return fmt.Errorf("downloading kube-controller-manager: %w", err)
+	}
+	return atomicInstall(tmpPath, destPath)
+}
+
+// buildFromSource downloads the official Kubernetes source tarball and
+// compiles kube-controller-manager with the host's Go toolchain, for
+// platforms Kubernetes doesn't publish a server binary for.
+func buildFromSource(version, destPath string, progress func(string)) error {
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		return fmt.Errorf("--with-controller-manager: building kube-controller-manager from source requires "+
+			"'go' in PATH (Kubernetes doesn't publish a server binary for %s/%s); install Go from https://go.dev/dl/",
+			runtime.GOOS, runtime.GOARCH)
+	}
+
+	srcURL := fmt.Sprintf("%s/%s/kubernetes-src.tar.gz", dlBaseURL, version)
+	progress(fmt.Sprintf("no official kube-controller-manager binary for %s/%s; building from official source "+
+		"%s (this can take a minute)", runtime.GOOS, runtime.GOARCH, srcURL))
+
+	tmpDir, err := os.MkdirTemp("", "kshark-k8s-src-*")
+	if err != nil {
+		return fmt.Errorf("creating temp build directory: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tarPath := filepath.Join(tmpDir, "kubernetes-src.tar.gz")
+	if err := downloadAndVerifyToFile(srcURL, tarPath); err != nil {
+		return fmt.Errorf("downloading Kubernetes source: %w", err)
+	}
+
+	srcDir := filepath.Join(tmpDir, "src")
+	if err := extractTarGz(tarPath, srcDir); err != nil {
+		return fmt.Errorf("extracting Kubernetes source: %w", err)
+	}
+
+	progress("compiling kube-controller-manager...")
+	tmpBinPath := destPath + ".download"
+	cmd := exec.Command(goBin, "build", "-o", tmpBinPath, "./cmd/"+binName)
+	cmd.Dir = srcDir
+	cmd.Env = os.Environ()
+	var stderr bytes.Buffer
+	cmd.Stdout = &stderr
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("go build ./cmd/%s: %w\n%s", binName, err, stderr.String())
+	}
+	return atomicInstall(tmpBinPath, destPath)
+}
+
+func atomicInstall(tmpPath, destPath string) error {
+	if err := os.Chmod(tmpPath, 0o755); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("marking binary executable: %w", err)
+	}
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("installing binary: %w", err)
+	}
+	return nil
+}
+
+// downloadAndVerifyToFile downloads url to destPath, verifying the content
+// against the SHA-256 checksum published at url+".sha256" (the convention
+// dl.k8s.io uses for every release artifact). destPath is removed on any
+// error, including a checksum mismatch, so a bad download never lingers
+// where a later run's isExecutableFile check would find it.
+func downloadAndVerifyToFile(url, destPath string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), downloadTimeout)
+	defer cancel()
+
+	wantSum, err := fetchChecksum(ctx, url+".sha256")
+	if err != nil {
+		return fmt.Errorf("fetching checksum: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(destPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	hasher := sha256.New()
+	_, copyErr := io.Copy(io.MultiWriter(f, hasher), resp.Body)
+	closeErr := f.Close()
+	if copyErr != nil {
+		_ = os.Remove(destPath)
+		return fmt.Errorf("downloading %s: %w", url, copyErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(destPath)
+		return closeErr
+	}
+
+	gotSum := hex.EncodeToString(hasher.Sum(nil))
+	if !strings.EqualFold(gotSum, wantSum) {
+		_ = os.Remove(destPath)
+		return fmt.Errorf("checksum mismatch for %s: got %s, want %s", url, gotSum, wantSum)
+	}
+	return nil
+}
+
+// fetchChecksum fetches a dl.k8s.io ".sha256" companion file, which is a
+// bare 64-character lowercase hex digest (optionally followed by whitespace
+// and a filename, per the common sha256sum(1) format).
+func fetchChecksum(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GET %s: HTTP %d", url, resp.StatusCode)
+	}
+	b, err := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	if err != nil {
+		return "", err
+	}
+	sum := strings.TrimSpace(string(b))
+	if i := strings.IndexAny(sum, " \t"); i >= 0 {
+		sum = sum[:i]
+	}
+	if len(sum) != 64 {
+		return "", fmt.Errorf("unexpected checksum format from %s: %q", url, sum)
+	}
+	return strings.ToLower(sum), nil
+}
+
+// maxExtractedBytes bounds total extracted size as a defense-in-depth guard
+// against a corrupted or hostile archive, independent of the checksum check
+// above (which only verifies the compressed tarball, not each entry as it's
+// decompressed).
+const maxExtractedBytes = 4 << 30 // 4 GiB
+
+// extractTarGz extracts a gzip-compressed tar archive into destDir, which is
+// created if needed. Entries are path-sanitized so nothing can escape
+// destDir (no "..", no absolute paths), and only regular files and
+// directories are extracted — symlinks and other special entry types are
+// skipped rather than followed.
+func extractTarGz(tarGzPath, destDir string) error {
+	f, err := os.Open(tarGzPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("opening gzip stream: %w", err)
+	}
+	defer gz.Close()
+
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return err
+	}
+	cleanDestDir := filepath.Clean(destDir)
+
+	tr := tar.NewReader(gz)
+	var extracted int64
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar entry: %w", err)
+		}
+
+		cleanName := filepath.Clean(hdr.Name)
+		if cleanName == "." || cleanName == ".." || strings.HasPrefix(cleanName, ".."+string(filepath.Separator)) || filepath.IsAbs(cleanName) {
+			continue
+		}
+		target := filepath.Join(cleanDestDir, cleanName)
+		if target != cleanDestDir && !strings.HasPrefix(target, cleanDestDir+string(filepath.Separator)) {
+			continue
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			mode := os.FileMode(hdr.Mode & 0o777)
+			if mode == 0 {
+				mode = 0o644
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+			if err != nil {
+				return err
+			}
+			extracted += hdr.Size
+			if extracted > maxExtractedBytes {
+				out.Close()
+				return fmt.Errorf("archive exceeds %d bytes extracted; aborting", int64(maxExtractedBytes))
+			}
+			_, err = io.Copy(out, io.LimitReader(tr, hdr.Size))
+			closeErr := out.Close()
+			if err != nil {
+				return fmt.Errorf("writing %s: %w", target, err)
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+		default:
+			// Skip symlinks and other special entry types.
+			continue
+		}
+	}
+}

--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -38,22 +38,29 @@ const (
 	downloadTimeout = 10 * time.Minute
 )
 
-// dlClient is the HTTP client used for every dl.k8s.io fetch (binary,
-// source tarball, and their .sha256 companions). Its CheckRedirect rejects a
-// redirect to a different host than the one originally requested: every
-// artifact this package fetches is served directly by dl.k8s.io with no
+// dlCheckRedirect rejects a redirect to a different host, or off HTTPS
+// entirely, than the request that started the chain: every artifact this
+// package fetches is served directly by dl.k8s.io over HTTPS with no
 // redirect involved (verified empirically), so this is pure defense in
 // depth against a compromised or malicious intermediate redirecting an
-// otherwise-trusted download to an attacker-controlled host — the checksum
-// fetch and the artifact fetch would otherwise both silently follow it.
-var dlClient = &http.Client{
-	CheckRedirect: func(req *http.Request, via []*http.Request) error {
-		if req.URL.Host != via[0].URL.Host {
-			return fmt.Errorf("refusing to follow redirect from %s to a different host %s", via[0].URL.Host, req.URL.Host)
-		}
-		return nil
-	},
+// otherwise-trusted download to an attacker-controlled host, or downgrading
+// it to plaintext — same-host doesn't imply same-scheme, so both are
+// checked. Exposed as its own function (rather than inlined in dlClient) so
+// tests can pair it with a test server's own trusted Transport instead of
+// dlClient's real one, which only trusts the public CA pool.
+func dlCheckRedirect(req *http.Request, via []*http.Request) error {
+	if req.URL.Scheme != "https" {
+		return fmt.Errorf("refusing to follow a non-HTTPS redirect to %s", req.URL)
+	}
+	if req.URL.Host != via[0].URL.Host {
+		return fmt.Errorf("refusing to follow redirect from %s to a different host %s", via[0].URL.Host, req.URL.Host)
+	}
+	return nil
 }
+
+// dlClient is the HTTP client used for every dl.k8s.io fetch (binary,
+// source tarball, and their .sha256 companions).
+var dlClient = &http.Client{CheckRedirect: dlCheckRedirect}
 
 // versionRE matches a dl.k8s.io release version, e.g. "v1.36.1" or
 // "v1.30.0-rc.1". Validated strictly before use in any URL or filesystem

--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -77,7 +77,7 @@ func EnsureControllerManager(gitVersion string, progress func(string)) (string, 
 		return "", fmt.Errorf("creating cache directory %s: %w", dir, err)
 	}
 
-	if runtime.GOOS == "linux" {
+	if hasPrebuiltBinary(runtime.GOOS, runtime.GOARCH) {
 		if err := downloadPrebuilt(version, destPath, progress); err != nil {
 			return "", err
 		}
@@ -87,6 +87,16 @@ func EnsureControllerManager(gitVersion string, progress func(string)) (string, 
 		}
 	}
 	return destPath, nil
+}
+
+// hasPrebuiltBinary reports whether dl.k8s.io publishes an official
+// kube-controller-manager binary for goos/goarch. Kubernetes only builds
+// server components for linux, and only for amd64 and arm64 among linux
+// architectures — linux/386, linux/ppc64le, linux/s390x, etc. have no
+// published binary either, so they must fall back to the source-build path
+// just like darwin/windows do.
+func hasPrebuiltBinary(goos, goarch string) bool {
+	return goos == "linux" && (goarch == "amd64" || goarch == "arm64")
 }
 
 // normalizeVersion strips any "+build" metadata and validates the result
@@ -280,27 +290,6 @@ func fetchChecksum(ctx context.Context, url string) (string, error) {
 // decompressed).
 const maxExtractedBytes = 4 << 30 // 4 GiB
 
-// safeJoin resolves a tar entry name against destDir (which must already be
-// filepath.Clean-ed) and reports whether the result stays within destDir.
-// name comes from an archive entry and must never be trusted directly: a
-// hostile ".."-laden or absolute name could otherwise write outside destDir
-// ("Zip Slip"). A traversal attempt is rejected outright — not remapped into
-// destDir — so entries never silently collide or land somewhere surprising.
-// filepath.Rel re-verifies containment on the joined result as a second,
-// independent check.
-func safeJoin(destDir, name string) (target string, safe bool) {
-	cleaned := filepath.Clean(name)
-	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) || filepath.IsAbs(cleaned) {
-		return "", false
-	}
-	target = filepath.Join(destDir, cleaned)
-	rel, err := filepath.Rel(destDir, target)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", false
-	}
-	return target, true
-}
-
 // extractTarGz extracts a gzip-compressed tar archive into destDir, which is
 // created if needed. Entries are path-sanitized so nothing can escape
 // destDir (no "..", no absolute paths), and only regular files and
@@ -335,8 +324,20 @@ func extractTarGz(tarGzPath, destDir string) error {
 			return fmt.Errorf("reading tar entry: %w", err)
 		}
 
-		target, safe := safeJoin(cleanDestDir, hdr.Name)
-		if !safe {
+		// hdr.Name comes from the archive and must never be trusted directly: a
+		// hostile ".."-laden or absolute name could otherwise write outside
+		// destDir ("Zip Slip"). Reject a traversal attempt outright — not
+		// remap it into destDir — so entries never silently collide or land
+		// somewhere surprising. filepath.Rel re-verifies containment on the
+		// joined result as a second, independent check before target is ever
+		// used in a filesystem operation below.
+		cleanedName := filepath.Clean(hdr.Name)
+		if cleanedName == ".." || strings.HasPrefix(cleanedName, ".."+string(filepath.Separator)) || filepath.IsAbs(cleanedName) {
+			continue
+		}
+		target := filepath.Join(cleanDestDir, cleanedName)
+		rel, relErr := filepath.Rel(cleanDestDir, target)
+		if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			continue
 		}
 

--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -280,6 +280,27 @@ func fetchChecksum(ctx context.Context, url string) (string, error) {
 // decompressed).
 const maxExtractedBytes = 4 << 30 // 4 GiB
 
+// safeJoin resolves a tar entry name against destDir (which must already be
+// filepath.Clean-ed) and reports whether the result stays within destDir.
+// name comes from an archive entry and must never be trusted directly: a
+// hostile ".."-laden or absolute name could otherwise write outside destDir
+// ("Zip Slip"). A traversal attempt is rejected outright — not remapped into
+// destDir — so entries never silently collide or land somewhere surprising.
+// filepath.Rel re-verifies containment on the joined result as a second,
+// independent check.
+func safeJoin(destDir, name string) (target string, safe bool) {
+	cleaned := filepath.Clean(name)
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) || filepath.IsAbs(cleaned) {
+		return "", false
+	}
+	target = filepath.Join(destDir, cleaned)
+	rel, err := filepath.Rel(destDir, target)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return target, true
+}
+
 // extractTarGz extracts a gzip-compressed tar archive into destDir, which is
 // created if needed. Entries are path-sanitized so nothing can escape
 // destDir (no "..", no absolute paths), and only regular files and
@@ -314,12 +335,8 @@ func extractTarGz(tarGzPath, destDir string) error {
 			return fmt.Errorf("reading tar entry: %w", err)
 		}
 
-		cleanName := filepath.Clean(hdr.Name)
-		if cleanName == "." || cleanName == ".." || strings.HasPrefix(cleanName, ".."+string(filepath.Separator)) || filepath.IsAbs(cleanName) {
-			continue
-		}
-		target := filepath.Join(cleanDestDir, cleanName)
-		if target != cleanDestDir && !strings.HasPrefix(target, cleanDestDir+string(filepath.Separator)) {
+		target, safe := safeJoin(cleanDestDir, hdr.Name)
+		if !safe {
 			continue
 		}
 

--- a/internal/k8sbin/k8sbin_test.go
+++ b/internal/k8sbin/k8sbin_test.go
@@ -214,6 +214,64 @@ func TestDownloadAndVerifyToFile(t *testing.T) {
 	})
 }
 
+// TestDlClient_RejectsCrossHostRedirect verifies dlClient's CheckRedirect:
+// a redirect to a different host is refused (defense in depth against a
+// compromised or malicious intermediate redirecting an otherwise-trusted
+// dl.k8s.io fetch to an attacker-controlled host), while a same-host
+// redirect — which dl.k8s.io doesn't currently use for anything this
+// package fetches, but might in the future — still works.
+func TestDlClient_RejectsCrossHostRedirect(t *testing.T) {
+	content := []byte("payload")
+
+	otherHost := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(content)
+	}))
+	defer otherHost.Close()
+
+	var originHost *httptest.Server
+	originHost = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/cross-host-redirect":
+			http.Redirect(w, r, otherHost.URL+"/target", http.StatusFound)
+		case "/same-host-redirect":
+			http.Redirect(w, r, originHost.URL+"/target", http.StatusFound)
+		case "/target":
+			_, _ = w.Write(content)
+		}
+	}))
+	defer originHost.Close()
+
+	t.Run("cross-host redirect refused", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, originHost.URL+"/cross-host-redirect", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := dlClient.Do(req)
+		if err == nil {
+			resp.Body.Close()
+			t.Fatalf("expected cross-host redirect to be refused, got a response")
+		}
+		if !strings.Contains(err.Error(), "different host") {
+			t.Errorf("error = %v, want it to mention the refused cross-host redirect", err)
+		}
+	})
+
+	t.Run("same-host redirect allowed", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, originHost.URL+"/same-host-redirect", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := dlClient.Do(req)
+		if err != nil {
+			t.Fatalf("same-host redirect: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("status = %d, want 200", resp.StatusCode)
+		}
+	})
+}
+
 // buildTarGz packs the given name->content map into a gzip-compressed tar
 // archive and returns its bytes.
 func buildTarGz(t *testing.T, files map[string]string) []byte {

--- a/internal/k8sbin/k8sbin_test.go
+++ b/internal/k8sbin/k8sbin_test.go
@@ -433,3 +433,40 @@ func TestIsExecutableFile(t *testing.T) {
 		t.Errorf("directory reported executable")
 	}
 }
+
+// TestWithEnvOverride verifies buildFromSource's env-scrubbing helper: an
+// override must win even when the base slice already has a same-named entry
+// (in either position), since duplicate-key lookup order in an environ slice
+// varies by platform/libc and can't be relied on to prefer a later entry.
+func TestWithEnvOverride(t *testing.T) {
+	base := []string{"PATH=/usr/bin", "GOFLAGS=-mod=mod", "GOPROXY=https://proxy.golang.org"}
+	got := withEnvOverride(base, "GOFLAGS=-mod=vendor", "GOPROXY=off")
+
+	want := map[string]string{
+		"PATH":    "/usr/bin",
+		"GOFLAGS": "-mod=vendor",
+		"GOPROXY": "off",
+	}
+	seen := map[string]int{}
+	for _, e := range got {
+		i := strings.IndexByte(e, '=')
+		if i < 0 {
+			t.Fatalf("malformed env entry %q", e)
+		}
+		name, val := e[:i], e[i+1:]
+		seen[name]++
+		if wantVal, ok := want[name]; ok && val != wantVal {
+			t.Errorf("%s = %q, want %q", name, val, wantVal)
+		}
+	}
+	for name, count := range seen {
+		if count != 1 {
+			t.Errorf("%s appears %d times in result, want exactly once", name, count)
+		}
+	}
+	for name := range want {
+		if seen[name] == 0 {
+			t.Errorf("%s missing from result", name)
+		}
+	}
+}

--- a/internal/k8sbin/k8sbin_test.go
+++ b/internal/k8sbin/k8sbin_test.go
@@ -143,11 +143,14 @@ func TestNormalizeVersion(t *testing.T) {
 	}{
 		{"v1.36.1", "v1.36.1", false},
 		{"v1.30.0-rc.1", "v1.30.0-rc.1", false},
-		{"v1.28.5+vmware.1", "v1.28.5", false}, // build metadata stripped
+		{"v1.28.5+vmware.1", "v1.28.5", false},          // build metadata stripped
+		{"v1.29.0-eks-a5c69e0", "v1.29.0", false},       // managed-distro suffix: fall back to upstream base
+		{"v1.29.0-gke.1500", "v1.29.0-gke.1500", false}, // single dash-delimited suffix already matches versionRE in full
 		{"unknown", "", true},
-		{"1.36.1", "", true},    // missing leading "v"
-		{"v1.36", "", true},     // not a full semver
-		{"../../etc", "", true}, // path traversal attempt
+		{"1.36.1", "", true},        // missing leading "v"
+		{"v1.36", "", true},         // not a full semver
+		{"v1.36-eks-abc", "", true}, // base itself isn't a full semver even after truncation
+		{"../../etc", "", true},     // path traversal attempt
 		{"v1.2.3; rm -rf", "", true},
 	}
 	for _, tc := range cases {

--- a/internal/k8sbin/k8sbin_test.go
+++ b/internal/k8sbin/k8sbin_test.go
@@ -149,14 +149,14 @@ func TestDownloadAndVerifyToFile(t *testing.T) {
 	sumHex := hex.EncodeToString(sum[:])
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/good/bin", func(w http.ResponseWriter, r *http.Request) { w.Write(content) })
-	mux.HandleFunc("/good/bin.sha256", func(w http.ResponseWriter, r *http.Request) { w.Write([]byte(sumHex)) })
+	mux.HandleFunc("/good/bin", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write(content) })
+	mux.HandleFunc("/good/bin.sha256", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(sumHex)) })
 	mux.HandleFunc("/good/bin.sha256-withname", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(sumHex + "  bin\n"))
+		_, _ = w.Write([]byte(sumHex + "  bin\n"))
 	})
-	mux.HandleFunc("/bad/bin", func(w http.ResponseWriter, r *http.Request) { w.Write(content) })
+	mux.HandleFunc("/bad/bin", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write(content) })
 	mux.HandleFunc("/bad/bin.sha256", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("0000000000000000000000000000000000000000000000000000000000000000"))
+		_, _ = w.Write([]byte("0000000000000000000000000000000000000000000000000000000000000000"))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()

--- a/internal/k8sbin/k8sbin_test.go
+++ b/internal/k8sbin/k8sbin_test.go
@@ -14,6 +14,37 @@ import (
 	"testing"
 )
 
+// TestSafeJoin locks in extractTarGz's zip-slip guard: an archive entry name
+// must never be able to resolve outside destDir.
+func TestSafeJoin(t *testing.T) {
+	destDir := "/tmp/kshark-extract-dest"
+	cases := []struct {
+		name     string
+		wantSafe bool
+	}{
+		{"go.mod", true},
+		{"cmd/kube-apiserver/main.go", true},
+		{".", true},
+		{"..", false},
+		{"../etc/passwd", false},
+		{"../../etc/passwd", false},
+		{"foo/../../bar", false},
+		{"/etc/passwd", false},
+		{"foo/../bar", true}, // cleans to "bar", still inside destDir
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			target, safe := safeJoin(destDir, tc.name)
+			if safe != tc.wantSafe {
+				t.Fatalf("safeJoin(%q) safe = %v, want %v (target=%q)", tc.name, safe, tc.wantSafe, target)
+			}
+			if safe && !strings.HasPrefix(target, destDir) {
+				t.Errorf("safeJoin(%q) = %q, want it under %q", tc.name, target, destDir)
+			}
+		})
+	}
+}
+
 func TestNormalizeVersion(t *testing.T) {
 	cases := []struct {
 		in      string

--- a/internal/k8sbin/k8sbin_test.go
+++ b/internal/k8sbin/k8sbin_test.go
@@ -14,17 +14,38 @@ import (
 	"testing"
 )
 
-// TestSafeJoin locks in extractTarGz's zip-slip guard: an archive entry name
-// must never be able to resolve outside destDir.
-func TestSafeJoin(t *testing.T) {
-	destDir := "/tmp/kshark-extract-dest"
+func TestHasPrebuiltBinary(t *testing.T) {
+	cases := []struct {
+		goos, goarch string
+		want         bool
+	}{
+		{"linux", "amd64", true},
+		{"linux", "arm64", true},
+		{"linux", "386", false},     // Kubernetes doesn't publish this either
+		{"linux", "ppc64le", false}, // ...nor this
+		{"linux", "s390x", false},   // ...nor this
+		{"darwin", "amd64", false},
+		{"darwin", "arm64", false},
+		{"windows", "amd64", false},
+	}
+	for _, tc := range cases {
+		if got := hasPrebuiltBinary(tc.goos, tc.goarch); got != tc.want {
+			t.Errorf("hasPrebuiltBinary(%q, %q) = %v, want %v", tc.goos, tc.goarch, got, tc.want)
+		}
+	}
+}
+
+// TestExtractTarGz_PathTraversalRejected locks in extractTarGz's zip-slip
+// guard across a range of traversal shapes: none of these entries may ever
+// land outside destDir, and none should silently collide into some other
+// remapped path inside destDir either — the entry is simply skipped.
+func TestExtractTarGz_PathTraversalRejected(t *testing.T) {
 	cases := []struct {
 		name     string
 		wantSafe bool
 	}{
 		{"go.mod", true},
 		{"cmd/kube-apiserver/main.go", true},
-		{".", true},
 		{"..", false},
 		{"../etc/passwd", false},
 		{"../../etc/passwd", false},
@@ -34,12 +55,56 @@ func TestSafeJoin(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			target, safe := safeJoin(destDir, tc.name)
-			if safe != tc.wantSafe {
-				t.Fatalf("safeJoin(%q) safe = %v, want %v (target=%q)", tc.name, safe, tc.wantSafe, target)
+			var buf bytes.Buffer
+			gz := gzip.NewWriter(&buf)
+			tw := tar.NewWriter(gz)
+			content := "payload"
+			if err := tw.WriteHeader(&tar.Header{Name: tc.name, Mode: 0o644, Size: int64(len(content))}); err != nil {
+				t.Fatal(err)
 			}
-			if safe && !strings.HasPrefix(target, destDir) {
-				t.Errorf("safeJoin(%q) = %q, want it under %q", tc.name, target, destDir)
+			if _, err := tw.Write([]byte(content)); err != nil {
+				t.Fatal(err)
+			}
+			tw.Close()
+			gz.Close()
+
+			tmp := t.TempDir()
+			tarPath := filepath.Join(tmp, "archive.tar.gz")
+			if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			destDir := filepath.Join(tmp, "out")
+			if err := extractTarGz(tarPath, destDir); err != nil {
+				t.Fatalf("extractTarGz: %v", err)
+			}
+
+			// Walk the whole tmp dir (destDir's parent) for any file carrying
+			// our marker content: this catches both "did a safe entry get
+			// extracted" and "did an unsafe one escape destDir" in one pass,
+			// since tmp is an isolated t.TempDir() a traversal within a few
+			// ".."s still lands under.
+			foundInside, foundOutside := false, false
+			_ = filepath.Walk(tmp, func(p string, info os.FileInfo, err error) error {
+				if err != nil || info.IsDir() {
+					return nil
+				}
+				b, rerr := os.ReadFile(p)
+				if rerr != nil || string(b) != content {
+					return nil
+				}
+				rel, rerr := filepath.Rel(destDir, p)
+				if rerr == nil && !strings.HasPrefix(rel, "..") {
+					foundInside = true
+				} else {
+					foundOutside = true
+				}
+				return nil
+			})
+			if foundOutside {
+				t.Fatalf("entry %q escaped destDir", tc.name)
+			}
+			if foundInside != tc.wantSafe {
+				t.Errorf("entry %q extracted inside destDir = %v, want %v", tc.name, foundInside, tc.wantSafe)
 			}
 		})
 	}

--- a/internal/k8sbin/k8sbin_test.go
+++ b/internal/k8sbin/k8sbin_test.go
@@ -1,0 +1,231 @@
+package k8sbin
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeVersion(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"v1.36.1", "v1.36.1", false},
+		{"v1.30.0-rc.1", "v1.30.0-rc.1", false},
+		{"v1.28.5+vmware.1", "v1.28.5", false}, // build metadata stripped
+		{"unknown", "", true},
+		{"1.36.1", "", true},    // missing leading "v"
+		{"v1.36", "", true},     // not a full semver
+		{"../../etc", "", true}, // path traversal attempt
+		{"v1.2.3; rm -rf", "", true},
+	}
+	for _, tc := range cases {
+		got, err := normalizeVersion(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("normalizeVersion(%q) = %q, want error", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("normalizeVersion(%q) unexpected error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("normalizeVersion(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDownloadAndVerifyToFile(t *testing.T) {
+	content := []byte("pretend kube-controller-manager binary contents")
+	sum := sha256.Sum256(content)
+	sumHex := hex.EncodeToString(sum[:])
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/good/bin", func(w http.ResponseWriter, r *http.Request) { w.Write(content) })
+	mux.HandleFunc("/good/bin.sha256", func(w http.ResponseWriter, r *http.Request) { w.Write([]byte(sumHex)) })
+	mux.HandleFunc("/good/bin.sha256-withname", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(sumHex + "  bin\n"))
+	})
+	mux.HandleFunc("/bad/bin", func(w http.ResponseWriter, r *http.Request) { w.Write(content) })
+	mux.HandleFunc("/bad/bin.sha256", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("0000000000000000000000000000000000000000000000000000000000000000"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	t.Run("checksum matches", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "out")
+		if err := downloadAndVerifyToFile(srv.URL+"/good/bin", dest); err != nil {
+			t.Fatalf("downloadAndVerifyToFile: %v", err)
+		}
+		got, err := os.ReadFile(dest)
+		if err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		}
+		if !bytes.Equal(got, content) {
+			t.Errorf("content mismatch")
+		}
+	})
+
+	t.Run("checksum mismatch removes dest", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "out")
+		err := downloadAndVerifyToFile(srv.URL+"/bad/bin", dest)
+		if err == nil {
+			t.Fatalf("expected checksum mismatch error, got nil")
+		}
+		if !strings.Contains(err.Error(), "checksum mismatch") {
+			t.Errorf("error = %v, want checksum mismatch", err)
+		}
+		if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+			t.Errorf("dest file should have been removed after checksum mismatch")
+		}
+	})
+}
+
+// buildTarGz packs the given name->content map into a gzip-compressed tar
+// archive and returns its bytes.
+func buildTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		hdr := &tar.Header{Name: name, Mode: 0o644, Size: int64(len(content))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("WriteHeader(%q): %v", name, err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("Write(%q): %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar Close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestExtractTarGz(t *testing.T) {
+	t.Run("extracts regular files and directories", func(t *testing.T) {
+		data := buildTarGz(t, map[string]string{
+			"go.mod":           "module k8s.io/kubernetes\n",
+			"cmd/kube-cm/x.go": "package main\n",
+		})
+		tmp := t.TempDir()
+		tarPath := filepath.Join(tmp, "archive.tar.gz")
+		if err := os.WriteFile(tarPath, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		destDir := filepath.Join(tmp, "out")
+		if err := extractTarGz(tarPath, destDir); err != nil {
+			t.Fatalf("extractTarGz: %v", err)
+		}
+		got, err := os.ReadFile(filepath.Join(destDir, "go.mod"))
+		if err != nil {
+			t.Fatalf("reading extracted go.mod: %v", err)
+		}
+		if string(got) != "module k8s.io/kubernetes\n" {
+			t.Errorf("go.mod content = %q", got)
+		}
+		if _, err := os.Stat(filepath.Join(destDir, "cmd/kube-cm/x.go")); err != nil {
+			t.Errorf("nested file missing: %v", err)
+		}
+	})
+
+	t.Run("rejects path traversal entries", func(t *testing.T) {
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gz)
+		evil := "../../../tmp/kshark-extract-escape-test"
+		content := "escaped!"
+		if err := tw.WriteHeader(&tar.Header{Name: evil, Mode: 0o644, Size: int64(len(content))}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+		tw.Close()
+		gz.Close()
+
+		tmp := t.TempDir()
+		tarPath := filepath.Join(tmp, "evil.tar.gz")
+		if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		destDir := filepath.Join(tmp, "out")
+		if err := extractTarGz(tarPath, destDir); err != nil {
+			t.Fatalf("extractTarGz: %v", err)
+		}
+		if _, err := os.Stat("/tmp/kshark-extract-escape-test"); !os.IsNotExist(err) {
+			t.Fatalf("path traversal entry escaped destDir")
+			_ = os.Remove("/tmp/kshark-extract-escape-test")
+		}
+	})
+
+	t.Run("skips symlink entries", func(t *testing.T) {
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gz)
+		if err := tw.WriteHeader(&tar.Header{
+			Name: "evil-link", Typeflag: tar.TypeSymlink, Linkname: "/etc/passwd",
+		}); err != nil {
+			t.Fatal(err)
+		}
+		tw.Close()
+		gz.Close()
+
+		tmp := t.TempDir()
+		tarPath := filepath.Join(tmp, "symlink.tar.gz")
+		if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		destDir := filepath.Join(tmp, "out")
+		if err := extractTarGz(tarPath, destDir); err != nil {
+			t.Fatalf("extractTarGz: %v", err)
+		}
+		if _, err := os.Lstat(filepath.Join(destDir, "evil-link")); !os.IsNotExist(err) {
+			t.Errorf("symlink entry should have been skipped, not created")
+		}
+	})
+}
+
+func TestIsExecutableFile(t *testing.T) {
+	tmp := t.TempDir()
+	notExec := filepath.Join(tmp, "notexec")
+	if err := os.WriteFile(notExec, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if isExecutableFile(notExec) {
+		t.Errorf("0o644 file reported executable")
+	}
+
+	exec := filepath.Join(tmp, "exec")
+	if err := os.WriteFile(exec, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !isExecutableFile(exec) {
+		t.Errorf("0o755 file not reported executable")
+	}
+
+	if isExecutableFile(filepath.Join(tmp, "missing")) {
+		t.Errorf("missing file reported executable")
+	}
+
+	if isExecutableFile(tmp) {
+		t.Errorf("directory reported executable")
+	}
+}

--- a/internal/k8sbin/k8sbin_test.go
+++ b/internal/k8sbin/k8sbin_test.go
@@ -212,6 +212,27 @@ func TestDownloadAndVerifyToFile(t *testing.T) {
 			t.Errorf("dest file should have been removed after checksum mismatch")
 		}
 	})
+
+	t.Run("checksum fetch failure leaves no stale temp file", func(t *testing.T) {
+		// A failure before downloadAndVerifyToFile ever opens dest (here: the
+		// checksum fetch 404s) doesn't reach downloadAndVerifyToFile's own
+		// cleanup path — downloadPrebuilt's caller-side os.Remove(tmpPath) on
+		// any error is what actually cleans this up. uniqueTempPath always
+		// creates its file up front, so replicate that exact composition.
+		dir := t.TempDir()
+		tmpPath, err := uniqueTempPath(dir)
+		if err != nil {
+			t.Fatalf("uniqueTempPath: %v", err)
+		}
+		derr := downloadAndVerifyToFile(srv.URL+"/missing/bin", tmpPath)
+		if derr == nil {
+			t.Fatalf("expected an error fetching a missing artifact's checksum")
+		}
+		_ = os.Remove(tmpPath) // mirrors downloadPrebuilt's cleanup-on-error
+		if _, statErr := os.Stat(tmpPath); !os.IsNotExist(statErr) {
+			t.Errorf("temp file should not remain after a checksum-fetch failure")
+		}
+	})
 }
 
 // TestDlClient_RejectsCrossHostRedirect verifies dlClient's CheckRedirect:

--- a/internal/k8sbin/k8sbin_test.go
+++ b/internal/k8sbin/k8sbin_test.go
@@ -14,6 +14,30 @@ import (
 	"testing"
 )
 
+// TestUniqueTempPath verifies concurrent EnsureControllerManager calls (e.g.
+// two kshrk processes downloading/building the same version at once) get
+// distinct temp files rather than racing through a shared fixed name.
+func TestUniqueTempPath(t *testing.T) {
+	dir := t.TempDir()
+	seen := map[string]bool{}
+	for i := 0; i < 20; i++ {
+		p, err := uniqueTempPath(dir)
+		if err != nil {
+			t.Fatalf("uniqueTempPath: %v", err)
+		}
+		if filepath.Dir(p) != dir {
+			t.Fatalf("uniqueTempPath returned %q, want it inside %q (same filesystem for atomic rename)", p, dir)
+		}
+		if seen[p] {
+			t.Fatalf("uniqueTempPath returned a duplicate path: %q", p)
+		}
+		seen[p] = true
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("uniqueTempPath's file doesn't exist: %v", err)
+		}
+	}
+}
+
 func TestHasPrebuiltBinary(t *testing.T) {
 	cases := []struct {
 		goos, goarch string

--- a/internal/k8sbin/k8sbin_test.go
+++ b/internal/k8sbin/k8sbin_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -236,38 +237,48 @@ func TestDownloadAndVerifyToFile(t *testing.T) {
 }
 
 // TestDlClient_RejectsCrossHostRedirect verifies dlClient's CheckRedirect:
-// a redirect to a different host is refused (defense in depth against a
-// compromised or malicious intermediate redirecting an otherwise-trusted
-// dl.k8s.io fetch to an attacker-controlled host), while a same-host
-// redirect — which dl.k8s.io doesn't currently use for anything this
-// package fetches, but might in the future — still works.
+// a redirect to a different host, or off HTTPS, is refused (defense in depth
+// against a compromised or malicious intermediate redirecting an otherwise-
+// trusted dl.k8s.io fetch to an attacker-controlled host or downgrading it
+// to plaintext), while a same-host HTTPS redirect — which dl.k8s.io doesn't
+// currently use for anything this package fetches, but might in the future
+// — still works. Uses real TLS test servers (not plain HTTP ones) so the
+// HTTPS-only check is genuinely exercised rather than trivially satisfied.
 func TestDlClient_RejectsCrossHostRedirect(t *testing.T) {
 	content := []byte("payload")
 
-	otherHost := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	otherHost := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(content)
 	}))
 	defer otherHost.Close()
 
 	var originHost *httptest.Server
-	originHost = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	originHost = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/cross-host-redirect":
 			http.Redirect(w, r, otherHost.URL+"/target", http.StatusFound)
 		case "/same-host-redirect":
 			http.Redirect(w, r, originHost.URL+"/target", http.StatusFound)
+		case "/downgrade-redirect":
+			plain := "http://" + r.Host + "/target"
+			http.Redirect(w, r, plain, http.StatusFound)
 		case "/target":
 			_, _ = w.Write(content)
 		}
 	}))
 	defer originHost.Close()
 
+	// A client using the real dlCheckRedirect policy, but trusting these test
+	// servers' self-signed certs (via their own Client()'s Transport) instead
+	// of dlClient's real one, which only trusts the public CA pool.
+	testClient := &http.Client{CheckRedirect: dlCheckRedirect, Transport: originHost.Client().Transport}
+
 	t.Run("cross-host redirect refused", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, originHost.URL+"/cross-host-redirect", nil)
 		if err != nil {
 			t.Fatal(err)
 		}
-		resp, err := dlClient.Do(req)
+		resp, err := testClient.Do(req)
 		if err == nil {
 			resp.Body.Close()
 			t.Fatalf("expected cross-host redirect to be refused, got a response")
@@ -277,12 +288,27 @@ func TestDlClient_RejectsCrossHostRedirect(t *testing.T) {
 		}
 	})
 
-	t.Run("same-host redirect allowed", func(t *testing.T) {
+	t.Run("HTTPS-to-HTTP downgrade redirect refused", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, originHost.URL+"/downgrade-redirect", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := testClient.Do(req)
+		if err == nil {
+			resp.Body.Close()
+			t.Fatalf("expected an HTTPS-to-HTTP downgrade redirect to be refused, got a response")
+		}
+		if !strings.Contains(err.Error(), "non-HTTPS") {
+			t.Errorf("error = %v, want it to mention the refused scheme downgrade", err)
+		}
+	})
+
+	t.Run("same-host HTTPS redirect allowed", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, originHost.URL+"/same-host-redirect", nil)
 		if err != nil {
 			t.Fatal(err)
 		}
-		resp, err := dlClient.Do(req)
+		resp, err := testClient.Do(req)
 		if err != nil {
 			t.Fatalf("same-host redirect: %v", err)
 		}
@@ -345,35 +371,9 @@ func TestExtractTarGz(t *testing.T) {
 		}
 	})
 
-	t.Run("rejects path traversal entries", func(t *testing.T) {
-		var buf bytes.Buffer
-		gz := gzip.NewWriter(&buf)
-		tw := tar.NewWriter(gz)
-		evil := "../../../tmp/kshark-extract-escape-test"
-		content := "escaped!"
-		if err := tw.WriteHeader(&tar.Header{Name: evil, Mode: 0o644, Size: int64(len(content))}); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := tw.Write([]byte(content)); err != nil {
-			t.Fatal(err)
-		}
-		tw.Close()
-		gz.Close()
-
-		tmp := t.TempDir()
-		tarPath := filepath.Join(tmp, "evil.tar.gz")
-		if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		destDir := filepath.Join(tmp, "out")
-		if err := extractTarGz(tarPath, destDir); err != nil {
-			t.Fatalf("extractTarGz: %v", err)
-		}
-		if _, err := os.Stat("/tmp/kshark-extract-escape-test"); !os.IsNotExist(err) {
-			t.Fatalf("path traversal entry escaped destDir")
-			_ = os.Remove("/tmp/kshark-extract-escape-test")
-		}
-	})
+	// Path traversal is covered thoroughly by TestExtractTarGz_PathTraversalRejected
+	// (portable: walks the whole temp tree for containment rather than
+	// assuming a Unix /tmp).
 
 	t.Run("skips symlink entries", func(t *testing.T) {
 		var buf bytes.Buffer
@@ -408,8 +408,13 @@ func TestIsExecutableFile(t *testing.T) {
 	if err := os.WriteFile(notExec, []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if isExecutableFile(notExec) {
-		t.Errorf("0o644 file reported executable")
+	// isExecutableFile intentionally treats any non-empty regular file as
+	// "executable" on Windows (the execute-bit isn't a meaningful concept
+	// there — see its doc comment); the mode-bit check below only applies on
+	// other platforms.
+	wantNotExec := runtime.GOOS == "windows"
+	if got := isExecutableFile(notExec); got != wantNotExec {
+		t.Errorf("isExecutableFile(non-empty 0o644 file) = %v, want %v", got, wantNotExec)
 	}
 
 	exec := filepath.Join(tmp, "exec")
@@ -417,7 +422,7 @@ func TestIsExecutableFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !isExecutableFile(exec) {
-		t.Errorf("0o755 file not reported executable")
+		t.Errorf("0o755 non-empty file not reported executable")
 	}
 
 	if isExecutableFile(filepath.Join(tmp, "missing")) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -45,15 +45,16 @@ type ReplayOptions struct {
 
 // Server represents a running mock API server.
 type Server struct {
-	address        string
-	kubeconfigPath string
-	certPEM        []byte // this run's self-signed TLS cert, for callers that need to pin it
-	ar             *archive.Archive
-	httpServer     *http.Server
-	done           chan struct{}
-	clock          *ReplayClock // non-nil in replay mode
-	writable       bool         // overlay enabled
-	hasWatch       bool         // capture contains watch events
+	address           string
+	kubeconfigPath    string
+	certPEM           []byte // this run's self-signed TLS cert, for callers that need to pin it
+	ar                *archive.Archive
+	httpServer        *http.Server
+	done              chan struct{}
+	clock             *ReplayClock // non-nil in replay mode
+	writable          bool         // overlay enabled
+	hasWatch          bool         // capture contains watch events
+	kubernetesVersion string       // capture's /version gitVersion, e.g. "v1.36.1"
 }
 
 // Open opens a capture archive, starts the mock HTTPS server, and writes
@@ -164,15 +165,16 @@ func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *Replay
 	}()
 
 	return &Server{
-		address:        addr,
-		kubeconfigPath: kubeconfigPath,
-		certPEM:        certPEM,
-		ar:             ar,
-		httpServer:     httpSrv,
-		done:           done,
-		clock:          clock,
-		writable:       h.overlay != nil,
-		hasWatch:       len(store.WatchIndex) > 0,
+		address:           addr,
+		kubeconfigPath:    kubeconfigPath,
+		certPEM:           certPEM,
+		ar:                ar,
+		httpServer:        httpSrv,
+		done:              done,
+		clock:             clock,
+		writable:          h.overlay != nil,
+		hasWatch:          len(store.WatchIndex) > 0,
+		kubernetesVersion: store.Metadata.KubernetesVersion,
 	}, nil
 }
 
@@ -198,6 +200,10 @@ func (s *Server) CertPEM() []byte {
 
 // Clock returns the replay clock, or nil when the server is not in replay mode.
 func (s *Server) Clock() *ReplayClock { return s.clock }
+
+// KubernetesVersion returns the capture's Kubernetes gitVersion (e.g.
+// "v1.36.1"), as reported by the captured cluster's /version endpoint.
+func (s *Server) KubernetesVersion() string { return s.kubernetesVersion }
 
 // HasWatchEvents reports whether the capture contains watch events to stream.
 // Poll-only captures return false; replay still serves LIST/GET as-of the clock

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
+	"k8s.io/apimachinery/pkg/api/meta"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 // CaptureStore holds the in-memory index and provides record lookups against
@@ -887,48 +889,46 @@ func parseAPIPath(path string) (group, version, resource, namespace string) {
 	return
 }
 
+// builtinKindByResource maps a bare plural resource name (e.g.
+// "endpointslices") to its canonical Kind (e.g. "EndpointSlice"), derived
+// once from client-go's built-in type registry — the same authority real
+// clients (kubectl, controller-manager informers) use to resolve Kind names.
+// A hand-maintained table drifts silently as the Kubernetes API grows, and a
+// naive "strip trailing s, capitalize" guess is wrong for most multi-word
+// Kinds ("endpointslices" -> "Endpointslice", not "EndpointSlice";
+// "csistoragecapacities" -> "Csistoragecapacitie", not "CSIStorageCapacity").
+var builtinKindByResource = buildBuiltinKindByResource()
+
+func buildBuiltinKindByResource() map[string]string {
+	m := map[string]string{}
+	for gvk := range clientgoscheme.Scheme.AllKnownTypes() {
+		if gvk.Kind == "" || strings.HasSuffix(gvk.Kind, "List") || strings.HasSuffix(gvk.Kind, "Options") {
+			continue
+		}
+		gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+		if gvr.Resource == "" {
+			continue
+		}
+		if _, ok := m[gvr.Resource]; !ok {
+			m[gvr.Resource] = gvk.Kind
+		}
+	}
+	return m
+}
+
 // resourceToKind maps a plural resource name to its Kind string.
 func resourceToKind(resource string) string {
-	known := map[string]string{
-		"bindings":                  "Binding",
-		"componentstatuses":         "ComponentStatus",
-		"configmaps":                "ConfigMap",
-		"endpoints":                 "Endpoints",
-		"events":                    "Event",
-		"limitranges":               "LimitRange",
-		"namespaces":                "Namespace",
-		"nodes":                     "Node",
-		"persistentvolumeclaims":    "PersistentVolumeClaim",
-		"persistentvolumes":         "PersistentVolume",
-		"pods":                      "Pod",
-		"podtemplates":              "PodTemplate",
-		"replicationcontrollers":    "ReplicationController",
-		"resourcequotas":            "ResourceQuota",
-		"secrets":                   "Secret",
-		"serviceaccounts":           "ServiceAccount",
-		"services":                  "Service",
-		"controllerrevisions":       "ControllerRevision",
-		"daemonsets":                "DaemonSet",
-		"deployments":               "Deployment",
-		"replicasets":               "ReplicaSet",
-		"statefulsets":              "StatefulSet",
-		"horizontalpodautoscalers":  "HorizontalPodAutoscaler",
-		"cronjobs":                  "CronJob",
-		"jobs":                      "Job",
-		"ingresses":                 "Ingress",
-		"ingressclasses":            "IngressClass",
-		"networkpolicies":           "NetworkPolicy",
-		"poddisruptionbudgets":      "PodDisruptionBudget",
-		"clusterrolebindings":       "ClusterRoleBinding",
-		"clusterroles":              "ClusterRole",
-		"rolebindings":              "RoleBinding",
-		"roles":                     "Role",
-		"storageclasses":            "StorageClass",
-		"volumeattachments":         "VolumeAttachment",
-		"customresourcedefinitions": "CustomResourceDefinition",
-	}
-	if k, ok := known[resource]; ok {
+	if k, ok := builtinKindByResource[resource]; ok {
 		return k
+	}
+	// A couple of well-known Kinds live in aggregated-API-server groups
+	// (apiextensions.k8s.io, apiregistration.k8s.io) whose types aren't
+	// registered in client-go's built-in scheme.
+	switch resource {
+	case "customresourcedefinitions":
+		return "CustomResourceDefinition"
+	case "apiservices":
+		return "APIService"
 	}
 	s := strings.TrimSuffix(resource, "s")
 	if s == "" {

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -39,11 +39,28 @@ func TestParseAPIPath(t *testing.T) {
 
 func TestResourceToKind(t *testing.T) {
 	cases := map[string]string{
-		"pods":        "Pod",
-		"deployments": "Deployment",
-		"configmaps":  "ConfigMap",
-		"services":    "Service",
-		"widgets":     "Widget", // fallback
+		"pods":                              "Pod",
+		"deployments":                       "Deployment",
+		"configmaps":                        "ConfigMap",
+		"services":                          "Service",
+		"endpointslices":                    "EndpointSlice", // naive singularize+capitalize would give "Endpointslice"
+		"ipaddresses":                       "IPAddress",
+		"csidrivers":                        "CSIDriver",
+		"csinodes":                          "CSINode",
+		"csistoragecapacities":              "CSIStorageCapacity", // irregular plural too ("capacitie")
+		"priorityclasses":                   "PriorityClass",
+		"validatingadmissionpolicies":       "ValidatingAdmissionPolicy", // irregular plural ("policie")
+		"validatingadmissionpolicybindings": "ValidatingAdmissionPolicyBinding",
+		"mutatingwebhookconfigurations":     "MutatingWebhookConfiguration",
+		"validatingwebhookconfigurations":   "ValidatingWebhookConfiguration",
+		"resourceclaimtemplates":            "ResourceClaimTemplate",
+		"servicecidrs":                      "ServiceCIDR",
+		"flowschemas":                       "FlowSchema",
+		"prioritylevelconfigurations":       "PriorityLevelConfiguration",
+		"certificatesigningrequests":        "CertificateSigningRequest",
+		"customresourcedefinitions":         "CustomResourceDefinition", // aggregated API group, not in client-go scheme
+		"apiservices":                       "APIService",               // aggregated API group, not in client-go scheme
+		"widgets":                           "Widget",                   // unknown resource: naive fallback
 	}
 	for resource, want := range cases {
 		if got := resourceToKind(resource); got != want {

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"sort"
 	"strconv"
@@ -860,6 +861,15 @@ func defaultObject(gvk schema.GroupVersionKind, body json.RawMessage) json.RawMe
 // Spec.Strategy.RollingUpdate.MaxSurge), so a Type of "RollingUpdate" with a
 // nil RollingUpdate struct panics deep inside the controller instead of
 // erroring cleanly.
+// isIPv6Address reports whether s parses as an IPv6 address. Used to infer a
+// Service's address family from an explicit ClusterIP/ClusterIPs value
+// rather than always assuming IPv4; returns false for "" and "None" (a
+// headless Service), which correctly fall through to the IPv4 default.
+func isIPv6Address(s string) bool {
+	ip := net.ParseIP(s)
+	return ip != nil && ip.To4() == nil
+}
+
 func applyKnownDefaults(obj runtime.Object) {
 	switch o := obj.(type) {
 	case *corev1.Service:
@@ -872,9 +882,25 @@ func applyKnownDefaults(obj runtime.Object) {
 		if len(o.Spec.IPFamilies) == 0 {
 			// The endpoint/endpointslice controllers index IPFamilies[0]
 			// unconditionally; a real apiserver always populates this from the
-			// cluster's configured service-cluster-ip-range. IPv4 matches every
-			// capture this project has captured so far.
-			o.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
+			// cluster's configured service-cluster-ip-range. Infer the family
+			// from an explicit IPv6 ClusterIP/ClusterIPs first — defaulting to
+			// IPv4 unconditionally would otherwise produce an inconsistent
+			// Service (an IPv6 address paired with an IPv4 family) and send
+			// the endpoint controller looking for the wrong address family.
+			// IPv4 remains the fallback when nothing indicates IPv6, matching
+			// every capture this project has captured so far.
+			family := corev1.IPv4Protocol
+			if isIPv6Address(o.Spec.ClusterIP) {
+				family = corev1.IPv6Protocol
+			} else {
+				for _, ip := range o.Spec.ClusterIPs {
+					if isIPv6Address(ip) {
+						family = corev1.IPv6Protocol
+						break
+					}
+				}
+			}
+			o.Spec.IPFamilies = []corev1.IPFamily{family}
 		}
 	case *appsv1.Deployment:
 		if o.Spec.Strategy.Type == "" {

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -450,6 +450,15 @@ func (h *handler) overlayPatch(w http.ResponseWriter, r *http.Request, group, ve
 		h.writeStatus(w, http.StatusUnprocessableEntity, "patch did not produce a JSON object")
 		return
 	}
+	// A patch (e.g. `kubectl apply`) can just as easily leave a defaultable
+	// field unset as a create/replace can — default the patched result the
+	// same way, so a controller reconciling an applied object doesn't panic
+	// on a field the apiserver would have defaulted (see defaultObject).
+	if sub != "status" {
+		if gvk, known := kindForResource(schema.GroupVersion{Group: group, Version: version}, resource); known {
+			next = defaultObject(gvk, next)
+		}
+	}
 	if h.identityMismatch(w, next, name, namespace) {
 		return
 	}

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -841,9 +841,33 @@ func defaultObject(gvk schema.GroupVersionKind, body json.RawMessage) json.RawMe
 	if err := json.Unmarshal(body, typed); err != nil {
 		return body
 	}
+	// Marshal the client's own object back out before defaulting (rather than
+	// reusing body directly) so the merge patch computed below only reflects
+	// fields defaulting actually changed, not differences between body's
+	// exact bytes/field order and typed's. Round-tripping through the typed
+	// struct at all would normally risk silently dropping fields the
+	// vendored k8s.io/api types don't know about (e.g. a newer API field) or
+	// explicitly-sent zero values omitempty would elide — but since this
+	// undefaulted marshal is only ever diffed against the defaulted one, not
+	// returned, neither loss ends up in the result: a field defaulting
+	// doesn't touch is absent from the diff either way, and the merge patch
+	// below is applied onto the original body, preserving every field body
+	// actually had.
+	before, err := json.Marshal(typed)
+	if err != nil {
+		return body
+	}
 	scheme.Scheme.Default(typed)
 	applyKnownDefaults(typed)
-	defaulted, err := json.Marshal(typed)
+	after, err := json.Marshal(typed)
+	if err != nil {
+		return body
+	}
+	patch, err := jsonpatch.CreateMergePatch(before, after)
+	if err != nil {
+		return body
+	}
+	defaulted, err := jsonpatch.MergePatch(body, patch)
 	if err != nil {
 		return body
 	}

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -12,10 +12,16 @@ import (
 
 	"github.com/google/uuid"
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 )
 
@@ -97,6 +103,9 @@ func (h *handler) overlayCreate(w http.ResponseWriter, r *http.Request, group, v
 	body, ok := h.readObjectBody(w, r)
 	if !ok {
 		return
+	}
+	if gvk, known := kindForResource(schema.GroupVersion{Group: group, Version: version}, resource); known {
+		body = defaultObject(gvk, body)
 	}
 	name := metaString(body, "name")
 	if name == "" {
@@ -379,6 +388,11 @@ func (h *handler) overlayReplace(w http.ResponseWriter, r *http.Request, group, 
 	body, ok := h.readObjectBody(w, r)
 	if !ok {
 		return
+	}
+	if sub != "status" {
+		if gvk, known := kindForResource(schema.GroupVersion{Group: group, Version: version}, resource); known {
+			body = defaultObject(gvk, body)
+		}
 	}
 	if h.identityMismatch(w, body, name, namespace) {
 		return
@@ -788,6 +802,139 @@ func kindForResource(gv schema.GroupVersion, resource string) (schema.GroupVersi
 		}
 	}
 	return schema.GroupVersionKind{}, false
+}
+
+// defaultObject applies Kubernetes API defaulting to body — e.g. an empty
+// Deployment.spec.strategy.type becomes "RollingUpdate" — matching what a real
+// apiserver does on every write. The overlay has no apiserver behind it, so
+// without this a freshly created object keeps whatever zero values the client
+// didn't set; a real controller (e.g. kube-controller-manager's deployment
+// controller) assumes defaulting already happened and errors on the zero value
+// ("unexpected deployment strategy type: \"\"") instead of treating it as
+// "use the default". Resources outside client-go's built-in scheme (CRDs) are
+// returned unchanged — there's no way to know their defaults without the CRD's
+// schema, which the overlay doesn't have.
+//
+// scheme.Scheme.Default only runs defaulters registered on the client-side
+// scheme, which — for the built-in types this project vendors
+// (k8s.io/api, not the full k8s.io/kubernetes apiserver) — is effectively
+// none of the fields real controllers care about; the actual
+// SetDefaults_Deployment-style functions live in k8s.io/kubernetes's internal
+// packages, which aren't meant to be imported as a library. applyKnownDefaults
+// hand-covers the specific, long-stable defaults our curated
+// --with-controller-manager controllers rely on instead.
+func defaultObject(gvk schema.GroupVersionKind, body json.RawMessage) json.RawMessage {
+	typed, err := scheme.Scheme.New(gvk)
+	if err != nil {
+		return body
+	}
+	if err := json.Unmarshal(body, typed); err != nil {
+		return body
+	}
+	scheme.Scheme.Default(typed)
+	applyKnownDefaults(typed)
+	defaulted, err := json.Marshal(typed)
+	if err != nil {
+		return body
+	}
+	return defaulted
+}
+
+// applyKnownDefaults hand-applies the handful of long-stable Kubernetes API
+// defaults that the controllers --with-controller-manager enables (see
+// cmd/controllermanager.go) assume are already in place: a zero-valued
+// strategy/update-strategy/concurrency-policy reads as "invalid", not "use the
+// default", to those controllers. Defaulting a *Type without also defaulting
+// its matching *RollingUpdate sub-struct is not enough — real
+// kube-controller-manager code unconditionally dereferences that pointer
+// (e.g. deployment_util.go's NewRSNewReplicas reads
+// Spec.Strategy.RollingUpdate.MaxSurge), so a Type of "RollingUpdate" with a
+// nil RollingUpdate struct panics deep inside the controller instead of
+// erroring cleanly.
+func applyKnownDefaults(obj runtime.Object) {
+	switch o := obj.(type) {
+	case *corev1.Service:
+		if o.Spec.Type == "" {
+			o.Spec.Type = corev1.ServiceTypeClusterIP
+		}
+		if o.Spec.SessionAffinity == "" {
+			o.Spec.SessionAffinity = corev1.ServiceAffinityNone
+		}
+		if len(o.Spec.IPFamilies) == 0 {
+			// The endpoint/endpointslice controllers index IPFamilies[0]
+			// unconditionally; a real apiserver always populates this from the
+			// cluster's configured service-cluster-ip-range. IPv4 matches every
+			// capture this project has captured so far.
+			o.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
+		}
+	case *appsv1.Deployment:
+		if o.Spec.Strategy.Type == "" {
+			o.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
+		}
+		if o.Spec.Strategy.Type == appsv1.RollingUpdateDeploymentStrategyType && o.Spec.Strategy.RollingUpdate == nil {
+			maxUnavailable := intstr.FromString("25%")
+			maxSurge := intstr.FromString("25%")
+			o.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+				MaxUnavailable: &maxUnavailable,
+				MaxSurge:       &maxSurge,
+			}
+		}
+	case *appsv1.DaemonSet:
+		if o.Spec.UpdateStrategy.Type == "" {
+			o.Spec.UpdateStrategy.Type = appsv1.RollingUpdateDaemonSetStrategyType
+		}
+		if o.Spec.UpdateStrategy.Type == appsv1.RollingUpdateDaemonSetStrategyType && o.Spec.UpdateStrategy.RollingUpdate == nil {
+			maxUnavailable := intstr.FromString("25%")
+			maxSurge := intstr.FromInt32(0)
+			o.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateDaemonSet{
+				MaxUnavailable: &maxUnavailable,
+				MaxSurge:       &maxSurge,
+			}
+		}
+	case *appsv1.StatefulSet:
+		if o.Spec.UpdateStrategy.Type == "" {
+			o.Spec.UpdateStrategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
+		}
+		if o.Spec.PodManagementPolicy == "" {
+			o.Spec.PodManagementPolicy = appsv1.OrderedReadyPodManagement
+		}
+		if o.Spec.UpdateStrategy.Type == appsv1.RollingUpdateStatefulSetStrategyType && o.Spec.UpdateStrategy.RollingUpdate == nil {
+			partition := int32(0)
+			o.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateStatefulSetStrategy{Partition: &partition}
+		}
+	case *batchv1.Job:
+		if o.Spec.Parallelism == nil {
+			o.Spec.Parallelism = ptr.To(int32(1))
+		}
+		if o.Spec.BackoffLimit == nil {
+			o.Spec.BackoffLimit = ptr.To(int32(6))
+		}
+		if o.Spec.CompletionMode == nil {
+			o.Spec.CompletionMode = ptr.To(batchv1.NonIndexedCompletion)
+		}
+		if o.Spec.Suspend == nil {
+			o.Spec.Suspend = ptr.To(false)
+		}
+		if o.Spec.ManualSelector == nil {
+			o.Spec.ManualSelector = ptr.To(false)
+		}
+		if o.Spec.PodReplacementPolicy == nil {
+			o.Spec.PodReplacementPolicy = ptr.To(batchv1.TerminatingOrFailed)
+		}
+	case *batchv1.CronJob:
+		if o.Spec.ConcurrencyPolicy == "" {
+			o.Spec.ConcurrencyPolicy = batchv1.AllowConcurrent
+		}
+		if o.Spec.Suspend == nil {
+			o.Spec.Suspend = ptr.To(false)
+		}
+		if o.Spec.SuccessfulJobsHistoryLimit == nil {
+			o.Spec.SuccessfulJobsHistoryLimit = ptr.To(int32(3))
+		}
+		if o.Spec.FailedJobsHistoryLimit == nil {
+			o.Spec.FailedJobsHistoryLimit = ptr.To(int32(1))
+		}
+	}
 }
 
 // allowedMethods returns the Allow-header value for a write path shape, used on

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -882,22 +882,24 @@ func applyKnownDefaults(obj runtime.Object) {
 		if len(o.Spec.IPFamilies) == 0 {
 			// The endpoint/endpointslice controllers index IPFamilies[0]
 			// unconditionally; a real apiserver always populates this from the
-			// cluster's configured service-cluster-ip-range. Infer the family
-			// from an explicit IPv6 ClusterIP/ClusterIPs first — defaulting to
-			// IPv4 unconditionally would otherwise produce an inconsistent
-			// Service (an IPv6 address paired with an IPv4 family) and send
-			// the endpoint controller looking for the wrong address family.
-			// IPv4 remains the fallback when nothing indicates IPv6, matching
-			// every capture this project has captured so far.
+			// cluster's configured service-cluster-ip-range. Infer the primary
+			// family from the primary address only — ClusterIP if set, else
+			// ClusterIPs[0] — never by scanning every ClusterIPs entry: for a
+			// dual-stack Service with an IPv4 ClusterIP and an IPv6 secondary in
+			// ClusterIPs, scanning all entries would pick IPv6 and produce
+			// IPFamilies[0] inconsistent with the primary ClusterIP, sending the
+			// endpoint controller down the wrong address family. IPv4 remains the
+			// fallback when nothing indicates IPv6, matching every capture this
+			// project has captured so far.
 			family := corev1.IPv4Protocol
-			if isIPv6Address(o.Spec.ClusterIP) {
-				family = corev1.IPv6Protocol
-			} else {
-				for _, ip := range o.Spec.ClusterIPs {
-					if isIPv6Address(ip) {
-						family = corev1.IPv6Protocol
-						break
-					}
+			switch {
+			case o.Spec.ClusterIP != "" && o.Spec.ClusterIP != corev1.ClusterIPNone:
+				if isIPv6Address(o.Spec.ClusterIP) {
+					family = corev1.IPv6Protocol
+				}
+			case len(o.Spec.ClusterIPs) > 0:
+				if isIPv6Address(o.Spec.ClusterIPs[0]) {
+					family = corev1.IPv6Protocol
 				}
 			}
 			o.Spec.IPFamilies = []corev1.IPFamily{family}

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -282,6 +282,114 @@ func TestKindForResource(t *testing.T) {
 	}
 }
 
+// TestOverlay_APIDefaulting verifies that objects of Kinds real controllers
+// reconcile get the same defaulting a live apiserver applies on create — a
+// regression test for panics found wiring up --with-controller-manager:
+// kube-controller-manager unconditionally dereferences fields like
+// Deployment.spec.strategy.rollingUpdate.maxSurge and Job.spec.backoffLimit,
+// assuming the apiserver already defaulted them.
+func TestOverlay_APIDefaulting(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	t.Run("Deployment strategy", func(t *testing.T) {
+		body := `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"nginx","namespace":"default"},
+			"spec":{"replicas":1,"selector":{"matchLabels":{"app":"nginx"}},
+			"template":{"metadata":{"labels":{"app":"nginx"}},"spec":{"containers":[{"name":"nginx","image":"nginx"}]}}}}`
+		code, out := doReq(t, http.MethodPost, srv.URL+"/apis/apps/v1/namespaces/default/deployments", "application/json", body)
+		if code != http.StatusCreated {
+			t.Fatalf("create: status %d: %s", code, out)
+		}
+		var d struct {
+			Spec struct {
+				Strategy struct {
+					Type          string `json:"type"`
+					RollingUpdate *struct {
+						MaxSurge       string `json:"maxSurge"`
+						MaxUnavailable string `json:"maxUnavailable"`
+					} `json:"rollingUpdate"`
+				} `json:"strategy"`
+			} `json:"spec"`
+		}
+		if err := json.Unmarshal(out, &d); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if d.Spec.Strategy.Type != "RollingUpdate" {
+			t.Errorf("strategy.type = %q, want RollingUpdate", d.Spec.Strategy.Type)
+		}
+		if d.Spec.Strategy.RollingUpdate == nil {
+			t.Fatalf("strategy.rollingUpdate is nil — kube-controller-manager panics dereferencing .maxSurge")
+		}
+		if d.Spec.Strategy.RollingUpdate.MaxSurge != "25%" || d.Spec.Strategy.RollingUpdate.MaxUnavailable != "25%" {
+			t.Errorf("rollingUpdate = %+v, want 25%%/25%%", d.Spec.Strategy.RollingUpdate)
+		}
+	})
+
+	t.Run("Job backoffLimit and friends", func(t *testing.T) {
+		body := `{"apiVersion":"batch/v1","kind":"Job","metadata":{"name":"hello","namespace":"default"},
+			"spec":{"template":{"spec":{"containers":[{"name":"hello","image":"busybox"}],"restartPolicy":"Never"}}}}`
+		code, out := doReq(t, http.MethodPost, srv.URL+"/apis/batch/v1/namespaces/default/jobs", "application/json", body)
+		if code != http.StatusCreated {
+			t.Fatalf("create: status %d: %s", code, out)
+		}
+		var j struct {
+			Spec struct {
+				Parallelism    *int32  `json:"parallelism"`
+				BackoffLimit   *int32  `json:"backoffLimit"`
+				CompletionMode *string `json:"completionMode"`
+			} `json:"spec"`
+		}
+		if err := json.Unmarshal(out, &j); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if j.Spec.BackoffLimit == nil || *j.Spec.BackoffLimit != 6 {
+			t.Errorf("backoffLimit = %v, want 6 — job controller panics dereferencing a nil backoffLimit", j.Spec.BackoffLimit)
+		}
+		if j.Spec.Parallelism == nil || *j.Spec.Parallelism != 1 {
+			t.Errorf("parallelism = %v, want 1", j.Spec.Parallelism)
+		}
+		if j.Spec.CompletionMode == nil || *j.Spec.CompletionMode != "NonIndexed" {
+			t.Errorf("completionMode = %v, want NonIndexed", j.Spec.CompletionMode)
+		}
+	})
+
+	t.Run("Service IPFamilies", func(t *testing.T) {
+		body := `{"apiVersion":"v1","kind":"Service","metadata":{"name":"web","namespace":"default"},
+			"spec":{"selector":{"app":"nginx"},"ports":[{"port":80}]}}`
+		code, out := doReq(t, http.MethodPost, srv.URL+"/api/v1/namespaces/default/services", "application/json", body)
+		if code != http.StatusCreated {
+			t.Fatalf("create: status %d: %s", code, out)
+		}
+		var s struct {
+			Spec struct {
+				Type       string   `json:"type"`
+				IPFamilies []string `json:"ipFamilies"`
+			} `json:"spec"`
+		}
+		if err := json.Unmarshal(out, &s); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if s.Spec.Type != "ClusterIP" {
+			t.Errorf("type = %q, want ClusterIP", s.Spec.Type)
+		}
+		if len(s.Spec.IPFamilies) == 0 {
+			t.Fatalf("ipFamilies is empty — the endpoint controller panics indexing ipFamilies[0]")
+		}
+	})
+
+	t.Run("unknown resource passes through unchanged", func(t *testing.T) {
+		body := `{"apiVersion":"example.com/v1","kind":"Widget","metadata":{"name":"w1","namespace":"default"},"spec":{}}`
+		code, out := doReq(t, http.MethodPost, srv.URL+"/apis/example.com/v1/namespaces/default/widgets", "application/json", body)
+		if code != http.StatusCreated {
+			t.Fatalf("create: status %d: %s", code, out)
+		}
+		if metaString(out, "name") != "w1" {
+			t.Errorf("name = %q, want w1 (custom resource create should be unaffected)", metaString(out, "name"))
+		}
+	})
+}
+
 func TestOverlay_DeleteTombstone(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -354,6 +354,104 @@ func TestOverlay_APIDefaulting(t *testing.T) {
 		}
 	})
 
+	t.Run("DaemonSet updateStrategy", func(t *testing.T) {
+		body := `{"apiVersion":"apps/v1","kind":"DaemonSet","metadata":{"name":"fluentd","namespace":"default"},
+			"spec":{"selector":{"matchLabels":{"app":"fluentd"}},
+			"template":{"metadata":{"labels":{"app":"fluentd"}},"spec":{"containers":[{"name":"fluentd","image":"fluentd"}]}}}}`
+		code, out := doReq(t, http.MethodPost, srv.URL+"/apis/apps/v1/namespaces/default/daemonsets", "application/json", body)
+		if code != http.StatusCreated {
+			t.Fatalf("create: status %d: %s", code, out)
+		}
+		var d struct {
+			Spec struct {
+				UpdateStrategy struct {
+					Type          string `json:"type"`
+					RollingUpdate *struct {
+						MaxUnavailable string `json:"maxUnavailable"`
+					} `json:"rollingUpdate"`
+				} `json:"updateStrategy"`
+			} `json:"spec"`
+		}
+		if err := json.Unmarshal(out, &d); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if d.Spec.UpdateStrategy.Type != "RollingUpdate" {
+			t.Errorf("updateStrategy.type = %q, want RollingUpdate", d.Spec.UpdateStrategy.Type)
+		}
+		if d.Spec.UpdateStrategy.RollingUpdate == nil || d.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable != "25%" {
+			t.Errorf("updateStrategy.rollingUpdate = %+v, want non-nil with maxUnavailable 25%%", d.Spec.UpdateStrategy.RollingUpdate)
+		}
+	})
+
+	t.Run("StatefulSet updateStrategy and podManagementPolicy", func(t *testing.T) {
+		body := `{"apiVersion":"apps/v1","kind":"StatefulSet","metadata":{"name":"web","namespace":"default"},
+			"spec":{"serviceName":"web","selector":{"matchLabels":{"app":"web"}},
+			"template":{"metadata":{"labels":{"app":"web"}},"spec":{"containers":[{"name":"web","image":"nginx"}]}}}}`
+		code, out := doReq(t, http.MethodPost, srv.URL+"/apis/apps/v1/namespaces/default/statefulsets", "application/json", body)
+		if code != http.StatusCreated {
+			t.Fatalf("create: status %d: %s", code, out)
+		}
+		var s struct {
+			Spec struct {
+				PodManagementPolicy string `json:"podManagementPolicy"`
+				UpdateStrategy      struct {
+					Type          string `json:"type"`
+					RollingUpdate *struct {
+						Partition *int32 `json:"partition"`
+					} `json:"rollingUpdate"`
+				} `json:"updateStrategy"`
+			} `json:"spec"`
+		}
+		if err := json.Unmarshal(out, &s); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if s.Spec.PodManagementPolicy != "OrderedReady" {
+			t.Errorf("podManagementPolicy = %q, want OrderedReady", s.Spec.PodManagementPolicy)
+		}
+		if s.Spec.UpdateStrategy.Type != "RollingUpdate" {
+			t.Errorf("updateStrategy.type = %q, want RollingUpdate", s.Spec.UpdateStrategy.Type)
+		}
+		if s.Spec.UpdateStrategy.RollingUpdate == nil || s.Spec.UpdateStrategy.RollingUpdate.Partition == nil {
+			t.Fatalf("updateStrategy.rollingUpdate.partition is nil — statefulset controller panics dereferencing it")
+		}
+		if *s.Spec.UpdateStrategy.RollingUpdate.Partition != 0 {
+			t.Errorf("partition = %d, want 0", *s.Spec.UpdateStrategy.RollingUpdate.Partition)
+		}
+	})
+
+	t.Run("CronJob concurrencyPolicy and history limits", func(t *testing.T) {
+		body := `{"apiVersion":"batch/v1","kind":"CronJob","metadata":{"name":"hello-cron","namespace":"default"},
+			"spec":{"schedule":"* * * * *","jobTemplate":{"spec":{"template":{"spec":{
+			"containers":[{"name":"hello","image":"busybox"}],"restartPolicy":"OnFailure"}}}}}}`
+		code, out := doReq(t, http.MethodPost, srv.URL+"/apis/batch/v1/namespaces/default/cronjobs", "application/json", body)
+		if code != http.StatusCreated {
+			t.Fatalf("create: status %d: %s", code, out)
+		}
+		var c struct {
+			Spec struct {
+				ConcurrencyPolicy          string `json:"concurrencyPolicy"`
+				Suspend                    *bool  `json:"suspend"`
+				SuccessfulJobsHistoryLimit *int32 `json:"successfulJobsHistoryLimit"`
+				FailedJobsHistoryLimit     *int32 `json:"failedJobsHistoryLimit"`
+			} `json:"spec"`
+		}
+		if err := json.Unmarshal(out, &c); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if c.Spec.ConcurrencyPolicy != "Allow" {
+			t.Errorf("concurrencyPolicy = %q, want Allow", c.Spec.ConcurrencyPolicy)
+		}
+		if c.Spec.Suspend == nil || *c.Spec.Suspend != false {
+			t.Errorf("suspend = %v, want false", c.Spec.Suspend)
+		}
+		if c.Spec.SuccessfulJobsHistoryLimit == nil || *c.Spec.SuccessfulJobsHistoryLimit != 3 {
+			t.Errorf("successfulJobsHistoryLimit = %v, want 3", c.Spec.SuccessfulJobsHistoryLimit)
+		}
+		if c.Spec.FailedJobsHistoryLimit == nil || *c.Spec.FailedJobsHistoryLimit != 1 {
+			t.Errorf("failedJobsHistoryLimit = %v, want 1", c.Spec.FailedJobsHistoryLimit)
+		}
+	})
+
 	t.Run("Service IPFamilies", func(t *testing.T) {
 		body := `{"apiVersion":"v1","kind":"Service","metadata":{"name":"web","namespace":"default"},
 			"spec":{"selector":{"app":"nginx"},"ports":[{"port":80}]}}`

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -390,6 +390,59 @@ func TestOverlay_APIDefaulting(t *testing.T) {
 	})
 }
 
+// TestOverlay_PatchAppliesDefaulting verifies that PATCHing a captured object
+// that predates this project's defaulting (e.g. an older/incomplete capture,
+// or a hand-authored fixture) — not just POST/PUT — backfills the same
+// defaults, since the patched result is just as capable of reaching a real
+// controller as a freshly created object.
+func TestOverlay_PatchAppliesDefaulting(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+
+	listPath := "/apis/apps/v1/namespaces/default/deployments"
+	deployPath := listPath + "/nginx"
+	deployItem := `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"nginx","namespace":"default"},
+		"spec":{"replicas":1,"selector":{"matchLabels":{"app":"nginx"}},"strategy":{},
+		"template":{"metadata":{"labels":{"app":"nginx"}},"spec":{"containers":[{"name":"nginx","image":"nginx"}]}}}}`
+	capturedList := `{"apiVersion":"apps/v1","kind":"DeploymentList","metadata":{},"items":[` + deployItem + `]}`
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{listPath: {id: "d", at: from, body: capturedList}}, nil)
+	srv := newWritableServer(t, store, clock)
+
+	// Confirm the captured object really does carry an empty strategy (i.e.
+	// this predates defaulting, not already fixed by something else).
+	code, before := doReq(t, http.MethodGet, srv.URL+deployPath, "", "")
+	if code != 200 {
+		t.Fatalf("GET before patch: status %d: %s", code, before)
+	}
+
+	patch := `{"spec":{"replicas":2}}`
+	code, after := doReq(t, http.MethodPatch, srv.URL+deployPath, "application/merge-patch+json", patch)
+	if code != 200 {
+		t.Fatalf("PATCH: status %d: %s", code, after)
+	}
+	var d struct {
+		Spec struct {
+			Replicas int `json:"replicas"`
+			Strategy struct {
+				Type          string `json:"type"`
+				RollingUpdate *struct {
+					MaxSurge string `json:"maxSurge"`
+				} `json:"rollingUpdate"`
+			} `json:"strategy"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal(after, &d); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if d.Spec.Replicas != 2 {
+		t.Errorf("replicas = %d, want 2 (the patch itself)", d.Spec.Replicas)
+	}
+	if d.Spec.Strategy.Type != "RollingUpdate" || d.Spec.Strategy.RollingUpdate == nil {
+		t.Errorf("strategy = %+v, want defaulted to RollingUpdate/25%% — PATCH must default just like POST/PUT", d.Spec.Strategy)
+	}
+}
+
 func TestOverlay_DeleteTombstone(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -520,6 +520,30 @@ func TestOverlay_APIDefaulting(t *testing.T) {
 		}
 	})
 
+	t.Run("dual-stack Service keeps IPv4 primary despite an IPv6 secondary in clusterIPs", func(t *testing.T) {
+		// Scanning every clusterIPs entry (instead of just the primary address)
+		// would pick IPv6 here and produce ipFamilies[0] inconsistent with the
+		// primary clusterIP, sending the endpoint controller down the wrong
+		// address family.
+		body := `{"apiVersion":"v1","kind":"Service","metadata":{"name":"web-dual","namespace":"default"},
+			"spec":{"clusterIP":"10.0.0.5","clusterIPs":["10.0.0.5","fd00::5678"],"selector":{"app":"nginx"},"ports":[{"port":80}]}}`
+		code, out := doReq(t, http.MethodPost, srv.URL+"/api/v1/namespaces/default/services", "application/json", body)
+		if code != http.StatusCreated {
+			t.Fatalf("create: status %d: %s", code, out)
+		}
+		var s struct {
+			Spec struct {
+				IPFamilies []string `json:"ipFamilies"`
+			} `json:"spec"`
+		}
+		if err := json.Unmarshal(out, &s); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(s.Spec.IPFamilies) == 0 || s.Spec.IPFamilies[0] != "IPv4" {
+			t.Errorf("ipFamilies = %v, want [IPv4] matching the primary clusterIP 10.0.0.5", s.Spec.IPFamilies)
+		}
+	})
+
 	t.Run("unknown resource passes through unchanged", func(t *testing.T) {
 		body := `{"apiVersion":"example.com/v1","kind":"Widget","metadata":{"name":"w1","namespace":"default"},"spec":{}}`
 		code, out := doReq(t, http.MethodPost, srv.URL+"/apis/example.com/v1/namespaces/default/widgets", "application/json", body)

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -282,6 +282,24 @@ func TestKindForResource(t *testing.T) {
 	}
 }
 
+func TestIsIPv6Address(t *testing.T) {
+	cases := map[string]bool{
+		"":               false,
+		"None":           false, // headless Service
+		"10.0.0.1":       false,
+		"172.16.0.5":     false,
+		"fd00::1234":     true,
+		"::1":            true,
+		"2001:db8::1":    true,
+		"not-an-ip-addr": false,
+	}
+	for in, want := range cases {
+		if got := isIPv6Address(in); got != want {
+			t.Errorf("isIPv6Address(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
 // TestOverlay_APIDefaulting verifies that objects of Kinds real controllers
 // reconcile get the same defaulting a live apiserver applies on create — a
 // regression test for panics found wiring up --with-controller-manager:
@@ -473,6 +491,32 @@ func TestOverlay_APIDefaulting(t *testing.T) {
 		}
 		if len(s.Spec.IPFamilies) == 0 {
 			t.Fatalf("ipFamilies is empty — the endpoint controller panics indexing ipFamilies[0]")
+		}
+		if s.Spec.IPFamilies[0] != "IPv4" {
+			t.Errorf("ipFamilies = %v, want [IPv4] as the fallback when nothing indicates IPv6", s.Spec.IPFamilies)
+		}
+	})
+
+	t.Run("Service IPFamilies infers IPv6 from an explicit ClusterIP", func(t *testing.T) {
+		// Defaulting to IPv4 unconditionally would pair an IPv6 ClusterIP with
+		// an IPv4 family — an inconsistent Service that sends the endpoint
+		// controller looking for the wrong address family.
+		body := `{"apiVersion":"v1","kind":"Service","metadata":{"name":"web6","namespace":"default"},
+			"spec":{"clusterIP":"fd00::1234","selector":{"app":"nginx"},"ports":[{"port":80}]}}`
+		code, out := doReq(t, http.MethodPost, srv.URL+"/api/v1/namespaces/default/services", "application/json", body)
+		if code != http.StatusCreated {
+			t.Fatalf("create: status %d: %s", code, out)
+		}
+		var s struct {
+			Spec struct {
+				IPFamilies []string `json:"ipFamilies"`
+			} `json:"spec"`
+		}
+		if err := json.Unmarshal(out, &s); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(s.Spec.IPFamilies) == 0 || s.Spec.IPFamilies[0] != "IPv6" {
+			t.Errorf("ipFamilies = %v, want [IPv6] inferred from clusterIP fd00::1234", s.Spec.IPFamilies)
 		}
 	})
 

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -554,6 +554,41 @@ func TestOverlay_APIDefaulting(t *testing.T) {
 			t.Errorf("name = %q, want w1 (custom resource create should be unaffected)", metaString(out, "name"))
 		}
 	})
+
+	t.Run("defaulting preserves fields unknown to the vendored types", func(t *testing.T) {
+		// defaultObject round-trips through a typed struct to compute what
+		// defaulting changed, but must apply that as a merge patch onto the
+		// original body rather than returning the re-marshaled typed struct
+		// directly — otherwise a field the vendored k8s.io/api types don't
+		// know about (e.g. a newer API field a live cluster's capture might
+		// have, or here a made-up one standing in for that case) would be
+		// silently dropped even though the client explicitly sent it.
+		body := `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"nginx-unknown","namespace":"default"},
+			"spec":{"replicas":1,"selector":{"matchLabels":{"app":"nginx"}},
+			"template":{"metadata":{"labels":{"app":"nginx"}},"spec":{"containers":[{"name":"nginx","image":"nginx"}]}},
+			"unknownFutureField":"should-survive"}}`
+		code, out := doReq(t, http.MethodPost, srv.URL+"/apis/apps/v1/namespaces/default/deployments", "application/json", body)
+		if code != http.StatusCreated {
+			t.Fatalf("create: status %d: %s", code, out)
+		}
+		var d struct {
+			Spec struct {
+				Strategy struct {
+					Type string `json:"type"`
+				} `json:"strategy"`
+				UnknownFutureField string `json:"unknownFutureField"`
+			} `json:"spec"`
+		}
+		if err := json.Unmarshal(out, &d); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if d.Spec.UnknownFutureField != "should-survive" {
+			t.Errorf("unknownFutureField = %q, want it preserved through defaulting", d.Spec.UnknownFutureField)
+		}
+		if d.Spec.Strategy.Type != "RollingUpdate" {
+			t.Errorf("strategy.type = %q, want defaulting to still apply alongside the unknown field", d.Spec.Strategy.Type)
+		}
+	})
 }
 
 // TestOverlay_PatchAppliesDefaulting verifies that PATCHing a captured object


### PR DESCRIPTION
## Summary

Pairs the writable overlay with a real `kube-controller-manager`, running a curated set of pure API-object controllers (`namespace`, `serviceaccount`, `resourcequota`, `garbagecollector`, `daemonset`, `deployment`, `replicaset`, `statefulset`, `job`, `cronjob`, `endpoint`, `endpointslice`, `endpointslicemirroring`, `disruption`) against the mock server. A Deployment now gets a real ReplicaSet and Pods, a CronJob spawns Jobs, and a Service gets Endpoints and an EndpointSlice — closing more of the loop than `--with-kwok` alone, without a full second cluster. See [docs/kwok.md](https://github.com/phenixblue/k8shark/blob/main/docs/kwok.md#closing-more-of-the-loop-with-controller-manager) for the full writeup, non-goals, and rationale.

- **`internal/k8sbin`** locates/builds `kube-controller-manager` matching the capture's Kubernetes version. Kubernetes only publishes this binary for `linux/{amd64,arm64}`, so on Linux it downloads the official release binary (verified against its published SHA-256), and on other platforms it downloads and builds the official Kubernetes **source** tarball with the host's Go toolchain — the same approach [KWOK's own docs recommend](https://kwok.sigs.k8s.io/docs/user/kwokctl-platform-specific-binaries/) for its own non-Linux gap. Both paths only ever fetch from `dl.k8s.io`; no third-party binary sources.
- **`cmd/controllermanager.go`** + a new `--with-controller-manager` flag on `kshrk replay`, mirroring the existing `--with-kwok` pattern (implies `--writable`, managed subprocess lifecycle).
- **`--with-kwok`/`--with-controller-manager` also added to `kshrk ui`**, mirroring `replay` exactly, so the dashboard can show a closed-loop simulation live (Pods flipping Pending → Running, etc.).

### Bugs found and fixed along the way

Getting a real controller-manager to run against the overlay surfaced real bugs — found only by actually observing panics that client-go's crash handler recovers and logs, but otherwise swallows silently (the object just never reconciles, with no obvious error):

- **`resourceToKind`'s hand-maintained plural→Kind map was wrong for ~20 multi-word Kinds** (`EndpointSlice`, `IPAddress`, `CSIDriver`, `PriorityClass`, ...) — a naive "strip trailing s, capitalize" fallback produced e.g. `Endpointslice` instead of `EndpointSlice`. Replaced with a map derived once from `client-go`'s built-in type scheme (`k8s.io/apimachinery/pkg/api/meta.UnsafeGuessKindToResource` over `scheme.Scheme.AllKnownTypes()`), so it can't silently drift as the Kubernetes API grows.
- **The overlay never applied Kubernetes API defaulting on write**, so real controller code — which assumes an apiserver already defaulted these fields — panicked dereferencing them: `Deployment`/`DaemonSet`/`StatefulSet`'s `.spec.*.rollingUpdate` (nil pointer), `Job.spec.backoffLimit` (nil), `Service.spec.ipFamilies` (empty slice indexed at `[0]`). `client-go`'s own `scheme.Scheme.Default()` doesn't help here — those defaulting functions live in `k8s.io/kubernetes`'s internal packages, not the public client libraries this project vendors — so `writes.go`'s new `applyKnownDefaults` hand-applies the specific, long-stable defaults these controllers need.

### Verification

- Full closed loop confirmed end-to-end, repeatedly, with zero panics: Deployment → ReplicaSet → Pod → KWOK → `Running`, Job/CronJob creation, Service → Endpoints, Service → EndpointSlice.
- Re-ran the upstream `[Conformance]` apps+network subset (103 specs) against the fixed setup: 0 panics across 90 attempted specs (vs. panicking on nearly every attempt beforehand). The strict conformance pass count itself didn't move much — the remaining failures need a real kubelet/container runtime/network stack, categorically out of scope here — but the reconciliation loop itself, which is the actual target use case, now works reliably.
- Filed [#185](https://github.com/phenixblue/k8shark/issues/185) to track a follow-up: Deployment `.status` (`observedGeneration`, replica counts) doesn't reliably sync in at least one conformance scenario, even though a simpler manual repro works fine — needs further investigation, not fixed here.
- New tests: `internal/k8sbin` (version validation, checksum verification, tar-extraction path-traversal/symlink safety), `internal/server` (`TestOverlay_APIDefaulting` covering Deployment/Job/Service defaulting and custom-resource passthrough, expanded `TestResourceToKind`), `cmd` (`TestRunUI_WithKwokImpliesReplayMode`).

## Test plan

- [x] `make fmt` / `make test` / `make lint` all clean
- [x] `go mod tidy` clean (added `k8s.io/utils` as a direct dep for the `ptr` helper)
- [x] Manual end-to-end verification: `kshrk replay --with-kwok --with-controller-manager`, create Deployment/Job/CronJob/Service, confirm ReplicaSet/Pods/Endpoints/EndpointSlice all reconcile correctly with zero panics
- [x] Re-verified after rebasing onto the latest `main` (which landed the unrelated-but-adjacent `--with-kwok` clock-race fix, #183) — no regressions, same clean result

Closes #185? No — #185 is a tracked follow-up, not resolved by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)