### PR TITLE
fix(server): writable overlay fidelity gaps found via the upstream conformance suite

### DIFF
--- a/docs/kwok.md
+++ b/docs/kwok.md
@@ -37,6 +37,24 @@ what KWOK's `pod-ready` stage selects on. It does **not** drive the Pod to
 `Running` — that's KWOK's job, which is what makes the loop realistic rather than
 faked by `kshrk`.
 
+## The LoadBalancer shim
+
+A `Service` of `type: LoadBalancer` never gets an external address without a
+real cloud-controller-manager (or an on-prem equivalent like MetalLB) — nothing
+in `--with-controller-manager`'s curated set provides one, deliberately (see
+"Closing more of the loop" below). Without one, `helm install --wait` and any
+other client polling for `status.loadBalancer.ingress` hangs forever — exactly
+what a chart like `istio/gateway` (which defaults its Service to
+`LoadBalancer`) does.
+
+So the overlay synthesizes one: a `LoadBalancer` Service gets a fake external
+IP in `203.0.113.0/24` (TEST-NET-3, reserved by RFC 5737 for documentation/
+example use, so it can never collide with a real address) as soon as it's
+written. The address is derived from the Service's namespace/name rather than
+assigned by a counter, so it stays the same across repeated writes to the same
+Service instead of changing on every update. Nothing routes traffic to it —
+this only exists to satisfy clients checking for a non-empty ingress.
+
 ## Quickstart: `--with-kwok`
 
 If a [`kwok` binary](https://kwok.sigs.k8s.io/docs/user/install/) is on your

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -247,6 +247,19 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if !h.tryServeFromStore(w, path, replayAt) {
 			h.serveGroupResourceList(w, path)
 		}
+	case strings.HasPrefix(path, "/apis/") && isBareGroupPath(path):
+		// The bare, version-less APIGroup discovery document (distinct from
+		// /apis/<group>/<version>'s resource list) — client-go's discovery
+		// client fetches this to enumerate a group's available versions
+		// before making a versioned request. Not synthesized before, so a
+		// group whose only captured resource is a version nested deeper (or
+		// simply never walked at this exact literal path) 404'd here even
+		// though /apis/<group>/<version> worked fine — breaking any client
+		// that discovers a group this way first (found via the upstream
+		// conformance suite's Ingress/IngressClass API specs).
+		if !h.tryServeFromStore(w, path, replayAt) {
+			h.serveAPIGroup(w, strings.TrimPrefix(path, "/apis/"))
+		}
 	case strings.HasSuffix(path, "/log"):
 		// Pod log sub-resource: serve captured content or a helpful stub.
 		h.serveLog(w, r, path, replayAt)
@@ -272,6 +285,14 @@ func (h *handler) tryServeFromStore(w http.ResponseWriter, path string, at time.
 func isGroupVersionPath(path string) bool {
 	rest := strings.TrimPrefix(path, "/apis/")
 	return len(strings.Split(rest, "/")) == 2
+}
+
+// isBareGroupPath returns true when path is exactly /apis/<group> (no version) —
+// the APIGroup discovery document, distinct from /apis/<group>/<version>'s
+// resource list.
+func isBareGroupPath(path string) bool {
+	rest := strings.TrimPrefix(path, "/apis/")
+	return rest != "" && len(strings.Split(rest, "/")) == 1
 }
 
 func (h *handler) serveVersion(w http.ResponseWriter) {
@@ -344,6 +365,46 @@ func (h *handler) serveAPIGroupList(w http.ResponseWriter) {
 		"kind":       "APIGroupList",
 		"apiVersion": "v1",
 		"groups":     groups,
+	})
+}
+
+// serveAPIGroup serves the single-group APIGroup discovery document for
+// /apis/<group> — the same grouping serveAPIGroupList does for the full
+// cross-group list, scoped to one group. 404s (matching a real apiserver)
+// when the group has no captured resources at all, rather than serving an
+// APIGroup with an empty version list.
+func (h *handler) serveAPIGroup(w http.ResponseWriter, group string) {
+	type gv struct{ version, groupVersion string }
+	var gvs []gv
+	seen := map[string]bool{}
+	for _, ri := range h.store.Resources() {
+		if ri.Group != group {
+			continue
+		}
+		groupVersion := ri.Group + "/" + ri.Version
+		if seen[groupVersion] {
+			continue
+		}
+		seen[groupVersion] = true
+		gvs = append(gvs, gv{ri.Version, groupVersion})
+	}
+	if len(gvs) == 0 {
+		h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("the server could not find the requested resource, group %q not found in capture", group))
+		return
+	}
+	versions := make([]map[string]string, 0, len(gvs))
+	for _, v := range gvs {
+		versions = append(versions, map[string]string{
+			"groupVersion": v.groupVersion,
+			"version":      v.version,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"kind":             "APIGroup",
+		"apiVersion":       "v1",
+		"name":             group,
+		"versions":         versions,
+		"preferredVersion": versions[0],
 	})
 }
 
@@ -432,11 +493,19 @@ func (h *handler) serveGroupResourceList(w http.ResponseWriter, path string) {
 }
 
 func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path string, at time.Time) {
+	g, v, res, ns, name, sub := parseWritePath(strings.TrimSuffix(path, "/"))
+	// GET .../scale works in both writable and read-only replay (unlike scale
+	// writes, which need the overlay) — it's just a read, synthesized from
+	// whatever the underlying object's current spec/status are.
+	if name != "" && sub == "scale" {
+		h.serveScale(w, g, v, res, ns, name, at)
+		return
+	}
+
 	// Writable replay: a single-object GET is served from the overlay when the
 	// overlay owns it (created/updated → the overlay copy; deleted → 404).
 	if h.overlay != nil {
 		h.syncEpoch()
-		g, v, res, ns, name, sub := parseWritePath(strings.TrimSuffix(path, "/"))
 		// A single-object GET in a namespace deleted in the overlay is gone
 		// (cascade), even for captured objects.
 		if name != "" && h.overlay.isNamespaceDeleted(ns) {
@@ -668,6 +737,30 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	_, _ = w.Write(body)
+}
+
+// serveScale handles GET .../scale: synthesizes an autoscaling/v1 Scale
+// representation of the underlying Deployment/ReplicaSet/StatefulSet/
+// ReplicationController — the only built-in Kinds with a real scale
+// subresource on a live apiserver. Works in read-only replay too (unlike
+// scale writes, which need --writable), by resolving the object via
+// objectForRead instead of currentObject.
+func (h *handler) serveScale(w http.ResponseWriter, group, version, resource, namespace, name string, at time.Time) {
+	if !scaleSubresourceResources[resource] {
+		h.writeStatus(w, http.StatusNotFound, resource+" has no scale subresource")
+		return
+	}
+	obj, ok := h.objectForRead(group, version, resource, namespace, name, at)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, notFoundStatus(group, resource, name))
+		return
+	}
+	scale, err := scaleObject(namespace, name, obj)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, statusObj(500, err.Error()))
+		return
+	}
+	writeJSON(w, http.StatusOK, json.RawMessage(scale))
 }
 
 // mergeOverlayList merges overlay objects into a list body for the list's scope.

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -4,10 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
 )
 
 // handler is the http.Handler for the mock Kubernetes API server.
