### PR TITLE
fix(release): switch k8shark@rc to a Homebrew cask, not a formula

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -70,15 +70,20 @@ brews:
     install: |
       bin.install "kshrk"
 
-  # Prerelease channel: `brew install phenixblue/tap/k8shark@rc`. The inverse of
-  # the stable entry — uploads only for prerelease tags (.Prerelease is the semver
-  # prerelease part, non-empty for -rc/-beta tags), so k8shark@rc.rb tracks the
-  # latest RC while stable releases leave it untouched.
+homebrew_casks:
+  # Prerelease channel: `brew install --cask phenixblue/tap/k8shark@rc`. This must be
+  # a cask, not a brews: entry — brews generates `class K8shark@rc < Formula`, and "@"
+  # is not a legal Ruby class-name character (this shipped broken in #189/#190; see
+  # https://github.com/phenixblue/k8shark/issues for the report). Casks instead
+  # generate `cask "k8shark@rc" do ... end`, a plain string argument, so "@" is fine.
+  # skip_upload mirrors the brews entry: uploads only for prerelease tags, so
+  # k8shark@rc.rb tracks the latest RC while stable releases leave it untouched.
   - name: k8shark@rc
     homepage: https://github.com/phenixblue/k8shark
     description: Kubernetes cluster state capture and mock API replay tool (prerelease channel)
-    license: Apache-2.0
     skip_upload: '{{ if .Prerelease }}false{{ else }}true{{ end }}'
+    binaries:
+      - kshrk
     repository:
       owner: "{{ .Env.HOMEBREW_TAP_OWNER }}"
       name: "{{ .Env.HOMEBREW_TAP_NAME }}"
@@ -86,10 +91,6 @@ brews:
     commit_author:
       name: github-actions[bot]
       email: github-actions[bot]@users.noreply.github.com
-    test: |
-      system "#{bin}/kshrk", "version"
-    install: |
-      bin.install "kshrk"
 
 release:
   draft: false

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,11 +17,14 @@ brew install phenixblue/tap/k8shark
 To follow the **prerelease (release-candidate) channel** instead of stable:
 
 ```sh
-brew install phenixblue/tap/k8shark@rc
+brew install --cask phenixblue/tap/k8shark@rc
 ```
 
 `k8shark@rc` tracks the latest `-rc` release; `k8shark` tracks the latest stable.
 They install the same `kshrk` binary, so use one or the other (not both at once).
+The prerelease channel is a Homebrew *cask*, not a formula — `@` in a Ruby class
+name is invalid, so `k8shark@rc` can only be distributed as a cask (which uses a
+`cask "name" do` string, not a class name). Hence the `--cask` flag.
 
 ### go install
 


### PR DESCRIPTION
## Summary
- `brew upgrade k8shark@rc` (and `brew install`) failed for every user with `Error: phenixblue/tap/k8shark@rc: undefined method '<' for nil`.
- Root cause: GoReleaser's `brews:` pipe generates `class K8shark@rc < Formula`, and `@` is not a legal Ruby class/constant-name character. Homebrew's own formula-name-to-class-name convention (`Formulary.class_s`) has the identical digit-only limitation for `@`-suffixes (e.g. `python@3.11` works, `k8shark@rc` doesn't) — confirmed locally by reproducing the exact error via `ruby -e 'class K8shark@rc < Object; end'`.
- Fix: move the `k8shark@rc` channel from `brews:` to `homebrew_casks:`. Casks generate `cask "k8shark@rc" do ... end` — a plain string argument, not a class name — so `@` works unmodified. Verified with a local `goreleaser release --snapshot --clean` run; the generated `Casks/k8shark@rc.rb` passes `ruby -c`.
- Updates `docs/usage.md` for the new `brew install --cask ...` command. The stable `k8shark` formula is untouched.
- Deleted the broken, unfixable `k8shark@rc.rb` from `phenixblue/homebrew-tap` directly (it can never work as a formula); the next release will publish the corrected `Casks/k8shark@rc.rb`.

## Test plan
- [x] `goreleaser check` — config valid (only the pre-existing, unrelated `brews:` deprecation warning for the stable channel, not a hard error)
- [x] `goreleaser release --snapshot --clean` locally generates `dist/homebrew/Casks/k8shark@rc.rb`
- [x] `ruby -c dist/homebrew/Casks/k8shark@rc.rb` — Syntax OK
- [ ] Cut the next `-rc` release and confirm `brew install --cask phenixblue/tap/k8shark@rc` works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)