### PR TITLE
fix(capture): make capture benchmarks deterministic

### DIFF
--- a/internal/capture/bench_test.go
+++ b/internal/capture/bench_test.go
@@ -13,10 +13,26 @@ import (
 	"github.com/phenixblue/k8shark/internal/config"
 )
 
-// fakeCaptureServer returns a TLS server with realistic responses for
-// benchmark use. It serves pods, nodes, and a /version endpoint.
-func fakeCaptureServer(b *testing.B) *httptest.Server {
-	b.Helper()
+// inProcessTransport serves requests by invoking an http.Handler directly,
+// with no real TCP dial or TLS handshake. Benchmarks use it instead of a real
+// httptest.Server (see fakeCaptureClient) because handshake cost and socket
+// scheduling vary run-to-run enough to dominate B/op measurements; what these
+// benchmarks measure is the capture engine's poll/decode/archive-write path,
+// not the network transport.
+type inProcessTransport struct {
+	handler http.Handler
+}
+
+func (t *inProcessTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rec := httptest.NewRecorder()
+	t.handler.ServeHTTP(rec, req)
+	return rec.Result(), nil
+}
+
+// fakeCaptureClient returns an HTTP client wired to an in-process handler
+// serving pods, nodes, and a /version endpoint, plus the base URL to pass to
+// newEngineWith.
+func fakeCaptureClient() (*http.Client, string) {
 	podList := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[` +
 		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"nginx","namespace":"default"}},` +
 		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"redis","namespace":"default"}}]}`
@@ -24,7 +40,7 @@ func fakeCaptureServer(b *testing.B) *httptest.Server {
 		`{"apiVersion":"v1","kind":"Node","metadata":{"name":"node1"}},` +
 		`{"apiVersion":"v1","kind":"Node","metadata":{"name":"node2"}}]}`
 
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/version":
@@ -37,27 +53,41 @@ func fakeCaptureServer(b *testing.B) *httptest.Server {
 			w.WriteHeader(http.StatusNotFound)
 			fmt.Fprint(w, `{"kind":"Status","code":404}`)
 		}
-	}))
-	return srv
+	})
+
+	client := &http.Client{Transport: &inProcessTransport{handler: handler}}
+	return client, "http://fake-api-server"
+}
+
+// benchPollPasses fixes the number of times each resource is fetched per
+// capture run, matching what a 500ms window at a 200ms poll interval would
+// have produced (immediate fetch + 2 ticks). Engine.pollPasses bypasses the
+// real time.Ticker so each benchmark iteration completes as fast as the fake
+// handler can respond rather than blocking for the configured wall-clock
+// window, letting b.N scale into the thousands.
+const benchPollPasses = 3
+
+func benchConfig(output string) *config.Config {
+	return &config.Config{
+		DurationRaw: "500ms",
+		Duration:    500 * time.Millisecond,
+		Output:      output,
+		Resources: []config.Resource{
+			{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+			{Version: "v1", Resource: "nodes", IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
+		},
+	}
 }
 
 // BenchmarkEngine_CaptureToArchive measures a full capture run writing to a
 // tar.gz archive.
 func BenchmarkEngine_CaptureToArchive(b *testing.B) {
-	srv := fakeCaptureServer(b)
-	defer srv.Close()
+	client, baseURL := fakeCaptureClient()
 
 	for i := 0; i < b.N; i++ {
-		cfg := &config.Config{
-			DurationRaw: "500ms",
-			Duration:    500 * time.Millisecond,
-			Output:      filepath.Join(b.TempDir(), "capture.kshrk"),
-			Resources: []config.Resource{
-				{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
-				{Version: "v1", Resource: "nodes", IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
-			},
-		}
-		eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+		cfg := benchConfig(filepath.Join(b.TempDir(), "capture.kshrk"))
+		eng := newEngineWith(cfg, client, baseURL, false)
+		eng.pollPasses = benchPollPasses
 		if _, err := eng.Run(); err != nil {
 			b.Fatal(err)
 		}
@@ -67,21 +97,13 @@ func BenchmarkEngine_CaptureToArchive(b *testing.B) {
 // BenchmarkEngine_CaptureToNDJSON measures a full capture run writing to NDJSON
 // (no I/O bottleneck from gzip compression).
 func BenchmarkEngine_CaptureToNDJSON(b *testing.B) {
-	srv := fakeCaptureServer(b)
-	defer srv.Close()
+	client, baseURL := fakeCaptureClient()
 
 	for i := 0; i < b.N; i++ {
-		cfg := &config.Config{
-			DurationRaw: "500ms",
-			Duration:    500 * time.Millisecond,
-			Output:      "-",
-			Resources: []config.Resource{
-				{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
-				{Version: "v1", Resource: "nodes", IntervalRaw: "200ms", Interval: 200 * time.Millisecond},
-			},
-		}
-		eng := newEngineWith(cfg, srv.Client(), srv.URL, false)
+		cfg := benchConfig("-")
+		eng := newEngineWith(cfg, client, baseURL, false)
 		eng.sink = archive.NewNDJSONWriter(&bytes.Buffer{})
+		eng.pollPasses = benchPollPasses
 		if _, err := eng.Run(); err != nil {
 			b.Fatal(err)
 		}

--- a/internal/capture/bench_test.go
+++ b/internal/capture/bench_test.go
@@ -80,7 +80,8 @@ func benchConfig(output string) *config.Config {
 }
 
 // BenchmarkEngine_CaptureToArchive measures a full capture run writing to a
-// tar.gz archive.
+// .kshrk archive (a ZIP container with Zstd-compressed record entries; see
+// archive.StreamWriter).
 func BenchmarkEngine_CaptureToArchive(b *testing.B) {
 	client, baseURL := fakeCaptureClient()
 	// archive.NewStreamWriter opens the output path with os.Create (O_TRUNC),
@@ -98,8 +99,9 @@ func BenchmarkEngine_CaptureToArchive(b *testing.B) {
 	}
 }
 
-// BenchmarkEngine_CaptureToNDJSON measures a full capture run writing to NDJSON
-// (no I/O bottleneck from gzip compression).
+// BenchmarkEngine_CaptureToNDJSON measures a full capture run writing NDJSON
+// to an in-memory buffer, with no archive compression in the write path
+// (unlike BenchmarkEngine_CaptureToArchive's Zstd-compressed .kshrk output).
 func BenchmarkEngine_CaptureToNDJSON(b *testing.B) {
 	client, baseURL := fakeCaptureClient()
 

--- a/internal/capture/bench_test.go
+++ b/internal/capture/bench_test.go
@@ -83,9 +83,13 @@ func benchConfig(output string) *config.Config {
 // tar.gz archive.
 func BenchmarkEngine_CaptureToArchive(b *testing.B) {
 	client, baseURL := fakeCaptureClient()
+	// archive.NewStreamWriter opens the output path with os.Create (O_TRUNC),
+	// so reusing one path across iterations is safe and avoids b.TempDir()'s
+	// per-call mkdir overhead from skewing the measurement.
+	output := filepath.Join(b.TempDir(), "capture.kshrk")
 
 	for i := 0; i < b.N; i++ {
-		cfg := benchConfig(filepath.Join(b.TempDir(), "capture.kshrk"))
+		cfg := benchConfig(output)
 		eng := newEngineWith(cfg, client, baseURL, false)
 		eng.pollPasses = benchPollPasses
 		if _, err := eng.Run(); err != nil {

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -88,16 +88,22 @@ const (
 )
 
 type Engine struct {
-	cfg            *config.Config
-	verbose        bool
-	httpClient     *http.Client
-	dynClient      dynamic.Interface // client-go dynamic client used for watch streams
-	baseURL        string
-	mu             sync.Mutex
-	index          Index
-	watchIndex     WatchIndex
-	sink           archive.RecordSink // set by Run(); exposed for tests
-	discoveryCache map[string][]byte  // bodies saved by fetchDiscovery for autoDiscoverResources
+	cfg        *config.Config
+	verbose    bool
+	httpClient *http.Client
+	dynClient  dynamic.Interface // client-go dynamic client used for watch streams
+	baseURL    string
+	mu         sync.Mutex
+	index      Index
+	watchIndex WatchIndex
+	sink       archive.RecordSink // set by Run(); exposed for tests
+	// pollPasses, when non-zero, makes pollResource fetch exactly this many
+	// times back-to-back instead of waiting on a real time.Ticker gated by
+	// res.Interval/e.cfg.Duration. Set by benchmarks so Run() finishes in the
+	// time actual fetches take rather than blocking for the wall-clock capture
+	// window, keeping the number of samples per run deterministic.
+	pollPasses     int
+	discoveryCache map[string][]byte // bodies saved by fetchDiscovery for autoDiscoverResources
 	lastHash       map[string][32]byte
 	dedupSkipped   int
 	warnedFallback map[string]bool // dedup set for allNotFound cluster-scoped fallback warnings
@@ -400,6 +406,13 @@ func kubeconfigLabel(cfg *config.Config) string {
 
 // pollResource polls a single resource kind at its configured interval until ctx is done.
 func (e *Engine) pollResource(ctx context.Context, res config.Resource) {
+	if e.pollPasses > 0 {
+		for i := 0; i < e.pollPasses && ctx.Err() == nil; i++ {
+			e.fetchResource(ctx, res)
+		}
+		return
+	}
+
 	ticker := time.NewTicker(res.Interval)
 	defer ticker.Stop()
 

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -98,10 +98,11 @@ type Engine struct {
 	watchIndex WatchIndex
 	sink       archive.RecordSink // set by Run(); exposed for tests
 	// pollPasses, when non-zero, makes pollResource fetch exactly this many
-	// times back-to-back instead of waiting on a real time.Ticker gated by
-	// res.Interval/e.cfg.Duration. Set by benchmarks so Run() finishes in the
-	// time actual fetches take rather than blocking for the wall-clock capture
-	// window, keeping the number of samples per run deterministic.
+	// times back-to-back instead of waiting on a real time.Ticker paced by
+	// res.Interval and bounded by the capture context's timeout (e.cfg.Duration).
+	// Set by benchmarks so Run() finishes in the time actual fetches take
+	// rather than blocking for the wall-clock capture window, keeping the
+	// number of samples per run deterministic.
 	pollPasses     int
 	discoveryCache map[string][]byte // bodies saved by fetchDiscovery for autoDiscoverResources
 	lastHash       map[string][32]byte
@@ -404,7 +405,9 @@ func kubeconfigLabel(cfg *config.Config) string {
 	return "default"
 }
 
-// pollResource polls a single resource kind at its configured interval until ctx is done.
+// pollResource polls a single resource kind at its configured interval until
+// ctx is done, unless e.pollPasses overrides this with a fixed fetch count
+// (see its doc comment on Engine).
 func (e *Engine) pollResource(ctx context.Context, res config.Resource) {
 	if e.pollPasses > 0 {
 		for i := 0; i < e.pollPasses && ctx.Err() == nil; i++ {


### PR DESCRIPTION
## Summary

- `BenchmarkEngine_CaptureToArchive`/`BenchmarkEngine_CaptureToNDJSON` hardcoded a 500ms real-time capture window with 200ms poll intervals, so `go test -bench` only managed `b.N=2` before the benchtime budget ran out — B/op was dominated by one-off GC/runtime noise, not the actual poll+archive-write work, and swung ~600KB–13MB across commits with no correlation to code changes, triggering spurious `benchmark-action/github-action-benchmark` performance alerts.
- Added `Engine.pollPasses` (benchmark-only): makes `pollResource` fetch a fixed number of times back-to-back instead of waiting on a real `time.Ticker` gated by the wall-clock duration. Production behavior (`pollPasses == 0`, the default) is unchanged.
- Swapped the benchmarks' `httptest.NewTLSServer` for an in-process `http.RoundTripper` — empirically the larger noise source once the ticker wait was removed (real TLS handshake/socket scheduling still caused 10x B/op swings at b.N≈700). Benchmarks now measure the capture engine's poll/decode/archive-write path without network-transport variance.

Result: b.N now scales from 2 into the thousands, and B/op is stable within ~13% (`CaptureToArchive`, bounded by legitimate real gzip/tar file I/O) to <0.1% (`CaptureToNDJSON`, in-memory sink) across repeated `-count=10` runs.

## Test plan

- [x] `go test -bench=BenchmarkEngine_CaptureToArchive -benchmem -run=^$ -count=10 ./internal/capture/...` — B/op stable ~291KB–343KB, b.N≈3400–3700
- [x] `go test -bench=BenchmarkEngine_CaptureToNDJSON -benchmem -run=^$ -count=10 ./internal/capture/...` — B/op stable ~87.9KB, b.N≈8700–9200
- [x] `make fmt` (no diff)
- [x] `make test`
- [x] `make test-race`
- [x] `make lint-ci`
- [x] `go mod tidy` (no diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)