### PR TITLE
fix(ci): pin GoReleaser's current tag to the pushed ref explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,13 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Without this, GoReleaser resolves the "current" tag via `git
+          # describe` on HEAD, which is ambiguous whenever two tags point at
+          # the same commit (e.g. promoting an -rc.N straight to stable) — it
+          # can silently pick the wrong one and collide with that tag's
+          # already-published release assets instead of releasing the tag
+          # that actually triggered this run.
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
           HOMEBREW_TAP_OWNER: phenixblue
           HOMEBREW_TAP_NAME: homebrew-tap
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Cutting `v0.5.1` right after `v0.5.1-rc.4` (same commit — promoting an RC straight to stable) failed the release workflow: GoReleaser resolves the "current" tag via `git describe` on HEAD when not told otherwise, which is ambiguous when two tags point at the same commit. It picked `v0.5.1-rc.4` again, then failed uploading duplicate-named assets to that tag's already-published release. No `v0.5.1` GitHub release was ever created.
- Sets `GORELEASER_CURRENT_TAG: ${{ github.ref_name }}` so GoReleaser is told explicitly which tag triggered each run — this is a documented, standard GoReleaser env var for exactly this ambiguity, and it doesn't depend on tags never sharing a commit (a reasonable thing to want, e.g. this exact rc→stable promotion).

## Test plan
- [ ] Re-tag/push `v0.5.1` after this merges and confirm the release workflow succeeds and creates a distinct `v0.5.1` GitHub release + updates the stable Homebrew formula.

🤖 Generated with [Claude Code](https://claude.com/claude-code)