### PR TITLE
feat(ui): make the writable overlay visible in the web dashboard

### DIFF
--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -135,7 +135,7 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	uiPort, _ := cmd.Flags().GetString("ui-port")
 	var uiSrv *ui.Server
 	if uiEnabled {
-		uiSrv, err = ui.Open(ui.OpenOptions{ArchivePath: args[0], Port: uiPort, Verbose: verbose, Clock: clock})
+		uiSrv, err = ui.Open(ui.OpenOptions{MockServer: srv, ArchivePath: args[0], Port: uiPort, Verbose: verbose, Clock: clock})
 		if err != nil {
 			srv.Shutdown()
 			return fmt.Errorf("starting dashboard: %w", err)

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -149,6 +149,7 @@ func runUI(cmd *cobra.Command, args []string) error {
 	}
 
 	uiSrv, err := ui.Open(ui.OpenOptions{
+		MockServer:  mockSrv,
 		ArchivePath: archivePath,
 		Port:        uiPort,
 		At:          at,

--- a/internal/server/overlay.go
+++ b/internal/server/overlay.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"sort"
 	"sync"
 )
 
@@ -390,6 +391,57 @@ func (o *overlay) get(group, version, resource, namespace, name string) (*overla
 	defer o.mu.RUnlock()
 	e, ok := o.items[overlayKey(group, version, resource, namespace, name)]
 	return e, ok
+}
+
+// overlayScope summarizes the live (non-tombstoned) overlay entries for one
+// group/version/resource/namespace combination — used by callers (the web UI)
+// that need to discover object kinds/namespaces which exist only because of
+// overlay writes and have no entry at all in the capture's static index (e.g.
+// custom resources of a CRD installed at runtime, or a namespace created by
+// `helm install --create-namespace`).
+type overlayScope struct {
+	group, version, resource, namespace string
+	count                               int
+	sample                              json.RawMessage // one live object's body, for Kind inference
+}
+
+// scopes returns every distinct scope with at least one live overlay entry,
+// sorted for deterministic output.
+func (o *overlay) scopes() []overlayScope {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	type key struct{ group, version, resource, namespace string }
+	agg := map[key]*overlayScope{}
+	for _, e := range o.items {
+		if e.deleted {
+			continue
+		}
+		k := key{e.group, e.version, e.resource, e.namespace}
+		s, ok := agg[k]
+		if !ok {
+			s = &overlayScope{group: e.group, version: e.version, resource: e.resource, namespace: e.namespace, sample: e.obj}
+			agg[k] = s
+		}
+		s.count++
+	}
+	out := make([]overlayScope, 0, len(agg))
+	for _, s := range agg {
+		out = append(out, *s)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		if a.group != b.group {
+			return a.group < b.group
+		}
+		if a.version != b.version {
+			return a.version < b.version
+		}
+		if a.resource != b.resource {
+			return a.resource < b.resource
+		}
+		return a.namespace < b.namespace
+	})
+	return out
 }
 
 // applyToList merges the overlay over a base list's items for a given list scope

--- a/internal/server/overlay_export.go
+++ b/internal/server/overlay_export.go
@@ -13,7 +13,13 @@ import "encoding/json"
 
 // Store returns the CaptureStore backing this server, so a second in-process
 // reader (the web UI) can share it instead of loading the archive again.
-func (s *Server) Store() *CaptureStore { return s.handler.store }
+// Returns nil on a nil *Server, matching every other accessor in this file.
+func (s *Server) Store() *CaptureStore {
+	if s == nil {
+		return nil
+	}
+	return s.handler.store
+}
 
 // OverlayScope identifies a group/version/resource/namespace combination with
 // at least one live object in the writable overlay, plus a representative

--- a/internal/server/overlay_export.go
+++ b/internal/server/overlay_export.go
@@ -1,0 +1,83 @@
+package server
+
+import "encoding/json"
+
+// This file exposes a read-only view of the store and (when writable replay
+// is on) the overlay to other in-process readers — namely the web UI
+// (internal/ui), which otherwise has no way to see client writes made through
+// the mock API server (kubectl/helm/kwok/controller-manager). All overlay
+// accessors are nil-safe, both on a nil *Server (a caller with no mock server
+// wired up at all) and on a Server without a writable overlay — either way
+// they behave as if the overlay were empty, so callers don't need to check
+// for nil or Writable() first.
+
+// Store returns the CaptureStore backing this server, so a second in-process
+// reader (the web UI) can share it instead of loading the archive again.
+func (s *Server) Store() *CaptureStore { return s.handler.store }
+
+// OverlayScope identifies a group/version/resource/namespace combination with
+// at least one live object in the writable overlay, plus a representative
+// object body — used to discover kinds/namespaces that exist only because of
+// overlay writes (e.g. a CRD's custom resources, or a namespace created by
+// `helm install --create-namespace`) and so have no entry in the capture's
+// static index at all. Namespace is "" for cluster-scoped resources.
+type OverlayScope struct {
+	Group, Version, Resource, Namespace string
+	Count                               int
+	Sample                              json.RawMessage
+}
+
+// OverlayScopes returns every distinct scope with at least one live overlay
+// entry. Returns nil when the server has no writable overlay.
+func (s *Server) OverlayScopes() []OverlayScope {
+	if s == nil || s.handler.overlay == nil {
+		return nil
+	}
+	scopes := s.handler.overlay.scopes()
+	out := make([]OverlayScope, len(scopes))
+	for i, sc := range scopes {
+		out[i] = OverlayScope{
+			Group: sc.group, Version: sc.version, Resource: sc.resource, Namespace: sc.namespace,
+			Count: sc.count, Sample: sc.sample,
+		}
+	}
+	return out
+}
+
+// MergeOverlayList merges overlay writes for (group, version, resource,
+// namespace — "" for cluster-wide/all-namespaces) over base, "overlay wins"
+// (see overlay.applyToList), and drops any items left in a namespace the
+// overlay deleted. Returns base unchanged when the server has no writable
+// overlay.
+func (s *Server) MergeOverlayList(group, version, resource, namespace string, base []json.RawMessage) []json.RawMessage {
+	if s == nil || s.handler.overlay == nil {
+		return base
+	}
+	merged, _ := s.handler.overlay.applyToList(group, version, resource, namespace, base)
+	return dropDeletedNamespaceItems(merged, s.handler.overlay.deletedNamespaces())
+}
+
+// OverlayObject returns the overlay's copy of a single object identity, if any
+// overlay write touched it. found is false when the server has no writable
+// overlay or no write ever touched this identity; deleted is true for a
+// tombstone (the object was created then deleted in the overlay).
+func (s *Server) OverlayObject(group, version, resource, namespace, name string) (obj json.RawMessage, deleted, found bool) {
+	if s == nil || s.handler.overlay == nil {
+		return nil, false, false
+	}
+	e, ok := s.handler.overlay.get(group, version, resource, namespace, name)
+	if !ok {
+		return nil, false, false
+	}
+	return e.obj, e.deleted, true
+}
+
+// OverlayDeletedNamespaces returns the set of namespaces deleted via the
+// overlay, so a reader can filter their (possibly still-captured) contents
+// out. Returns nil when the server has no writable overlay.
+func (s *Server) OverlayDeletedNamespaces() map[string]struct{} {
+	if s == nil || s.handler.overlay == nil {
+		return nil
+	}
+	return s.handler.overlay.deletedNamespaces()
+}

--- a/internal/server/overlay_export_test.go
+++ b/internal/server/overlay_export_test.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+// TestServer_Store_ReturnsSharedInstance covers the whole point of exposing
+// Store(): a second in-process reader (the web UI) must see the exact same
+// CaptureStore the mock API server reads from, not a fresh independent load.
+func TestServer_Store_ReturnsSharedInstance(t *testing.T) {
+	archivePath := buildTestArchive(t)
+	srv, err := Open(OpenOptions{ArchivePath: archivePath, KubeconfigOut: filepath.Join(t.TempDir(), "kubeconfig.yaml")})
+	if err != nil {
+		t.Fatalf("server.Open: %v", err)
+	}
+	defer srv.Shutdown()
+
+	if got := srv.Store(); got != srv.handler.store {
+		t.Errorf("Store() = %p, want the handler's own store %p", got, srv.handler.store)
+	}
+}
+
+// TestServer_OverlayAccessors_NilSafeWithoutOverlay covers a plain `open`/`ui`
+// server (no --writable): every overlay accessor must behave as an empty
+// overlay rather than panicking, so a caller (the web UI) doesn't need to
+// special-case Writable() before calling them.
+func TestServer_OverlayAccessors_NilSafeWithoutOverlay(t *testing.T) {
+	archivePath := buildTestArchive(t)
+	srv, err := Open(OpenOptions{ArchivePath: archivePath, KubeconfigOut: filepath.Join(t.TempDir(), "kubeconfig.yaml")})
+	if err != nil {
+		t.Fatalf("server.Open: %v", err)
+	}
+	defer srv.Shutdown()
+
+	if scopes := srv.OverlayScopes(); scopes != nil {
+		t.Errorf("OverlayScopes() = %v, want nil", scopes)
+	}
+	base := []json.RawMessage{json.RawMessage(`{"metadata":{"name":"nginx"}}`)}
+	if got := srv.MergeOverlayList("", "v1", "pods", "default", base); len(got) != 1 || string(got[0]) != string(base[0]) {
+		t.Errorf("MergeOverlayList() = %v, want base unchanged", got)
+	}
+	if _, _, found := srv.OverlayObject("", "v1", "pods", "default", "nginx"); found {
+		t.Error("OverlayObject() found = true, want false")
+	}
+	if dns := srv.OverlayDeletedNamespaces(); dns != nil {
+		t.Errorf("OverlayDeletedNamespaces() = %v, want nil", dns)
+	}
+}
+
+// TestServer_OverlayAccessors_WritableServer drives a writable replay
+// server's overlay directly (same package) and checks the exported
+// accessors — the surface the web UI will use — return what was written.
+func TestServer_OverlayAccessors_WritableServer(t *testing.T) {
+	archivePath := buildTestArchive(t)
+	srv, err := Replay(ReplayOptions{
+		ArchivePath:       archivePath,
+		KubeconfigOut:     filepath.Join(t.TempDir(), "kubeconfig.yaml"),
+		Writable:          true,
+		DisableScheduling: true, // keep the overlay free of the synthetic scheduling node
+	})
+	if err != nil {
+		t.Fatalf("server.Replay: %v", err)
+	}
+	defer srv.Shutdown()
+
+	ov := srv.handler.overlay
+	if ov == nil {
+		t.Fatal("expected a writable server to have an overlay")
+	}
+
+	// A brand-new CRD's custom resource: a GVR never in the capture's index.
+	vsBody := json.RawMessage(`{"apiVersion":"networking.istio.io/v1beta1","kind":"VirtualService","metadata":{"name":"reviews","namespace":"istio-system"}}`)
+	ov.store("networking.istio.io", "v1beta1", "virtualservices", "istio-system", "reviews", vsBody, ov.nextRV(0))
+
+	// A namespace object, created via the overlay (e.g. --create-namespace).
+	nsBody := json.RawMessage(`{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"istio-system"}}`)
+	ov.store("", "v1", "namespaces", "", "istio-system", nsBody, ov.nextRV(0))
+
+	scopes := srv.OverlayScopes()
+	if len(scopes) != 2 {
+		t.Fatalf("OverlayScopes() = %d scopes, want 2: %+v", len(scopes), scopes)
+	}
+	var sawVS bool
+	for _, sc := range scopes {
+		if sc.Group == "networking.istio.io" && sc.Resource == "virtualservices" {
+			sawVS = true
+			if sc.Namespace != "istio-system" || sc.Count != 1 {
+				t.Errorf("virtualservices scope = %+v, want namespace=istio-system count=1", sc)
+			}
+			if string(sc.Sample) != string(vsBody) {
+				t.Errorf("virtualservices sample = %s, want %s", sc.Sample, vsBody)
+			}
+		}
+	}
+	if !sawVS {
+		t.Errorf("OverlayScopes() missing the overlay-only virtualservices scope: %+v", scopes)
+	}
+
+	merged := srv.MergeOverlayList("networking.istio.io", "v1beta1", "virtualservices", "istio-system", nil)
+	if len(merged) != 1 || string(merged[0]) != string(vsBody) {
+		t.Errorf("MergeOverlayList() = %v, want [%s]", merged, vsBody)
+	}
+
+	obj, deleted, found := srv.OverlayObject("networking.istio.io", "v1beta1", "virtualservices", "istio-system", "reviews")
+	if !found || deleted || string(obj) != string(vsBody) {
+		t.Errorf("OverlayObject() = (%s, deleted=%v, found=%v), want (%s, false, true)", obj, deleted, found, vsBody)
+	}
+
+	// Deleting the namespace should surface it via OverlayDeletedNamespaces
+	// and MergeOverlayList should drop the virtualservices item accordingly.
+	ov.cascadeDeleteNamespace("istio-system")
+	ov.del("", "v1", "namespaces", "", "istio-system", nsBody, ov.nextRV(0))
+	dns := srv.OverlayDeletedNamespaces()
+	if _, ok := dns["istio-system"]; !ok {
+		t.Errorf("OverlayDeletedNamespaces() = %v, want istio-system present", dns)
+	}
+	if merged := srv.MergeOverlayList("networking.istio.io", "v1beta1", "virtualservices", "istio-system", nil); len(merged) != 0 {
+		t.Errorf("MergeOverlayList() after namespace delete = %v, want empty", merged)
+	}
+}

--- a/internal/server/overlay_export_test.go
+++ b/internal/server/overlay_export_test.go
@@ -22,6 +22,16 @@ func TestServer_Store_ReturnsSharedInstance(t *testing.T) {
 	}
 }
 
+// TestServer_Store_NilReceiver covers the contract every accessor in this
+// file shares: nil-safe on a nil *Server, not just on a Server without a
+// writable overlay.
+func TestServer_Store_NilReceiver(t *testing.T) {
+	var srv *Server
+	if got := srv.Store(); got != nil {
+		t.Errorf("Store() on nil *Server = %v, want nil", got)
+	}
+}
+
 // TestServer_OverlayAccessors_NilSafeWithoutOverlay covers a plain `open`/`ui`
 // server (no --writable): every overlay accessor must behave as an empty
 // overlay rather than panicking, so a caller (the web UI) doesn't need to

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -58,6 +58,7 @@ type Server struct {
 	kubeconfigPath    string
 	certPEM           []byte // this run's self-signed TLS cert, for callers that need to pin it
 	ar                *archive.Archive
+	handler           *handler // shared with other in-process readers, e.g. the web UI (see overlay_export.go)
 	httpServer        *http.Server
 	done              chan struct{}
 	clock             *ReplayClock // non-nil in replay mode
@@ -181,6 +182,7 @@ func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *Replay
 		kubeconfigPath:    kubeconfigPath,
 		certPEM:           certPEM,
 		ar:                ar,
+		handler:           h,
 		httpServer:        httpSrv,
 		done:              done,
 		clock:             clock,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -196,6 +196,31 @@ func TestParseReplayAt(t *testing.T) {
 	})
 }
 
