### PR TITLE
build(release): add k8shark@rc Homebrew channel; keep stable tap off prereleases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,10 +50,35 @@ signs:
       - ${artifact}
 
 brews:
+  # Stable channel: `brew install phenixblue/tap/k8shark`. skip_upload=auto keeps
+  # the tap on the latest non-prerelease — a prerelease tag (e.g. -rc.1) does not
+  # overwrite k8shark.rb.
   - name: k8shark
     homepage: https://github.com/phenixblue/k8shark
     description: Kubernetes cluster state capture and mock API replay tool
     license: Apache-2.0
+    skip_upload: auto
+    repository:
+      owner: "{{ .Env.HOMEBREW_TAP_OWNER }}"
+      name: "{{ .Env.HOMEBREW_TAP_NAME }}"
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    commit_author:
+      name: github-actions[bot]
+      email: github-actions[bot]@users.noreply.github.com
+    test: |
+      system "#{bin}/kshrk", "version"
+    install: |
+      bin.install "kshrk"
+
+  # Prerelease channel: `brew install phenixblue/tap/k8shark@rc`. The inverse of
+  # the stable entry — uploads only for prerelease tags (.Prerelease is the semver
+  # prerelease part, non-empty for -rc/-beta tags), so k8shark@rc.rb tracks the
+  # latest RC while stable releases leave it untouched.
+  - name: k8shark@rc
+    homepage: https://github.com/phenixblue/k8shark
+    description: Kubernetes cluster state capture and mock API replay tool (prerelease channel)
+    license: Apache-2.0
+    skip_upload: '{{ if .Prerelease }}false{{ else }}true{{ end }}'
     repository:
       owner: "{{ .Env.HOMEBREW_TAP_OWNER }}"
       name: "{{ .Env.HOMEBREW_TAP_NAME }}"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,11 +14,22 @@
 brew install phenixblue/tap/k8shark
 ```
 
+To follow the **prerelease (release-candidate) channel** instead of stable:
+
+```sh
+brew install phenixblue/tap/k8shark@rc
+```
+
+`k8shark@rc` tracks the latest `-rc` release; `k8shark` tracks the latest stable.
+They install the same `kshrk` binary, so use one or the other (not both at once).
+
 ### go install
 
 ```sh
 go install github.com/phenixblue/k8shark@latest
 ```
+
+For a specific prerelease, pin the tag, e.g. `go install github.com/phenixblue/k8shark@v0.5.1-rc.1`.
 
 The binary is named `kshrk`.
 


### PR DESCRIPTION
## Problem

The GoReleaser `brews:` entry had no `skip_upload`, so cutting a prerelease tag (e.g. `v0.5.1-rc.1`) overwrote the tap's `k8shark.rb`. Right now `brew install phenixblue/tap/k8shark` serves **0.5.1-rc.1** to everyone instead of the latest stable (`v0.4.0`).

## Change (`.goreleaser.yaml`)

- **Stable entry** → `skip_upload: auto`: a prerelease tag no longer updates `k8shark.rb`, so the tap tracks the latest **stable** again.
- **New `k8shark@rc` entry** → the inverse (`skip_upload: '{{ if .Prerelease }}false{{ else }}true{{ end }}'`): uploads only for prerelease tags, so `brew install phenixblue/tap/k8shark@rc` tracks the latest **RC**.

```sh
brew install phenixblue/tap/k8shark       # latest stable
brew install phenixblue/tap/k8shark@rc    # latest release candidate
```

Both formulae install the same `kshrk` binary, so they conflict — users pick a channel (same model as stable-vs-beta casks). Docs (`usage.md`) updated with the `@rc` install and the `go install …@v0.5.1-rc.1` pin.

## Companion PR (the tap)

The tap's `k8shark.rb` is currently pinned to `0.5.1-rc.1`. This config prevents recurrence on the next release but doesn't rewrite the current formula — companion PR resets `k8shark.rb` to `v0.4.0`: https://github.com/phenixblue/homebrew-tap/pull/1

## Notes / verification
- `.Prerelease` is the semver prerelease part (`rc.1`, empty on stable) — truthy for `-rc`/`-beta` tags. Your tags are proper semver (`v0.5.1-rc.1`), and `release.prerelease: auto` already flags the GitHub release correctly.
- GoReleaser generates `k8shark@rc.rb` (class `K8sharkATRc`) automatically. Worth a `goreleaser check` / `goreleaser release --snapshot` locally to confirm the `@`-formula renders before the next tag (goreleaser isn't installed in my env).
- **Merge this before cutting the next release** so the new behavior takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