@@ -326,34 +329,33 @@ func (h *handler) serveAPIVersions(w http.ResponseWriter) {
 
 func (h *handler) serveAPIGroupList(w http.ResponseWriter) {
 	// Collect non-core API groups present in the capture.
-	type gv struct{ group, version, groupVersion string }
-	seen := map[string][]gv{}
+	seen := map[string][]groupVersion{}
 	for _, ri := range h.store.Resources() {
 		if ri.Group == "" {
 			continue
 		}
-		groupVersion := ri.Group + "/" + ri.Version
+		gv := groupVersion{ri.Version, ri.Group + "/" + ri.Version}
 		duplicate := false
 		for _, existing := range seen[ri.Group] {
-			if existing.groupVersion == groupVersion {
+			if existing.groupVersion == gv.groupVersion {
 				duplicate = true
 				break
 			}
 		}
 		if !duplicate {
-			seen[ri.Group] = append(seen[ri.Group], gv{ri.Group, ri.Version, groupVersion})
+			seen[ri.Group] = append(seen[ri.Group], gv)
 		}
 	}
 
+	groupNames := make([]string, 0, len(seen))
+	for g := range seen {
+		groupNames = append(groupNames, g)
+	}
+	sort.Strings(groupNames) // seen is a map; iteration order is nondeterministic
+
 	groups := make([]map[string]any, 0, len(seen))
-	for g, gvs := range seen {
-		versions := make([]map[string]string, 0, len(gvs))
-		for _, v := range gvs {
-			versions = append(versions, map[string]string{
-				"groupVersion": v.groupVersion,
-				"version":      v.version,
-			})
-		}
+	for _, g := range groupNames {
+		versions := sortedGroupVersions(seen[g])
 		groups = append(groups, map[string]any{
 			"name":             g,
 			"versions":         versions,
@@ -368,37 +370,58 @@ func (h *handler) serveAPIGroupList(w http.ResponseWriter) {
 	})
 }
 
+// groupVersion is one version entry within a group, as returned by
+// CaptureStore.Resources() (an unordered map iteration — see
+// sortedGroupVersions).
+type groupVersion struct{ version, groupVersion string }
+
+// sortedGroupVersions renders gvs (a single group's versions) as the
+// {groupVersion, version} maps APIGroup/APIGroupList expect, ordered by real
+// Kubernetes version priority (GA descending, then beta descending, then
+// alpha descending — e.g. v2, v1, v1beta2, v1beta1, v1alpha1) so
+// versions[0]/preferredVersion is deterministic and semantically correct.
+// h.store.Resources() iterates a map internally, so gvs arrives in random
+// order on every call — without this, preferredVersion could flip between
+// any of the group's versions from one call to the next.
+func sortedGroupVersions(gvs []groupVersion) []map[string]string {
+	sorted := append([]groupVersion(nil), gvs...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return apimachineryversion.CompareKubeAwareVersionStrings(sorted[i].version, sorted[j].version) > 0
+	})
+	versions := make([]map[string]string, 0, len(sorted))
+	for _, v := range sorted {
+		versions = append(versions, map[string]string{
+			"groupVersion": v.groupVersion,
+			"version":      v.version,
+		})
+	}
+	return versions
+}
+
 // serveAPIGroup serves the single-group APIGroup discovery document for
 // /apis/<group> — the same grouping serveAPIGroupList does for the full
 // cross-group list, scoped to one group. 404s (matching a real apiserver)
 // when the group has no captured resources at all, rather than serving an
 // APIGroup with an empty version list.
 func (h *handler) serveAPIGroup(w http.ResponseWriter, group string) {
-	type gv struct{ version, groupVersion string }
-	var gvs []gv
+	var gvs []groupVersion
 	seen := map[string]bool{}
 	for _, ri := range h.store.Resources() {
 		if ri.Group != group {
 			continue
 		}
-		groupVersion := ri.Group + "/" + ri.Version
-		if seen[groupVersion] {
+		groupVersionStr := ri.Group + "/" + ri.Version
+		if seen[groupVersionStr] {
 			continue
 		}
-		seen[groupVersion] = true
-		gvs = append(gvs, gv{ri.Version, groupVersion})
+		seen[groupVersionStr] = true
+		gvs = append(gvs, groupVersion{ri.Version, groupVersionStr})
 	}
 	if len(gvs) == 0 {
 		h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("the server could not find the requested resource, group %q not found in capture", group))
 		return
 	}
-	versions := make([]map[string]string, 0, len(gvs))
-	for _, v := range gvs {
-		versions = append(versions, map[string]string{
-			"groupVersion": v.groupVersion,
-			"version":      v.version,
-		})
-	}
+	versions := sortedGroupVersions(gvs)
 	writeJSON(w, http.StatusOK, map[string]any{
 		"kind":             "APIGroup",
 		"apiVersion":       "v1",

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -88,6 +88,50 @@ func TestHandler_APIGroupList(t *testing.T) {
 	assertJSON(t, rw, 200, "kind", "APIGroupList")
 }
 
+// TestHandler_APIGroupList_PreferredVersionDeterministic verifies a group
+// with multiple captured versions always reports the highest-priority one
+// (GA over beta/alpha, highest major/minor within a type) as preferredVersion
+// — CaptureStore.Resources() iterates a map internally, so without sorting,
+// preferredVersion could flip between any of the group's versions from one
+// call to the next. Found via Copilot review of the /apis/<group> fix.
+func TestHandler_APIGroupList_PreferredVersionDeterministic(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{
+		"/apis/autoscaling/v2beta2/horizontalpodautoscalers": []byte(`{"kind":"HorizontalPodAutoscalerList","items":[]}`),
+		"/apis/autoscaling/v1/horizontalpodautoscalers":      []byte(`{"kind":"HorizontalPodAutoscalerList","items":[]}`),
+		"/apis/autoscaling/v2beta1/horizontalpodautoscalers": []byte(`{"kind":"HorizontalPodAutoscalerList","items":[]}`),
+		"/apis/autoscaling/v2/horizontalpodautoscalers":      []byte(`{"kind":"HorizontalPodAutoscalerList","items":[]}`),
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	for i := 0; i < 20; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/apis", nil)
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+		var body struct {
+			Groups []struct {
+				Name             string            `json:"name"`
+				PreferredVersion map[string]string `json:"preferredVersion"`
+			} `json:"groups"`
+		}
+		if err := json.Unmarshal(rw.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode: %v\n%s", err, rw.Body.String())
+		}
+		found := false
+		for _, g := range body.Groups {
+			if g.Name != "autoscaling" {
+				continue
+			}
+			found = true
+			if g.PreferredVersion["version"] != "v2" {
+				t.Fatalf("run %d: preferredVersion = %v, want v2 (highest GA)", i, g.PreferredVersion)
+			}
+		}
+		if !found {
+			t.Fatalf("run %d: autoscaling group missing from /apis", i)
+		}
+	}
+}
+
 func TestHandler_CoreResourceList(t *testing.T) {
 	store := buildTestStore(t, map[string][]byte{
 		"/api/v1/namespaces/default/pods": []byte(`{"kind":"PodList","items":[]}`),
@@ -153,6 +197,33 @@ func TestHandler_BareGroupDiscovery(t *testing.T) {
 	}
 	if body.PreferredVersion["groupVersion"] != "networking.k8s.io/v1" {
 		t.Errorf("preferredVersion = %v", body.PreferredVersion)
+	}
+}
+
+// TestHandler_BareGroupDiscovery_PreferredVersionDeterministic is
+// serveAPIGroup's analog of TestHandler_APIGroupList_PreferredVersionDeterministic.
+func TestHandler_BareGroupDiscovery_PreferredVersionDeterministic(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{
+		"/apis/autoscaling/v2beta2/horizontalpodautoscalers": []byte(`{"kind":"HorizontalPodAutoscalerList","items":[]}`),
+		"/apis/autoscaling/v1/horizontalpodautoscalers":      []byte(`{"kind":"HorizontalPodAutoscalerList","items":[]}`),
+		"/apis/autoscaling/v2beta1/horizontalpodautoscalers": []byte(`{"kind":"HorizontalPodAutoscalerList","items":[]}`),
+		"/apis/autoscaling/v2/horizontalpodautoscalers":      []byte(`{"kind":"HorizontalPodAutoscalerList","items":[]}`),
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	for i := 0; i < 20; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/apis/autoscaling", nil)
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+		var body struct {
+			PreferredVersion map[string]string `json:"preferredVersion"`
+		}
+		if err := json.Unmarshal(rw.Body.Bytes(), &body); err != nil {
+			t.Fatalf("run %d: decode: %v\n%s", i, err, rw.Body.String())
+		}
+		if body.PreferredVersion["version"] != "v2" {
+			t.Fatalf("run %d: preferredVersion = %v, want v2 (highest GA)", i, body.PreferredVersion)
+		}
 	}
 }
 

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -114,6 +114,65 @@ func TestHandler_GroupResourceList(t *testing.T) {
 	assertJSON(t, rw, 200, "kind", "APIResourceList")
 }
 
+// TestHandler_BareGroupDiscovery verifies GET /apis/<group> (no version) —
+// the APIGroup discovery document distinct from /apis/<group>/<version>'s
+// resource list — synthesizes an APIGroup rather than 404ing. client-go's
+// discovery client fetches this to enumerate a group's versions before
+// making a versioned request; found missing via the upstream conformance
+// suite's Ingress/IngressClass API specs, which do exactly that.
+func TestHandler_BareGroupDiscovery(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{
+		"/apis/networking.k8s.io/v1/ingresses": []byte(`{"kind":"IngressList","items":[]}`),
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/apis/networking.k8s.io", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rw.Code, rw.Body.String())
+	}
+	var body struct {
+		Kind             string              `json:"kind"`
+		Name             string              `json:"name"`
+		Versions         []map[string]string `json:"versions"`
+		PreferredVersion map[string]string   `json:"preferredVersion"`
+	}
+	if err := json.Unmarshal(rw.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v\n%s", err, rw.Body.String())
+	}
+	if body.Kind != "APIGroup" {
+		t.Errorf("kind = %q, want APIGroup", body.Kind)
+	}
+	if body.Name != "networking.k8s.io" {
+		t.Errorf("name = %q, want networking.k8s.io", body.Name)
+	}
+	if len(body.Versions) != 1 || body.Versions[0]["groupVersion"] != "networking.k8s.io/v1" {
+		t.Errorf("versions = %v, want [{groupVersion: networking.k8s.io/v1, version: v1}]", body.Versions)
+	}
+	if body.PreferredVersion["groupVersion"] != "networking.k8s.io/v1" {
+		t.Errorf("preferredVersion = %v", body.PreferredVersion)
+	}
+}
+
+// TestHandler_BareGroupDiscovery_UnknownGroup404s verifies a group with no
+// captured resources 404s rather than serving an empty-versions APIGroup.
+func TestHandler_BareGroupDiscovery_UnknownGroup404s(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/default/pods": []byte(`{"kind":"PodList","items":[]}`),
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/apis/does-not-exist.example.com", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404: %s", rw.Code, rw.Body.String())
+	}
+}
+
 // TestHandler_NotFound_ListPath verifies that a list-level resource not in the capture
 // returns 200 + empty list + Warning header rather than a 404 error.
 func TestHandler_NotFound_ListPath(t *testing.T) {

--- a/internal/server/overlay.go
+++ b/internal/server/overlay.go
@@ -47,7 +47,8 @@ type overlayEntry struct {
 	namespace, name          string
 	obj                      json.RawMessage // last-known body (kept even when deleted, for the DELETED event)
 	deleted                  bool            // tombstone
-	rv                       int64
+	rv                       int64           // RV of the most recent write
+	createdRV                int64           // RV of the write that (re-)created this identity; see store
 }
 
 // overlayWatchEvent is a single live overlay change delivered to subscribers.
@@ -196,6 +197,29 @@ func (o *overlay) scopeRV(group, version, resource, namespace string) int64 {
 	return maxRV
 }
 
+// entriesSince returns every overlay entry in scope (group/version/resource,
+// and namespace — empty for cluster-wide, matching applyToList/scopeRV) whose
+// last write RV exceeds floorRV — live or tombstoned — plus the highest RV
+// among them (floorRV itself if none matched). Used to catch a resuming watch
+// (resourceVersion=X>0) up on overlay writes already committed between X and
+// when the watch actually connects; see streamReplayWatch's resume branch.
+func (o *overlay) entriesSince(group, version, resource, namespace string, floorRV int64) ([]*overlayEntry, int64) {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	var out []*overlayEntry
+	maxRV := floorRV
+	for _, e := range o.items {
+		if e.group == group && e.version == version && e.resource == resource &&
+			(namespace == "" || e.namespace == namespace) && e.rv > floorRV {
+			out = append(out, e)
+			if e.rv > maxRV {
+				maxRV = e.rv
+			}
+		}
+	}
+	return out, maxRV
+}
+
 // bumpRV advances the monotonic counter to at least floorRV+1 and returns it.
 // Callers hold o.mu.
 func (o *overlay) bumpRVLocked(floorRV int64) int64 {
@@ -224,12 +248,14 @@ func (o *overlay) store(group, version, resource, namespace, name string, obj js
 	defer o.mu.Unlock()
 	key := overlayKey(group, version, resource, namespace, name)
 	typ := "ADDED"
+	createdRV := rv
 	if prior, ok := o.items[key]; ok && !prior.deleted {
 		typ = "MODIFIED"
+		createdRV = prior.createdRV // preserve — this identity isn't new
 	}
 	o.items[key] = &overlayEntry{
 		group: group, version: version, resource: resource,
-		namespace: namespace, name: name, obj: obj, rv: rv,
+		namespace: namespace, name: name, obj: obj, rv: rv, createdRV: createdRV,
 	}
 	o.publishLocked(overlayWatchEvent{
 		typ: typ, rv: rv, obj: obj,
@@ -252,7 +278,7 @@ func (o *overlay) storeIfAbsent(group, version, resource, namespace, name string
 	}
 	o.items[key] = &overlayEntry{
 		group: group, version: version, resource: resource,
-		namespace: namespace, name: name, obj: obj, rv: rv,
+		namespace: namespace, name: name, obj: obj, rv: rv, createdRV: rv,
 	}
 	o.publishLocked(overlayWatchEvent{
 		typ: "ADDED", rv: rv, obj: obj,

--- a/internal/server/watch_overlay_test.go
+++ b/internal/server/watch_overlay_test.go
@@ -63,6 +63,98 @@ func TestOverlay_WatchFeedback_LiveWrites(t *testing.T) {
 	}
 }
 
+// TestOverlay_WatchResume_CatchesUpMissedOverlayWrite reproduces the exact
+// race client-go's List-then-Watch pattern relies on a real apiserver's watch
+// cache to cover: List() to get a baseline resourceVersion, create an object
+// (landing in the overlay, bumping the RV past that baseline) — *completing*
+// before the watch is ever opened — then resume a watch from the baseline RV,
+// expecting to see the object's ADDED event even though it already happened.
+// Found via running the upstream conformance suite: "Deployment should run
+// the lifecycle of a Deployment" hung forever ("failed to see ADDED event:
+// timed out") on exactly this, since the overlay's live pub-sub only reaches
+// watchers already subscribed at write time.
+func TestOverlay_WatchResume_CatchesUpMissedOverlayWrite(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{podsPath: {id: "s", at: from, body: emptyPodList}}, nil)
+	srv := newWritableServer(t, store, clock)
+
+	// Baseline: LIST to get a resourceVersion, as client-go's Reflector does
+	// before opening a watch.
+	_, list := doReq(t, http.MethodGet, srv.URL+podsPath, "", "")
+	var l struct {
+		Metadata struct {
+			ResourceVersion string `json:"resourceVersion"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(list, &l); err != nil {
+		t.Fatalf("decode list: %v\n%s", err, list)
+	}
+	baselineRV := l.Metadata.ResourceVersion
+	if baselineRV == "" {
+		t.Fatalf("list has no resourceVersion: %s", list)
+	}
+
+	// The object is created — and the request completes — before the watch is
+	// ever opened, exactly like the conformance spec's Create-then-Watch order.
+	if code, body := doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-missed")); code != http.StatusCreated {
+		t.Fatalf("create: status %d: %s", code, body)
+	}
+
+	// Resuming a watch from the baseline RV must still surface the object.
+	next, _, cancel := openWatchStream(t, srv.URL+podsPath+"?watch=1&resourceVersion="+baselineRV)
+	defer cancel()
+	if e := nextNonBookmark(next); e.Type != "ADDED" || e.Object.Metadata.Name != "pod-missed" {
+		t.Fatalf("resumed watch: got %s/%s, want ADDED/pod-missed", e.Type, e.Object.Metadata.Name)
+	}
+}
+
+// TestOverlay_WatchResume_CatchesUpAsModified is the update-side counterpart:
+// an identity that already existed as of the client's resume RV, and was then
+// changed (not created) between that RV and the watch connecting, must be
+// replayed as MODIFIED — not ADDED, which a client's watch.Modified-only
+// condition function (e.g. waiting for a status update) would never match,
+// hanging exactly like the ADDED case ("failed to see MODIFIED event: timed
+// out", also found via the "Deployment should run the lifecycle" spec, a step
+// further than the ADDED race).
+func TestOverlay_WatchResume_CatchesUpAsModified(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{podsPath: {id: "s", at: from, body: emptyPodList}}, nil)
+	srv := newWritableServer(t, store, clock)
+
+	// The pod is created and already visible before the client's baseline LIST.
+	if code, body := doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-modded")); code != http.StatusCreated {
+		t.Fatalf("create: status %d: %s", code, body)
+	}
+	_, list := doReq(t, http.MethodGet, srv.URL+podsPath, "", "")
+	var l struct {
+		Metadata struct {
+			ResourceVersion string `json:"resourceVersion"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(list, &l); err != nil {
+		t.Fatalf("decode list: %v\n%s", err, list)
+	}
+	baselineRV := l.Metadata.ResourceVersion
+
+	// Updated — and the request completes — before the watch is ever opened.
+	if code, body := doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-modded",
+		"application/merge-patch+json", `{"metadata":{"labels":{"tier":"web"}}}`); code != 200 {
+		t.Fatalf("patch: status %d: %s", code, body)
+	}
+
+	// Resuming a watch from the baseline RV must surface the update as
+	// MODIFIED, since the object already existed as of that RV.
+	next, _, cancel := openWatchStream(t, srv.URL+podsPath+"?watch=1&resourceVersion="+baselineRV)
+	defer cancel()
+	if e := nextNonBookmark(next); e.Type != "MODIFIED" || e.Object.Metadata.Name != "pod-modded" {
+		t.Fatalf("resumed watch: got %s/%s, want MODIFIED/pod-modded", e.Type, e.Object.Metadata.Name)
+	}
+}
+
 // TestOverlay_WatchFeedback_OverlayWinsSuppression verifies that once the overlay
 // owns an identity, replayed captured events for that identity are suppressed —
 // the overlay copy wins — while events for unowned identities still replay.

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -429,6 +430,43 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 			emit("ADDED", withResourceVersion(item, minRV))
 		}
 		emitBookmark(list, minRV, sendInitialEvents)
+	} else if h.overlay != nil {
+		// Catch up on overlay writes already committed between reqRV and now — the
+		// exact race client-go's List-then-Watch pattern relies on a real
+		// apiserver's watch cache to cover (List gets RV=X, an object is created,
+		// *then* the client watches from X expecting to see it). Our overlay's live
+		// pub-sub (the pump below) only reaches watchers already subscribed at
+		// write time; a subscription created after the write — which is exactly
+		// what happens here, since subscribe() (above) necessarily runs after any
+		// write that already completed before this request even arrived — would
+		// otherwise miss it forever, hanging any client that resumes a watch
+		// expecting to observe its own just-created object (#185's watch-ADDED
+		// timeouts, e.g. "Deployment should run the lifecycle of a Deployment").
+		entries, caughtUpRV := h.overlay.entriesSince(g, v, resource, watchNS, reqRV)
+		sort.Slice(entries, func(i, j int) bool { return entries[i].rv < entries[j].rv })
+		for _, e := range entries {
+			if !matchesSelectors(e.obj, labelSel, fieldSel) {
+				continue
+			}
+			switch {
+			case e.deleted:
+				emit("DELETED", withResourceVersion(e.obj, e.rv))
+			case e.createdRV > reqRV:
+				// This identity didn't exist as of the client's RV — its List
+				// (or an earlier resumed watch) never saw it.
+				emit("ADDED", withResourceVersion(e.obj, e.rv))
+			default:
+				// Already existed as of the client's RV; it's since changed.
+				emit("MODIFIED", withResourceVersion(e.obj, e.rv))
+			}
+		}
+		// Events up to caughtUpRV are now reflected in the client's stream; the
+		// live pump below only needs to deliver anything after that (mirroring how
+		// the !resume branch's overlaySkip = list.OverlaySkipRV keeps the fresh
+		// burst and the live pump from double-delivering the same write).
+		if caughtUpRV > overlaySkip {
+			overlaySkip = caughtUpRV
+		}
 	}
 
 	// Overlay pump: deliver live overlay writes (create/update/delete) as watch

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"net"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -60,10 +62,18 @@ func (h *handler) handleWrite(w http.ResponseWriter, r *http.Request, path strin
 			h.writeStatus(w, http.StatusBadRequest, "PUT requires an object name")
 			return
 		}
+		if sub == "scale" {
+			h.overlayScaleWrite(w, r, group, version, resource, namespace, name)
+			return
+		}
 		h.overlayReplace(w, r, group, version, resource, namespace, name, sub)
 	case http.MethodPatch:
 		if name == "" {
 			h.writeStatus(w, http.StatusBadRequest, "PATCH requires an object name")
+			return
+		}
+		if sub == "scale" {
+			h.overlayScaleWrite(w, r, group, version, resource, namespace, name)
 			return
 		}
 		h.overlayPatch(w, r, group, version, resource, namespace, name, sub)
@@ -135,6 +145,17 @@ func (h *handler) overlayCreate(w http.ResponseWriter, r *http.Request, group, v
 		return
 	}
 
+	obj := h.storeNewObject(group, version, resource, namespace, name, body)
+	writeJSON(w, http.StatusCreated, json.RawMessage(stampTypeMeta(group, version, resource, obj)))
+}
+
+// storeNewObject stamps and stores a brand-new object identity in the overlay,
+// applying the same create-time side effects regardless of whether the create
+// arrived via POST (overlayCreate) or a first Server-Side Apply PATCH
+// (overlayApplyCreate): the Pod scheduling/pending shim, RV/uid/creationTimestamp
+// stamping, and namespace-default synthesis. Callers are responsible for any
+// pre-checks (identity match, AlreadyExists) — this always stores.
+func (h *handler) storeNewObject(group, version, resource, namespace, name string, body json.RawMessage) json.RawMessage {
 	if group == "" && resource == "pods" {
 		// The apiserver stamps a freshly created Pod with status.phase=Pending; the
 		// overlay has no registry doing that. Replicate it — both for fidelity and
@@ -166,7 +187,7 @@ func (h *handler) overlayCreate(w http.ResponseWriter, r *http.Request, group, v
 	if group == "" && resource == "namespaces" {
 		h.ensureNamespaceDefaults(name)
 	}
-	writeJSON(w, http.StatusCreated, json.RawMessage(obj))
+	return obj
 }
 
 // ensureNamespaceDefaults synthesizes the per-namespace objects a real cluster's
@@ -408,13 +429,13 @@ func (h *handler) overlayReplace(w http.ResponseWriter, r *http.Request, group, 
 	}
 	var next json.RawMessage
 	if sub == "status" {
-		next = replaceField(current, "status", body) // status subresource: only status changes
+		next = protectSpecOnly(body, current)
 	} else {
 		next = body
 	}
 	// Status updates don't bump generation (which tracks spec changes).
 	next = h.stampUpdate(next, current, group, version, resource, namespace, name, sub != "status")
-	writeJSON(w, http.StatusOK, json.RawMessage(next))
+	writeJSON(w, http.StatusOK, json.RawMessage(stampTypeMeta(group, version, resource, next)))
 }
 
 func (h *handler) overlayPatch(w http.ResponseWriter, r *http.Request, group, version, resource, namespace, name, sub string) {
@@ -439,6 +460,18 @@ func (h *handler) overlayPatch(w http.ResponseWriter, r *http.Request, group, ve
 	}
 	current := h.currentObject(group, version, resource, namespace, name)
 	if current == nil {
+		// Server-Side Apply (Content-Type: application/apply-patch+yaml) is
+		// create-or-update, matching the real apiserver: a first apply to an
+		// object that doesn't exist yet creates it, rather than 404ing. This is
+		// how `helm install --create-namespace`, `kubectl apply --server-side`,
+		// and CRD/webhook installers all provision brand-new objects — without
+		// this, every first-apply to a not-yet-existing object in the overlay
+		// fails with "object not found". The status subresource can't
+		// create its parent object, so it keeps the 404.
+		if sub == "" && patchMediaType(r.Header.Get("Content-Type")) == "application/apply-patch+yaml" {
+			h.overlayApplyCreate(w, group, version, resource, namespace, name, patch)
+			return
+		}
 		h.writeStatus(w, http.StatusNotFound, "object not found: "+name)
 		return
 	}
@@ -463,13 +496,40 @@ func (h *handler) overlayPatch(w http.ResponseWriter, r *http.Request, group, ve
 	if h.identityMismatch(w, next, name, namespace) {
 		return
 	}
-	// A status-subresource patch may only change status; keep the rest of the
-	// current object, and don't bump generation.
+	// A status-subresource patch protects .spec; don't bump generation (which
+	// tracks spec changes, and spec remains unchanged either way).
 	if sub == "status" {
-		next = replaceField(current, "status", next)
+		next = protectSpecOnly(next, current)
 	}
 	next = h.stampUpdate(next, current, group, version, resource, namespace, name, sub != "status")
-	writeJSON(w, http.StatusOK, json.RawMessage(next))
+	writeJSON(w, http.StatusOK, json.RawMessage(stampTypeMeta(group, version, resource, next)))
+}
+
+// overlayApplyCreate handles a Server-Side Apply PATCH targeting an object
+// identity that doesn't exist yet: the patch's YAML body is the entire desired
+// object (there's no `current` to merge onto), so it's decoded and stored
+// through the same create path as a POST (storeNewObject), rather than
+// jsonpatch-merged. Responds 201, matching a real apiserver's response to a
+// first apply that creates an object.
+func (h *handler) overlayApplyCreate(w http.ResponseWriter, group, version, resource, namespace, name string, patch []byte) {
+	j, err := yaml.YAMLToJSON(patch)
+	if err != nil {
+		h.writeStatus(w, http.StatusBadRequest, "decoding apply patch: "+err.Error())
+		return
+	}
+	if !isJSONObject(j) {
+		h.writeStatus(w, http.StatusUnprocessableEntity, "apply patch did not produce a JSON object")
+		return
+	}
+	body := json.RawMessage(j)
+	if gvk, known := kindForResource(schema.GroupVersion{Group: group, Version: version}, resource); known {
+		body = defaultObject(gvk, body)
+	}
+	if h.identityMismatch(w, body, name, namespace) {
+		return
+	}
+	obj := h.storeNewObject(group, version, resource, namespace, name, body)
+	writeJSON(w, http.StatusCreated, json.RawMessage(stampTypeMeta(group, version, resource, obj)))
 }
 
 // deleteOneObject tombstones a single object identity if it currently exists
@@ -718,6 +778,198 @@ func (h *handler) currentObject(group, version, resource, namespace, name string
 	return body
 }
 
+// objectForRead resolves a single object for a read (GET-style) request,
+// correctly whether or not the overlay is enabled. currentObject always calls
+// h.overlay.get, which panics on a nil *overlay — safe only on the write path,
+// which is reached exclusively when h.overlay != nil. This is the read-path
+// equivalent, used by serveScale (GET works in read-only replay too, unlike
+// scale writes).
+func (h *handler) objectForRead(group, version, resource, namespace, name string, at time.Time) (json.RawMessage, bool) {
+	if h.overlay != nil {
+		obj := h.currentObject(group, version, resource, namespace, name)
+		return obj, obj != nil
+	}
+	body, code := h.trySingleItemGet(listPathFor(group, version, resource, namespace)+"/"+name, at)
+	return body, code == 200
+}
+
+// scaleSubresourceResources are the built-in Kinds with a real /scale
+// subresource on a live apiserver (Deployment, ReplicaSet, StatefulSet,
+// ReplicationController) — anything else 404s, matching upstream.
+var scaleSubresourceResources = map[string]bool{
+	"deployments":            true,
+	"replicasets":            true,
+	"statefulsets":           true,
+	"replicationcontrollers": true,
+}
+
+// scaleObject synthesizes an autoscaling/v1 Scale representation of a
+// Deployment/ReplicaSet/StatefulSet/ReplicationController — the real
+// apiserver does the same conversion server-side for its generic scale
+// subresource (e.g. pkg/registry/apps/deployment/storage's scaleClient).
+func scaleObject(namespace, name string, obj json.RawMessage) (json.RawMessage, error) {
+	var o struct {
+		Metadata struct {
+			UID             string `json:"uid"`
+			ResourceVersion string `json:"resourceVersion"`
+		} `json:"metadata"`
+		Spec struct {
+			Replicas *int32                `json:"replicas"`
+			Selector *metav1.LabelSelector `json:"selector"`
+		} `json:"spec"`
+		Status struct {
+			Replicas int32 `json:"replicas"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal(obj, &o); err != nil {
+		return nil, err
+	}
+	var replicas int32
+	if o.Spec.Replicas != nil {
+		replicas = *o.Spec.Replicas
+	}
+	// HPA (and kubectl) reads status.selector to count matching Pods directly,
+	// rather than via the scaled resource's own selector field.
+	selectorStr := ""
+	if o.Spec.Selector != nil {
+		if sel, err := metav1.LabelSelectorAsSelector(o.Spec.Selector); err == nil {
+			selectorStr = sel.String()
+		}
+	}
+	return json.Marshal(map[string]any{
+		"apiVersion": "autoscaling/v1",
+		"kind":       "Scale",
+		"metadata": map[string]any{
+			"name":            name,
+			"namespace":       namespace,
+			"uid":             o.Metadata.UID,
+			"resourceVersion": o.Metadata.ResourceVersion,
+		},
+		"spec":   map[string]any{"replicas": replicas},
+		"status": map[string]any{"replicas": o.Status.Replicas, "selector": selectorStr},
+	})
+}
+
+// scaleReplicas extracts .spec.replicas from a Scale-shaped body (the PUT
+// body, or a patch already applied onto a synthesized current Scale).
+func scaleReplicas(body []byte) (int32, error) {
+	var s struct {
+		Spec struct {
+			Replicas int32 `json:"replicas"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal(body, &s); err != nil {
+		return 0, err
+	}
+	return s.Spec.Replicas, nil
+}
+
+// setSpecReplicas returns body with spec.replicas set, preserving the rest of
+// the object. On a decode/encode error the body is returned unchanged.
+func setSpecReplicas(body json.RawMessage, replicas int32) json.RawMessage {
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil || m == nil {
+		return body
+	}
+	spec, ok := m["spec"].(map[string]any)
+	if !ok || spec == nil {
+		spec = map[string]any{}
+		m["spec"] = spec
+	}
+	spec["replicas"] = replicas
+	out, err := json.Marshal(m)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+// overlayScaleWrite handles PUT/PATCH .../scale: only .spec.replicas on the
+// underlying object is settable this way (matching the real apiserver's scale
+// subresource — every other field, including the rest of .spec, is read-only
+// through this path), so unlike overlayReplace/overlayPatch there's no
+// defaultObject/identityMismatch handling here — those apply to the
+// underlying resource's own body shape, not a Scale request.
+func (h *handler) overlayScaleWrite(w http.ResponseWriter, r *http.Request, group, version, resource, namespace, name string) {
+	if !scaleSubresourceResources[resource] {
+		h.writeStatus(w, http.StatusNotFound, resource+" has no scale subresource")
+		return
+	}
+	current := h.currentObject(group, version, resource, namespace, name)
+	if current == nil {
+		h.writeStatus(w, http.StatusNotFound, "object not found: "+name)
+		return
+	}
+
+	var replicas int32
+	if r.Method == http.MethodPut {
+		body, ok := h.readObjectBody(w, r)
+		if !ok {
+			return
+		}
+		rep, err := scaleReplicas(body)
+		if err != nil {
+			h.writeStatus(w, http.StatusBadRequest, "decoding scale: "+err.Error())
+			return
+		}
+		replicas = rep
+	} else { // PATCH
+		if !supportedPatchType(r.Header.Get("Content-Type")) {
+			h.writeStatus(w, http.StatusUnsupportedMediaType,
+				"unsupported patch Content-Type "+strconv.Quote(r.Header.Get("Content-Type")))
+			return
+		}
+		patch, err := io.ReadAll(io.LimitReader(r.Body, maxWriteBytes))
+		if err != nil {
+			h.writeStatus(w, http.StatusBadRequest, "reading body: "+err.Error())
+			return
+		}
+		currentScale, err := scaleObject(namespace, name, current)
+		if err != nil {
+			h.writeStatus(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		// Scale has no listType/patchMergeKey fields to strategically merge, so
+		// treat a strategic-merge-patch request the same as a plain merge patch
+		// rather than resolving it against the underlying resource's own Kind
+		// (which has an entirely different shape than Scale).
+		patched, perr := jsonMergeOrPatch(currentScale, patch, r.Header.Get("Content-Type"))
+		if perr != nil {
+			h.writeStatus(w, http.StatusUnprocessableEntity, "applying patch: "+perr.Error())
+			return
+		}
+		rep, err := scaleReplicas(patched)
+		if err != nil {
+			h.writeStatus(w, http.StatusUnprocessableEntity, "patch did not produce a valid scale object")
+			return
+		}
+		replicas = rep
+	}
+
+	next := setSpecReplicas(current, replicas)
+	next = h.stampUpdate(next, current, group, version, resource, namespace, name, true) // scaling is a spec change
+	scale, err := scaleObject(namespace, name, next)
+	if err != nil {
+		h.writeStatus(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, json.RawMessage(scale))
+}
+
+// jsonMergeOrPatch applies patch to current per contentType, supporting JSON
+// Patch (RFC 6902) and treating anything else (merge-patch, strategic-merge,
+// unspecified) as a plain JSON merge patch.
+func jsonMergeOrPatch(current, patch []byte, contentType string) ([]byte, error) {
+	if patchMediaType(contentType) == "application/json-patch+json" {
+		p, err := jsonpatch.DecodePatch(patch)
+		if err != nil {
+			return nil, err
+		}
+		return p.Apply(current)
+	}
+	return jsonpatch.MergePatch(current, patch)
+}
+
 func (h *handler) nowRFC3339() string {
 	if h.clock != nil {
 		return h.clock.Now().UTC().Format(time.RFC3339)
@@ -749,11 +1001,12 @@ func supportedPatchType(contentType string) bool {
 	return false
 }
 
-// applyPatch applies a patch of the given (already-validated) content type to the
-// current object. Supports JSON merge patch, JSON patch (RFC 6902), and
-// strategic-merge patch (for built-in types, via their registered schema).
-// Server-side apply still falls back to a JSON merge patch for now (real SSA
-// field management lands in a later PR).
+// applyPatch applies a patch of the given (already-validated) content type onto
+// an existing current object (the create-on-first-apply case is handled
+// earlier, by overlayApplyCreate, before this is reached). Supports JSON merge
+// patch, JSON patch (RFC 6902), and strategic-merge patch (for built-in types,
+// via their registered schema). Server-side apply still falls back to a JSON
+// merge patch for now (real SSA field management lands in a later PR).
 func applyPatch(current, patch []byte, contentType, group, version, resource string) ([]byte, error) {
 	switch patchMediaType(contentType) {
 	case "application/json-patch+json":
@@ -812,6 +1065,31 @@ func kindForResource(gv schema.GroupVersion, resource string) (schema.GroupVersi
 		}
 	}
 	return schema.GroupVersionKind{}, false
+}
+
+// stampTypeMeta returns obj with apiVersion/kind stamped, for a resource that
+// maps to a known built-in Kind (a no-op via withKind if already present or
+// the Kind is unknown/custom). Reads already do this (see handler.go's
+// trySingleItemGet and watch_replay.go's withKind for streamed events); write
+// responses need it too — client-go's typed Update/UpdateStatus calls
+// round-trip an object fetched via Get/List, whose TypeMeta the apiserver
+// strips on read (a well-known client-go quirk), so the request body often
+// carries no kind/apiVersion at all. A real apiserver's response is always
+// fully typed regardless; without stamping it here, a typed client-go decoder
+// fails the response with `Object 'Kind' is missing` — exactly what broke the
+// deployment controller's DeploymentStatus update path, found via the
+// upstream conformance suite's "Deployment should run the lifecycle of a
+// Deployment" spec.
+func stampTypeMeta(group, version, resource string, obj json.RawMessage) json.RawMessage {
+	gvk, ok := kindForResource(schema.GroupVersion{Group: group, Version: version}, resource)
+	if !ok {
+		return obj
+	}
+	apiVersion := version
+	if group != "" {
+		apiVersion = group + "/" + version
+	}
+	return withKind(obj, apiVersion, gvk.Kind)
 }
 
 // defaultObject applies Kubernetes API defaulting to body — e.g. an empty
@@ -884,7 +1162,12 @@ func defaultObject(gvk schema.GroupVersionKind, body json.RawMessage) json.RawMe
 // (e.g. deployment_util.go's NewRSNewReplicas reads
 // Spec.Strategy.RollingUpdate.MaxSurge), so a Type of "RollingUpdate" with a
 // nil RollingUpdate struct panics deep inside the controller instead of
-// erroring cleanly.
+// erroring cleanly. The same function also dereferences
+// *deployment.Spec.Replicas unconditionally, so a manifest that omits
+// `replicas` (relying on the apiserver's default of 1, as e.g. Istio's charts
+// do) panics the same way — hence Deployment/StatefulSet/ReplicaSet.Replicas
+// are defaulted here too.
+
 // isIPv6Address reports whether s parses as an IPv6 address. Used to infer a
 // Service's address family from an explicit ClusterIP/ClusterIPs value
 // rather than always assuming IPv4; returns false for "" and "None" (a
@@ -892,6 +1175,32 @@ func defaultObject(gvk schema.GroupVersionKind, body json.RawMessage) json.RawMe
 func isIPv6Address(s string) bool {
 	ip := net.ParseIP(s)
 	return ip != nil && ip.To4() == nil
+}
+
+// syntheticLoadBalancerIP deterministically derives a fake external address
+// for a LoadBalancer Service from its identity, landing in TEST-NET-3
+// (203.0.113.0/24 — reserved by RFC 5737 for documentation/example use, so it
+// can never collide with anything real). Deterministic rather than a counter
+// so the same Service gets the same address across repeated writes instead of
+// a new one every time defaultObject runs.
+func syntheticLoadBalancerIP(namespace, name string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(namespace + "/" + name))
+	return fmt.Sprintf("203.0.113.%d", 1+h.Sum32()%254)
+}
+
+// syntheticClusterIP deterministically derives a fake ClusterIP for a Service
+// from its identity, landing in 10.96.0.0/12 — the conventional kubeadm
+// service-cluster-ip-range, so it looks at home next to a typical capture's
+// real ClusterIPs. Deterministic (like syntheticLoadBalancerIP) rather than a
+// counter, so the same Service keeps the same address across repeated writes.
+func syntheticClusterIP(namespace, name string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte("clusterip/" + namespace + "/" + name))
+	sum := h.Sum32()
+	// 10.96.0.0/12 spans 10.96.0.0-10.111.255.255: only the low 4 bits of the
+	// second octet vary (96 = 0110_0000 through 111 = 0110_1111).
+	return fmt.Sprintf("10.%d.%d.%d", 96+sum%16, (sum>>8)%256, 1+(sum>>16)%254)
 }
 
 func applyKnownDefaults(obj runtime.Object) {
@@ -902,6 +1211,23 @@ func applyKnownDefaults(obj runtime.Object) {
 		}
 		if o.Spec.SessionAffinity == "" {
 			o.Spec.SessionAffinity = corev1.ServiceAffinityNone
+		}
+		// The real apiserver's IP allocator assigns every Service a ClusterIP —
+		// even LoadBalancer/NodePort ones — as soon as it's created; the overlay
+		// has no IPAM, so nothing else ever populates this. kstatus's readiness
+		// check for a LoadBalancer Service (which Helm v4's `--wait` uses via
+		// sigs.k8s.io/cli-utils) specifically requires spec.clusterIP to be
+		// non-empty — NOT status.loadBalancer.ingress — so a Service that never
+		// gets one hangs `helm install --wait` forever regardless of the
+		// synthesized external address below. A headless Service
+		// (clusterIP: "None", set explicitly by the client) and ExternalName
+		// Services are left alone — they don't get one on a real cluster either.
+		if o.Spec.Type != corev1.ServiceTypeExternalName && o.Spec.ClusterIP == "" {
+			ip := syntheticClusterIP(o.Namespace, o.Name)
+			o.Spec.ClusterIP = ip
+			if len(o.Spec.ClusterIPs) == 0 {
+				o.Spec.ClusterIPs = []string{ip}
+			}
 		}
 		if len(o.Spec.IPFamilies) == 0 {
 			// The endpoint/endpointslice controllers index IPFamilies[0]
@@ -928,7 +1254,24 @@ func applyKnownDefaults(obj runtime.Object) {
 			}
 			o.Spec.IPFamilies = []corev1.IPFamily{family}
 		}
+		// A real cloud-controller-manager (or an on-prem equivalent like MetalLB)
+		// eventually assigns a LoadBalancer Service an external address;
+		// --with-controller-manager's curated set deliberately excludes
+		// cloud-provider controllers (see cmd/controllermanager.go — no real cloud
+		// provider to ask), so nothing else in the overlay ever populates this
+		// field. Without it, `helm install --wait` and any other client polling
+		// for a LoadBalancer Service to become ready hangs forever. Synthesize an
+		// address deterministically from the Service's identity (rather than a
+		// counter) so repeated writes to the same Service don't reassign it.
+		if o.Spec.Type == corev1.ServiceTypeLoadBalancer && len(o.Status.LoadBalancer.Ingress) == 0 {
+			o.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{
+				{IP: syntheticLoadBalancerIP(o.Namespace, o.Name)},
+			}
+		}
 	case *appsv1.Deployment:
+		if o.Spec.Replicas == nil {
+			o.Spec.Replicas = ptr.To(int32(1))
+		}
 		if o.Spec.Strategy.Type == "" {
 			o.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
 		}
@@ -939,6 +1282,10 @@ func applyKnownDefaults(obj runtime.Object) {
 				MaxUnavailable: &maxUnavailable,
 				MaxSurge:       &maxSurge,
 			}
+		}
+	case *appsv1.ReplicaSet:
+		if o.Spec.Replicas == nil {
+			o.Spec.Replicas = ptr.To(int32(1))
 		}
 	case *appsv1.DaemonSet:
 		if o.Spec.UpdateStrategy.Type == "" {
@@ -952,9 +1299,32 @@ func applyKnownDefaults(obj runtime.Object) {
 				MaxSurge:       &maxSurge,
 			}
 		}
+		// pkg/controller/daemon/update.go's cleanupHistory dereferences
+		// *ds.Spec.RevisionHistoryLimit unconditionally (`toKeep :=
+		// int(*ds.Spec.RevisionHistoryLimit)`) — unlike the deployment
+		// controller's equivalent cleanup, which nil-checks first
+		// (HasRevisionHistoryLimit). A nil value here crashes the whole
+		// daemonset controller goroutine (client-go's crash handler logs it,
+		// then repanics — this isn't a swallowed panic like the others in this
+		// function, it takes the controller-manager process down).
+		if o.Spec.RevisionHistoryLimit == nil {
+			o.Spec.RevisionHistoryLimit = ptr.To(int32(10))
+		}
 	case *appsv1.StatefulSet:
+		if o.Spec.Replicas == nil {
+			o.Spec.Replicas = ptr.To(int32(1))
+		}
 		if o.Spec.UpdateStrategy.Type == "" {
 			o.Spec.UpdateStrategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
+		}
+		// pkg/controller/statefulset/stateful_set_control.go's truncateHistory
+		// dereferences *set.Spec.RevisionHistoryLimit unconditionally
+		// (`historyLimit := int(*set.Spec.RevisionHistoryLimit)`) — same
+		// unguarded-pointer class as DaemonSet's cleanupHistory above, and
+		// likewise fatal to the whole controller-manager process, not just
+		// that one StatefulSet's reconcile.
+		if o.Spec.RevisionHistoryLimit == nil {
+			o.Spec.RevisionHistoryLimit = ptr.To(int32(10))
 		}
 		if o.Spec.PodManagementPolicy == "" {
 			o.Spec.PodManagementPolicy = appsv1.OrderedReadyPodManagement
@@ -1008,7 +1378,7 @@ func allowedMethods(name, sub string) string {
 		return "GET, HEAD, POST, DELETE"
 	case sub == "":
 		return "GET, HEAD, PUT, PATCH, DELETE"
-	case sub == "status":
+	case sub == "status", sub == "scale":
 		return "GET, HEAD, PUT, PATCH"
 	default:
 		return "GET, HEAD"
@@ -1187,8 +1557,25 @@ func mergeMeta(obj json.RawMessage, updates map[string]any) json.RawMessage {
 	return out
 }
 
+// protectSpecOnly returns next with .spec forced back to current's .spec,
+// otherwise unchanged — the status subresource's real apiserver semantics
+// (see e.g. pkg/registry/apps/deployment/strategy.go's
+// deploymentStatusStrategy.PrepareForUpdate): only .spec is universally
+// protected against a status-subresource write, while .status and .metadata
+// (annotations, and often labels — this varies slightly per resource type
+// upstream, but protecting only .spec is the one rule that holds everywhere)
+// pass through from the submitted body. This matters in practice: the
+// deployment controller sets `deployment.kubernetes.io/revision` on the
+// Deployment itself via UpdateStatus (a full-object PUT to .../status), not a
+// spec/metadata write — an earlier version of this code protected all of
+// metadata too, which silently dropped that annotation and broke revision
+// tracking for every Deployment reconciled by --with-controller-manager.
+func protectSpecOnly(next, current json.RawMessage) json.RawMessage {
+	return replaceField(next, "spec", current)
+}
+
 // replaceField returns base with top-level field set to the same field taken
-// from src (used for the status subresource: only status changes).
+// from src.
 func replaceField(base json.RawMessage, field string, src json.RawMessage) json.RawMessage {
 	var b map[string]json.RawMessage
 	if err := json.Unmarshal(base, &b); err != nil || b == nil {

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -19,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -803,6 +804,37 @@ var scaleSubresourceResources = map[string]bool{
 	"replicationcontrollers": true,
 }
 
+// scaleSelectorString renders a resource's .spec.selector as the label-query
+// string HPA (and kubectl) read from a Scale's status.selector — handling
+// both selector shapes real Kubernetes types use: Deployment/ReplicaSet/
+// StatefulSet's structured metav1.LabelSelector ({matchLabels,
+// matchExpressions}), and ReplicationController's plain map[string]string.
+// Trying the map shape first is required, not just sufficient: unmarshaling a
+// flat map like {"app":"foo"} into a LabelSelector struct silently succeeds
+// with a zero-value result (unknown JSON fields are ignored on structs), so
+// checking LabelSelector first would always win and produce an empty
+// selector for every ReplicationController. A real LabelSelector's fields
+// nest an object/array under "matchLabels"/"matchExpressions", which cannot
+// decode into a map[string]string value, so that shape reliably fails first.
+func scaleSelectorString(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var flat map[string]string
+	if err := json.Unmarshal(raw, &flat); err == nil {
+		return labels.SelectorFromSet(flat).String()
+	}
+	var sel metav1.LabelSelector
+	if err := json.Unmarshal(raw, &sel); err != nil {
+		return ""
+	}
+	selector, err := metav1.LabelSelectorAsSelector(&sel)
+	if err != nil {
+		return ""
+	}
+	return selector.String()
+}
+
 // scaleObject synthesizes an autoscaling/v1 Scale representation of a
 // Deployment/ReplicaSet/StatefulSet/ReplicationController — the real
 // apiserver does the same conversion server-side for its generic scale
@@ -814,8 +846,8 @@ func scaleObject(namespace, name string, obj json.RawMessage) (json.RawMessage, 
 			ResourceVersion string `json:"resourceVersion"`
 		} `json:"metadata"`
 		Spec struct {
-			Replicas *int32                `json:"replicas"`
-			Selector *metav1.LabelSelector `json:"selector"`
+			Replicas *int32          `json:"replicas"`
+			Selector json.RawMessage `json:"selector"`
 		} `json:"spec"`
 		Status struct {
 			Replicas int32 `json:"replicas"`
@@ -830,12 +862,7 @@ func scaleObject(namespace, name string, obj json.RawMessage) (json.RawMessage, 
 	}
 	// HPA (and kubectl) reads status.selector to count matching Pods directly,
 	// rather than via the scaled resource's own selector field.
-	selectorStr := ""
-	if o.Spec.Selector != nil {
-		if sel, err := metav1.LabelSelectorAsSelector(o.Spec.Selector); err == nil {
-			selectorStr = sel.String()
-		}
-	}
+	selectorStr := scaleSelectorString(o.Spec.Selector)
 	return json.Marshal(map[string]any{
 		"apiVersion": "autoscaling/v1",
 		"kind":       "Scale",
@@ -957,17 +984,28 @@ func (h *handler) overlayScaleWrite(w http.ResponseWriter, r *http.Request, grou
 }
 
 // jsonMergeOrPatch applies patch to current per contentType, supporting JSON
-// Patch (RFC 6902) and treating anything else (merge-patch, strategic-merge,
-// unspecified) as a plain JSON merge patch.
+// Patch (RFC 6902), Server-Side Apply (application/apply-patch+yaml — the
+// body is YAML, unlike every other supported type here, so it needs
+// converting before merging same as the main write path's applyPatch), and
+// treating anything else (merge-patch, strategic-merge, unspecified) as a
+// plain JSON merge patch.
 func jsonMergeOrPatch(current, patch []byte, contentType string) ([]byte, error) {
-	if patchMediaType(contentType) == "application/json-patch+json" {
+	switch patchMediaType(contentType) {
+	case "application/json-patch+json":
 		p, err := jsonpatch.DecodePatch(patch)
 		if err != nil {
 			return nil, err
 		}
 		return p.Apply(current)
+	case "application/apply-patch+yaml":
+		j, err := yaml.YAMLToJSON(patch)
+		if err != nil {
+			return nil, err
+		}
+		return jsonpatch.MergePatch(current, j)
+	default:
+		return jsonpatch.MergePatch(current, patch)
 	}
-	return jsonpatch.MergePatch(current, patch)
 }
 
 func (h *handler) nowRFC3339() string {

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -344,6 +344,85 @@ func TestOverlay_APIDefaulting(t *testing.T) {
 		}
 	})
 
+	t.Run("Deployment/StatefulSet/ReplicaSet replicas default to 1 when omitted", func(t *testing.T) {
+		// Some charts (e.g. Istio's istiod) omit `replicas` entirely, relying on
+		// the apiserver's default of 1 — a nil Spec.Replicas panics
+		// kube-controller-manager's NewRSNewReplicas (which dereferences it
+		// unconditionally), so the Deployment never gets a ReplicaSet.
+		cases := []struct {
+			name, path, body string
+		}{
+			{"deployment", "/apis/apps/v1/namespaces/default/deployments", `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"no-replicas-d","namespace":"default"},
+				"spec":{"selector":{"matchLabels":{"app":"x"}},
+				"template":{"metadata":{"labels":{"app":"x"}},"spec":{"containers":[{"name":"x","image":"x"}]}}}}`},
+			{"statefulset", "/apis/apps/v1/namespaces/default/statefulsets", `{"apiVersion":"apps/v1","kind":"StatefulSet","metadata":{"name":"no-replicas-s","namespace":"default"},
+				"spec":{"serviceName":"x","selector":{"matchLabels":{"app":"x"}},
+				"template":{"metadata":{"labels":{"app":"x"}},"spec":{"containers":[{"name":"x","image":"x"}]}}}}`},
+			{"replicaset", "/apis/apps/v1/namespaces/default/replicasets", `{"apiVersion":"apps/v1","kind":"ReplicaSet","metadata":{"name":"no-replicas-r","namespace":"default"},
+				"spec":{"selector":{"matchLabels":{"app":"x"}},
+				"template":{"metadata":{"labels":{"app":"x"}},"spec":{"containers":[{"name":"x","image":"x"}]}}}}`},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				code, out := doReq(t, http.MethodPost, srv.URL+c.path, "application/json", c.body)
+				if code != http.StatusCreated {
+					t.Fatalf("create: status %d: %s", code, out)
+				}
+				var d struct {
+					Spec struct {
+						Replicas *int32 `json:"replicas"`
+					} `json:"spec"`
+				}
+				if err := json.Unmarshal(out, &d); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if d.Spec.Replicas == nil || *d.Spec.Replicas != 1 {
+					t.Errorf("replicas = %v, want 1", d.Spec.Replicas)
+				}
+			})
+		}
+	})
+
+	t.Run("StatefulSet/DaemonSet revisionHistoryLimit defaults to 10 when omitted", func(t *testing.T) {
+		// Unlike Deployment's cleanup (which nil-checks via HasRevisionHistoryLimit
+		// before dereferencing), the StatefulSet and DaemonSet controllers'
+		// history-truncation code (truncateHistory / cleanupHistory) dereference
+		// *set.Spec.RevisionHistoryLimit unconditionally — a nil value crashes
+		// the whole controller-manager process (client-go's crash handler logs
+		// it, then repanics), not just that one object's reconcile. Found by
+		// actually running the upstream conformance suite against
+		// --with-controller-manager.
+		cases := []struct {
+			name, path, body string
+		}{
+			{"statefulset", "/apis/apps/v1/namespaces/default/statefulsets", `{"apiVersion":"apps/v1","kind":"StatefulSet","metadata":{"name":"no-rhl-s","namespace":"default"},
+				"spec":{"serviceName":"x","selector":{"matchLabels":{"app":"x"}},
+				"template":{"metadata":{"labels":{"app":"x"}},"spec":{"containers":[{"name":"x","image":"x"}]}}}}`},
+			{"daemonset", "/apis/apps/v1/namespaces/default/daemonsets", `{"apiVersion":"apps/v1","kind":"DaemonSet","metadata":{"name":"no-rhl-d","namespace":"default"},
+				"spec":{"selector":{"matchLabels":{"app":"x"}},
+				"template":{"metadata":{"labels":{"app":"x"}},"spec":{"containers":[{"name":"x","image":"x"}]}}}}`},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				code, out := doReq(t, http.MethodPost, srv.URL+c.path, "application/json", c.body)
+				if code != http.StatusCreated {
+					t.Fatalf("create: status %d: %s", code, out)
+				}
+				var d struct {
+					Spec struct {
+						RevisionHistoryLimit *int32 `json:"revisionHistoryLimit"`
+					} `json:"spec"`
+				}
+				if err := json.Unmarshal(out, &d); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if d.Spec.RevisionHistoryLimit == nil || *d.Spec.RevisionHistoryLimit != 10 {
+					t.Errorf("revisionHistoryLimit = %v, want 10 — a nil value crashes the whole controller-manager process", d.Spec.RevisionHistoryLimit)
+				}
+			})
+		}
+	})
+
 	t.Run("Job backoffLimit and friends", func(t *testing.T) {
 		body := `{"apiVersion":"batch/v1","kind":"Job","metadata":{"name":"hello","namespace":"default"},
 			"spec":{"template":{"spec":{"containers":[{"name":"hello","image":"busybox"}],"restartPolicy":"Never"}}}}`
@@ -541,6 +620,119 @@ func TestOverlay_APIDefaulting(t *testing.T) {
 		}
 		if len(s.Spec.IPFamilies) == 0 || s.Spec.IPFamilies[0] != "IPv4" {
 			t.Errorf("ipFamilies = %v, want [IPv4] matching the primary clusterIP 10.0.0.5", s.Spec.IPFamilies)
+		}
+	})
+
+	t.Run("LoadBalancer Service gets a synthesized external IP", func(t *testing.T) {
+		// No cloud-controller-manager runs against the overlay (see
+		// cmd/controllermanager.go), so nothing else would ever populate
+		// status.loadBalancer.ingress — `helm install --wait` (and any client
+		// polling for a LoadBalancer Service to become ready) hangs without this.
+		body := `{"apiVersion":"v1","kind":"Service","metadata":{"name":"gw","namespace":"default"},
+			"spec":{"type":"LoadBalancer","selector":{"app":"gw"},"ports":[{"port":80}]}}`
+		code, out := doReq(t, http.MethodPost, srv.URL+"/api/v1/namespaces/default/services", "application/json", body)
+		if code != http.StatusCreated {
+			t.Fatalf("create: status %d: %s", code, out)
+		}
+		var s struct {
+			Status struct {
+				LoadBalancer struct {
+					Ingress []struct {
+						IP string `json:"ip"`
+					} `json:"ingress"`
+				} `json:"loadBalancer"`
+			} `json:"status"`
+		}
+		if err := json.Unmarshal(out, &s); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(s.Status.LoadBalancer.Ingress) == 0 || s.Status.LoadBalancer.Ingress[0].IP == "" {
+			t.Fatalf("loadBalancer.ingress is empty — helm install --wait hangs forever on this Service")
+		}
+		gotIP := s.Status.LoadBalancer.Ingress[0].IP
+
+		// A ClusterIP Service (the common case) must not get a bogus LoadBalancer
+		// ingress synthesized.
+		cbody := `{"apiVersion":"v1","kind":"Service","metadata":{"name":"web-clusterip","namespace":"default"},
+			"spec":{"selector":{"app":"nginx"},"ports":[{"port":80}]}}`
+		_, cout := doReq(t, http.MethodPost, srv.URL+"/api/v1/namespaces/default/services", "application/json", cbody)
+		if strings.Contains(string(cout), "loadBalancer") {
+			t.Errorf("ClusterIP Service got a loadBalancer status: %s", cout)
+		}
+
+		// A subsequent write to the same Service (e.g. a label patch) must keep
+		// the same address rather than reassigning a new one.
+		_, patched := doReq(t, http.MethodPatch, srv.URL+"/api/v1/namespaces/default/services/gw",
+			"application/merge-patch+json", `{"metadata":{"labels":{"x":"y"}}}`)
+		var s2 struct {
+			Status struct {
+				LoadBalancer struct {
+					Ingress []struct {
+						IP string `json:"ip"`
+					} `json:"ingress"`
+				} `json:"loadBalancer"`
+			} `json:"status"`
+		}
+		if err := json.Unmarshal(patched, &s2); err != nil {
+			t.Fatalf("decode patched: %v\n%s", err, patched)
+		}
+		if len(s2.Status.LoadBalancer.Ingress) == 0 || s2.Status.LoadBalancer.Ingress[0].IP != gotIP {
+			t.Errorf("loadBalancer ingress changed across writes: got %v, want stable %q", s2.Status.LoadBalancer.Ingress, gotIP)
+		}
+	})
+
+	t.Run("Service gets a synthesized ClusterIP", func(t *testing.T) {
+		// kstatus's readiness check (which Helm v4's `--wait` uses) requires
+		// spec.clusterIP to be non-empty for a LoadBalancer Service — NOT
+		// status.loadBalancer.ingress — so a missing ClusterIP hangs
+		// `helm install --wait` forever even with an external address assigned.
+		body := `{"apiVersion":"v1","kind":"Service","metadata":{"name":"gw-cip","namespace":"default"},
+			"spec":{"type":"LoadBalancer","selector":{"app":"gw"},"ports":[{"port":80}]}}`
+		code, out := doReq(t, http.MethodPost, srv.URL+"/api/v1/namespaces/default/services", "application/json", body)
+		if code != http.StatusCreated {
+			t.Fatalf("create: status %d: %s", code, out)
+		}
+		var s struct {
+			Spec struct {
+				ClusterIP  string   `json:"clusterIP"`
+				ClusterIPs []string `json:"clusterIPs"`
+			} `json:"spec"`
+		}
+		if err := json.Unmarshal(out, &s); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if s.Spec.ClusterIP == "" {
+			t.Fatalf("clusterIP is empty — kstatus reports this LoadBalancer Service InProgress forever")
+		}
+		if len(s.Spec.ClusterIPs) == 0 || s.Spec.ClusterIPs[0] != s.Spec.ClusterIP {
+			t.Errorf("clusterIPs = %v, want [%q]", s.Spec.ClusterIPs, s.Spec.ClusterIP)
+		}
+		gotIP := s.Spec.ClusterIP
+
+		// A headless Service (explicit clusterIP: None) is left alone.
+		hbody := `{"apiVersion":"v1","kind":"Service","metadata":{"name":"headless","namespace":"default"},
+			"spec":{"clusterIP":"None","selector":{"app":"x"},"ports":[{"port":80}]}}`
+		_, hout := doReq(t, http.MethodPost, srv.URL+"/api/v1/namespaces/default/services", "application/json", hbody)
+		if got := metaString(hout, "name"); got != "headless" {
+			t.Fatalf("create headless: %s", hout)
+		}
+		var h struct {
+			Spec struct {
+				ClusterIP string `json:"clusterIP"`
+			} `json:"spec"`
+		}
+		if err := json.Unmarshal(hout, &h); err != nil {
+			t.Fatalf("decode headless: %v", err)
+		}
+		if h.Spec.ClusterIP != "None" {
+			t.Errorf("headless Service clusterIP = %q, want None left untouched", h.Spec.ClusterIP)
+		}
+
+		// A subsequent write keeps the same ClusterIP rather than reassigning one.
+		_, patched := doReq(t, http.MethodPatch, srv.URL+"/api/v1/namespaces/default/services/gw-cip",
+			"application/merge-patch+json", `{"metadata":{"labels":{"x":"y"}}}`)
+		if !strings.Contains(string(patched), `"clusterIP":"`+gotIP+`"`) {
+			t.Errorf("clusterIP changed across writes: %s, want stable %q", patched, gotIP)
 		}
 	})
 
@@ -766,6 +958,107 @@ func TestOverlay_StatusSubresource(t *testing.T) {
 	}
 }
 
+// TestOverlay_StatusPUTSetsAnnotation reproduces the exact write pattern the
+// real deployment controller uses to stamp `deployment.kubernetes.io/revision`
+// onto a Deployment: client-go's UpdateStatus PUTs the *entire* object
+// (metadata included) to .../status. Discovered by actually running the
+// upstream conformance suite against --with-controller-manager: every
+// Deployment reconciled that way never got its revision annotation, because
+// an earlier version of the overlay's status-subresource handling protected
+// all of metadata, not just .spec.
+func TestOverlay_StatusPUTSetsAnnotation(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	deployPath := "/apis/apps/v1/namespaces/default/deployments"
+	depBody := `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"dep-s"},
+		"spec":{"replicas":1,"selector":{"matchLabels":{"app":"x"}},
+		"template":{"metadata":{"labels":{"app":"x"}},"spec":{"containers":[{"name":"x","image":"x"}]}}}}`
+	code, created := doReq(t, http.MethodPost, srv.URL+deployPath, "application/json", depBody)
+	if code != http.StatusCreated {
+		t.Fatalf("create: status %d: %s", code, created)
+	}
+
+	// Simulate UpdateStatus: PUT the whole object (with a new annotation and a
+	// spec change that must NOT take effect) to .../status.
+	var full map[string]any
+	if err := json.Unmarshal(created, &full); err != nil {
+		t.Fatalf("decode created: %v", err)
+	}
+	meta := full["metadata"].(map[string]any)
+	meta["annotations"] = map[string]any{"deployment.kubernetes.io/revision": "1"}
+	full["spec"].(map[string]any)["replicas"] = float64(99) // must be dropped
+	full["status"] = map[string]any{"observedGeneration": float64(1), "replicas": float64(1)}
+	putBody, err := json.Marshal(full)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	code, got := doReq(t, http.MethodPut, srv.URL+deployPath+"/dep-s/status", "application/json", string(putBody))
+	if code != 200 {
+		t.Fatalf("PUT status: %d: %s", code, got)
+	}
+	if !strings.Contains(string(got), `"deployment.kubernetes.io/revision":"1"`) {
+		t.Errorf("annotation set via status PUT did not persist: %s", got)
+	}
+	if strings.Contains(string(got), `"replicas":99`) {
+		t.Errorf("status PUT leaked a spec change: %s", got)
+	}
+	if !strings.Contains(string(got), `"observedGeneration":1`) {
+		t.Errorf("status change did not apply: %s", got)
+	}
+}
+
+// TestOverlay_WriteResponseStampsKind verifies a write response always
+// carries apiVersion/kind, even when the client's request body omitted them —
+// exactly what client-go's typed Update/UpdateStatus calls do (they
+// round-trip an object fetched via Get/List, whose TypeMeta the apiserver
+// strips on read, a well-known client-go quirk). Reads already stamped this;
+// writes didn't, so a typed client-go decoder failed the *response* to its
+// own UpdateStatus call with "Object 'Kind' is missing" — found via the
+// upstream conformance suite's "Deployment should run the lifecycle of a
+// Deployment" spec, which does exactly this after creating a Deployment.
+func TestOverlay_WriteResponseStampsKind(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	deployPath := "/apis/apps/v1/namespaces/default/deployments"
+	// No apiVersion/kind at all — mirrors a client-go object fetched via
+	// Get/List, whose TypeMeta the apiserver strips.
+	noKindBody := `{"metadata":{"name":"d-nokind"},
+		"spec":{"replicas":1,"selector":{"matchLabels":{"app":"x"}},
+		"template":{"metadata":{"labels":{"app":"x"}},"spec":{"containers":[{"name":"x","image":"x"}]}}}}`
+	code, created := doReq(t, http.MethodPost, srv.URL+deployPath, "application/json", noKindBody)
+	if code != http.StatusCreated {
+		t.Fatalf("create: status %d: %s", code, created)
+	}
+	if !strings.Contains(string(created), `"apiVersion":"apps/v1"`) || !strings.Contains(string(created), `"kind":"Deployment"`) {
+		t.Errorf("create response missing apiVersion/kind: %s", created)
+	}
+
+	// PUT .../status with a body that (like a real UpdateStatus call) also
+	// carries no apiVersion/kind.
+	putBody := `{"metadata":{"name":"d-nokind","namespace":"default"},"status":{"readyReplicas":1}}`
+	code, put := doReq(t, http.MethodPut, srv.URL+deployPath+"/d-nokind/status", "application/json", putBody)
+	if code != 200 {
+		t.Fatalf("PUT status: status %d: %s", code, put)
+	}
+	if !strings.Contains(string(put), `"apiVersion":"apps/v1"`) || !strings.Contains(string(put), `"kind":"Deployment"`) {
+		t.Errorf("PUT status response missing apiVersion/kind: %s", put)
+	}
+
+	// PATCH .../status likewise.
+	code, patched := doReq(t, http.MethodPatch, srv.URL+deployPath+"/d-nokind/status",
+		"application/merge-patch+json", `{"status":{"readyReplicas":2}}`)
+	if code != 200 {
+		t.Fatalf("PATCH status: status %d: %s", code, patched)
+	}
+	if !strings.Contains(string(patched), `"apiVersion":"apps/v1"`) || !strings.Contains(string(patched), `"kind":"Deployment"`) {
+		t.Errorf("PATCH status response missing apiVersion/kind: %s", patched)
+	}
+}
+
 func TestOverlay_CreateConflict(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
@@ -788,11 +1081,146 @@ func TestOverlay_UnknownSubresourceRejected(t *testing.T) {
 	srv := newWritableServer(t, writableTestStore(t, from), clock)
 	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-x"))
 
-	if code, _ := doReq(t, http.MethodPut, srv.URL+podsPath+"/pod-x/scale", "application/json", `{"spec":{"replicas":2}}`); code != http.StatusMethodNotAllowed {
+	// "scale" itself isn't a good example here: it's a real subresource, just
+	// inapplicable to Pods (see TestOverlay_Scale_UnsupportedResourceRejected
+	// for that 404 case). Use a name that isn't a subresource on anything.
+	if code, _ := doReq(t, http.MethodPut, srv.URL+podsPath+"/pod-x/frobnicate", "application/json", `{"x":1}`); code != http.StatusMethodNotAllowed {
 		t.Errorf("PUT unknown subresource: status %d, want 405", code)
 	}
-	if code, _ := doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-x/scale", "application/merge-patch+json", `{"spec":{"replicas":2}}`); code != http.StatusMethodNotAllowed {
+	if code, _ := doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-x/frobnicate", "application/merge-patch+json", `{"x":1}`); code != http.StatusMethodNotAllowed {
 		t.Errorf("PATCH unknown subresource: status %d, want 405", code)
+	}
+}
+
+// TestOverlay_Scale_UnsupportedResourceRejected verifies GET/PUT .../scale
+// 404s for a resource kind with no real scale subresource (Pods), matching a
+// real apiserver's response for an unregistered route — unlike Deployments/
+// ReplicaSets/StatefulSets/ReplicationControllers, which do have one.
+func TestOverlay_Scale_UnsupportedResourceRejected(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-x"))
+
+	if code, _ := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-x/scale", "", ""); code != http.StatusNotFound {
+		t.Errorf("GET pod scale: status %d, want 404", code)
+	}
+	if code, _ := doReq(t, http.MethodPut, srv.URL+podsPath+"/pod-x/scale", "application/json",
+		`{"apiVersion":"autoscaling/v1","kind":"Scale","spec":{"replicas":2}}`); code != http.StatusNotFound {
+		t.Errorf("PUT pod scale: status %d, want 404", code)
+	}
+}
+
+// TestOverlay_Scale_GetPutPatch covers the full /scale lifecycle for a
+// Deployment: GET reflects current spec/status, PUT sets a new replica count
+// (and nothing else, even if the client tries to sneak in other spec/status
+// fields), and a subsequent merge-patch and JSON-patch each update replicas
+// too. Discovered via actually running the upstream conformance suite's
+// "Deployment should have a working scale subresource" spec against
+// --with-controller-manager, which uses exactly this GET→PUT round trip
+// (client-go's ScalesGetter).
+func TestOverlay_Scale_GetPutPatch(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	deployPath := "/apis/apps/v1/namespaces/default/deployments"
+	body := `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"scale-d"},
+		"spec":{"replicas":2,"selector":{"matchLabels":{"app":"x"}},
+		"template":{"metadata":{"labels":{"app":"x"}},"spec":{"containers":[{"name":"x","image":"x"}]}}}}`
+	if code, out := doReq(t, http.MethodPost, srv.URL+deployPath, "application/json", body); code != http.StatusCreated {
+		t.Fatalf("create: status %d: %s", code, out)
+	}
+
+	// GET reflects the created object's spec.replicas and derived selector.
+	code, got := doReq(t, http.MethodGet, srv.URL+deployPath+"/scale-d/scale", "", "")
+	if code != 200 {
+		t.Fatalf("GET scale: status %d: %s", code, got)
+	}
+	var s struct {
+		APIVersion string `json:"apiVersion"`
+		Kind       string `json:"kind"`
+		Spec       struct {
+			Replicas int32 `json:"replicas"`
+		} `json:"spec"`
+		Status struct {
+			Selector string `json:"selector"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal(got, &s); err != nil {
+		t.Fatalf("decode: %v\n%s", err, got)
+	}
+	if s.APIVersion != "autoscaling/v1" || s.Kind != "Scale" {
+		t.Errorf("apiVersion/kind = %s/%s, want autoscaling/v1/Scale", s.APIVersion, s.Kind)
+	}
+	if s.Spec.Replicas != 2 {
+		t.Errorf("GET scale replicas = %d, want 2", s.Spec.Replicas)
+	}
+	if s.Status.Selector != "app=x" {
+		t.Errorf("GET scale status.selector = %q, want app=x", s.Status.Selector)
+	}
+
+	// PUT a higher replica count, and try to sneak in an unrelated spec field —
+	// only replicas may change on the underlying Deployment.
+	putBody := `{"apiVersion":"autoscaling/v1","kind":"Scale","metadata":{"name":"scale-d","namespace":"default"},"spec":{"replicas":5}}`
+	code, put := doReq(t, http.MethodPut, srv.URL+deployPath+"/scale-d/scale", "application/json", putBody)
+	if code != 200 {
+		t.Fatalf("PUT scale: status %d: %s", code, put)
+	}
+	if !strings.Contains(string(put), `"replicas":5`) {
+		t.Errorf("PUT scale response = %s, want replicas 5", put)
+	}
+	_, dep := doReq(t, http.MethodGet, srv.URL+deployPath+"/scale-d", "", "")
+	if !strings.Contains(string(dep), `"replicas":5`) {
+		t.Errorf("underlying Deployment not scaled: %s", dep)
+	}
+	if metaInt(dep, "generation") != 2 {
+		t.Errorf("scaling did not bump generation: %s", dep)
+	}
+
+	// A merge-patch to scale also updates replicas.
+	code, patched := doReq(t, http.MethodPatch, srv.URL+deployPath+"/scale-d/scale",
+		"application/merge-patch+json", `{"spec":{"replicas":7}}`)
+	if code != 200 || !strings.Contains(string(patched), `"replicas":7`) {
+		t.Fatalf("merge-patch scale: status %d: %s", code, patched)
+	}
+
+	// A JSON patch (RFC 6902) works too.
+	code, jpatched := doReq(t, http.MethodPatch, srv.URL+deployPath+"/scale-d/scale",
+		"application/json-patch+json", `[{"op":"replace","path":"/spec/replicas","value":3}]`)
+	if code != 200 || !strings.Contains(string(jpatched), `"replicas":3`) {
+		t.Fatalf("json-patch scale: status %d: %s", code, jpatched)
+	}
+	_, dep2 := doReq(t, http.MethodGet, srv.URL+deployPath+"/scale-d", "", "")
+	if !strings.Contains(string(dep2), `"replicas":3`) {
+		t.Errorf("underlying Deployment not scaled by json-patch: %s", dep2)
+	}
+}
+
+// TestOverlay_Scale_ReadOnlyGet verifies GET .../scale works against a plain
+// captured Deployment even without --writable (unlike scale writes, which
+// need the overlay).
+func TestOverlay_Scale_ReadOnlyGet(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	depList := `{"apiVersion":"apps/v1","kind":"DeploymentList","metadata":{},"items":[
+		{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"web","namespace":"default"},
+		 "spec":{"replicas":4,"selector":{"matchLabels":{"app":"web"}}},
+		 "status":{"replicas":4}}]}`
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{"/apis/apps/v1/namespaces/default/deployments": {id: "s", at: from, body: depList}},
+		nil)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	h := newHandler(store, time.Time{}, false)
+	h.clock = clock
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	code, got := doReq(t, http.MethodGet, srv.URL+"/apis/apps/v1/namespaces/default/deployments/web/scale", "", "")
+	if code != 200 {
+		t.Fatalf("GET scale (read-only): status %d: %s", code, got)
+	}
+	if !strings.Contains(string(got), `"replicas":4`) {
+		t.Errorf("read-only scale = %s, want replicas 4", got)
 	}
 }
 
@@ -856,9 +1284,16 @@ func TestOverlay_NullBodyNoPanic(t *testing.T) {
 	}
 }
 
-// TestOverlay_StatusPatchIsolated verifies a PATCH to .../status only changes
-// status (not spec/metadata) and does not bump generation, while a spec PATCH
-// does bump it.
+// TestOverlay_StatusPatchIsolated verifies a PATCH to .../status protects
+// .spec (reset back to the current object) and does not bump generation
+// (which tracks spec changes), while a spec PATCH does bump it. Metadata
+// (annotations, labels) is NOT protected — matching the real apiserver's
+// per-type status strategies (e.g. pkg/registry/core/pod/strategy.go's
+// podStatusStrategy.PrepareForUpdate only resets Spec/DeletionTimestamp/
+// OwnerReferences, not labels or annotations). This matters in practice: the
+// deployment controller sets `deployment.kubernetes.io/revision` on the
+// Deployment itself via UpdateStatus (a full-object PUT to .../status), not a
+// spec/metadata write.
 func TestOverlay_StatusPatchIsolated(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
@@ -866,15 +1301,20 @@ func TestOverlay_StatusPatchIsolated(t *testing.T) {
 
 	doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-s")) // generation 1
 
-	// Status patch also tries to sneak in a label — the label must be ignored.
+	// Status patch also sets a label and tries to sneak in a spec change — the
+	// label must pass through (matching a real apiserver); the spec change must
+	// be dropped (reset back to current).
 	doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-s/status", "application/merge-patch+json",
-		`{"metadata":{"labels":{"hacked":"x"}},"status":{"phase":"Running"}}`)
+		`{"metadata":{"labels":{"team":"a"}},"spec":{"nodeName":"sneaky"},"status":{"phase":"Running"}}`)
 	_, got := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-s", "", "")
 	if !strings.Contains(string(got), `"phase":"Running"`) {
 		t.Errorf("status not applied: %s", got)
 	}
-	if strings.Contains(string(got), `"hacked"`) {
-		t.Errorf("status patch leaked a metadata change: %s", got)
+	if !strings.Contains(string(got), `"team":"a"`) {
+		t.Errorf("status patch dropped a metadata change (should pass through): %s", got)
+	}
+	if strings.Contains(string(got), `"nodeName":"sneaky"`) {
+		t.Errorf("status patch leaked a spec change: %s", got)
 	}
 	if g := metaInt(got, "generation"); g != 1 {
 		t.Errorf("status patch bumped generation to %d, want 1", g)
@@ -987,6 +1427,64 @@ func TestOverlay_ApplyPatchYAML(t *testing.T) {
 	}
 	if !strings.Contains(string(got), `"applied":"yes"`) {
 		t.Errorf("apply-patch did not merge YAML body: %s", got)
+	}
+}
+
+// TestOverlay_ApplyPatchCreatesMissingObject verifies a Server-Side Apply
+// PATCH (Content-Type: application/apply-patch+yaml) targeting an object that
+// doesn't exist yet creates it — matching the real apiserver's
+// create-or-update SSA semantics — rather than 404ing. This is the codepath
+// `helm install --create-namespace`, `kubectl apply --server-side`, and
+// CRD/webhook installers rely on to provision brand-new objects.
+func TestOverlay_ApplyPatchCreatesMissingObject(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	// Namespaced resource, mirroring a Helm chart's first apply of a new object.
+	yamlBody := "apiVersion: v1\nkind: Pod\nmetadata:\n  name: pod-ssa\n  namespace: default\n  labels:\n    applied: \"yes\"\n"
+	code, got := doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-ssa", "application/apply-patch+yaml", yamlBody)
+	if code != http.StatusCreated {
+		t.Fatalf("apply-patch create: status %d, want 201: %s", code, got)
+	}
+	if !strings.Contains(string(got), `"applied":"yes"`) {
+		t.Errorf("created object missing applied label: %s", got)
+	}
+	if rv := bodyRV(t, got); rv == "" || rv == "0" {
+		t.Errorf("created object rv = %q, want non-zero", rv)
+	}
+	if metaString(got, "uid") == "" {
+		t.Errorf("created object missing uid: %s", got)
+	}
+	code, get := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-ssa", "", "")
+	if code != 200 || metaString(get, "name") != "pod-ssa" {
+		t.Fatalf("GET pod-ssa: status %d name %q", code, metaString(get, "name"))
+	}
+
+	// Cluster-scoped resource — mirrors `helm install --create-namespace`.
+	nsYAML := "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: ns-ssa\n"
+	code, nsGot := doReq(t, http.MethodPatch, srv.URL+"/api/v1/namespaces/ns-ssa", "application/apply-patch+yaml", nsYAML)
+	if code != http.StatusCreated {
+		t.Fatalf("apply-patch create namespace: status %d, want 201: %s", code, nsGot)
+	}
+	// Namespace-create side effects (default SA, kube-root-ca.crt) still fire.
+	code, sa := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/ns-ssa/serviceaccounts/default", "", "")
+	if code != http.StatusOK {
+		t.Fatalf("GET default SA after apply-create: status %d, want 200\n%s", code, sa)
+	}
+
+	// A status-subresource apply cannot create its (missing) parent object.
+	code, _ = doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-nope/status", "application/apply-patch+yaml",
+		"apiVersion: v1\nkind: Pod\nstatus:\n  phase: Running\n")
+	if code != http.StatusNotFound {
+		t.Errorf("status apply-create on missing object: status %d, want 404", code)
+	}
+
+	// A body identity mismatched with the request path is still rejected on create.
+	code, _ = doReq(t, http.MethodPatch, srv.URL+podsPath+"/pod-mismatch", "application/apply-patch+yaml",
+		"apiVersion: v1\nkind: Pod\nmetadata:\n  name: other-name\n  namespace: default\n")
+	if code != http.StatusBadRequest {
+		t.Errorf("mismatched name on apply-create: status %d, want 400", code)
 	}
 }
 

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -1197,6 +1197,79 @@ func TestOverlay_Scale_GetPutPatch(t *testing.T) {
 	}
 }
 
+// TestOverlay_Scale_ApplyPatchYAML verifies a Server-Side Apply PATCH
+// (Content-Type: application/apply-patch+yaml, body is YAML) against .../scale
+// works — supportedPatchType() accepts this content type for any subresource,
+// but the scale path's patch application didn't actually convert YAML to JSON
+// before merging, so it would 422 instead of scaling. Found via Copilot
+// review.
+func TestOverlay_Scale_ApplyPatchYAML(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	deployPath := "/apis/apps/v1/namespaces/default/deployments"
+	body := `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"scale-yaml"},
+		"spec":{"replicas":1,"selector":{"matchLabels":{"app":"x"}},
+		"template":{"metadata":{"labels":{"app":"x"}},"spec":{"containers":[{"name":"x","image":"x"}]}}}}`
+	if code, out := doReq(t, http.MethodPost, srv.URL+deployPath, "application/json", body); code != http.StatusCreated {
+		t.Fatalf("create: status %d: %s", code, out)
+	}
+
+	yamlPatch := "apiVersion: autoscaling/v1\nkind: Scale\nspec:\n  replicas: 4\n"
+	code, out := doReq(t, http.MethodPatch, srv.URL+deployPath+"/scale-yaml/scale", "application/apply-patch+yaml", yamlPatch)
+	if code != 200 {
+		t.Fatalf("apply-patch scale: status %d: %s", code, out)
+	}
+	if !strings.Contains(string(out), `"replicas":4`) {
+		t.Errorf("apply-patch scale response = %s, want replicas 4", out)
+	}
+	_, dep := doReq(t, http.MethodGet, srv.URL+deployPath+"/scale-yaml", "", "")
+	if !strings.Contains(string(dep), `"replicas":4`) {
+		t.Errorf("underlying Deployment not scaled by apply-patch: %s", dep)
+	}
+}
+
+// TestOverlay_Scale_ReplicationControllerSelector verifies a
+// ReplicationController's Scale.status.selector is populated correctly.
+// Unlike Deployment/ReplicaSet/StatefulSet, RC's .spec.selector is a plain
+// map[string]string, not a structured metav1.LabelSelector — decoding it as
+// the latter silently succeeds with a zero-value result (unknown JSON fields
+// on a struct are ignored), producing an empty status.selector that breaks
+// HPA/kubectl expectations. Found via Copilot review.
+func TestOverlay_Scale_ReplicationControllerSelector(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	rcPath := "/api/v1/namespaces/default/replicationcontrollers"
+	body := `{"apiVersion":"v1","kind":"ReplicationController","metadata":{"name":"rc-scale"},
+		"spec":{"replicas":2,"selector":{"app":"x","tier":"web"},
+		"template":{"metadata":{"labels":{"app":"x","tier":"web"}},"spec":{"containers":[{"name":"x","image":"x"}]}}}}`
+	if code, out := doReq(t, http.MethodPost, srv.URL+rcPath, "application/json", body); code != http.StatusCreated {
+		t.Fatalf("create: status %d: %s", code, out)
+	}
+
+	code, out := doReq(t, http.MethodGet, srv.URL+rcPath+"/rc-scale/scale", "", "")
+	if code != 200 {
+		t.Fatalf("GET scale: status %d: %s", code, out)
+	}
+	var s struct {
+		Status struct {
+			Selector string `json:"selector"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal(out, &s); err != nil {
+		t.Fatalf("decode: %v\n%s", err, out)
+	}
+	if s.Status.Selector == "" {
+		t.Fatalf("RC scale status.selector is empty, want app=x,tier=web (or similar): %s", out)
+	}
+	if !strings.Contains(s.Status.Selector, "app=x") || !strings.Contains(s.Status.Selector, "tier=web") {
+		t.Errorf("RC scale status.selector = %q, want both app=x and tier=web", s.Status.Selector)
+	}
+}
+
 // TestOverlay_Scale_ReadOnlyGet verifies GET .../scale works against a plain
 // captured Deployment even without --writable (unlike scale writes, which
 // need the overlay).


### PR DESCRIPTION
## Summary

Eight real bugs in the writable overlay, all found by actually running `kube-controller-manager` and the upstream `[Conformance]` apps/network suite against `--writable --with-kwok --with-controller-manager` — not just unit tests. Started from a real Istio-via-Helm install hitting SSA/apply failures; expanded once running the actual conformance suite kept surfacing deeper issues each fix uncovered.

- **Server-Side Apply create-on-first-apply.** A PATCH with `Content-Type: application/apply-patch+yaml` targeting a not-yet-existing object now creates it instead of 404ing, matching the real apiserver's create-or-update semantics. This is what `helm install --create-namespace`, `kubectl apply --server-side`, and CRD/webhook installers all rely on.
- **Missing `Replicas` default.** Deployment/StatefulSet/ReplicaSet now default `.spec.replicas` to 1 when omitted (some charts, e.g. istiod, rely on this apiserver default) — a nil value was panicking the deployment controller's `NewRSNewReplicas`.
- **Missing `RevisionHistoryLimit` default (process-crashing).** StatefulSet/DaemonSet now default `.spec.revisionHistoryLimit` to 10. Unlike Deployment's equivalent cleanup path (which nil-checks first), these controllers' history-truncation code dereferences it unconditionally — a nil value crashed the *entire* `kube-controller-manager` process, silently killing all reconciliation for the rest of a run.
- **LoadBalancer Service synthesis.** A `LoadBalancer` Service now gets a synthesized external IP and ClusterIP. kstatus (which Helm v4's `--wait` uses) specifically requires `spec.clusterIP` non-empty for LoadBalancer Services — not the external address — so a Service missing one hung `helm install --wait` forever.
- **`/scale` subresource support** (GET/PUT/PATCH) for Deployment/ReplicaSet/StatefulSet/ReplicationController.
- **Status-subresource metadata leak.** The status subresource now protects only `.spec` (reset to current), matching real per-type apiserver strategies — it previously protected all of metadata too, silently dropping the `deployment.kubernetes.io/revision` annotation the deployment controller sets via `UpdateStatus` (a full-object PUT to `.../status`).
- **Watch resume misses recent overlay writes.** A watch resuming from `resourceVersion=X>0` now catches up on overlay writes already committed between X and when the watch connects, correctly replayed as ADDED or MODIFIED depending on whether the identity existed as of X. This is the exact race client-go's List-then-Watch pattern relies on a real apiserver's watch cache to cover; the overlay's live pub-sub only reached watchers already subscribed at write time, hanging any client watching for its own just-created or just-updated object.
- **Write responses missing `apiVersion`/`kind`.** Create/replace/patch responses now stamp TypeMeta like reads and watch events already did. client-go's typed Update/UpdateStatus calls round-trip an object whose TypeMeta the apiserver strips on read, so the request body often omits it — but a real apiserver's response is always fully typed, and a typed client-go decoder fails on the response with `Object 'Kind' is missing` otherwise.
- **Missing bare `/apis/<group>` discovery document.** Synthesizes the version-less APIGroup document (distinct from `/apis/<group>/<version>`'s resource list) — client-go's discovery client fetches this to enumerate a group's versions before making a versioned request, and it 404'd even though the versioned path worked fine, breaking any client (e.g. the Ingress/IngressClass API conformance specs) that discovers a group this way first.

## Verification

Every fix was confirmed live against a real `kube-controller-manager` + KWOK + writable-overlay rig, not just unit tests — including deliberately reverting each fix and confirming its regression test actually fails (hangs or produces the wrong output) beforehand. Specific end-to-end confirmations:

- `helm install istio-base/istiod/istio-ingress ... --wait` all succeed against the writable overlay.
- Upstream conformance specs that previously hung/failed now pass end-to-end: `Deployment should have a working scale subresource`, `Services should complete a service status lifecycle`, `Deployment should run the lifecycle of a Deployment`.
- `kube-controller-manager` survives a full 90-minute conformance run with zero crashes (previously died ~6 minutes in).

## Test plan

- [x] `make fmt` / `make test` / `make lint` all clean
- [x] `go test -race ./internal/server/...` clean
- [x] `go vet ./...` clean
- [x] New/updated regression tests for every fix, each verified to fail without the fix and pass with it
- [x] Manual end-to-end verification against a real `kube-controller-manager` subprocess (not just the mock's own tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)