+// TestServer_Open_ClosesArchiveOnShutdown is a regression test for the
+// file-handle leak fixed in #91: Shutdown must release the archive's
+// underlying file descriptor. Asserted by checking that a second Close on the
+// archive errors — proving Shutdown already closed it (closing an
+// already-closed *os.File returns os.ErrClosed). internal/ui no longer opens
+// its own archive (it shares this one via Server.Store()), so this server is
+// now the only place that owns and must close it — see docs/CLAUDE.md's
+// "Archive lifecycle" section.
+func TestServer_Open_ClosesArchiveOnShutdown(t *testing.T) {
+	archivePath := buildTestArchive(t)
+	srv, err := Open(OpenOptions{ArchivePath: archivePath, KubeconfigOut: filepath.Join(t.TempDir(), "kubeconfig.yaml")})
+	if err != nil {
+		t.Fatalf("server.Open: %v", err)
+	}
+	if srv.ar == nil {
+		t.Fatal("Server did not retain the archive; it can never be closed")
+	}
+
+	srv.Shutdown()
+
+	if err := srv.ar.Close(); err == nil {
+		t.Error("archive still open after Shutdown; expected it to be closed (file-handle leak)")
+	}
+}
+
 func TestServer_Open_RejectsOutOfRangeAt(t *testing.T) {
 	archivePath := buildTestArchive(t)
 	_, err := Open(OpenOptions{ArchivePath: archivePath, At: "1900-01-01T00:00:00Z"})

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -15,13 +15,19 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/server"
 	v2 "github.com/phenixblue/k8shark/internal/ui/v2"
 )
 
 // OpenOptions configures a UI server for a single capture archive.
 type OpenOptions struct {
+	// MockServer is the already-running mock API server for this archive
+	// (`kshrk ui`/`kshrk replay --ui` always start one first). Its store is
+	// reused directly — the UI no longer loads the archive a second time —
+	// and, when writable, its overlay is merged into every v2 read so client
+	// writes (kubectl/helm/kwok/controller-manager) are visible in the
+	// dashboard too. Required.
+	MockServer  *server.Server
 	ArchivePath string
 	Port        string
 	At          string
@@ -38,30 +44,18 @@ type Server struct {
 	address    string
 	httpServer *http.Server
 	done       chan struct{}
-
-	archive   *archive.Archive
-	closeOnce sync.Once
+	closeOnce  sync.Once
 }
 
-// Open loads the archive, mounts the v2 dashboard, and starts serving on the
-// requested port (random when empty/"0"). The archive is kept open for the life
-// of the server so the store can read records on demand, and is closed by
-// Shutdown/Wait once the server stops.
+// Open mounts the v2 dashboard over MockServer's store (and overlay, when
+// writable) and starts serving on the requested port (random when empty/"0").
+// The archive itself is owned by MockServer — Shutdown/Wait here only stop
+// this HTTP server, they don't touch the archive.
 func Open(opts OpenOptions) (*Server, error) {
-	ar, err := archive.Open(opts.ArchivePath)
-	if err != nil {
-		return nil, fmt.Errorf("opening archive: %w", err)
-	}
-
-	store, err := server.LoadStore(ar)
-	if err != nil {
-		_ = ar.Close()
-		return nil, fmt.Errorf("loading capture: %w", err)
-	}
+	store := opts.MockServer.Store()
 
 	at, err := parseReplayAt(store.Metadata.CapturedAt, store.Metadata.CapturedUntil, opts.At)
 	if err != nil {
-		_ = ar.Close()
 		return nil, err
 	}
 
@@ -71,7 +65,6 @@ func Open(opts OpenOptions) (*Server, error) {
 	}
 	ln, err := net.Listen("tcp", "127.0.0.1:"+port)
 	if err != nil {
-		_ = ar.Close()
 		return nil, fmt.Errorf("listening: %w", err)
 	}
 
@@ -80,6 +73,7 @@ func Open(opts OpenOptions) (*Server, error) {
 	mux.HandleFunc("/", serveRoot)
 	v2h := &v2.Handler{
 		Store:       store,
+		Overlay:     opts.MockServer,
 		At:          at,
 		ArchivePath: opts.ArchivePath,
 		Verbose:     opts.Verbose,
@@ -95,17 +89,7 @@ func Open(opts OpenOptions) (*Server, error) {
 	}()
 
 	addr := fmt.Sprintf("http://127.0.0.1:%d", ln.Addr().(*net.TCPAddr).Port)
-	return &Server{address: addr, httpServer: httpSrv, done: done, archive: ar}, nil
-}
-
-// closeArchive releases the underlying archive file handle. It is safe to call
-// from both Shutdown and Wait; only the first call closes the archive.
-func (s *Server) closeArchive() {
-	s.closeOnce.Do(func() {
-		if s.archive != nil {
-			_ = s.archive.Close()
-		}
-	})
+	return &Server{address: addr, httpServer: httpSrv, done: done}, nil
 }
 
 // Address returns the base URL the server is listening on.
@@ -113,11 +97,12 @@ func (s *Server) Address() string { return s.address }
 
 // Shutdown gracefully stops the server.
 func (s *Server) Shutdown() {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	_ = s.httpServer.Shutdown(ctx)
-	<-s.done
-	s.closeArchive()
+	s.closeOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = s.httpServer.Shutdown(ctx)
+		<-s.done
+	})
 }
 
 // Wait blocks until the server stops or an interrupt signal is received.
@@ -126,13 +111,10 @@ func (s *Server) Wait() error {
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	select {
 	case <-s.done:
+		return nil
 	case <-sigCh:
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = s.httpServer.Shutdown(ctx)
-		<-s.done
 	}
-	s.closeArchive()
+	s.Shutdown()
 	return nil
 }
 

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -52,6 +52,9 @@ type Server struct {
 // The archive itself is owned by MockServer — Shutdown/Wait here only stop
 // this HTTP server, they don't touch the archive.
 func Open(opts OpenOptions) (*Server, error) {
+	if opts.MockServer == nil {
+		return nil, fmt.Errorf("opening UI: MockServer is required")
+	}
 	store := opts.MockServer.Store()
 
 	at, err := parseReplayAt(store.Metadata.CapturedAt, store.Metadata.CapturedUntil, opts.At)

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/server"
 )
 
 func TestParseReplayAt(t *testing.T) {
@@ -79,25 +80,28 @@ func TestServeRoot(t *testing.T) {
 	})
 }
 
-// TestOpen_ClosesArchiveOnShutdown is a regression test for the file-handle
-// leak introduced when the UI moved to the held-open ZIP archive: Shutdown must
-// release the archive's underlying file descriptor. We assert this by checking
-// that a second Close on the archive errors — proving Shutdown already closed it
-// (closing an already-closed *os.File returns os.ErrClosed).
-func TestOpen_ClosesArchiveOnShutdown(t *testing.T) {
+// TestOpen_DoesNotOwnArchive covers the ui/server split: the mock API server
+// (MockServer) owns the archive now — Open reuses its store rather than
+// loading a second copy — so ui.Server.Shutdown must not touch it. We assert
+// this by shutting the UI server down first and checking the archive is still
+// readable through the (still-running) mock server's store.
+func TestOpen_DoesNotOwnArchive(t *testing.T) {
 	path := writeMinimalArchive(t)
-	srv, err := Open(OpenOptions{ArchivePath: path, Port: "0"})
+	mockSrv, err := server.Open(server.OpenOptions{ArchivePath: path, Port: "0"})
+	if err != nil {
+		t.Fatalf("server.Open: %v", err)
+	}
+	defer mockSrv.Shutdown()
+
+	uiSrv, err := Open(OpenOptions{MockServer: mockSrv, ArchivePath: path, Port: "0"})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	if srv.archive == nil {
-		t.Fatal("Server did not retain the archive; it can never be closed")
-	}
 
-	srv.Shutdown()
+	uiSrv.Shutdown()
 
-	if err := srv.archive.Close(); err == nil {
-		t.Error("archive still open after Shutdown; expected it to be closed (file-handle leak)")
+	if _, _, err := mockSrv.Store().ReconstructAt("/api/v1/namespaces/default/pods", time.Time{}); err != nil {
+		t.Errorf("mock server's store unusable after ui.Server.Shutdown (archive closed prematurely): %v", err)
 	}
 }
 
@@ -105,7 +109,13 @@ func TestOpen_ClosesArchiveOnShutdown(t *testing.T) {
 // "/" redirects to /v2/ and the v2 API responds.
 func TestOpen_ServesV2(t *testing.T) {
 	path := writeMinimalArchive(t)
-	srv, err := Open(OpenOptions{ArchivePath: path, Port: "0"})
+	mockSrv, err := server.Open(server.OpenOptions{ArchivePath: path, Port: "0"})
+	if err != nil {
+		t.Fatalf("server.Open: %v", err)
+	}
+	defer mockSrv.Shutdown()
+
+	srv, err := Open(OpenOptions{MockServer: mockSrv, ArchivePath: path, Port: "0"})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/internal/ui/v2/lists.go
+++ b/internal/ui/v2/lists.go
@@ -163,9 +163,15 @@ func (h *Handler) loadAllWorkloadRows(at time.Time) []ClusterWorkloadRow {
 		"jobs":         {"Job", "Job"},
 		"cronjobs":     {"CronJob", "CronJob"},
 	}
+	wanted := make(map[string]bool, len(kinds))
+	for resource := range kinds {
+		wanted[resource] = true
+	}
+	pathsByResource := h.resourcePathsForResources(wanted)
+
 	var rows []ClusterWorkloadRow
 	for resource, k := range kinds {
-		for _, path := range h.resourcePathsFor(resource) {
+		for _, path := range pathsByResource[resource] {
 			_, _, _, ns := parseAPIPath(path)
 			if ns == "" {
 				continue

--- a/internal/ui/v2/lists.go
+++ b/internal/ui/v2/lists.go
@@ -1,11 +1,9 @@
 package v2
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
-	"strings"
 	"time"
 )
 
@@ -111,35 +109,19 @@ func (h *Handler) serveAllWorkloads(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-// loadAllPodRows walks every per-namespace pod LIST in the index and builds a
-// flat, sorted slice of rows. Returns the rows and the count of unhealthy pods
-// (matching the overview unhealthy_pods KPI: pods whose health has issues).
+// loadAllPodRows walks every per-namespace pod LIST in the index (plus any
+// overlay-only namespace) and builds a flat, sorted slice of rows. Returns the
+// rows and the count of unhealthy pods (matching the overview unhealthy_pods
+// KPI: pods whose health has issues).
 func (h *Handler) loadAllPodRows(at time.Time) ([]ClusterPodRow, int) {
-	store := h.Store
 	var rows []ClusterPodRow
 	unhealthy := 0
-	for path, entry := range store.Index {
-		if entry == nil || len(entry.Seqs) == 0 {
+	for _, path := range h.resourcePathsFor("pods") {
+		_, _, _, ns := parseAPIPath(path)
+		if ns == "" {
 			continue
 		}
-		if strings.Contains(path, "?") {
-			continue // skip Table and other query-suffix variants
-		}
-		_, _, resource, ns := parseAPIPath(path)
-		if resource != "pods" || ns == "" {
-			continue
-		}
-		body, code, err := store.ReconstructAt(path, at)
-		if err != nil || code != http.StatusOK || len(body) == 0 {
-			continue
-		}
-		var list struct {
-			Items []json.RawMessage `json:"items"`
-		}
-		if err := json.Unmarshal(body, &list); err != nil {
-			continue
-		}
-		for _, raw := range list.Items {
+		for _, raw := range h.reconstructMergedItems(path, at) {
 			name := getName(raw)
 			if name == "" {
 				continue
@@ -169,10 +151,9 @@ func (h *Handler) loadAllPodRows(at time.Time) ([]ClusterPodRow, int) {
 	return rows, unhealthy
 }
 
-// loadAllWorkloadRows walks every per-namespace workload LIST in the index and
-// builds a flat, sorted slice of rows.
+// loadAllWorkloadRows walks every per-namespace workload LIST in the index
+// (plus any overlay-only namespace) and builds a flat, sorted slice of rows.
 func (h *Handler) loadAllWorkloadRows(at time.Time) []ClusterWorkloadRow {
-	store := h.Store
 	// resource → (full kind, short label) for the workload kinds we surface.
 	kinds := map[string]struct{ kind, short string }{
 		"deployments":  {"Deployment", "Deploy"},
@@ -183,45 +164,27 @@ func (h *Handler) loadAllWorkloadRows(at time.Time) []ClusterWorkloadRow {
 		"cronjobs":     {"CronJob", "CronJob"},
 	}
 	var rows []ClusterWorkloadRow
-	for path, entry := range store.Index {
-		if entry == nil || len(entry.Seqs) == 0 {
-			continue
-		}
-		if strings.Contains(path, "?") {
-			continue
-		}
-		_, _, resource, ns := parseAPIPath(path)
-		if ns == "" {
-			continue
-		}
-		k, ok := kinds[resource]
-		if !ok {
-			continue
-		}
-		body, code, err := store.ReconstructAt(path, at)
-		if err != nil || code != http.StatusOK || len(body) == 0 {
-			continue
-		}
-		var list struct {
-			Items []json.RawMessage `json:"items"`
-		}
-		if err := json.Unmarshal(body, &list); err != nil {
-			continue
-		}
-		for _, raw := range list.Items {
-			row := classifyWorkload(k.short, k.kind, raw, at)
-			rows = append(rows, ClusterWorkloadRow{
-				Namespace: ns,
-				Kind:      k.kind,
-				Resource:  resource,
-				Name:      row.Name,
-				Status:    row.Status,
-				Severity:  row.Severity,
-				Restarts:  row.Restarts,
-				Age:       row.Age,
-				Link:      "#/ns/" + escapeHash(ns),
-				Labels:    getLabels(raw),
-			})
+	for resource, k := range kinds {
+		for _, path := range h.resourcePathsFor(resource) {
+			_, _, _, ns := parseAPIPath(path)
+			if ns == "" {
+				continue
+			}
+			for _, raw := range h.reconstructMergedItems(path, at) {
+				row := classifyWorkload(k.short, k.kind, raw, at)
+				rows = append(rows, ClusterWorkloadRow{
+					Namespace: ns,
+					Kind:      k.kind,
+					Resource:  resource,
+					Name:      row.Name,
+					Status:    row.Status,
+					Severity:  row.Severity,
+					Restarts:  row.Restarts,
+					Age:       row.Age,
+					Link:      "#/ns/" + escapeHash(ns),
+					Labels:    getLabels(raw),
+				})
+			}
 		}
 	}
 	sort.SliceStable(rows, func(i, j int) bool {

--- a/internal/ui/v2/namespace.go
+++ b/internal/ui/v2/namespace.go
@@ -109,17 +109,32 @@ func (h *Handler) buildNamespaceDetail(ns string, at time.Time) (*NamespaceDetai
 	for res, n := range byRes {
 		resTotal[res] = n
 		d.KPIs.Resources += n
-		switch {
-		case workloadResources[res]:
-			d.KPIs.Workloads += n
-		case res == "pods":
-			d.KPIs.Pods += n
-		case vmResources[res]:
-			d.KPIs.VirtualMachines += n
-		case res == "configmaps":
+		switch res {
+		case "configmaps":
 			d.KPIs.ConfigMaps += n
-		case res == "secrets":
+		case "secrets":
 			d.KPIs.Secrets += n
+		}
+	}
+	// Resource kinds that exist in this namespace only because of overlay
+	// writes (e.g. a CRD's custom resources) have no index entry at all, so
+	// the loop above misses them entirely. Pods/workloads/VMs are excluded
+	// here — their KPIs are set below from the exact, already overlay-merged
+	// row lists rather than this approximate index-derived count.
+	if h.Overlay != nil {
+		for _, sc := range h.Overlay.OverlayScopes() {
+			if sc.Namespace != ns || sc.Count == 0 || resTotal[sc.Resource] != 0 ||
+				workloadResources[sc.Resource] || sc.Resource == "pods" || vmResources[sc.Resource] {
+				continue
+			}
+			resTotal[sc.Resource] = sc.Count
+			d.KPIs.Resources += sc.Count
+			switch sc.Resource {
+			case "configmaps":
+				d.KPIs.ConfigMaps += sc.Count
+			case "secrets":
+				d.KPIs.Secrets += sc.Count
+			}
 		}
 	}
 
@@ -139,10 +154,14 @@ func (h *Handler) buildNamespaceDetail(ns string, at time.Time) (*NamespaceDetai
 	})
 	d.Pods = podRows
 	d.Issues = buildIssues(pods, 8)
+	d.KPIs.Pods = len(podRows)
 
-	// Workloads + VMs (read the per-ns list bodies and turn into compact rows).
+	// Workloads + VMs (read the per-ns list bodies and turn into compact
+	// rows) — exact, overlay-merged counts, unlike the index-derived resTotal.
 	d.Workloads = h.loadWorkloadRowsForNS(ns, at)
 	d.VMs = h.loadVMRowsForNS(ns, at)
+	d.KPIs.Workloads = len(d.Workloads)
+	d.KPIs.VirtualMachines = len(d.VMs)
 
 	// Resource tiles: every non-workload, non-pod, non-vm resource.
 	d.Resources = buildNamespaceTiles(ns, resTotal)
@@ -161,21 +180,11 @@ func (h *Handler) buildNamespaceDetail(ns string, at time.Time) (*NamespaceDetai
 // slice (for the drill-down table).
 func (h *Handler) loadPodsForNS(ns string, at time.Time) ([]podHealthEntry, []PodRow) {
 	listPath := "/api/v1/namespaces/" + ns + "/pods"
-	body, code, err := h.Store.ReconstructAt(listPath, at)
-	if err != nil || code != http.StatusOK || len(body) == 0 {
-		return nil, nil
-	}
-	var list struct {
-		Items []json.RawMessage `json:"items"`
-	}
-	if err := json.Unmarshal(body, &list); err != nil {
-		return nil, nil
-	}
 	var (
 		entries []podHealthEntry
 		rows    []PodRow
 	)
-	for _, raw := range list.Items {
+	for _, raw := range h.reconstructMergedItems(listPath, at) {
 		name := getName(raw)
 		if name == "" {
 			continue
@@ -252,19 +261,10 @@ func (h *Handler) loadWorkloadRowsForNS(ns string, at time.Time) []ResourceRow {
 }
 
 func (h *Handler) loadWorkloadGroup(path, kind, short string, at time.Time) []ResourceRow {
-	body, code, err := h.Store.ReconstructAt(path, at)
-	if err != nil || code != http.StatusOK || len(body) == 0 {
-		return nil
-	}
-	var list struct {
-		Items []json.RawMessage `json:"items"`
-	}
-	if err := json.Unmarshal(body, &list); err != nil {
-		return nil
-	}
+	items := h.reconstructMergedItems(path, at)
 	_, _, resource, _ := parseAPIPath(path)
-	out := make([]ResourceRow, 0, len(list.Items))
-	for _, raw := range list.Items {
+	out := make([]ResourceRow, 0, len(items))
+	for _, raw := range items {
 		row := classifyWorkload(short, kind, raw, at)
 		row.Resource = resource
 		out = append(out, row)
@@ -353,17 +353,7 @@ func (h *Handler) loadVMRowsForNS(ns string, at time.Time) []ResourceRow {
 	}
 	var out []ResourceRow
 	for _, g := range groups {
-		body, code, err := h.Store.ReconstructAt(g.path, at)
-		if err != nil || code != http.StatusOK || len(body) == 0 {
-			continue
-		}
-		var list struct {
-			Items []json.RawMessage `json:"items"`
-		}
-		if err := json.Unmarshal(body, &list); err != nil {
-			continue
-		}
-		for _, raw := range list.Items {
+		for _, raw := range h.reconstructMergedItems(g.path, at) {
 			var v struct {
 				Metadata struct {
 					Name              string    `json:"name"`
@@ -401,17 +391,7 @@ func (h *Handler) loadVMRowsForNS(ns string, at time.Time) []ResourceRow {
 // loadNamespaceMetadata reads the namespace object from /api/v1/namespaces
 // (the cluster-wide list) and surfaces labels/annotations/age/phase.
 func (h *Handler) loadNamespaceMetadata(ns string, at time.Time) NamespaceMetadata {
-	body, code, err := h.Store.ReconstructAt("/api/v1/namespaces", at)
-	if err != nil || code != http.StatusOK || len(body) == 0 {
-		return NamespaceMetadata{}
-	}
-	var list struct {
-		Items []json.RawMessage `json:"items"`
-	}
-	if err := json.Unmarshal(body, &list); err != nil {
-		return NamespaceMetadata{}
-	}
-	for _, raw := range list.Items {
+	for _, raw := range h.reconstructMergedItems("/api/v1/namespaces", at) {
 		var n struct {
 			Metadata struct {
 				Name              string            `json:"name"`

--- a/internal/ui/v2/namespace.go
+++ b/internal/ui/v2/namespace.go
@@ -103,12 +103,18 @@ func (h *Handler) buildNamespaceDetail(ns string, at time.Time) (*NamespaceDetai
 		},
 	}
 
-	// Per-resource counts scoped to this ns (no body reads).
+	// Per-resource counts scoped to this ns (no body reads). Pods/workloads/
+	// VMs are excluded from resTotal — those KPIs are set below from the
+	// exact, overlay-merged row lists, and KPIs.Resources is computed once at
+	// the end from resTotal plus those exact figures, so nothing is
+	// double-counted or missed for an overlay-only namespace.
 	byRes := store.NamespaceItemCountsAt(at)[ns]
 	resTotal := map[string]int{}
 	for res, n := range byRes {
+		if workloadResources[res] || res == "pods" || vmResources[res] {
+			continue
+		}
 		resTotal[res] = n
-		d.KPIs.Resources += n
 		switch res {
 		case "configmaps":
 			d.KPIs.ConfigMaps += n
@@ -118,9 +124,7 @@ func (h *Handler) buildNamespaceDetail(ns string, at time.Time) (*NamespaceDetai
 	}
 	// Resource kinds that exist in this namespace only because of overlay
 	// writes (e.g. a CRD's custom resources) have no index entry at all, so
-	// the loop above misses them entirely. Pods/workloads/VMs are excluded
-	// here — their KPIs are set below from the exact, already overlay-merged
-	// row lists rather than this approximate index-derived count.
+	// the loop above misses them entirely.
 	if h.Overlay != nil {
 		for _, sc := range h.Overlay.OverlayScopes() {
 			if sc.Namespace != ns || sc.Count == 0 || resTotal[sc.Resource] != 0 ||
@@ -128,7 +132,6 @@ func (h *Handler) buildNamespaceDetail(ns string, at time.Time) (*NamespaceDetai
 				continue
 			}
 			resTotal[sc.Resource] = sc.Count
-			d.KPIs.Resources += sc.Count
 			switch sc.Resource {
 			case "configmaps":
 				d.KPIs.ConfigMaps += sc.Count
@@ -165,6 +168,14 @@ func (h *Handler) buildNamespaceDetail(ns string, at time.Time) (*NamespaceDetai
 
 	// Resource tiles: every non-workload, non-pod, non-vm resource.
 	d.Resources = buildNamespaceTiles(ns, resTotal)
+
+	// KPIs.Resources sums every resource kind in this namespace: the
+	// non-pod/workload/vm kinds in resTotal, plus the exact pod/workload/vm
+	// counts just computed (kept out of resTotal to avoid double-counting).
+	for _, n := range resTotal {
+		d.KPIs.Resources += n
+	}
+	d.KPIs.Resources += d.KPIs.Pods + d.KPIs.Workloads + d.KPIs.VirtualMachines
 
 	// Pod-state sparkline scoped to this namespace.
 	d.Sparkline = h.sparklineForNS(ns, sparkBucketCount)

--- a/internal/ui/v2/objects.go
+++ b/internal/ui/v2/objects.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/phenixblue/k8shark/internal/server"
 )
 
 // ObjectDetail is the response from /v2/api/object — a single captured object
@@ -353,10 +355,21 @@ type discMeta struct {
 // short names} map from the captured API discovery documents (/api/v1 and
 // /apis/<group>/<version>). This gives correct kinds (incl. CRDs / irregular
 // plurals) and the kubectl short names for searching. Keyed by
-// "group/version/resource" and, as a fallback, by bare "resource".
+// "group/version/resource" and, as a fallback, by bare "resource". The result
+// depends only on the capture's own (time-invariant) discovery documents, so
+// it's computed once per Handler and cached — serveResourceList/
+// serveResourceCatalog/resourceKind would otherwise each re-scan the whole
+// index and re-parse every discovery document on every request.
 func (h *Handler) discoveryResourceMeta() map[string]discMeta {
+	h.discoveryMetaOnce.Do(func() {
+		h.discoveryMetaCache = buildDiscoveryResourceMeta(h.Store)
+	})
+	return h.discoveryMetaCache
+}
+
+func buildDiscoveryResourceMeta(store *server.CaptureStore) map[string]discMeta {
 	m := map[string]discMeta{}
-	for path, entry := range h.Store.Index {
+	for path, entry := range store.Index {
 		if entry == nil || len(entry.Seqs) == 0 {
 			continue
 		}
@@ -367,7 +380,7 @@ func (h *Handler) discoveryResourceMeta() map[string]discMeta {
 		if path != "/api/v1" && !(strings.HasPrefix(path, "/apis/") && strings.Count(path, "/") == 3) {
 			continue
 		}
-		body, code, err := h.Store.Latest(path, time.Time{})
+		body, code, err := store.Latest(path, time.Time{})
 		if err != nil || code != http.StatusOK || len(body) == 0 {
 			continue
 		}

--- a/internal/ui/v2/objects.go
+++ b/internal/ui/v2/objects.go
@@ -114,7 +114,21 @@ func listEnvelopeWithItems(capturedBody []byte, resource string, items []json.Ra
 		_ = json.Unmarshal(capturedBody, &list)
 	}
 	if list == nil {
-		list = map[string]any{"kind": kindFromResource(resource) + "List", "metadata": map[string]any{}}
+		// No captured envelope at all — a resource kind that exists only via
+		// overlay writes. normalizeObjectBody leaves list envelopes untouched,
+		// so get Kind/apiVersion right here: a sample overlay item carries both
+		// (a real write payload does), giving correct casing (e.g.
+		// "VirtualServiceList", not "Virtualservicelist" from kindFromResource).
+		kind := kindFromResource(resource)
+		var apiVersion string
+		if len(items) > 0 {
+			kind = kindFromSample(items[0], resource)
+			apiVersion = apiVersionFromSample(items[0])
+		}
+		list = map[string]any{"kind": kind + "List", "metadata": map[string]any{}}
+		if apiVersion != "" {
+			list["apiVersion"] = apiVersion
+		}
 	}
 	if items == nil {
 		items = []json.RawMessage{} // a real (possibly captured-empty) list always has "items": [], never null
@@ -125,6 +139,16 @@ func listEnvelopeWithItems(capturedBody []byte, resource string, items []json.Ra
 		return capturedBody
 	}
 	return out
+}
+
+// apiVersionFromSample reads the "apiVersion" field from a live overlay
+// object body (see kindFromSample).
+func apiVersionFromSample(sample json.RawMessage) string {
+	var m struct {
+		APIVersion string `json:"apiVersion"`
+	}
+	_ = json.Unmarshal(sample, &m)
+	return m.APIVersion
 }
 
 // ResourceObjectRow is a single object in a generic resource-type list.

--- a/internal/ui/v2/objects.go
+++ b/internal/ui/v2/objects.go
@@ -48,12 +48,13 @@ func (h *Handler) serveObject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if name == "" {
+		capturedBody, code, err := h.Store.ReconstructAt(path, at)
+		captured := err == nil && code == http.StatusOK && len(capturedBody) > 0
 		items := h.reconstructMergedItems(path, at)
-		if len(items) == 0 {
-			writeJSON(w, http.StatusOK, resp) // Found=false
+		if !captured && len(items) == 0 {
+			writeJSON(w, http.StatusOK, resp) // Found=false: never captured, and the overlay has nothing either
 			return
 		}
-		capturedBody, _, _ := h.Store.ReconstructAt(path, at) // best-effort, for the envelope's Kind/apiVersion
 		_, _, resource, _ := parseAPIPath(path)
 		h.writeObjectFound(w, &resp, listEnvelopeWithItems(capturedBody, resource, items), path, "", "")
 		return
@@ -114,6 +115,9 @@ func listEnvelopeWithItems(capturedBody []byte, resource string, items []json.Ra
 	}
 	if list == nil {
 		list = map[string]any{"kind": kindFromResource(resource) + "List", "metadata": map[string]any{}}
+	}
+	if items == nil {
+		items = []json.RawMessage{} // a real (possibly captured-empty) list always has "items": [], never null
 	}
 	list["items"] = items
 	out, err := json.Marshal(list)

--- a/internal/ui/v2/objects.go
+++ b/internal/ui/v2/objects.go
@@ -25,6 +25,16 @@ type ObjectDetail struct {
 	YAML      string `json:"yaml"`
 }
 
+// capturedListEnvelope is the subset of a captured list body serveObject
+// needs: the envelope's Kind/APIVersion (for casing hints on an item) and the
+// raw items (as the overlay merge's base), parsed once and reused by both of
+// serveObject's branches instead of each re-reading/re-parsing the body.
+type capturedListEnvelope struct {
+	Kind       string            `json:"kind"`
+	APIVersion string            `json:"apiVersion"`
+	Items      []json.RawMessage `json:"items"`
+}
+
 // serveObject returns one captured object (by list path + name) as JSON+YAML.
 // When name is empty the whole list body is returned, which lets the view show
 // cluster/list-scoped resources too. A writable overlay's copy of the object
@@ -49,10 +59,15 @@ func (h *Handler) serveObject(w http.ResponseWriter, r *http.Request) {
 		resp.At = at.UTC().Format(time.RFC3339)
 	}
 
+	capturedBody, code, err := h.Store.ReconstructAt(path, at)
+	captured := err == nil && code == http.StatusOK && len(capturedBody) > 0
+	var capturedList capturedListEnvelope
+	if captured && json.Unmarshal(capturedBody, &capturedList) != nil {
+		captured = false // malformed body — treat exactly like "nothing captured"
+	}
+
 	if name == "" {
-		capturedBody, code, err := h.Store.ReconstructAt(path, at)
-		captured := err == nil && code == http.StatusOK && len(capturedBody) > 0
-		items := h.reconstructMergedItems(path, at)
+		items := h.mergeOverlay(path, capturedList.Items)
 		if !captured && len(items) == 0 {
 			writeJSON(w, http.StatusOK, resp) // Found=false: never captured, and the overlay has nothing either
 			return
@@ -72,24 +87,18 @@ func (h *Handler) serveObject(w http.ResponseWriter, r *http.Request) {
 	// resource name. An overlay-only item already carries its own kind/
 	// apiVersion (a real write payload), so these hints simply go unused for it.
 	var apiVersionHint, kindHint string
-	if capturedBody, code, err := h.Store.ReconstructAt(path, at); err == nil && code == http.StatusOK && len(capturedBody) > 0 {
-		var list struct {
-			Kind       string `json:"kind"`
-			APIVersion string `json:"apiVersion"`
-		}
-		if json.Unmarshal(capturedBody, &list) == nil {
-			apiVersionHint = list.APIVersion
-			kindHint = strings.TrimSuffix(list.Kind, "List")
-			if kindHint == list.Kind { // didn't end in "List" — not a usable hint
-				kindHint = ""
-			}
+	if captured {
+		apiVersionHint = capturedList.APIVersion
+		kindHint = strings.TrimSuffix(capturedList.Kind, "List")
+		if kindHint == capturedList.Kind { // didn't end in "List" — not a usable hint
+			kindHint = ""
 		}
 	}
 
-	// reconstructMergedItems already applies overlay-wins semantics (including
-	// a tombstone dropping the item, which correctly reads as not-found here)
+	// mergeOverlay already applies overlay-wins semantics (including a
+	// tombstone dropping the item, which correctly reads as not-found here)
 	// and tolerates a path the capture never recorded at all.
-	for _, it := range h.reconstructMergedItems(path, at) {
+	for _, it := range h.mergeOverlay(path, capturedList.Items) {
 		if getName(it) == name {
 			h.writeObjectFound(w, &resp, it, path, apiVersionHint, kindHint)
 			return

--- a/internal/ui/v2/objects.go
+++ b/internal/ui/v2/objects.go
@@ -55,6 +55,9 @@ func (h *Handler) serveObject(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusOK, resp) // Found=false: never captured, and the overlay has nothing either
 			return
 		}
+		if !captured {
+			capturedBody = nil // not a successful captured list response — don't treat it as the envelope
+		}
 		_, _, resource, _ := parseAPIPath(path)
 		h.writeObjectFound(w, &resp, listEnvelopeWithItems(capturedBody, resource, items), path, "", "")
 		return

--- a/internal/ui/v2/objects.go
+++ b/internal/ui/v2/objects.go
@@ -25,7 +25,11 @@ type ObjectDetail struct {
 
 // serveObject returns one captured object (by list path + name) as JSON+YAML.
 // When name is empty the whole list body is returned, which lets the view show
-// cluster/list-scoped resources too.
+// cluster/list-scoped resources too. A writable overlay's copy of the object
+// wins outright — including a tombstone, which reads as not-found even if a
+// stale captured copy still exists — and an overlay-only identity (a resource
+// kind or namespace the capture never recorded at all) is served the same way
+// a captured object would be.
 func (h *Handler) serveObject(w http.ResponseWriter, r *http.Request) {
 	if h.Store == nil {
 		writeError(w, http.StatusInternalServerError, "store not initialized")
@@ -38,55 +42,85 @@ func (h *Handler) serveObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	at := h.resolveAt(r)
-	body, code, err := h.Store.ReconstructAt(path, at)
 	resp := ObjectDetail{Path: path, Name: name}
 	if !at.IsZero() {
 		resp.At = at.UTC().Format(time.RFC3339)
 	}
-	if err != nil || code != http.StatusOK || len(body) == 0 {
-		writeJSON(w, http.StatusOK, resp) // Found=false
+
+	if name == "" {
+		items := h.reconstructMergedItems(path, at)
+		if len(items) == 0 {
+			writeJSON(w, http.StatusOK, resp) // Found=false
+			return
+		}
+		capturedBody, _, _ := h.Store.ReconstructAt(path, at) // best-effort, for the envelope's Kind/apiVersion
+		_, _, resource, _ := parseAPIPath(path)
+		h.writeObjectFound(w, &resp, listEnvelopeWithItems(capturedBody, resource, items), path, "", "")
 		return
 	}
 
-	raw := body
-	// The parent List envelope carries the correctly-cased kind
-	// (e.g. "MutatingWebhookConfigurationList") and the real apiVersion, which
-	// individual items inside the list omit. Capture them as hints so we can
-	// restore them on the item without guessing casing from the resource name.
+	// The parent List envelope carries the correctly-cased kind (e.g.
+	// "MutatingWebhookConfigurationList") and the real apiVersion, which
+	// individual items inside a captured list omit. Capture them as hints so
+	// we can restore them on the item without guessing casing from the
+	// resource name. An overlay-only item already carries its own kind/
+	// apiVersion (a real write payload), so these hints simply go unused for it.
 	var apiVersionHint, kindHint string
-	if name != "" {
+	if capturedBody, code, err := h.Store.ReconstructAt(path, at); err == nil && code == http.StatusOK && len(capturedBody) > 0 {
 		var list struct {
-			Kind       string            `json:"kind"`
-			APIVersion string            `json:"apiVersion"`
-			Items      []json.RawMessage `json:"items"`
+			Kind       string `json:"kind"`
+			APIVersion string `json:"apiVersion"`
 		}
-		found := false
-		if err := json.Unmarshal(body, &list); err == nil {
+		if json.Unmarshal(capturedBody, &list) == nil {
 			apiVersionHint = list.APIVersion
 			kindHint = strings.TrimSuffix(list.Kind, "List")
 			if kindHint == list.Kind { // didn't end in "List" — not a usable hint
 				kindHint = ""
 			}
-			for _, it := range list.Items {
-				if getName(it) == name {
-					raw = it
-					found = true
-					break
-				}
-			}
-		}
-		if !found {
-			writeJSON(w, http.StatusOK, resp) // Found=false
-			return
 		}
 	}
 
+	// reconstructMergedItems already applies overlay-wins semantics (including
+	// a tombstone dropping the item, which correctly reads as not-found here)
+	// and tolerates a path the capture never recorded at all.
+	for _, it := range h.reconstructMergedItems(path, at) {
+		if getName(it) == name {
+			h.writeObjectFound(w, &resp, it, path, apiVersionHint, kindHint)
+			return
+		}
+	}
+	writeJSON(w, http.StatusOK, resp) // Found=false
+}
+
+// writeObjectFound finishes an ObjectDetail response for a resolved object
+// body: normalizes it, fills in Kind/Namespace/JSON/YAML, and writes it.
+func (h *Handler) writeObjectFound(w http.ResponseWriter, resp *ObjectDetail, raw json.RawMessage, path, apiVersionHint, kindHint string) {
 	resp.Found = true
 	raw = normalizeObjectBody(raw, path, apiVersionHint, kindHint)
 	resp.Kind, resp.Namespace = kindAndNamespace(raw)
 	resp.JSON = prettyJSON(raw)
 	resp.YAML = toYAML(raw)
-	writeJSON(w, http.StatusOK, resp)
+	writeJSON(w, http.StatusOK, *resp)
+}
+
+// listEnvelopeWithItems re-marshals a captured list body with its items
+// replaced by an overlay-merged set. Falls back to a minimal synthetic
+// envelope when there was no captured body at all — a resource kind that
+// exists only because of overlay writes, e.g. a CRD installed at runtime.
+func listEnvelopeWithItems(capturedBody []byte, resource string, items []json.RawMessage) json.RawMessage {
+	var list map[string]any
+	if len(capturedBody) > 0 {
+		_ = json.Unmarshal(capturedBody, &list)
+	}
+	if list == nil {
+		list = map[string]any{"kind": kindFromResource(resource) + "List", "metadata": map[string]any{}}
+	}
+	list["items"] = items
+	out, err := json.Marshal(list)
+	if err != nil {
+		return capturedBody
+	}
+	return out
 }
 
 // ResourceObjectRow is a single object in a generic resource-type list.
@@ -126,36 +160,17 @@ func (h *Handler) serveResourceList(w http.ResponseWriter, r *http.Request) {
 	}
 	at := h.resolveAt(r)
 
-	out := ResourceList{Resource: resource, Kind: kindFromResource(resource), Namespace: nsFilter}
+	out := ResourceList{Resource: resource, Kind: h.resourceKind(resource), Namespace: nsFilter}
 	if !at.IsZero() {
 		out.At = at.UTC().Format(time.RFC3339)
 	}
 
-	for path, entry := range h.Store.Index {
-		if entry == nil || len(entry.Seqs) == 0 {
-			continue
-		}
-		if strings.Contains(path, "?") {
-			continue
-		}
-		_, _, res, ns := parseAPIPath(path)
-		if res != resource {
-			continue
-		}
+	for _, path := range h.resourcePathsFor(resource) {
+		_, _, _, ns := parseAPIPath(path)
 		if nsFilter != "" && ns != nsFilter {
 			continue
 		}
-		body, code, err := h.Store.ReconstructAt(path, at)
-		if err != nil || code != http.StatusOK || len(body) == 0 {
-			continue
-		}
-		var list struct {
-			Items []json.RawMessage `json:"items"`
-		}
-		if err := json.Unmarshal(body, &list); err != nil {
-			continue
-		}
-		for _, it := range list.Items {
+		for _, it := range h.reconstructMergedItems(path, at) {
 			name := getName(it)
 			if name == "" {
 				continue
@@ -245,6 +260,25 @@ func (h *Handler) serveResourceCatalog(w http.ResponseWriter, r *http.Request) {
 		if i := latestIndex(entry, at); i >= 0 && i < len(entry.Counts) && entry.Counts[i] > 0 {
 			row.Count += entry.Counts[i]
 		}
+	}
+	// Resource kinds/namespaces that exist only because of overlay writes (a
+	// CRD installed at runtime, or objects in a namespace the capture never
+	// saw) have no index entry at all, so the loop above never visits them —
+	// add or extend their rows here from the overlay directly.
+	for _, sc := range h.Overlay.OverlayScopes() {
+		k := key{sc.Group, sc.Version, sc.Resource}
+		row := agg[k]
+		if row == nil {
+			row = &ResourceCatalogRow{
+				Group: sc.Group, Version: sc.Version, Resource: sc.Resource,
+				Kind: kindFromSample(sc.Sample, sc.Resource), Link: resourceLink(sc.Resource, ""),
+			}
+			agg[k] = row
+		}
+		if sc.Namespace != "" {
+			row.Namespaced = true
+		}
+		row.Count += sc.Count
 	}
 
 	out := ResourceCatalog{Capture: h.captureMeta()}
@@ -372,6 +406,36 @@ func getLabels(raw json.RawMessage) map[string]string {
 		return nil
 	}
 	return m.Metadata.Labels
+}
+
+// resourceKind resolves a resource plural name's display Kind the same way
+// the catalog does: the capture's own discovery documents first, then (for a
+// resource kind the capture never saw at all, e.g. a CRD's custom resources)
+// an overlay sample, falling back to a titlecased guess.
+func (h *Handler) resourceKind(resource string) string {
+	if dm, ok := h.discoveryResourceMeta()[resource]; ok && dm.Kind != "" {
+		return dm.Kind
+	}
+	for _, sc := range h.Overlay.OverlayScopes() {
+		if sc.Resource == resource {
+			return kindFromSample(sc.Sample, resource)
+		}
+	}
+	return kindFromResource(resource)
+}
+
+// kindFromSample reads the "kind" field from a live overlay object body — a
+// real write payload from kubectl/helm/a controller always carries it, unlike
+// individual items inside a captured list — falling back to kindFromResource
+// when it's missing or unparseable.
+func kindFromSample(sample json.RawMessage, resource string) string {
+	var m struct {
+		Kind string `json:"kind"`
+	}
+	if json.Unmarshal(sample, &m) == nil && m.Kind != "" {
+		return m.Kind
+	}
+	return kindFromResource(resource)
 }
 
 // kindAndNamespace pulls apiVersion/kind and metadata.namespace from a raw

--- a/internal/ui/v2/objects.go
+++ b/internal/ui/v2/objects.go
@@ -292,7 +292,16 @@ func (h *Handler) serveResourceCatalog(w http.ResponseWriter, r *http.Request) {
 	// Resource kinds/namespaces that exist only because of overlay writes (a
 	// CRD installed at runtime, or objects in a namespace the capture never
 	// saw) have no index entry at all, so the loop above never visits them —
-	// add or extend their rows here from the overlay directly.
+	// add or extend their rows here from the overlay directly. zeroIndexCount
+	// snapshots, before any overlay scope is folded in, which rows had no
+	// index-derived count at all: OverlayScopes' Count is every *live* overlay
+	// entry (including in-place updates to already-captured objects), so
+	// summing it into an already-nonzero index count would double-count —
+	// only fill Count in when the index gave us nothing for this resource.
+	zeroIndexCount := map[key]bool{}
+	for k, row := range agg {
+		zeroIndexCount[k] = row.Count == 0
+	}
 	for _, sc := range h.Overlay.OverlayScopes() {
 		k := key{sc.Group, sc.Version, sc.Resource}
 		row := agg[k]
@@ -302,11 +311,14 @@ func (h *Handler) serveResourceCatalog(w http.ResponseWriter, r *http.Request) {
 				Kind: kindFromSample(sc.Sample, sc.Resource), Link: resourceLink(sc.Resource, ""),
 			}
 			agg[k] = row
+			zeroIndexCount[k] = true // brand-new row — nothing from the index at all
 		}
 		if sc.Namespace != "" {
 			row.Namespaced = true
 		}
-		row.Count += sc.Count
+		if zeroIndexCount[k] {
+			row.Count += sc.Count
+		}
 	}
 
 	out := ResourceCatalog{Capture: h.captureMeta()}

--- a/internal/ui/v2/objects_test.go
+++ b/internal/ui/v2/objects_test.go
@@ -173,6 +173,43 @@ func TestServeObject_MissingPath(t *testing.T) {
 	}
 }
 
+// TestDiscoveryResourceMeta_CachedAcrossCalls is a regression test: the
+// capture's discovery documents never change, so discoveryResourceMeta must
+// compute its index scan + discovery-document parse once per Handler and
+// reuse the result, not redo it on every call (serveResourceList and
+// serveResourceCatalog both call it, once per request).
+func TestDiscoveryResourceMeta_CachedAcrossCalls(t *testing.T) {
+	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	discoveryDoc := `{"kind":"APIResourceList","groupVersion":"apps/v1","resources":[` +
+		`{"name":"deployments","singularName":"deployment","kind":"Deployment","shortNames":["deploy"]}]}`
+	recs := []*capture.Record{
+		{ID: "d1", CapturedAt: now, APIPath: "/apis/apps/v1", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(discoveryDoc)},
+	}
+	idx := capture.Index{
+		"/apis/apps/v1": {APIPath: "/apis/apps/v1", Seqs: []int{0}, Times: []time.Time{now}},
+	}
+	meta := &capture.CaptureMetadata{CaptureID: "discovery-meta-test", CapturedAt: now.Add(-5 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
+	h := &Handler{Store: buildV2TestStore(t, recs, idx, meta), At: now}
+
+	first := h.discoveryResourceMeta()
+	if len(first) == 0 {
+		t.Fatal("discoveryResourceMeta() returned empty — fixture has no discovery docs to assert caching against")
+	}
+	// Mutate the map returned by the first call, then call again: if the
+	// result is truly cached (the same map instance), the second call sees
+	// the mutation too. If discoveryResourceMeta rebuilt it instead, the
+	// second call would come back full-sized again.
+	before := len(first)
+	for k := range first {
+		delete(first, k)
+		break
+	}
+	second := h.discoveryResourceMeta()
+	if len(second) != before-1 {
+		t.Errorf("discoveryResourceMeta() len = %d after mutating the prior result, want %d — not returning the cached map", len(second), before-1)
+	}
+}
+
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 func doObject(t *testing.T, h *Handler, path, name string) ObjectDetail {

--- a/internal/ui/v2/objects_test.go
+++ b/internal/ui/v2/objects_test.go
@@ -128,6 +128,41 @@ func TestServeObject_NotFound(t *testing.T) {
 	}
 }
 
+// TestServeObject_CapturedEmptyList_FoundWithEmptyItems is a regression test:
+// a whole-list view (name == "") of a path the capture recorded as a 200 with
+// zero items must read as Found=true with "items": [], not as not-found and
+// not as "items": null — a genuinely empty captured list is a real, distinct
+// answer from "this path was never captured".
+func TestServeObject_CapturedEmptyList_FoundWithEmptyItems(t *testing.T) {
+	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	emptyCMList := `{"apiVersion":"v1","kind":"ConfigMapList","items":[]}`
+	recs := []*capture.Record{
+		{ID: "r1", CapturedAt: now, APIPath: "/api/v1/namespaces/default/configmaps", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(emptyCMList)},
+	}
+	idx := capture.Index{
+		"/api/v1/namespaces/default/configmaps": {APIPath: "/api/v1/namespaces/default/configmaps", Seqs: []int{0}, Times: []time.Time{now}},
+	}
+	meta := &capture.CaptureMetadata{CaptureID: "v2-obj-empty-test", CapturedAt: now.Add(-5 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
+	h := &Handler{Store: buildV2TestStore(t, recs, idx, meta), At: now}
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/api/object?path=%2Fapi%2Fv1%2Fnamespaces%2Fdefault%2Fconfigmaps", nil)
+	w := httptest.NewRecorder()
+	h.serveObject(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var d ObjectDetail
+	if err := json.Unmarshal(w.Body.Bytes(), &d); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !d.Found {
+		t.Errorf("Found = false, want true for a captured-empty list")
+	}
+	if !strings.Contains(d.JSON, `"items": []`) {
+		t.Errorf("JSON = %s, want an explicit empty items array, not null", d.JSON)
+	}
+}
+
 func TestServeObject_MissingPath(t *testing.T) {
 	h := newObjectTestHandler(t)
 	req := httptest.NewRequest(http.MethodGet, "/v2/api/object?name=x", nil)

--- a/internal/ui/v2/overlay.go
+++ b/internal/ui/v2/overlay.go
@@ -1,0 +1,114 @@
+package v2
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/server"
+)
+
+// reconstructMergedItems reconstructs the list body at path (parsed for its
+// group/version/resource/namespace) and merges any writable-overlay writes
+// over it — see server.Server.MergeOverlayList. This is the one-stop read for
+// every list view in this package: it returns overlay-created items even for
+// a path the capture never recorded at all (a brand-new namespace, or a
+// resource kind that didn't exist until a CRD was installed at runtime), since
+// MergeOverlayList tolerates a nil/empty base. Returns nil if there is nothing
+// to show either way.
+func (h *Handler) reconstructMergedItems(path string, at time.Time) []json.RawMessage {
+	var items []json.RawMessage
+	if body, code, err := h.Store.ReconstructAt(path, at); err == nil && code == http.StatusOK && len(body) > 0 {
+		var list struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		if json.Unmarshal(body, &list) == nil {
+			items = list.Items
+		}
+	}
+	if h.Overlay != nil {
+		group, version, resource, ns := parseAPIPath(path)
+		items = h.Overlay.MergeOverlayList(group, version, resource, ns, items)
+	}
+	return items
+}
+
+// resourcePathsFor returns every distinct API list path for a resource plural
+// name (e.g. "pods") — every namespaced/cluster-scoped path the capture's
+// index has for it, plus (when overlay is present) any overlay-only scope
+// with no index entry at all, such as a namespace created purely by a
+// `helm install --create-namespace` mid-replay. Callers that already
+// hardcode a resource's list path(s) per namespace (namespace.go's workload/
+// VM/pod groups) don't need this — reconstructMergedItems alone is enough,
+// since it tolerates an uncaptured path. This is for callers that otherwise
+// discover paths by walking the index (lists.go, overview.go).
+func (h *Handler) resourcePathsFor(resource string) []string {
+	seen := map[string]bool{}
+	var paths []string
+	for path, entry := range h.Store.Index {
+		if entry == nil || len(entry.Seqs) == 0 || strings.Contains(path, "?") {
+			continue
+		}
+		_, _, res, _ := parseAPIPath(path)
+		if res != resource || seen[path] {
+			continue
+		}
+		seen[path] = true
+		paths = append(paths, path)
+	}
+	if h.Overlay != nil {
+		for _, sc := range h.Overlay.OverlayScopes() {
+			if sc.Resource != resource {
+				continue
+			}
+			path := apiListPath(sc.Group, sc.Version, sc.Resource, sc.Namespace)
+			if seen[path] {
+				continue
+			}
+			seen[path] = true
+			paths = append(paths, path)
+		}
+	}
+	return paths
+}
+
+// mergeOverlayNamespaceCounts folds overlay-only per-namespace resource counts
+// into counts (as returned by CaptureStore.NamespaceItemCountsAt), so a
+// namespace or resource kind that exists only because of overlay writes still
+// shows up in namespace/workload/pod KPI totals. It only fills in counts the
+// capture recorded as zero: a resource kind the namespace already had
+// captured records for is left as-is rather than re-read and re-summed here,
+// which would need a full list-body read per resource kind across every
+// namespace — the exact cost NamespaceItemCountsAt exists to avoid on the
+// overview page. The per-namespace drill-down (namespace.go) reads real
+// bodies and is exact; this is a best-effort summary.
+func mergeOverlayNamespaceCounts(counts map[string]map[string]int, scopes []server.OverlayScope) {
+	for _, sc := range scopes {
+		if sc.Namespace == "" || sc.Count == 0 {
+			continue
+		}
+		byRes, ok := counts[sc.Namespace]
+		if !ok {
+			byRes = map[string]int{}
+			counts[sc.Namespace] = byRes
+		}
+		if byRes[sc.Resource] == 0 {
+			byRes[sc.Resource] = sc.Count
+		}
+	}
+}
+
+// mergeOverlayClusterCounts is mergeOverlayNamespaceCounts for cluster-scoped
+// resources (e.g. a CRD created at runtime), folding into the map returned by
+// clusterScopedResourceCounts. Same best-effort semantics.
+func mergeOverlayClusterCounts(counts map[string]int, scopes []server.OverlayScope) {
+	for _, sc := range scopes {
+		if sc.Namespace != "" || sc.Count == 0 {
+			continue
+		}
+		if counts[sc.Resource] == 0 {
+			counts[sc.Resource] = sc.Count
+		}
+	}
+}

--- a/internal/ui/v2/overlay.go
+++ b/internal/ui/v2/overlay.go
@@ -9,14 +9,28 @@ import (
 	"github.com/phenixblue/k8shark/internal/server"
 )
 
-// reconstructMergedItems reconstructs the list body at path (parsed for its
-// group/version/resource/namespace) and merges any writable-overlay writes
-// over it — see server.Server.MergeOverlayList. This is the one-stop read for
-// every list view in this package: it returns overlay-created items even for
+// mergeOverlay merges the overlay's writes for path's scope over
+// capturedItems (the base list, already read and parsed by the caller, or nil
+// when the path was never captured) — see server.Server.MergeOverlayList.
+// Callers that already read the captured body for another reason (e.g. to
+// pull List-envelope Kind/apiVersion hints) should call this directly instead
+// of reconstructMergedItems, to avoid reading and re-parsing it twice.
+func (h *Handler) mergeOverlay(path string, capturedItems []json.RawMessage) []json.RawMessage {
+	if h.Overlay == nil {
+		return capturedItems
+	}
+	group, version, resource, ns := parseAPIPath(path)
+	return h.Overlay.MergeOverlayList(group, version, resource, ns, capturedItems)
+}
+
+// reconstructMergedItems reconstructs the list body at path and merges any
+// writable-overlay writes over it (see mergeOverlay). This is the one-stop
+// read for every list view in this package that doesn't already need the raw
+// captured body for something else: it returns overlay-created items even for
 // a path the capture never recorded at all (a brand-new namespace, or a
 // resource kind that didn't exist until a CRD was installed at runtime), since
-// MergeOverlayList tolerates a nil/empty base. Returns nil if there is nothing
-// to show either way.
+// mergeOverlay tolerates a nil/empty base. Returns nil if there is nothing to
+// show either way.
 func (h *Handler) reconstructMergedItems(path string, at time.Time) []json.RawMessage {
 	var items []json.RawMessage
 	if body, code, err := h.Store.ReconstructAt(path, at); err == nil && code == http.StatusOK && len(body) > 0 {
@@ -27,11 +41,7 @@ func (h *Handler) reconstructMergedItems(path string, at time.Time) []json.RawMe
 			items = list.Items
 		}
 	}
-	if h.Overlay != nil {
-		group, version, resource, ns := parseAPIPath(path)
-		items = h.Overlay.MergeOverlayList(group, version, resource, ns, items)
-	}
-	return items
+	return h.mergeOverlay(path, items)
 }
 
 // resourcePathsFor returns every distinct API list path for a resource plural

--- a/internal/ui/v2/overlay.go
+++ b/internal/ui/v2/overlay.go
@@ -42,24 +42,34 @@ func (h *Handler) reconstructMergedItems(path string, at time.Time) []json.RawMe
 // hardcode a resource's list path(s) per namespace (namespace.go's workload/
 // VM/pod groups) don't need this — reconstructMergedItems alone is enough,
 // since it tolerates an uncaptured path. This is for callers that otherwise
-// discover paths by walking the index (lists.go, overview.go).
+// discover paths by walking the index (lists.go, overview.go). A caller
+// needing several resources at once (e.g. every workload kind) should use
+// resourcePathsForResources instead, to scan the index only once.
 func (h *Handler) resourcePathsFor(resource string) []string {
+	return h.resourcePathsForResources(map[string]bool{resource: true})[resource]
+}
+
+// resourcePathsForResources is resourcePathsFor for several resources at
+// once: it scans the index (and overlay scopes) exactly once, grouping
+// matching paths by resource, instead of once per resource — the cluster-wide
+// workload list would otherwise re-walk the whole index per workload kind.
+func (h *Handler) resourcePathsForResources(resources map[string]bool) map[string][]string {
+	out := map[string][]string{}
 	seen := map[string]bool{}
-	var paths []string
 	for path, entry := range h.Store.Index {
 		if entry == nil || len(entry.Seqs) == 0 || strings.Contains(path, "?") {
 			continue
 		}
 		_, _, res, _ := parseAPIPath(path)
-		if res != resource || seen[path] {
+		if !resources[res] || seen[path] {
 			continue
 		}
 		seen[path] = true
-		paths = append(paths, path)
+		out[res] = append(out[res], path)
 	}
 	if h.Overlay != nil {
 		for _, sc := range h.Overlay.OverlayScopes() {
-			if sc.Resource != resource {
+			if !resources[sc.Resource] {
 				continue
 			}
 			path := apiListPath(sc.Group, sc.Version, sc.Resource, sc.Namespace)
@@ -67,10 +77,10 @@ func (h *Handler) resourcePathsFor(resource string) []string {
 				continue
 			}
 			seen[path] = true
-			paths = append(paths, path)
+			out[sc.Resource] = append(out[sc.Resource], path)
 		}
 	}
-	return paths
+	return out
 }
 
 // mergeOverlayNamespaceCounts folds overlay-only per-namespace resource counts

--- a/internal/ui/v2/overlay_test.go
+++ b/internal/ui/v2/overlay_test.go
@@ -363,3 +363,66 @@ func TestResourcePathsForResources_GroupsBySingleScan(t *testing.T) {
 		t.Errorf("resourcePathsFor(pods) = %v, want to match resourcePathsForResources' pods entry %v", single, got["pods"])
 	}
 }
+
+// TestServeObject_WholeListView_IgnoresNonListCapturedBody is a regression
+// test: when the path's last captured record was NOT a successful list
+// response (e.g. a Kubernetes Status object from a 404, from before a CRD
+// existed), the whole-list view must build the synthetic envelope from the
+// live overlay items instead of treating the Status body as the envelope —
+// which would otherwise leak a bogus kind/apiVersion/status into the output.
+func TestServeObject_WholeListView_IgnoresNonListCapturedBody(t *testing.T) {
+	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "capture.kshrk")
+
+	statusBody := `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"the server could not find the requested resource","code":404}`
+	recs := []*capture.Record{
+		{ID: "s1", CapturedAt: now, APIPath: vsPath, HTTPMethod: "GET", ResponseCode: 404, ResponseBody: json.RawMessage(statusBody)},
+	}
+	idx := capture.Index{
+		vsPath: {APIPath: vsPath, Seqs: []int{0}, Times: []time.Time{now}},
+	}
+	meta := &capture.CaptureMetadata{CaptureID: "overlay-404-test", CapturedAt: now.Add(-5 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
+
+	sw, err := archive.NewStreamWriter(path)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	for _, r := range recs {
+		if err := sw.WriteRecord(r); err != nil {
+			t.Fatalf("WriteRecord: %v", err)
+		}
+	}
+	if err := sw.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("archive Finish: %v", err)
+	}
+	srv, err := server.Replay(server.ReplayOptions{
+		ArchivePath:       path,
+		KubeconfigOut:     filepath.Join(dir, "kubeconfig.yaml"),
+		StartPaused:       true,
+		PauseAtWindowEnd:  true,
+		Writable:          true,
+		DisableScheduling: true,
+	})
+	if err != nil {
+		t.Fatalf("server.Replay: %v", err)
+	}
+	t.Cleanup(srv.Shutdown)
+	h := &Handler{Store: srv.Store(), Overlay: srv, At: now}
+
+	overlayPost(t, srv, vsPath, vsBody)
+
+	var d ObjectDetail
+	if code := getJSONInto(t, h, h.serveObject, "/v2/api/object", "?path="+strings.ReplaceAll(vsPath, "/", "%2F"), &d); code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	if !d.Found {
+		t.Fatalf("Found = false, want true (the overlay has a live item)")
+	}
+	if !strings.Contains(d.JSON, `"kind": "VirtualServiceList"`) {
+		t.Errorf("JSON missing correct synthetic envelope kind:\n%s", d.JSON)
+	}
+	if strings.Contains(d.JSON, "Failure") || strings.Contains(d.JSON, `"code": 404`) {
+		t.Errorf("JSON leaked the captured 404 Status body instead of a synthetic list envelope:\n%s", d.JSON)
+	}
+}

--- a/internal/ui/v2/overlay_test.go
+++ b/internal/ui/v2/overlay_test.go
@@ -56,6 +56,7 @@ func newOverlayTestHandler(t *testing.T) (*Handler, *server.Server) {
 		ArchivePath:       path,
 		KubeconfigOut:     filepath.Join(dir, "kubeconfig.yaml"),
 		StartPaused:       true,
+		PauseAtWindowEnd:  true, // park after the pod/namespace records, not before
 		Writable:          true,
 		DisableScheduling: true,
 	})
@@ -82,6 +83,27 @@ func overlayPost(t *testing.T, srv *server.Server, path, body string) {
 	if resp.StatusCode != http.StatusCreated {
 		b, _ := io.ReadAll(resp.Body)
 		t.Fatalf("POST %s = %d, want 201: %s", path, resp.StatusCode, b)
+	}
+}
+
+// overlayPatch strategic-merge-patches an object (adopting it into the
+// overlay if it was only ever captured) through the mock server's real
+// HTTPS API.
+func overlayPatch(t *testing.T, srv *server.Server, path, body string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPatch, srv.Address()+path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new PATCH request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/strategic-merge-patch+json")
+	resp, err := overlayTestClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH %s: %v", path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("PATCH %s = %d, want 200: %s", path, resp.StatusCode, b)
 	}
 }
 
@@ -208,6 +230,33 @@ func TestOverlay_NewCRDResourceType_VisibleEverywhere(t *testing.T) {
 	})
 }
 
+// TestOverlay_UpdateExistingObject_CatalogCountNotDoubled is a regression
+// test: an overlay write that updates an object the capture already had
+// (not a new one) must not inflate the resource catalog's count. Before the
+// fix, OverlayScopes' count (every *live* overlay entry, including updates)
+// was summed on top of the index-derived count unconditionally.
+func TestOverlay_UpdateExistingObject_CatalogCountNotDoubled(t *testing.T) {
+	h, srv := newOverlayTestHandler(t)
+	overlayPatch(t, srv, "/api/v1/namespaces/default/pods/web", `{"metadata":{"labels":{"updated":"true"}}}`)
+
+	var out ResourceCatalog
+	if code := getJSONInto(t, h, h.serveResourceCatalog, "/v2/api/resources", "", &out); code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	var row *ResourceCatalogRow
+	for i := range out.Resources {
+		if out.Resources[i].Resource == "pods" {
+			row = &out.Resources[i]
+		}
+	}
+	if row == nil {
+		t.Fatalf("serveResourceCatalog missing pods: %+v", out.Resources)
+	}
+	if row.Count != 1 {
+		t.Errorf("pods Count = %d, want 1 (the same pod, updated in place — not double-counted against the index)", row.Count)
+	}
+}
+
 // TestOverlay_NewNamespace_VisibleInPicker covers a namespace created purely
 // via the overlay (e.g. `helm install --create-namespace`), which — like the
 // CRD case above — has no index entry at all: it must still appear in the
@@ -232,6 +281,28 @@ func TestOverlay_NewNamespace_VisibleInPicker(t *testing.T) {
 	}
 	if found.Resources < 1 {
 		t.Errorf("istio-system.Resources = %d, want >= 1 (the virtualservice)", found.Resources)
+	}
+}
+
+// TestOverlay_NewNamespace_KPIsResourcesIncludesPodsWorkloadsVMs is a
+// regression test: KPIs.Resources for an overlay-only namespace (no index
+// counts at all) must include the exact pod/workload/VM counts, not just the
+// index-derived resTotal — before the fix it stayed at 0 for those kinds.
+func TestOverlay_NewNamespace_KPIsResourcesIncludesPodsWorkloadsVMs(t *testing.T) {
+	h, srv := newOverlayTestHandler(t)
+	overlayPost(t, srv, "/api/v1/namespaces", `{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"istio-system"}}`)
+	overlayPost(t, srv, "/api/v1/namespaces/istio-system/pods",
+		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"istiod","namespace":"istio-system"},"status":{"phase":"Running"}}`)
+
+	var d NamespaceDetail
+	if code := getJSONInto(t, h, h.serveNamespace, "/v2/api/namespace", "?ns=istio-system", &d); code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	if d.KPIs.Pods != 1 {
+		t.Fatalf("KPIs.Pods = %d, want 1", d.KPIs.Pods)
+	}
+	if d.KPIs.Resources < 1 {
+		t.Errorf("KPIs.Resources = %d, want >= 1 (must include the overlay-only pod)", d.KPIs.Resources)
 	}
 }
 

--- a/internal/ui/v2/overlay_test.go
+++ b/internal/ui/v2/overlay_test.go
@@ -70,6 +70,7 @@ func newOverlayTestHandler(t *testing.T) (*Handler, *server.Server) {
 
 var overlayTestClient = &http.Client{
 	Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, // #nosec G402 -- test only
+	Timeout:   10 * time.Second,                                                        // bound test failures instead of hanging on a stalled server
 }
 
 // overlayPost creates an object through the mock server's real HTTPS API.

--- a/internal/ui/v2/overlay_test.go
+++ b/internal/ui/v2/overlay_test.go
@@ -1,0 +1,251 @@
+package v2
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/server"
+)
+
+// newOverlayTestHandler starts a real writable-replay mock server over a
+// minimal one-pod, one-namespace capture and wires its store+overlay into a
+// v2 Handler exactly the way ui.Open does in production. Tests drive writes
+// through the server's real HTTPS API (see overlayPost/overlayDelete) rather
+// than reaching into overlay internals, so they exercise the same integration
+// a real kubectl/helm client would.
+func newOverlayTestHandler(t *testing.T) (*Handler, *server.Server) {
+	t.Helper()
+	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "capture.kshrk")
+
+	nsList := `{"apiVersion":"v1","kind":"NamespaceList","items":[{"metadata":{"name":"default"}}]}`
+	podList := `{"apiVersion":"v1","kind":"PodList","items":[{"metadata":{"name":"web","namespace":"default"},"status":{"phase":"Running"}}]}`
+	recs := []*capture.Record{
+		{ID: "n1", CapturedAt: now, APIPath: "/api/v1/namespaces", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(nsList)},
+		{ID: "p1", CapturedAt: now, APIPath: "/api/v1/namespaces/default/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(podList)},
+	}
+	idx := capture.Index{
+		"/api/v1/namespaces":              {APIPath: "/api/v1/namespaces", Seqs: []int{0}, Times: []time.Time{now}, Counts: []int{1}},
+		"/api/v1/namespaces/default/pods": {APIPath: "/api/v1/namespaces/default/pods", Seqs: []int{0}, Times: []time.Time{now}, Counts: []int{1}},
+	}
+	meta := &capture.CaptureMetadata{CaptureID: "overlay-test", CapturedAt: now.Add(-5 * time.Minute), CapturedUntil: now, RecordCount: len(recs)}
+
+	sw, err := archive.NewStreamWriter(path)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	for _, r := range recs {
+		if err := sw.WriteRecord(r); err != nil {
+			t.Fatalf("WriteRecord: %v", err)
+		}
+	}
+	if err := sw.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("archive Finish: %v", err)
+	}
+
+	srv, err := server.Replay(server.ReplayOptions{
+		ArchivePath:       path,
+		KubeconfigOut:     filepath.Join(dir, "kubeconfig.yaml"),
+		StartPaused:       true,
+		Writable:          true,
+		DisableScheduling: true,
+	})
+	if err != nil {
+		t.Fatalf("server.Replay: %v", err)
+	}
+	t.Cleanup(srv.Shutdown)
+
+	return &Handler{Store: srv.Store(), Overlay: srv, At: now}, srv
+}
+
+var overlayTestClient = &http.Client{
+	Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, // #nosec G402 -- test only
+}
+
+// overlayPost creates an object through the mock server's real HTTPS API.
+func overlayPost(t *testing.T, srv *server.Server, path, body string) {
+	t.Helper()
+	resp, err := overlayTestClient.Post(srv.Address()+path, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("POST %s = %d, want 201: %s", path, resp.StatusCode, b)
+	}
+}
+
+// overlayDelete deletes an object through the mock server's real HTTPS API.
+func overlayDelete(t *testing.T, srv *server.Server, path string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodDelete, srv.Address()+path, nil)
+	if err != nil {
+		t.Fatalf("new DELETE request: %v", err)
+	}
+	resp, err := overlayTestClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE %s: %v", path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("DELETE %s = %d, want 200: %s", path, resp.StatusCode, b)
+	}
+}
+
+const vsPath = "/apis/networking.istio.io/v1beta1/namespaces/istio-system/virtualservices"
+const vsBody = `{"apiVersion":"networking.istio.io/v1beta1","kind":"VirtualService","metadata":{"name":"reviews","namespace":"istio-system"},"spec":{"hosts":["reviews"]}}`
+
+// TestOverlay_NewCRDResourceType_VisibleEverywhere covers the core "resources
+// created only via the writable overlay have no entry in the capture's index"
+// case: a namespace and a custom-resource kind the capture never saw (as if a
+// CRD were installed and a CR created mid-replay) must still surface through
+// every discovery path — the generic resource list, the resource catalog, and
+// the single-object view.
+func TestOverlay_NewCRDResourceType_VisibleEverywhere(t *testing.T) {
+	h, srv := newOverlayTestHandler(t)
+	overlayPost(t, srv, vsPath, vsBody)
+
+	t.Run("resourcePathsFor discovers the overlay-only path", func(t *testing.T) {
+		paths := h.resourcePathsFor("virtualservices")
+		found := false
+		for _, p := range paths {
+			if p == vsPath {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("resourcePathsFor(virtualservices) = %v, want it to include %s", paths, vsPath)
+		}
+	})
+
+	t.Run("serveResourceList includes it", func(t *testing.T) {
+		var out ResourceList
+		if code := getJSONInto(t, h, h.serveResourceList, "/v2/api/resource", "?resource=virtualservices", &out); code != http.StatusOK {
+			t.Fatalf("status = %d", code)
+		}
+		if out.Total != 1 || len(out.Items) != 1 || out.Items[0].Name != "reviews" || out.Items[0].Namespace != "istio-system" {
+			t.Errorf("serveResourceList = %+v, want one reviews/istio-system item", out)
+		}
+	})
+
+	t.Run("serveResourceCatalog includes it with the right Kind and count", func(t *testing.T) {
+		var out ResourceCatalog
+		if code := getJSONInto(t, h, h.serveResourceCatalog, "/v2/api/resources", "", &out); code != http.StatusOK {
+			t.Fatalf("status = %d", code)
+		}
+		var row *ResourceCatalogRow
+		for i := range out.Resources {
+			if out.Resources[i].Resource == "virtualservices" {
+				row = &out.Resources[i]
+			}
+		}
+		if row == nil {
+			t.Fatalf("serveResourceCatalog missing virtualservices: %+v", out.Resources)
+		}
+		if row.Kind != "VirtualService" {
+			t.Errorf("Kind = %q, want VirtualService (derived from the overlay object's own kind field)", row.Kind)
+		}
+		if row.Count != 1 || !row.Namespaced {
+			t.Errorf("row = %+v, want Count=1 Namespaced=true", row)
+		}
+	})
+
+	t.Run("serveObject finds the single object", func(t *testing.T) {
+		var d ObjectDetail
+		if code := getJSONInto(t, h, h.serveObject, "/v2/api/object", "?path="+strings.ReplaceAll(vsPath, "/", "%2F")+"&name=reviews", &d); code != http.StatusOK {
+			t.Fatalf("status = %d", code)
+		}
+		if !d.Found || d.Kind != "VirtualService" || d.Namespace != "istio-system" {
+			t.Errorf("ObjectDetail = %+v, want Found=true Kind=VirtualService", d)
+		}
+	})
+
+	t.Run("delete tombstones it everywhere", func(t *testing.T) {
+		overlayDelete(t, srv, vsPath+"/reviews")
+
+		var d ObjectDetail
+		if code := getJSONInto(t, h, h.serveObject, "/v2/api/object", "?path="+strings.ReplaceAll(vsPath, "/", "%2F")+"&name=reviews", &d); code != http.StatusOK {
+			t.Fatalf("status = %d", code)
+		}
+		if d.Found {
+			t.Errorf("ObjectDetail.Found = true after delete, want false")
+		}
+
+		var out ResourceList
+		if code := getJSONInto(t, h, h.serveResourceList, "/v2/api/resource", "?resource=virtualservices", &out); code != http.StatusOK {
+			t.Fatalf("status = %d", code)
+		}
+		if out.Total != 0 {
+			t.Errorf("serveResourceList after delete = %+v, want empty", out)
+		}
+	})
+}
+
+// TestOverlay_NewNamespace_VisibleInPicker covers a namespace created purely
+// via the overlay (e.g. `helm install --create-namespace`), which — like the
+// CRD case above — has no index entry at all: it must still appear in the
+// namespace picker (the overview's namespace list).
+func TestOverlay_NewNamespace_VisibleInPicker(t *testing.T) {
+	h, srv := newOverlayTestHandler(t)
+	overlayPost(t, srv, "/api/v1/namespaces", `{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"istio-system"}}`)
+	overlayPost(t, srv, vsPath, vsBody)
+
+	var ov Overview
+	if code := getJSONInto(t, h, h.serveOverview, "/v2/api/overview", "", &ov); code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	var found *NamespaceSummary
+	for i := range ov.Namespaces {
+		if ov.Namespaces[i].Name == "istio-system" {
+			found = &ov.Namespaces[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("overview.Namespaces missing istio-system: %+v", ov.Namespaces)
+	}
+	if found.Resources < 1 {
+		t.Errorf("istio-system.Resources = %d, want >= 1 (the virtualservice)", found.Resources)
+	}
+}
+
+// TestOverlay_PodInExistingNamespace_VisibleInLists is the more common case:
+// a pod added to a namespace the capture already had, e.g. via kwok/
+// controller-manager. Existing list views (already index-known paths) must
+// merge it in.
+func TestOverlay_PodInExistingNamespace_VisibleInLists(t *testing.T) {
+	h, srv := newOverlayTestHandler(t)
+	overlayPost(t, srv, "/api/v1/namespaces/default/pods",
+		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"sidecar-injected","namespace":"default"},"status":{"phase":"Running"}}`)
+
+	var resp PodsList
+	if code := getJSONInto(t, h, h.serveAllPods, "/v2/api/pods", "", &resp); code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	if resp.Total != 2 {
+		t.Errorf("Total = %d, want 2 (captured web + overlay sidecar-injected)", resp.Total)
+	}
+	var names []string
+	for _, p := range resp.Pods {
+		names = append(names, p.Name)
+	}
+	found := false
+	for _, n := range names {
+		if n == "sidecar-injected" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("pods = %v, want sidecar-injected included", names)
+	}
+}

--- a/internal/ui/v2/overlay_test.go
+++ b/internal/ui/v2/overlay_test.go
@@ -336,3 +336,30 @@ func TestOverlay_PodInExistingNamespace_VisibleInLists(t *testing.T) {
 		t.Errorf("pods = %v, want sidecar-injected included", names)
 	}
 }
+
+// TestResourcePathsForResources_GroupsBySingleScan covers the multi-resource
+// helper the cluster-wide workload list uses to avoid scanning the index once
+// per workload kind: a single call must correctly group paths — including an
+// overlay-only one with no index entry at all — by resource.
+func TestResourcePathsForResources_GroupsBySingleScan(t *testing.T) {
+	h, srv := newOverlayTestHandler(t)
+	overlayPost(t, srv, "/apis/apps/v1/namespaces/default/deployments",
+		`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"web","namespace":"default"}}`)
+
+	got := h.resourcePathsForResources(map[string]bool{"pods": true, "deployments": true, "statefulsets": true})
+
+	if paths := got["pods"]; len(paths) != 1 || paths[0] != "/api/v1/namespaces/default/pods" {
+		t.Errorf("pods = %v, want exactly the captured path", paths)
+	}
+	if paths := got["deployments"]; len(paths) != 1 || paths[0] != "/apis/apps/v1/namespaces/default/deployments" {
+		t.Errorf("deployments = %v, want the overlay-only path (no index entry for it)", paths)
+	}
+	if paths := got["statefulsets"]; len(paths) != 0 {
+		t.Errorf("statefulsets = %v, want none (neither captured nor overlay-created)", paths)
+	}
+
+	// resourcePathsFor(resource) must agree with the grouped result.
+	if single := h.resourcePathsFor("pods"); len(single) != 1 || single[0] != got["pods"][0] {
+		t.Errorf("resourcePathsFor(pods) = %v, want to match resourcePathsForResources' pods entry %v", single, got["pods"])
+	}
+}

--- a/internal/ui/v2/overlay_test.go
+++ b/internal/ui/v2/overlay_test.go
@@ -171,6 +171,22 @@ func TestOverlay_NewCRDResourceType_VisibleEverywhere(t *testing.T) {
 		}
 	})
 
+	t.Run("serveObject whole-list view has correct synthetic Kind/apiVersion casing", func(t *testing.T) {
+		var d ObjectDetail
+		if code := getJSONInto(t, h, h.serveObject, "/v2/api/object", "?path="+strings.ReplaceAll(vsPath, "/", "%2F"), &d); code != http.StatusOK {
+			t.Fatalf("status = %d", code)
+		}
+		if !d.Found {
+			t.Fatalf("ObjectDetail.Found = false, want true")
+		}
+		if !strings.Contains(d.JSON, `"kind": "VirtualServiceList"`) {
+			t.Errorf("JSON missing correctly-cased synthetic envelope kind:\n%s", d.JSON)
+		}
+		if !strings.Contains(d.JSON, `"apiVersion": "networking.istio.io/v1beta1"`) {
+			t.Errorf("JSON missing synthetic envelope apiVersion:\n%s", d.JSON)
+		}
+	})
+
 	t.Run("delete tombstones it everywhere", func(t *testing.T) {
 		overlayDelete(t, srv, vsPath+"/reviews")
 

--- a/internal/ui/v2/overview.go
+++ b/internal/ui/v2/overview.go
@@ -93,6 +93,14 @@ func (h *Handler) buildOverview(at time.Time) (*Overview, error) {
 	// Cluster-scoped resource totals from the index — at the latest record per path.
 	clusterCounts := clusterScopedResourceCounts(store.Index, at)
 
+	// Fold in resource kinds/namespaces that exist only because of overlay
+	// writes (a CRD's custom resources, or a namespace + its contents created
+	// mid-replay) — the index-based counts above never see these.
+	if scopes := h.Overlay.OverlayScopes(); len(scopes) > 0 {
+		mergeOverlayNamespaceCounts(counts, scopes)
+		mergeOverlayClusterCounts(clusterCounts, scopes)
+	}
+
 	// Aggregate KPIs + per-resource totals.
 	resourceTotals := map[string]int{}
 	hasPerNS := map[string]bool{}
@@ -168,18 +176,21 @@ func (h *Handler) buildOverview(at time.Time) (*Overview, error) {
 			ns.Unhealthy++
 		}
 	}
-	// Attach namespace labels from the captured namespaces list (one read).
-	if body, code, err := store.ReconstructAt("/api/v1/namespaces", at); err == nil && code == http.StatusOK && len(body) > 0 {
-		var list struct {
-			Items []json.RawMessage `json:"items"`
+	// Attach namespace labels from the namespaces list, merged with any
+	// overlay writes — this also picks up a namespace created mid-replay
+	// (e.g. `helm install --create-namespace`) that has no resources counted
+	// above yet, so it still appears in the namespace picker.
+	for _, raw := range h.reconstructMergedItems("/api/v1/namespaces", at) {
+		name := getName(raw)
+		if name == "" {
+			continue
 		}
-		if json.Unmarshal(body, &list) == nil {
-			for _, raw := range list.Items {
-				if s := nsByName[getName(raw)]; s != nil {
-					s.Labels = getLabels(raw)
-				}
-			}
+		s, ok := nsByName[name]
+		if !ok {
+			s = &NamespaceSummary{Name: name}
+			nsByName[name] = s
 		}
+		s.Labels = getLabels(raw)
 	}
 	ov.Namespaces = make([]NamespaceSummary, 0, len(nsByName))
 	for _, s := range nsByName {
@@ -214,35 +225,18 @@ type podHealthEntry struct {
 	health    PodHealth
 }
 
-// readAllPodHealths walks every per-namespace pod LIST in the index, reads
-// the latest record at or before `at`, and classifies each pod's health.
+// readAllPodHealths walks every per-namespace pod LIST in the index (plus any
+// overlay-only namespace), reads the latest record at or before `at` merged
+// with overlay writes, and classifies each pod's health.
 func (h *Handler) readAllPodHealths(at time.Time) []podHealthEntry {
-	store := h.Store
 	var out []podHealthEntry
 
-	for path, entry := range store.Index {
-		if entry == nil || len(entry.Seqs) == 0 {
+	for _, path := range h.resourcePathsFor("pods") {
+		_, _, _, ns := parseAPIPath(path)
+		if ns == "" {
 			continue
 		}
-		if strings.Contains(path, "?") {
-			continue // skip Table records and other query-suffix variants
-		}
-		_, _, resource, ns := parseAPIPath(path)
-		if resource != "pods" || ns == "" {
-			continue
-		}
-
-		body, code, err := store.ReconstructAt(path, at)
-		if err != nil || code != http.StatusOK || len(body) == 0 {
-			continue
-		}
-		var list struct {
-			Items []json.RawMessage `json:"items"`
-		}
-		if err := json.Unmarshal(body, &list); err != nil {
-			continue
-		}
-		for _, raw := range list.Items {
+		for _, raw := range h.reconstructMergedItems(path, at) {
 			name := getName(raw)
 			if name == "" {
 				continue

--- a/internal/ui/v2/pod.go
+++ b/internal/ui/v2/pod.go
@@ -145,20 +145,10 @@ func (h *Handler) buildPodDetail(ns, name string, at time.Time) (*PodDetail, err
 		return nil, fmt.Errorf("store not initialized")
 	}
 
-	// Find the pod's raw body inside the captured pods list.
+	// Find the pod's raw body inside the pods list, merged with any overlay write.
 	listPath := "/api/v1/namespaces/" + ns + "/pods"
-	body, code, err := store.ReconstructAt(listPath, at)
-	if err != nil || code != http.StatusOK || len(body) == 0 {
-		return nil, nil
-	}
-	var list struct {
-		Items []json.RawMessage `json:"items"`
-	}
-	if err := json.Unmarshal(body, &list); err != nil {
-		return nil, nil
-	}
 	var raw json.RawMessage
-	for _, it := range list.Items {
+	for _, it := range h.reconstructMergedItems(listPath, at) {
 		if getName(it) == name {
 			raw = it
 			break
@@ -418,18 +408,8 @@ func (h *Handler) readLogTail(indexKey string, n int) ([]string, bool) {
 // matches this pod.
 func (h *Handler) loadPodEvents(ns, name string, at time.Time, limit int) []PodEvent {
 	listPath := "/api/v1/namespaces/" + ns + "/events"
-	body, code, err := h.Store.ReconstructAt(listPath, at)
-	if err != nil || code != http.StatusOK || len(body) == 0 {
-		return nil
-	}
-	var list struct {
-		Items []json.RawMessage `json:"items"`
-	}
-	if err := json.Unmarshal(body, &list); err != nil {
-		return nil
-	}
 	var out []PodEvent
-	for _, raw := range list.Items {
+	for _, raw := range h.reconstructMergedItems(listPath, at) {
 		var ev eventObject
 		if err := json.Unmarshal(raw, &ev); err != nil {
 			continue

--- a/internal/ui/v2/relationships.go
+++ b/internal/ui/v2/relationships.go
@@ -63,19 +63,11 @@ func (h *Handler) serveObjectRelationships(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, http.StatusOK, out)
 }
 
-// readObjectRaw returns the raw JSON of one object inside a captured list.
+// readObjectRaw returns the raw JSON of one object, by list path + name,
+// merged with any overlay write (overlay wins, including a tombstone dropping
+// the item so it reads as not-found).
 func (h *Handler) readObjectRaw(path, name string, at time.Time) (json.RawMessage, bool) {
-	body, code, err := h.Store.ReconstructAt(path, at)
-	if err != nil || code != http.StatusOK || len(body) == 0 {
-		return nil, false
-	}
-	var list struct {
-		Items []json.RawMessage `json:"items"`
-	}
-	if err := json.Unmarshal(body, &list); err != nil {
-		return nil, false
-	}
-	for _, it := range list.Items {
+	for _, it := range h.reconstructMergedItems(path, at) {
 		if getName(it) == name {
 			return it, true
 		}
@@ -84,17 +76,7 @@ func (h *Handler) readObjectRaw(path, name string, at time.Time) (json.RawMessag
 }
 
 func (h *Handler) podsInNS(ns string, at time.Time) []json.RawMessage {
-	body, code, err := h.Store.ReconstructAt("/api/v1/namespaces/"+ns+"/pods", at)
-	if err != nil || code != http.StatusOK || len(body) == 0 {
-		return nil
-	}
-	var list struct {
-		Items []json.RawMessage `json:"items"`
-	}
-	if err := json.Unmarshal(body, &list); err != nil {
-		return nil
-	}
-	return list.Items
+	return h.reconstructMergedItems("/api/v1/namespaces/"+ns+"/pods", at)
 }
 
 // ownerItems parses metadata.ownerReferences into linked RelatedItems.
@@ -232,34 +214,26 @@ func (h *Handler) ownedChildren(res, name, ns string, at time.Time) []RelatedGro
 	}
 	// Deployments own ReplicaSets (which in turn own the pods).
 	if res == "deployments" {
-		body, code, err := h.Store.ReconstructAt("/apis/apps/v1/namespaces/"+ns+"/replicasets", at)
-		if err == nil && code == http.StatusOK && len(body) > 0 {
-			var list struct {
-				Items []json.RawMessage `json:"items"`
+		var rss []RelatedItem
+		for _, rraw := range h.reconstructMergedItems("/apis/apps/v1/namespaces/"+ns+"/replicasets", at) {
+			var rs struct {
+				Metadata struct {
+					Name            string     `json:"name"`
+					OwnerReferences []ownerRef `json:"ownerReferences"`
+				} `json:"metadata"`
 			}
-			if json.Unmarshal(body, &list) == nil {
-				var rss []RelatedItem
-				for _, rraw := range list.Items {
-					var rs struct {
-						Metadata struct {
-							Name            string     `json:"name"`
-							OwnerReferences []ownerRef `json:"ownerReferences"`
-						} `json:"metadata"`
-					}
-					if json.Unmarshal(rraw, &rs) != nil {
-						continue
-					}
-					for _, o := range rs.Metadata.OwnerReferences {
-						if o.Name == name {
-							rss = append(rss, RelatedItem{Kind: "ReplicaSet", Name: rs.Metadata.Name, Link: objectLink(apiListPath("apps", "v1", "replicasets", ns), rs.Metadata.Name)})
-							break
-						}
-					}
-				}
-				if len(rss) > 0 {
-					groups = append(groups, RelatedGroup{Title: "ReplicaSets", Items: rss})
+			if json.Unmarshal(rraw, &rs) != nil {
+				continue
+			}
+			for _, o := range rs.Metadata.OwnerReferences {
+				if o.Name == name {
+					rss = append(rss, RelatedItem{Kind: "ReplicaSet", Name: rs.Metadata.Name, Link: objectLink(apiListPath("apps", "v1", "replicasets", ns), rs.Metadata.Name)})
+					break
 				}
 			}
+		}
+		if len(rss) > 0 {
+			groups = append(groups, RelatedGroup{Title: "ReplicaSets", Items: rss})
 		}
 	}
 	for i := range groups {

--- a/internal/ui/v2/v2.go
+++ b/internal/ui/v2/v2.go
@@ -25,6 +25,14 @@ type Handler struct {
 	// Clock, when non-nil, puts the dashboard in replay mode: resolveAt follows
 	// the clock and /v2/api/replay drives it (see replay.go).
 	Clock *server.ReplayClock
+	// Overlay, when non-nil, is the mock API server backing this same archive.
+	// Every list/detail read merges its writable-overlay writes (kubectl/helm/
+	// kwok/controller-manager) over the captured state, so the dashboard shows
+	// live changes instead of only what was captured. Its accessor methods are
+	// nil-safe on a Server without a writable overlay, so callers here never
+	// need to check for that case separately — only for Overlay itself being
+	// nil (plain `open`, or a caller that didn't wire one up).
+	Overlay *server.Server
 }
 
 // Mount registers all /v2/* routes on mux. The /v2/ HTML shell is served

--- a/internal/ui/v2/v2.go
+++ b/internal/ui/v2/v2.go
@@ -8,6 +8,7 @@ import (
 	"embed"
 	"io/fs"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/phenixblue/k8shark/internal/server"
@@ -25,14 +26,24 @@ type Handler struct {
 	// Clock, when non-nil, puts the dashboard in replay mode: resolveAt follows
 	// the clock and /v2/api/replay drives it (see replay.go).
 	Clock *server.ReplayClock
-	// Overlay, when non-nil, is the mock API server backing this same archive.
-	// Every list/detail read merges its writable-overlay writes (kubectl/helm/
-	// kwok/controller-manager) over the captured state, so the dashboard shows
-	// live changes instead of only what was captured. Its accessor methods are
-	// nil-safe on a Server without a writable overlay, so callers here never
-	// need to check for that case separately — only for Overlay itself being
-	// nil (plain `open`, or a caller that didn't wire one up).
+	// Overlay is the mock API server backing this same archive. Every
+	// list/detail read merges its writable-overlay writes (kubectl/helm/kwok/
+	// controller-manager) over the captured state, so the dashboard shows
+	// live changes instead of only what was captured. Its accessor methods
+	// (OverlayScopes, MergeOverlayList, ...) are nil-safe on both a nil
+	// *Server (plain `open`, or a caller that didn't wire one up) and a
+	// Server without a writable overlay — callers here can call them on
+	// h.Overlay directly without checking either case first.
 	Overlay *server.Server
+
+	// discoveryMetaOnce/discoveryMetaCache memoize discoveryResourceMeta
+	// (objects.go): it's derived purely from the capture's own discovery
+	// documents, which never change for a given archive, but computing it
+	// scans the whole index and re-parses every discovery document — worth
+	// doing once per Handler (one per running dashboard) rather than per
+	// request.
+	discoveryMetaOnce  sync.Once
+	discoveryMetaCache map[string]discMeta
 }
 
 // Mount registers all /v2/* routes on mux. The /v2/ HTML shell is served


### PR DESCRIPTION
## Summary
- `kshrk ui`/`kshrk replay --ui` previously opened two independent readers over the same archive: the mock API server (with the writable overlay) and the v2 dashboard (its own separate store, no overlay awareness). Anything written through kubectl/helm/kwok/controller-manager was invisible in the UI.
- `internal/server/overlay_export.go` exposes a minimal, nil-safe read API on `*Server` (`Store`, `OverlayScopes`, `MergeOverlayList`, `OverlayObject`, `OverlayDeletedNamespaces`) without exporting the overlay type itself.
- `internal/ui` now reuses the mock server's store (no second archive load) and wires its overlay into the v2 `Handler`.
- `internal/ui/v2/overlay.go` merges overlay writes into every list/detail view and synthesizes catalog/list entries for resource kinds or namespaces that exist *only* because of overlay writes — e.g. a CRD's custom resources, or a namespace created by `helm install --create-namespace` — which otherwise have no entry in the capture's static index at all.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -w .` clean
- [x] `go test -race ./...` passes
- [x] New unit tests: `internal/server/overlay_export_test.go`, `internal/ui/v2/overlay_test.go` (brand-new CRD resource type, brand-new namespace, pod added to an existing namespace, delete/tombstone semantics)
- [x] Manual end-to-end verification against a real 146MB OpenShift capture: started `kshrk ui --writable`, used kubectl to create a namespace + Deployment and curl to create a never-captured Istio-style `VirtualService`, confirmed all three appeared correctly in the dashboard's overview, namespace detail, resource catalog, and object view

🤖 Generated with [Claude Code](https://claude.com/claude-code)