### PR TITLE
fix(server): register a CRD's discovery entry when created via the overlay

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -405,6 +405,7 @@ func (h *handler) tryServeAPIGroupListFromStore(w http.ResponseWriter, path stri
 		return true
 	}
 
+	resources := h.store.Resources()
 	changed := false
 	known := make(map[string]bool, len(groups))
 	for i, raw := range groups {
@@ -424,7 +425,7 @@ func (h *handler) tryServeAPIGroupListFromStore(w http.ResponseWriter, path stri
 				knownVersions[v.GroupVersion] = true
 			}
 		}
-		additions := groupVersionsFor(h.store.Resources(), g.Name, knownVersions)
+		additions := groupVersionsFor(resources, g.Name, knownVersions)
 		if len(additions) == 0 {
 			continue
 		}
@@ -435,7 +436,7 @@ func (h *handler) tryServeAPIGroupListFromStore(w http.ResponseWriter, path stri
 	}
 
 	// Append any group the captured document never listed at all.
-	newGroups := groupVersionsByGroup(h.store.Resources(), known)
+	newGroups := groupVersionsByGroup(resources, known)
 	for _, g := range groupEntries(newGroups) {
 		if entryBytes, err := json.Marshal(g); err == nil {
 			groups = append(groups, entryBytes)

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -324,33 +324,72 @@ func mergeJSONArrayField(body []byte, fieldName string) (doc map[string]json.Raw
 	return doc, arr, true
 }
 
-// writeMergedJSON re-marshals doc with fieldName set to arr and writes it, or
-// falls back to serving fallback (the original captured bytes) verbatim on
-// any marshal error.
-func writeMergedJSON(w http.ResponseWriter, code int, doc map[string]json.RawMessage, fieldName string, arr []json.RawMessage, fallback []byte) {
+// setJSONArrayField re-marshals doc with fieldName set to arr, returning
+// ok=false on any marshal error (the map value type is json.RawMessage, so
+// this can only fail if arr itself contains something unmarshalable, which
+// none of this file's callers ever produce — but propagating rather than
+// panicking keeps every caller's existing verbatim-fallback path working).
+func setJSONArrayField(doc map[string]json.RawMessage, fieldName string, arr []json.RawMessage) ([]byte, bool) {
 	merged, err := json.Marshal(arr)
 	if err != nil {
-		writeRawJSON(w, code, fallback)
-		return
+		return nil, false
 	}
 	doc[fieldName] = merged
 	out, err := json.Marshal(doc)
 	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+// writeMergedJSON re-marshals doc with fieldName set to arr and writes it, or
+// falls back to serving fallback (the original captured bytes) verbatim on
+// any marshal error.
+func writeMergedJSON(w http.ResponseWriter, code int, doc map[string]json.RawMessage, fieldName string, arr []json.RawMessage, fallback []byte) {
+	out, ok := setJSONArrayField(doc, fieldName, arr)
+	if !ok {
 		writeRawJSON(w, code, fallback)
 		return
 	}
 	writeRawJSON(w, code, out)
 }
 
-// tryServeAPIGroupListFromStore serves the captured /apis document, appending
-// any group a CRD created via the overlay (see registerCRDResourceInfo)
-// registered that the document doesn't already list. Every pre-existing
-// group entry is passed through as the exact bytes capture recorded —
-// unlike fully re-synthesizing the document from h.store.Resources(), this
-// can't lose fields a real apiserver's response had that the synthesizer
-// doesn't reproduce. Serves the captured bytes verbatim when there's nothing
-// new to add (the common case). Returns false only when path wasn't
-// captured at all, matching tryServeFromStore.
+// mergeVersionsIntoGroup appends additions to a single raw APIGroupList group
+// entry's own "versions" array, leaving every other field of that entry (its
+// name, preferredVersion, and pre-existing version entries) untouched.
+// Returns rawGroup unchanged with ok=false if it isn't a JSON object with a
+// "versions" array, or on a marshal error — callers should skip the merge
+// for that entry (not fail the whole response) in either case.
+func mergeVersionsIntoGroup(rawGroup json.RawMessage, additions []groupVersion) (json.RawMessage, bool) {
+	doc, versions, ok := mergeJSONArrayField(rawGroup, "versions")
+	if !ok {
+		return rawGroup, false
+	}
+	for _, v := range sortedGroupVersions(additions) {
+		if b, err := json.Marshal(v); err == nil {
+			versions = append(versions, b)
+		}
+	}
+	out, ok := setJSONArrayField(doc, "versions", versions)
+	if !ok {
+		return rawGroup, false
+	}
+	return out, true
+}
+
+// tryServeAPIGroupListFromStore serves the captured /apis document, merging
+// in whatever a CRD created via the overlay (see registerCRDResourceInfo)
+// registered that the document doesn't already reflect: a version added
+// under a group the document already lists (merged into that group's own
+// versions array — a second CRD commonly adds a new version to a group
+// capture already saw, e.g. Istio's networking.istio.io), and any group the
+// document never listed at all (appended wholesale). Every pre-existing
+// group/version entry is passed through as the exact bytes capture
+// recorded — unlike fully re-synthesizing the document from
+// h.store.Resources(), this can't lose fields a real apiserver's response
+// had that the synthesizer doesn't reproduce. Serves the captured bytes
+// verbatim when there's nothing new to add (the common case). Returns false
+// only when path wasn't captured at all, matching tryServeFromStore.
 func (h *handler) tryServeAPIGroupListFromStore(w http.ResponseWriter, path string, at time.Time) bool {
 	body, code, err := h.store.Latest(path, at)
 	if err != nil || code != 200 {
@@ -365,24 +404,48 @@ func (h *handler) tryServeAPIGroupListFromStore(w http.ResponseWriter, path stri
 		writeRawJSON(w, code, body)
 		return true
 	}
+
+	changed := false
 	known := make(map[string]bool, len(groups))
-	for _, raw := range groups {
+	for i, raw := range groups {
 		var g struct {
-			Name string `json:"name"`
+			Name     string `json:"name"`
+			Versions []struct {
+				GroupVersion string `json:"groupVersion"`
+			} `json:"versions"`
 		}
-		if json.Unmarshal(raw, &g) == nil && g.Name != "" {
-			known[g.Name] = true
+		if json.Unmarshal(raw, &g) != nil || g.Name == "" {
+			continue
+		}
+		known[g.Name] = true
+		knownVersions := make(map[string]bool, len(g.Versions))
+		for _, v := range g.Versions {
+			if v.GroupVersion != "" {
+				knownVersions[v.GroupVersion] = true
+			}
+		}
+		additions := groupVersionsFor(h.store.Resources(), g.Name, knownVersions)
+		if len(additions) == 0 {
+			continue
+		}
+		if merged, ok := mergeVersionsIntoGroup(raw, additions); ok {
+			groups[i] = merged
+			changed = true
 		}
 	}
-	seen := groupVersionsByGroup(h.store.Resources(), known)
-	if len(seen) == 0 {
-		writeRawJSON(w, code, body) // nothing new since capture — serve verbatim
-		return true
-	}
-	for _, g := range groupEntries(seen) {
+
+	// Append any group the captured document never listed at all.
+	newGroups := groupVersionsByGroup(h.store.Resources(), known)
+	for _, g := range groupEntries(newGroups) {
 		if entryBytes, err := json.Marshal(g); err == nil {
 			groups = append(groups, entryBytes)
+			changed = true
 		}
+	}
+
+	if !changed {
+		writeRawJSON(w, code, body) // nothing new since capture — serve verbatim
+		return true
 	}
 	writeMergedJSON(w, code, doc, "groups", groups, body)
 	return true

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -239,7 +239,15 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			h.serveAPIVersions(w)
 		}
 	case path == "/apis":
-		if !h.tryServeFromStore(w, path, replayAt) {
+		// Discovery documents are the one read path a capture always records
+		// unconditionally (see the capture engine's fetchDiscovery), so
+		// tryServeFromStore almost always wins here — plain tryServeFromStore
+		// would then serve the frozen captured document forever, hiding any
+		// group a CRD created via the writable overlay defines after capture
+		// (see registerCRDResourceInfo in writes.go). tryServeAPIGroupListFromStore
+		// merges those in while still serving the captured bytes verbatim
+		// whenever there's nothing new to add.
+		if !h.tryServeAPIGroupListFromStore(w, path, replayAt) {
 			h.serveAPIGroupList(w)
 		}
 	case path == "/api/v1":
@@ -247,7 +255,10 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			h.serveAPIResourceList(w, "", "v1")
 		}
 	case strings.HasPrefix(path, "/apis/") && isGroupVersionPath(path):
-		if !h.tryServeFromStore(w, path, replayAt) {
+		// Same captured-document-shadows-runtime-additions problem as /apis
+		// above, for a group/version that already existed at capture time —
+		// merge in any resource a CRD registered under it afterward.
+		if !h.tryServeAPIResourceListFromStore(w, path, replayAt) {
 			h.serveGroupResourceList(w, path)
 		}
 	case strings.HasPrefix(path, "/apis/") && isBareGroupPath(path):
@@ -260,8 +271,9 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// though /apis/<group>/<version> worked fine — breaking any client
 		// that discovers a group this way first (found via the upstream
 		// conformance suite's Ingress/IngressClass API specs).
-		if !h.tryServeFromStore(w, path, replayAt) {
-			h.serveAPIGroup(w, strings.TrimPrefix(path, "/apis/"))
+		group := strings.TrimPrefix(path, "/apis/")
+		if !h.tryServeAPIGroupFromStore(w, path, group, replayAt) {
+			h.serveAPIGroup(w, group)
 		}
 	case strings.HasSuffix(path, "/log"):
 		// Pod log sub-resource: serve captured content or a helpful stub.
@@ -278,9 +290,201 @@ func (h *handler) tryServeFromStore(w http.ResponseWriter, path string, at time.
 	if err != nil || code != 200 {
 		return false
 	}
+	writeRawJSON(w, code, body)
+	return true
+}
+
+// writeRawJSON writes body verbatim (unlike writeJSON, which marshals a Go
+// value) — used to serve a captured response's exact bytes.
+func writeRawJSON(w http.ResponseWriter, code int, body []byte) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	_, _ = w.Write(body)
+}
+
+// mergeJSONArrayField parses body as a JSON object, decodes the array under
+// fieldName (defaulting to an empty array if the field is absent), and
+// returns it alongside the full decoded object — so a caller can inspect what
+// the array already contains, append raw additions, and re-marshal only that
+// one field while every other key (and every existing array element) passes
+// through completely untouched. ok is false when body isn't a JSON object or
+// fieldName isn't a JSON array, signaling the caller should give up and serve
+// body verbatim rather than risk corrupting a differently-shaped document.
+func mergeJSONArrayField(body []byte, fieldName string) (doc map[string]json.RawMessage, arr []json.RawMessage, ok bool) {
+	if json.Unmarshal(body, &doc) != nil {
+		return nil, nil, false
+	}
+	raw, present := doc[fieldName]
+	if !present {
+		return doc, nil, true
+	}
+	if json.Unmarshal(raw, &arr) != nil {
+		return nil, nil, false
+	}
+	return doc, arr, true
+}
+
+// writeMergedJSON re-marshals doc with fieldName set to arr and writes it, or
+// falls back to serving fallback (the original captured bytes) verbatim on
+// any marshal error.
+func writeMergedJSON(w http.ResponseWriter, code int, doc map[string]json.RawMessage, fieldName string, arr []json.RawMessage, fallback []byte) {
+	merged, err := json.Marshal(arr)
+	if err != nil {
+		writeRawJSON(w, code, fallback)
+		return
+	}
+	doc[fieldName] = merged
+	out, err := json.Marshal(doc)
+	if err != nil {
+		writeRawJSON(w, code, fallback)
+		return
+	}
+	writeRawJSON(w, code, out)
+}
+
+// tryServeAPIGroupListFromStore serves the captured /apis document, appending
+// any group a CRD created via the overlay (see registerCRDResourceInfo)
+// registered that the document doesn't already list. Every pre-existing
+// group entry is passed through as the exact bytes capture recorded —
+// unlike fully re-synthesizing the document from h.store.Resources(), this
+// can't lose fields a real apiserver's response had that the synthesizer
+// doesn't reproduce. Serves the captured bytes verbatim when there's nothing
+// new to add (the common case). Returns false only when path wasn't
+// captured at all, matching tryServeFromStore.
+func (h *handler) tryServeAPIGroupListFromStore(w http.ResponseWriter, path string, at time.Time) bool {
+	body, code, err := h.store.Latest(path, at)
+	if err != nil || code != 200 {
+		return false
+	}
+	if h.overlay == nil {
+		writeRawJSON(w, code, body)
+		return true
+	}
+	doc, groups, ok := mergeJSONArrayField(body, "groups")
+	if !ok {
+		writeRawJSON(w, code, body)
+		return true
+	}
+	known := make(map[string]bool, len(groups))
+	for _, raw := range groups {
+		var g struct {
+			Name string `json:"name"`
+		}
+		if json.Unmarshal(raw, &g) == nil && g.Name != "" {
+			known[g.Name] = true
+		}
+	}
+	seen := groupVersionsByGroup(h.store.Resources(), known)
+	if len(seen) == 0 {
+		writeRawJSON(w, code, body) // nothing new since capture — serve verbatim
+		return true
+	}
+	for _, g := range groupEntries(seen) {
+		if entryBytes, err := json.Marshal(g); err == nil {
+			groups = append(groups, entryBytes)
+		}
+	}
+	writeMergedJSON(w, code, doc, "groups", groups, body)
+	return true
+}
+
+// tryServeAPIGroupFromStore is tryServeAPIGroupListFromStore's analogue for
+// the single-group /apis/<group> document: appends any version of group a
+// CRD registered via the overlay that the captured document doesn't already
+// list, leaving every other field (including preferredVersion — an appended
+// version is treated as additive, never promoted over whatever the captured
+// document already preferred) and pre-existing version entry untouched.
+func (h *handler) tryServeAPIGroupFromStore(w http.ResponseWriter, path, group string, at time.Time) bool {
+	body, code, err := h.store.Latest(path, at)
+	if err != nil || code != 200 {
+		return false
+	}
+	if h.overlay == nil {
+		writeRawJSON(w, code, body)
+		return true
+	}
+	doc, versions, ok := mergeJSONArrayField(body, "versions")
+	if !ok {
+		writeRawJSON(w, code, body)
+		return true
+	}
+	known := make(map[string]bool, len(versions))
+	for _, raw := range versions {
+		var v struct {
+			GroupVersion string `json:"groupVersion"`
+		}
+		if json.Unmarshal(raw, &v) == nil && v.GroupVersion != "" {
+			known[v.GroupVersion] = true
+		}
+	}
+	additions := groupVersionsFor(h.store.Resources(), group, known)
+	if len(additions) == 0 {
+		writeRawJSON(w, code, body)
+		return true
+	}
+	for _, v := range sortedGroupVersions(additions) {
+		if entryBytes, err := json.Marshal(v); err == nil {
+			versions = append(versions, entryBytes)
+		}
+	}
+	writeMergedJSON(w, code, doc, "versions", versions, body)
+	return true
+}
+
+// tryServeAPIResourceListFromStore is tryServeAPIGroupListFromStore's
+// analogue for /apis/<group>/<version>'s APIResourceList: appends any
+// resource a CRD registered via the overlay under this exact group/version
+// (e.g. a second CRD added to a group/version a chart's earlier CRDs already
+// captured) that the captured document doesn't already list, leaving every
+// pre-existing resource entry's original fields (verbs, categories, etc. —
+// none of which apiResourceEntry's synthesized entry reproduces) untouched.
+func (h *handler) tryServeAPIResourceListFromStore(w http.ResponseWriter, path string, at time.Time) bool {
+	body, code, err := h.store.Latest(path, at)
+	if err != nil || code != 200 {
+		return false
+	}
+	if h.overlay == nil {
+		writeRawJSON(w, code, body)
+		return true
+	}
+	parts := strings.SplitN(strings.TrimPrefix(path, "/apis/"), "/", 2)
+	if len(parts) != 2 {
+		writeRawJSON(w, code, body)
+		return true
+	}
+	group, version := parts[0], parts[1]
+	doc, resources, ok := mergeJSONArrayField(body, "resources")
+	if !ok {
+		writeRawJSON(w, code, body)
+		return true
+	}
+	known := make(map[string]bool, len(resources))
+	for _, raw := range resources {
+		var r struct {
+			Name string `json:"name"`
+		}
+		if json.Unmarshal(raw, &r) == nil && r.Name != "" {
+			known[r.Name] = true
+		}
+	}
+	added := false
+	for _, ri := range h.store.Resources() {
+		if ri.Group != group || ri.Version != version || known[ri.Resource] {
+			continue
+		}
+		entryBytes, err := json.Marshal(apiResourceEntry(ri))
+		if err != nil {
+			continue
+		}
+		resources = append(resources, entryBytes)
+		known[ri.Resource] = true
+		added = true
+	}
+	if !added {
+		writeRawJSON(w, code, body)
+		return true
+	}
+	writeMergedJSON(w, code, doc, "resources", resources, body)
 	return true
 }
 
@@ -327,11 +531,16 @@ func (h *handler) serveAPIVersions(w http.ResponseWriter) {
 	})
 }
 
-func (h *handler) serveAPIGroupList(w http.ResponseWriter) {
-	// Collect non-core API groups present in the capture.
+// groupVersionsByGroup buckets resources' distinct (version, groupVersion)
+// pairs by non-core group name, skipping any group name present in exclude
+// (nil is fine — a nil map read always reports "absent"). Shared by
+// serveAPIGroupList (building a full APIGroupList from scratch) and
+// tryServeAPIGroupListFromStore (checking for/merging only the groups a
+// captured discovery document doesn't already list).
+func groupVersionsByGroup(resources []ResourceInfo, exclude map[string]bool) map[string][]groupVersion {
 	seen := map[string][]groupVersion{}
-	for _, ri := range h.store.Resources() {
-		if ri.Group == "" {
+	for _, ri := range resources {
+		if ri.Group == "" || exclude[ri.Group] {
 			continue
 		}
 		gv := groupVersion{ri.Version, ri.Group + "/" + ri.Version}
@@ -346,7 +555,12 @@ func (h *handler) serveAPIGroupList(w http.ResponseWriter) {
 			seen[ri.Group] = append(seen[ri.Group], gv)
 		}
 	}
+	return seen
+}
 
+// groupEntries renders seen (as returned by groupVersionsByGroup) as the
+// sorted []map[string]any groups list APIGroupList expects.
+func groupEntries(seen map[string][]groupVersion) []map[string]any {
 	groupNames := make([]string, 0, len(seen))
 	for g := range seen {
 		groupNames = append(groupNames, g)
@@ -362,11 +576,15 @@ func (h *handler) serveAPIGroupList(w http.ResponseWriter) {
 			"preferredVersion": versions[0],
 		})
 	}
+	return groups
+}
 
+func (h *handler) serveAPIGroupList(w http.ResponseWriter) {
+	seen := groupVersionsByGroup(h.store.Resources(), nil)
 	writeJSON(w, http.StatusOK, map[string]any{
 		"kind":       "APIGroupList",
 		"apiVersion": "v1",
-		"groups":     groups,
+		"groups":     groupEntries(seen),
 	})
 }
 
@@ -398,25 +616,35 @@ func sortedGroupVersions(gvs []groupVersion) []map[string]string {
 	return versions
 }
 
+// groupVersionsFor returns the distinct (version, groupVersion) pairs for a
+// single group's resources, skipping any groupVersion string present in
+// exclude (nil is fine). Shared by serveAPIGroup (building a full APIGroup
+// from scratch) and tryServeAPIGroupFromStore (checking for/merging only the
+// versions a captured discovery document doesn't already list).
+func groupVersionsFor(resources []ResourceInfo, group string, exclude map[string]bool) []groupVersion {
+	var gvs []groupVersion
+	seen := map[string]bool{}
+	for _, ri := range resources {
+		if ri.Group != group {
+			continue
+		}
+		gv := ri.Group + "/" + ri.Version
+		if seen[gv] || exclude[gv] {
+			continue
+		}
+		seen[gv] = true
+		gvs = append(gvs, groupVersion{ri.Version, gv})
+	}
+	return gvs
+}
+
 // serveAPIGroup serves the single-group APIGroup discovery document for
 // /apis/<group> — the same grouping serveAPIGroupList does for the full
 // cross-group list, scoped to one group. 404s (matching a real apiserver)
 // when the group has no captured resources at all, rather than serving an
 // APIGroup with an empty version list.
 func (h *handler) serveAPIGroup(w http.ResponseWriter, group string) {
-	var gvs []groupVersion
-	seen := map[string]bool{}
-	for _, ri := range h.store.Resources() {
-		if ri.Group != group {
-			continue
-		}
-		groupVersionStr := ri.Group + "/" + ri.Version
-		if seen[groupVersionStr] {
-			continue
-		}
-		seen[groupVersionStr] = true
-		gvs = append(gvs, groupVersion{ri.Version, groupVersionStr})
-	}
+	gvs := groupVersionsFor(h.store.Resources(), group, nil)
 	if len(gvs) == 0 {
 		h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("the server could not find the requested resource, group %q not found in capture", group))
 		return
@@ -466,31 +694,43 @@ func shortNamesFor(resource string) []string {
 	return known[resource]
 }
 
+// apiResourceEntry renders a single APIResourceList entry for ri. verbs is
+// always the read-only set — the store has no record of which verbs a
+// resource's real APIResource advertised, only what got captured/registered
+// (see ResourceInfo). Shared by serveAPIResourceList (building a full
+// APIResourceList from scratch, where this is the entire entry) and
+// tryServeAPIResourceListFromStore (only for a resource newly registered
+// after capture — e.g. a CRD created via the overlay — since an
+// already-captured resource keeps its original, richer entry untouched).
+func apiResourceEntry(ri ResourceInfo) map[string]any {
+	entry := map[string]any{
+		"name":       ri.Resource,
+		"namespaced": ri.Namespaced,
+		"kind":       ri.Kind,
+		"verbs":      []string{"get", "list", "watch"},
+	}
+	// Prefer short names from the captured discovery document; fall back to
+	// the built-in static map for well-known Kubernetes types.
+	sn := ri.ShortNames
+	if len(sn) == 0 {
+		sn = shortNamesFor(ri.Resource)
+	}
+	if len(sn) > 0 {
+		entry["shortNames"] = sn
+	}
+	if ri.SingularName != "" {
+		entry["singularName"] = ri.SingularName
+	}
+	return entry
+}
+
 func (h *handler) serveAPIResourceList(w http.ResponseWriter, group, version string) {
 	resources := make([]map[string]any, 0)
 	for _, ri := range h.store.Resources() {
 		if ri.Group != group || ri.Version != version {
 			continue
 		}
-		entry := map[string]any{
-			"name":       ri.Resource,
-			"namespaced": ri.Namespaced,
-			"kind":       ri.Kind,
-			"verbs":      []string{"get", "list", "watch"},
-		}
-		// Prefer short names from the captured discovery document; fall back to
-		// the built-in static map for well-known Kubernetes types.
-		sn := ri.ShortNames
-		if len(sn) == 0 {
-			sn = shortNamesFor(ri.Resource)
-		}
-		if len(sn) > 0 {
-			entry["shortNames"] = sn
-		}
-		if ri.SingularName != "" {
-			entry["singularName"] = ri.SingularName
-		}
-		resources = append(resources, entry)
+		resources = append(resources, apiResourceEntry(ri))
 	}
 
 	groupVersion := version

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -307,18 +307,21 @@ func writeRawJSON(w http.ResponseWriter, code int, body []byte) {
 // returns it alongside the full decoded object — so a caller can inspect what
 // the array already contains, append raw additions, and re-marshal only that
 // one field while every other key (and every existing array element) passes
-// through completely untouched. ok is false when body isn't a JSON object or
-// fieldName isn't a JSON array, signaling the caller should give up and serve
-// body verbatim rather than risk corrupting a differently-shaped document.
+// through completely untouched. ok is false when body isn't a JSON object
+// (including a literal JSON "null", which unmarshals into a nil map without
+// error) or fieldName isn't a JSON array (including a literal "null" value,
+// which unmarshals into a nil slice without error), signaling the caller
+// should give up and serve body verbatim rather than risk mutating a nil map
+// or corrupting a differently-shaped document.
 func mergeJSONArrayField(body []byte, fieldName string) (doc map[string]json.RawMessage, arr []json.RawMessage, ok bool) {
-	if json.Unmarshal(body, &doc) != nil {
+	if err := json.Unmarshal(body, &doc); err != nil || doc == nil {
 		return nil, nil, false
 	}
 	raw, present := doc[fieldName]
 	if !present {
 		return doc, nil, true
 	}
-	if json.Unmarshal(raw, &arr) != nil {
+	if err := json.Unmarshal(raw, &arr); err != nil || arr == nil {
 		return nil, nil, false
 	}
 	return doc, arr, true

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -1280,3 +1280,51 @@ func TestHandler_WatchFallsBackToClusterPath(t *testing.T) {
 		t.Errorf("redis (kube-system) must not appear in default namespace watch")
 	}
 }
+
+// TestMergeJSONArrayField_RejectsNull verifies that a literal JSON "null" —
+// either as the whole body or as the named field's value — is rejected with
+// ok=false rather than silently unmarshaling into a nil map/slice, which
+// would later panic in setJSONArrayField when assigning into a nil map.
+func TestMergeJSONArrayField_RejectsNull(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"null body", `null`},
+		{"null field", `{"groups": null}`},
+		{"non-object body", `[1,2,3]`},
+		{"non-array field", `{"groups": "not-an-array"}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			doc, arr, ok := mergeJSONArrayField([]byte(c.body), "groups")
+			if ok {
+				t.Errorf("expected ok=false for %s, got doc=%v arr=%v", c.body, doc, arr)
+			}
+		})
+	}
+}
+
+// TestMergeJSONArrayField_AcceptsEmptyAndMissing verifies the two legitimate
+// no-elements shapes are still accepted: an explicit empty array, and the
+// field being absent entirely (both should let a caller proceed to append).
+func TestMergeJSONArrayField_AcceptsEmptyAndMissing(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty array", `{"groups": []}`},
+		{"missing field", `{}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			doc, _, ok := mergeJSONArrayField([]byte(c.body), "groups")
+			if !ok {
+				t.Errorf("expected ok=true for %s", c.body)
+			}
+			if doc == nil {
+				t.Errorf("expected non-nil doc for %s", c.body)
+			}
+		})
+	}
+}

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -476,7 +476,11 @@ func (h *handler) registerCRDResourceInfo(body json.RawMessage) {
 	if err := json.Unmarshal(body, &crd); err != nil {
 		return
 	}
-	if crd.Spec.Group == "" || crd.Spec.Names.Plural == "" {
+	if crd.Spec.Group == "" || crd.Spec.Names.Plural == "" || crd.Spec.Names.Kind == "" {
+		// A missing Kind would otherwise fall through to mergeResourceInfo's
+		// resourceToKind heuristic fallback, which is a plural-depluralizing
+		// guess known to be wrong for most CRDs — skipping keeps a malformed
+		// CRD body from polluting discovery with a made-up Kind.
 		return
 	}
 	// mergeResourceInfo treats namespaced as authoritative and overwrites any

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -179,6 +179,16 @@ func (h *handler) storeNewObject(group, version, resource, namespace, name strin
 		// "InProgress: Install in progress" forever, hanging any
 		// CRD-heavy chart (e.g. Istio's `base` chart) waiting for its CRDs.
 		body = ensureCRDEstablished(body, h.nowRFC3339())
+		// A real apiextensions-apiserver also registers the CRD's defined type
+		// with the aggregated discovery document the moment it's created. The
+		// store's resourceInfo is otherwise a snapshot built once from the
+		// capture archive (see CaptureStore.buildResourceInfo/LoadStore), so
+		// without this a CRD applied at runtime (e.g. `istioctl install`) is
+		// visible via `kubectl get crd` (a plain object read) but absent from
+		// `kubectl api-resources` / `istioctl analyze` (which walk discovery),
+		// since /apis and /apis/<group>/<version> only ever reflect that
+		// snapshot.
+		h.registerCRDResourceInfo(body)
 	}
 
 	rv := h.overlay.nextRV(h.replayFloorRV(group, version, resource, namespace))
@@ -433,6 +443,58 @@ func ensureCRDEstablished(body json.RawMessage, now string) json.RawMessage {
 		return body
 	}
 	return out
+}
+
+// registerCRDResourceInfo parses a freshly created CustomResourceDefinition's
+// spec and registers its defined group/version/resource/kind with the store's
+// discovery metadata (CaptureStore.mergeResourceInfo), so /apis and
+// /apis/<group>/<version> — and therefore `kubectl api-resources` and any
+// client that walks discovery (e.g. `istioctl analyze`) — reflect it
+// immediately, rather than only once the archive is reloaded. Best-effort: a
+// malformed/unparseable CRD body is silently skipped rather than failing the
+// create — the CRD object itself is still stored either way; only its
+// discovery visibility is affected.
+func (h *handler) registerCRDResourceInfo(body json.RawMessage) {
+	type crdVersion struct {
+		Name   string `json:"name"`
+		Served bool   `json:"served"`
+	}
+	var crd struct {
+		Spec struct {
+			Group string `json:"group"`
+			Names struct {
+				Kind       string   `json:"kind"`
+				Singular   string   `json:"singular"`
+				Plural     string   `json:"plural"`
+				ShortNames []string `json:"shortNames"`
+			} `json:"names"`
+			Scope    string       `json:"scope"`
+			Versions []crdVersion `json:"versions"`
+			Version  string       `json:"version"` // legacy apiextensions.k8s.io/v1beta1
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal(body, &crd); err != nil {
+		return
+	}
+	if crd.Spec.Group == "" || crd.Spec.Names.Plural == "" {
+		return
+	}
+	versions := crd.Spec.Versions
+	if len(versions) == 0 && crd.Spec.Version != "" {
+		// Legacy v1beta1 CRDs specify a single top-level spec.version instead
+		// of the spec.versions list v1 introduced; treat it as the (only)
+		// served version, mirroring ensureCRDEstablished's storedVersions
+		// fallback above.
+		versions = []crdVersion{{Name: crd.Spec.Version, Served: true}}
+	}
+	namespaced := crd.Spec.Scope != "Cluster"
+	for _, v := range versions {
+		if !v.Served || v.Name == "" {
+			continue
+		}
+		h.store.mergeResourceInfo(crd.Spec.Group, v.Name, crd.Spec.Names.Plural, namespaced,
+			crd.Spec.Names.Kind, crd.Spec.Names.Singular, crd.Spec.Names.ShortNames)
+	}
 }
 
 // podNodeName returns a pod body's spec.nodeName ("" if unset).

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -479,6 +479,18 @@ func (h *handler) registerCRDResourceInfo(body json.RawMessage) {
 	if crd.Spec.Group == "" || crd.Spec.Names.Plural == "" {
 		return
 	}
+	// mergeResourceInfo treats namespaced as authoritative and overwrites any
+	// existing value, so an empty/unrecognized spec.scope (a malformed body)
+	// must be skipped entirely rather than defaulting to namespaced=true.
+	var namespaced bool
+	switch crd.Spec.Scope {
+	case "Namespaced":
+		namespaced = true
+	case "Cluster":
+		namespaced = false
+	default:
+		return
+	}
 	versions := crd.Spec.Versions
 	if len(versions) == 0 && crd.Spec.Version != "" {
 		// Legacy v1beta1 CRDs specify a single top-level spec.version instead
@@ -487,7 +499,6 @@ func (h *handler) registerCRDResourceInfo(body json.RawMessage) {
 		// fallback above.
 		versions = []crdVersion{{Name: crd.Spec.Version, Served: true}}
 	}
-	namespaced := crd.Spec.Scope != "Cluster"
 	for _, v := range versions {
 		if !v.Served || v.Name == "" {
 			continue

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -2186,6 +2186,86 @@ func TestOverlay_CRDEstablishedOnCreate(t *testing.T) {
 	}
 }
 
+// TestOverlay_CRDRegistersDiscoveryOnCreate verifies a freshly created CRD is
+// immediately visible via the discovery endpoints (/apis and
+// /apis/<group>/<version>), not just via a plain object read (`kubectl get
+// crd`). CaptureStore.resourceInfo is otherwise a snapshot built once from the
+// capture archive at startup (see LoadStore/buildResourceInfo), so without
+// registering the CRD's defined type on create, a CRD applied at runtime
+// (e.g. `istioctl install`) never shows up in `kubectl api-resources` or
+// `istioctl analyze`, both of which walk discovery rather than reading the
+// CRD object itself.
+func TestOverlay_CRDRegistersDiscoveryOnCreate(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	crdBody := `{"apiVersion":"apiextensions.k8s.io/v1","kind":"CustomResourceDefinition",
+		"metadata":{"name":"virtualservices.networking.istio.io"},
+		"spec":{"group":"networking.istio.io","scope":"Namespaced",
+			"names":{"kind":"VirtualService","listKind":"VirtualServiceList","plural":"virtualservices","singular":"virtualservice","shortNames":["vs"]},
+			"versions":[
+				{"name":"v1beta1","served":true,"storage":false},
+				{"name":"v1","served":true,"storage":true}
+			]}}`
+	code, out := doReq(t, http.MethodPost, srv.URL+"/apis/apiextensions.k8s.io/v1/customresourcedefinitions", "application/json", crdBody)
+	if code != http.StatusCreated {
+		t.Fatalf("create CRD: status %d, want 201: %s", code, out)
+	}
+
+	code, out = doReq(t, http.MethodGet, srv.URL+"/apis", "", "")
+	if code != http.StatusOK {
+		t.Fatalf("GET /apis: status %d: %s", code, out)
+	}
+	if !strings.Contains(string(out), `"networking.istio.io"`) {
+		t.Errorf("/apis response missing the networking.istio.io group: %s", out)
+	}
+
+	var resList struct {
+		Resources []struct {
+			Name       string   `json:"name"`
+			Kind       string   `json:"kind"`
+			Namespaced bool     `json:"namespaced"`
+			ShortNames []string `json:"shortNames"`
+		} `json:"resources"`
+	}
+	code, out = doReq(t, http.MethodGet, srv.URL+"/apis/networking.istio.io/v1", "", "")
+	if code != http.StatusOK {
+		t.Fatalf("GET /apis/networking.istio.io/v1: status %d: %s", code, out)
+	}
+	if err := json.Unmarshal(out, &resList); err != nil {
+		t.Fatalf("decode: %v\n%s", err, out)
+	}
+	var found bool
+	for _, r := range resList.Resources {
+		if r.Name != "virtualservices" {
+			continue
+		}
+		found = true
+		if r.Kind != "VirtualService" {
+			t.Errorf("kind = %q, want VirtualService", r.Kind)
+		}
+		if !r.Namespaced {
+			t.Error("namespaced = false, want true")
+		}
+		if !contains(r.ShortNames, "vs") {
+			t.Errorf("shortNames = %v, want to contain vs", r.ShortNames)
+		}
+	}
+	if !found {
+		t.Fatalf("virtualservices missing from /apis/networking.istio.io/v1: %s", out)
+	}
+
+	// The served-but-non-storage v1beta1 version is registered too.
+	code, out = doReq(t, http.MethodGet, srv.URL+"/apis/networking.istio.io/v1beta1", "", "")
+	if code != http.StatusOK {
+		t.Fatalf("GET /apis/networking.istio.io/v1beta1: status %d: %s", code, out)
+	}
+	if !strings.Contains(string(out), `"name":"virtualservices"`) {
+		t.Errorf("v1beta1 resource list missing virtualservices: %s", out)
+	}
+}
+
 // TestOverlay_CRDEstablished_EdgeCases covers edge cases in the synthesized
 // CRD status: storedVersions must be an empty JSON array (not null) when
 // spec.versions is missing/malformed, it must fall back to a legacy

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -2186,6 +2186,91 @@ func TestOverlay_CRDEstablishedOnCreate(t *testing.T) {
 	}
 }
 
+// TestOverlay_CRDMergesIntoCapturedDiscovery verifies a CRD created via the
+// overlay under a group/version a capture already recorded a discovery
+// document for (unlike TestOverlay_CRDRegistersDiscoveryOnCreate's
+// brand-new group, which was never captured in the first place) still shows
+// up in discovery, and that the already-captured resource in the same
+// document keeps its original fields (e.g. verbs) untouched. /apis and
+// /apis/<group>/<version> are the one read path a capture (almost) always
+// records — naively serving that frozen captured document verbatim
+// (tryServeFromStore) would otherwise permanently mask any resource type a
+// CRD registers afterward via the overlay. Found via Copilot review of the
+// original CRD discovery registration fix.
+func TestOverlay_CRDMergesIntoCapturedDiscovery(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{
+		"/apis": []byte(`{"kind":"APIGroupList","apiVersion":"v1","groups":[
+			{"name":"networking.istio.io","versions":[{"groupVersion":"networking.istio.io/v1","version":"v1"}],"preferredVersion":{"groupVersion":"networking.istio.io/v1","version":"v1"}}
+		]}`),
+		"/apis/networking.istio.io/v1": []byte(`{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"networking.istio.io/v1","resources":[
+			{"name":"gateways","namespaced":true,"kind":"Gateway","verbs":["create","delete","get","list","patch","update","watch"]}
+		]}`),
+	})
+	store.discoveryEnrichmentDone.Wait() // deterministically wait for the async enrichment pass
+
+	// No fake replay clock here: buildTestStore stamps captured records with
+	// the real wall-clock time, so a clock pinned to an arbitrary past instant
+	// would make Latest's "at or before" filter reject them as being from the
+	// future — unlike buildTestStoreWithWatch (writableTestStore), which lets
+	// a test pin explicit record times to match a fake clock.
+	h := newHandler(store, time.Time{}, false)
+	h.overlay = newOverlay()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	// Create a VirtualService CRD under the SAME group/version the capture
+	// already has a discovery document for.
+	crdBody := `{"apiVersion":"apiextensions.k8s.io/v1","kind":"CustomResourceDefinition",
+		"metadata":{"name":"virtualservices.networking.istio.io"},
+		"spec":{"group":"networking.istio.io","scope":"Namespaced",
+			"names":{"kind":"VirtualService","listKind":"VirtualServiceList","plural":"virtualservices","singular":"virtualservice"},
+			"versions":[{"name":"v1","served":true,"storage":true}]}}`
+	code, out := doReq(t, http.MethodPost, srv.URL+"/apis/apiextensions.k8s.io/v1/customresourcedefinitions", "application/json", crdBody)
+	if code != http.StatusCreated {
+		t.Fatalf("create CRD: status %d: %s", code, out)
+	}
+
+	code, out = doReq(t, http.MethodGet, srv.URL+"/apis/networking.istio.io/v1", "", "")
+	if code != http.StatusOK {
+		t.Fatalf("GET /apis/networking.istio.io/v1: status %d: %s", code, out)
+	}
+	var resList struct {
+		Resources []struct {
+			Name  string   `json:"name"`
+			Verbs []string `json:"verbs"`
+		} `json:"resources"`
+	}
+	if err := json.Unmarshal(out, &resList); err != nil {
+		t.Fatalf("decode: %v\n%s", err, out)
+	}
+	var gateways, virtualservices bool
+	for _, r := range resList.Resources {
+		switch r.Name {
+		case "gateways":
+			gateways = true
+			if !contains(r.Verbs, "create") {
+				t.Errorf("gateways lost its originally captured verbs %v — should be untouched by the merge", r.Verbs)
+			}
+		case "virtualservices":
+			virtualservices = true
+		}
+	}
+	if !gateways {
+		t.Errorf("gateways (originally captured) missing after merge: %s", out)
+	}
+	if !virtualservices {
+		t.Errorf("virtualservices (registered by the runtime CRD create) missing from /apis/networking.istio.io/v1 — the captured document shadowed it: %s", out)
+	}
+
+	code, out = doReq(t, http.MethodGet, srv.URL+"/apis", "", "")
+	if code != http.StatusOK {
+		t.Fatalf("GET /apis: status %d: %s", code, out)
+	}
+	if !strings.Contains(string(out), `"networking.istio.io"`) {
+		t.Errorf("/apis lost the already-captured networking.istio.io group: %s", out)
+	}
+}
+
 // TestOverlay_CRDRegistersDiscoveryOnCreate verifies a freshly created CRD is
 // immediately visible via the discovery endpoints (/apis and
 // /apis/<group>/<version>), not just via a plain object read (`kubectl get

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -2271,6 +2271,118 @@ func TestOverlay_CRDMergesIntoCapturedDiscovery(t *testing.T) {
 	}
 }
 
+// TestOverlay_CRDNewVersionMergesIntoCapturedGroup verifies a CRD that adds a
+// *new served version* to a group /apis already lists (rather than an
+// entirely new group) is merged into that group's own versions array in
+// /apis, not just visible via /apis/<group>/<version> and /apis/<group>.
+// groupVersionsByGroup's exclude set is keyed by group name, so a naive
+// "skip any resource whose group is already known" merge would drop this
+// version from /apis entirely — a discovery client that only walks /apis's
+// per-group version lists (rather than trying /apis/<group> too) would never
+// even attempt the new version. Found via Copilot review.
+func TestOverlay_CRDNewVersionMergesIntoCapturedGroup(t *testing.T) {
+	store := buildTestStore(t, map[string][]byte{
+		"/apis": []byte(`{"kind":"APIGroupList","apiVersion":"v1","groups":[
+			{"name":"networking.istio.io","versions":[{"groupVersion":"networking.istio.io/v1","version":"v1"}],"preferredVersion":{"groupVersion":"networking.istio.io/v1","version":"v1"}}
+		]}`),
+		"/apis/networking.istio.io/v1": []byte(`{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"networking.istio.io/v1","resources":[
+			{"name":"gateways","namespaced":true,"kind":"Gateway"}
+		]}`),
+	})
+	store.discoveryEnrichmentDone.Wait()
+
+	h := newHandler(store, time.Time{}, false) // see TestOverlay_CRDMergesIntoCapturedDiscovery for why no fake clock
+	h.overlay = newOverlay()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	// A CRD registering a NEW version (v1beta1) under the ALREADY-CAPTURED
+	// networking.istio.io group.
+	crdBody := `{"apiVersion":"apiextensions.k8s.io/v1","kind":"CustomResourceDefinition",
+		"metadata":{"name":"sidecars.networking.istio.io"},
+		"spec":{"group":"networking.istio.io","scope":"Namespaced",
+			"names":{"kind":"Sidecar","listKind":"SidecarList","plural":"sidecars","singular":"sidecar"},
+			"versions":[{"name":"v1beta1","served":true,"storage":true}]}}`
+	code, out := doReq(t, http.MethodPost, srv.URL+"/apis/apiextensions.k8s.io/v1/customresourcedefinitions", "application/json", crdBody)
+	if code != http.StatusCreated {
+		t.Fatalf("create CRD: status %d: %s", code, out)
+	}
+
+	code, out = doReq(t, http.MethodGet, srv.URL+"/apis", "", "")
+	if code != http.StatusOK {
+		t.Fatalf("GET /apis: status %d: %s", code, out)
+	}
+	var doc struct {
+		Groups []struct {
+			Name     string `json:"name"`
+			Versions []struct {
+				GroupVersion string `json:"groupVersion"`
+			} `json:"versions"`
+		} `json:"groups"`
+	}
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("decode: %v\n%s", err, out)
+	}
+	var found *struct {
+		Name     string
+		Versions []string
+	}
+	for _, g := range doc.Groups {
+		if g.Name != "networking.istio.io" {
+			continue
+		}
+		var vs []string
+		for _, v := range g.Versions {
+			vs = append(vs, v.GroupVersion)
+		}
+		found = &struct {
+			Name     string
+			Versions []string
+		}{g.Name, vs}
+	}
+	if found == nil {
+		t.Fatalf("networking.istio.io group missing from /apis: %s", out)
+	}
+	if !contains(found.Versions, "networking.istio.io/v1") {
+		t.Errorf("networking.istio.io lost its originally captured v1 version: %v", found.Versions)
+	}
+	if !contains(found.Versions, "networking.istio.io/v1beta1") {
+		t.Errorf("networking.istio.io/v1beta1 (registered by the runtime CRD create) missing from /apis's group entry: %v", found.Versions)
+	}
+}
+
+// TestOverlay_CRDMissingKindSkipsDiscoveryRegistration verifies a CRD whose
+// spec.names.kind is missing (a malformed body a real apiserver's OpenAPI
+// validation would reject, but registerCRDResourceInfo is deliberately
+// best-effort) doesn't get registered in discovery at all — falling through
+// to mergeResourceInfo's resourceToKind heuristic would guess a Kind that's
+// almost certainly wrong for a CRD (the heuristic is only reliable for
+// built-in types), polluting discovery with bad data. Found via Copilot
+// review.
+func TestOverlay_CRDMissingKindSkipsDiscoveryRegistration(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	crdBody := `{"apiVersion":"apiextensions.k8s.io/v1","kind":"CustomResourceDefinition",
+		"metadata":{"name":"thingamajigs.example.com"},
+		"spec":{"group":"example.com","scope":"Namespaced",
+			"names":{"plural":"thingamajigs","singular":"thingamajig"},
+			"versions":[{"name":"v1","served":true,"storage":true}]}}`
+	code, out := doReq(t, http.MethodPost, srv.URL+"/apis/apiextensions.k8s.io/v1/customresourcedefinitions", "application/json", crdBody)
+	if code != http.StatusCreated {
+		t.Fatalf("create CRD: status %d: %s", code, out)
+	}
+
+	code, out = doReq(t, http.MethodGet, srv.URL+"/apis/example.com/v1", "", "")
+	if code != http.StatusOK {
+		t.Fatalf("GET /apis/example.com/v1: status %d: %s", code, out)
+	}
+	if strings.Contains(string(out), "thingamajigs") {
+		t.Errorf("thingamajigs registered in discovery despite a missing kind — should have been skipped: %s", out)
+	}
+}
+
 // TestOverlay_CRDRegistersDiscoveryOnCreate verifies a freshly created CRD is
 // immediately visible via the discovery endpoints (/apis and
 // /apis/<group>/<version>), not just via a plain object read (`kubectl get


### PR DESCRIPTION
## Summary
- A CRD applied at runtime through the writable overlay (e.g. `istioctl install`, `helm install` for a CRD-heavy chart) was visible via `kubectl get crd` but never showed up in `kubectl api-resources` or any client that walks discovery (`istioctl analyze`, client-go's discovery client), since `CaptureStore.resourceInfo` is a snapshot built once from the capture archive at startup and nothing updated it when a CRD was created.
- `storeNewObject`'s existing CRD special-case (which already synthesizes `Established`/`NamesAccepted` status) now also parses the CRD's `spec.group`/`spec.scope`/`spec.names`/`spec.versions` (with the legacy v1beta1 `spec.version` fallback) and registers each served version via `CaptureStore.mergeResourceInfo` — the same method the archive's captured-discovery enrichment path already uses — so `/apis`, `/apis/<group>`, and `/apis/<group>/<version>` reflect the new type immediately.

## Test plan
- [x] `TestOverlay_CRDRegistersDiscoveryOnCreate` (new): creates a VirtualService-shaped CRD via the writable overlay, then verifies `/apis` lists the group and `/apis/networking.istio.io/{v1,v1beta1}` lists `virtualservices` with the correct kind/namespaced/shortNames.
- [x] `make test-race` — full suite passes
- [x] `make lint-ci` — clean
- [x] `gofmt -w .` / `go mod tidy` — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)