### PR TITLE
feat(query): add kshrk query — JSONPath search across every captured object

### DIFF
--- a/cmd/diagnose.go
+++ b/cmd/diagnose.go
@@ -66,7 +66,7 @@ func runDiagnose(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("loading capture: %w", err)
 	}
 
-	at, err := parseDiagnoseAt(atRaw, store.Metadata.CapturedAt, store.Metadata.CapturedUntil)
+	at, err := parseAtFlag(atRaw, store.Metadata.CapturedAt, store.Metadata.CapturedUntil)
 	if err != nil {
 		return err
 	}
@@ -125,9 +125,9 @@ func printDiagnoseTable(cmd *cobra.Command, r diagnose.Report) {
 		len(r.Findings), r.Summary.Critical, r.Summary.Warning, r.Summary.Info)
 }
 
-// parseDiagnoseAt resolves --at: empty = latest; RFC3339 timestamp; or a
+// parseAtFlag resolves an --at flag: empty = latest; RFC3339 timestamp; or a
 // relative duration like -5m against the capture end.
-func parseDiagnoseAt(raw string, start, end time.Time) (time.Time, error) {
+func parseAtFlag(raw string, start, end time.Time) (time.Time, error) {
 	if raw == "" {
 		return time.Time{}, nil
 	}

--- a/cmd/diagnose_test.go
+++ b/cmd/diagnose_test.go
@@ -89,16 +89,16 @@ func TestRunDiagnose_BadSeverity(t *testing.T) {
 	}
 }
 
-func TestParseDiagnoseAt_Window(t *testing.T) {
+func TestParseAtFlag_Window(t *testing.T) {
 	start := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
 	end := time.Date(2026, 4, 10, 10, 10, 0, 0, time.UTC)
-	if _, err := parseDiagnoseAt("2026-04-10T10:05:00Z", start, end); err != nil {
+	if _, err := parseAtFlag("2026-04-10T10:05:00Z", start, end); err != nil {
 		t.Errorf("in-window time rejected: %v", err)
 	}
-	if _, err := parseDiagnoseAt("-1h", start, end); err == nil {
+	if _, err := parseAtFlag("-1h", start, end); err == nil {
 		t.Error("expected out-of-window (before start) to error")
 	}
-	if _, err := parseDiagnoseAt("2026-04-10T11:00:00Z", start, end); err == nil {
+	if _, err := parseAtFlag("2026-04-10T11:00:00Z", start, end); err == nil {
 		t.Error("expected out-of-window (after end) to error")
 	}
 }

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/query"
+	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/spf13/cobra"
+)
+
+var queryCmd = &cobra.Command{
+	Use:   "query <capture.kshrk> <jsonpath-expression>",
+	Short: "Run a JSONPath query across every captured object",
+	Long: `Evaluates a kubectl-style JSONPath expression against every object captured
+in the archive — across all resource types and namespaces — at a chosen
+snapshot, and prints the objects where it matched.
+
+Limit the scope with --resource and --namespace, and pin the snapshot in time
+with --at. Objects that don't have the queried field are skipped, not
+reported as errors.`,
+	Example: `  # Every container image in the capture
+  kshrk query capture.kshrk '{.spec.containers[*].image}'
+
+  # Just Deployments' replica counts, as JSON
+  kshrk query capture.kshrk '{.spec.replicas}' --resource deployments -o json
+
+  # Pod phases at a point in time
+  kshrk query capture.kshrk '{.status.phase}' --resource pods --at -5m`,
+	Args: cobra.ExactArgs(2),
+	RunE: runQuery,
+}
+
+func init() {
+	rootCmd.AddCommand(queryCmd)
+	queryCmd.Flags().StringP("output", "o", "table", "output format: table or json")
+	queryCmd.Flags().String("at", "", "query state at a timestamp (RFC3339 or relative duration like -5m); default latest")
+	queryCmd.Flags().String("resource", "", "limit the query to one resource type, e.g. pods")
+	queryCmd.Flags().String("namespace", "", "limit the query to one namespace")
+	_ = queryCmd.RegisterFlagCompletionFunc("output",
+		cobra.FixedCompletions([]string{"table", "json"}, cobra.ShellCompDirectiveNoFileComp))
+}
+
+func runQuery(cmd *cobra.Command, args []string) error {
+	output, _ := cmd.Flags().GetString("output")
+	atRaw, _ := cmd.Flags().GetString("at")
+	resource, _ := cmd.Flags().GetString("resource")
+	namespace, _ := cmd.Flags().GetString("namespace")
+
+	ar, err := archive.Open(args[0])
+	if err != nil {
+		return fmt.Errorf("opening archive: %w", err)
+	}
+	defer ar.Close()
+	store, err := server.LoadStore(ar)
+	if err != nil {
+		return fmt.Errorf("loading capture: %w", err)
+	}
+
+	at, err := parseAtFlag(atRaw, store.Metadata.CapturedAt, store.Metadata.CapturedUntil)
+	if err != nil {
+		return err
+	}
+
+	result, err := query.Run(store, query.Options{
+		Expression: args[1],
+		At:         at,
+		Resource:   resource,
+		Namespace:  namespace,
+	})
+	if err != nil {
+		return err
+	}
+
+	switch strings.ToLower(output) {
+	case "json":
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	default:
+		printQueryTable(cmd, result)
+	}
+	return nil
+}
+
+func printQueryTable(cmd *cobra.Command, r *query.Result) {
+	out := cmd.OutOrStdout()
+	if len(r.Matches) == 0 {
+		fmt.Fprintln(out, "No matches.")
+		return
+	}
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "RESOURCE\tNAMESPACE\tNAME\tVALUE")
+	for _, m := range r.Matches {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", m.Resource, m.Namespace, m.Name, string(m.Value))
+	}
+	_ = tw.Flush()
+	fmt.Fprintf(out, "\n%d match(es)\n", len(r.Matches))
+}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -13,23 +13,29 @@ import (
 )
 
 var queryCmd = &cobra.Command{
-	Use:   "query <capture.kshrk> <jsonpath-expression>",
-	Short: "Run a JSONPath query across every captured object",
-	Long: `Evaluates a kubectl-style JSONPath expression against every object captured
-in the archive — across all resource types and namespaces — at a chosen
-snapshot, and prints the objects where it matched.
+	Use:   "query <capture.kshrk> <expression>",
+	Short: "Search or run a JSONPath query across every captured object",
+	Long: `Evaluates an expression against every object captured in the archive — across
+all resource types and namespaces — at a chosen snapshot, and prints what
+matched.
+
+By default the expression is a kubectl-style JSONPath template. With --text
+or --regex, it's instead a plain substring or regular expression searched
+across every object body and captured pod log (current and --previous).
 
 Limit the scope with --resource and --namespace, and pin the snapshot in time
-with --at. Objects that don't have the queried field are skipped, not
-reported as errors.`,
-	Example: `  # Every container image in the capture
+with --at.`,
+	Example: `  # Every container image in the capture (JSONPath)
   kshrk query capture.kshrk '{.spec.containers[*].image}'
 
   # Just Deployments' replica counts, as JSON
   kshrk query capture.kshrk '{.spec.replicas}' --resource deployments -o json
 
-  # Pod phases at a point in time
-  kshrk query capture.kshrk '{.status.phase}' --resource pods --at -5m`,
+  # Where does this error string appear, across objects and pod logs?
+  kshrk query capture.kshrk 'connection refused' --text
+
+  # Same, with a regular expression
+  kshrk query capture.kshrk 'connection (refused|reset)' --regex`,
 	Args: cobra.ExactArgs(2),
 	RunE: runQuery,
 }
@@ -40,6 +46,8 @@ func init() {
 	queryCmd.Flags().String("at", "", "query state at a timestamp (RFC3339 or relative duration like -5m); default latest")
 	queryCmd.Flags().String("resource", "", "limit the query to one resource type, e.g. pods")
 	queryCmd.Flags().String("namespace", "", "limit the query to one namespace")
+	queryCmd.Flags().Bool("text", false, "treat the expression as a plain substring, searched across object bodies and pod logs instead of JSONPath")
+	queryCmd.Flags().Bool("regex", false, "treat the expression as a regular expression, searched across object bodies and pod logs instead of JSONPath")
 	_ = queryCmd.RegisterFlagCompletionFunc("output",
 		cobra.FixedCompletions([]string{"table", "json"}, cobra.ShellCompDirectiveNoFileComp))
 }
@@ -49,6 +57,11 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	atRaw, _ := cmd.Flags().GetString("at")
 	resource, _ := cmd.Flags().GetString("resource")
 	namespace, _ := cmd.Flags().GetString("namespace")
+	text, _ := cmd.Flags().GetBool("text")
+	useRegex, _ := cmd.Flags().GetBool("regex")
+	if text && useRegex {
+		return fmt.Errorf("--text and --regex are mutually exclusive")
+	}
 
 	ar, err := archive.Open(args[0])
 	if err != nil {
@@ -63,6 +76,28 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	at, err := parseAtFlag(atRaw, store.Metadata.CapturedAt, store.Metadata.CapturedUntil)
 	if err != nil {
 		return err
+	}
+
+	if text || useRegex {
+		result, err := query.SearchText(store, query.TextOptions{
+			Pattern:   args[1],
+			Regex:     useRegex,
+			At:        at,
+			Resource:  resource,
+			Namespace: namespace,
+		})
+		if err != nil {
+			return err
+		}
+		switch strings.ToLower(output) {
+		case "json":
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(result)
+		default:
+			printTextTable(cmd, result)
+		}
+		return nil
 	}
 
 	result, err := query.Run(store, query.Options{
@@ -96,6 +131,28 @@ func printQueryTable(cmd *cobra.Command, r *query.Result) {
 	fmt.Fprintln(tw, "RESOURCE\tNAMESPACE\tNAME\tVALUE")
 	for _, m := range r.Matches {
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", m.Resource, m.Namespace, m.Name, string(m.Value))
+	}
+	_ = tw.Flush()
+	fmt.Fprintf(out, "\n%d match(es)\n", len(r.Matches))
+}
+
+func printTextTable(cmd *cobra.Command, r *query.TextResult) {
+	out := cmd.OutOrStdout()
+	if len(r.Matches) == 0 {
+		fmt.Fprintln(out, "No matches.")
+		return
+	}
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "RESOURCE\tNAMESPACE\tNAME\tLOCATION\tSNIPPET")
+	for _, m := range r.Matches {
+		loc := m.Field
+		if m.Container != "" {
+			loc = "log:" + m.Container
+			if m.Previous {
+				loc += " (previous)"
+			}
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", m.Resource, m.Namespace, m.Name, loc, m.Snippet)
 	}
 	_ = tw.Flush()
 	fmt.Fprintf(out, "\n%d match(es)\n", len(r.Matches))

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -152,8 +152,19 @@ func printTextTable(cmd *cobra.Command, r *query.TextResult) {
 				loc += " (previous)"
 			}
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", m.Resource, m.Namespace, m.Name, loc, m.Snippet)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", m.Resource, m.Namespace, m.Name, tableSafe(loc), tableSafe(m.Snippet))
 	}
 	_ = tw.Flush()
 	fmt.Fprintf(out, "\n%d match(es)\n", len(r.Matches))
+}
+
+// tableSafe replaces tab and newline characters so a matched value (e.g. a
+// multi-line ConfigMap entry or log line) can't split a tabwriter row/column
+// when printed as a table cell.
+func tableSafe(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", `\n`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\n`)
+	s = strings.ReplaceAll(s, "\t", `\t`)
+	return s
 }

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -146,8 +146,11 @@ func printTextTable(cmd *cobra.Command, r *query.TextResult) {
 	fmt.Fprintln(tw, "RESOURCE\tNAMESPACE\tNAME\tLOCATION\tSNIPPET")
 	for _, m := range r.Matches {
 		loc := m.Field
-		if m.Container != "" {
-			loc = "log:" + m.Container
+		if m.Log {
+			loc = "log"
+			if m.Container != "" {
+				loc += ":" + m.Container
+			}
 			if m.Previous {
 				loc += " (previous)"
 			}

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -109,6 +109,32 @@ func TestRunQuery_NoMatches(t *testing.T) {
 	}
 }
 
+func TestRunQuery_TextMode_TableOutputEscapesNewlines(t *testing.T) {
+	// A matched value containing a raw newline or tab must not split the
+	// tabwriter row/column when rendered as a table.
+	podWithMultilineAnnotation := `{"apiVersion":"v1","kind":"PodList","items":[` +
+		`{"metadata":{"name":"web-1","namespace":"default","annotations":{"note":"line one\nline two\tindented"}}}]}`
+	arch := buildDiffArchive(t, podWithMultilineAnnotation)
+	cmd := newTestQueryCommand()
+	_ = cmd.Flags().Set("text", "true")
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runQuery(cmd, []string{arch, "line one"}); err != nil {
+		t.Fatalf("runQuery: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "line one\nline two") {
+		t.Errorf("expected the embedded newline to be escaped, not printed raw:\n%s", out)
+	}
+	if !strings.Contains(out, `line one\nline two\tindented`) {
+		t.Errorf("expected escaped snippet in output:\n%s", out)
+	}
+	if strings.Count(out, "web-1") != 1 {
+		t.Errorf("expected exactly one match row, got:\n%s", out)
+	}
+}
+
 func TestRunQuery_TextMode(t *testing.T) {
 	arch := buildDiffArchive(t, queryPodList)
 	cmd := newTestQueryCommand()

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/query"
+	"github.com/spf13/cobra"
+)
+
+func newTestQueryCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().StringP("output", "o", "table", "")
+	cmd.Flags().String("at", "", "")
+	cmd.Flags().String("resource", "", "")
+	cmd.Flags().String("namespace", "", "")
+	return cmd
+}
+
+const queryPodList = `{"apiVersion":"v1","kind":"PodList","items":[` +
+	`{"metadata":{"name":"web-1","namespace":"default"},"spec":{"containers":[{"name":"app","image":"nginx:alpine"}]}},` +
+	`{"metadata":{"name":"web-2","namespace":"default"},"spec":{"containers":[{"name":"app","image":"nginx:alpine"}]}}]}`
+
+func TestRunQuery_JSON(t *testing.T) {
+	arch := buildDiffArchive(t, queryPodList) // writes /api/v1/namespaces/default/pods
+	cmd := newTestQueryCommand()
+	_ = cmd.Flags().Set("output", "json")
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runQuery(cmd, []string{arch, "{.spec.containers[*].image}"}); err != nil {
+		t.Fatalf("runQuery: %v", err)
+	}
+	var result query.Result
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("output not valid JSON: %v\n%s", err, buf.String())
+	}
+	if len(result.Matches) != 2 {
+		t.Fatalf("expected 2 matches, got %d: %+v", len(result.Matches), result.Matches)
+	}
+	for _, m := range result.Matches {
+		if string(m.Value) != `"nginx:alpine"` {
+			t.Errorf("unexpected value %s", m.Value)
+		}
+	}
+}
+
+func TestRunQuery_TableOutput(t *testing.T) {
+	arch := buildDiffArchive(t, queryPodList)
+	cmd := newTestQueryCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runQuery(cmd, []string{arch, "{.metadata.name}"}); err != nil {
+		t.Fatalf("runQuery: %v", err)
+	}
+	if !strings.Contains(buf.String(), "web-1") || !strings.Contains(buf.String(), "web-2") {
+		t.Errorf("expected table to list both pods:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "2 match(es)") {
+		t.Errorf("expected match count summary:\n%s", buf.String())
+	}
+}
+
+func TestRunQuery_ResourceFilter(t *testing.T) {
+	arch := buildDiffArchive(t, queryPodList)
+	cmd := newTestQueryCommand()
+	_ = cmd.Flags().Set("output", "json")
+	_ = cmd.Flags().Set("resource", "deployments")
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runQuery(cmd, []string{arch, "{.metadata.name}"}); err != nil {
+		t.Fatalf("runQuery: %v", err)
+	}
+	var result query.Result
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("output not valid JSON: %v", err)
+	}
+	if len(result.Matches) != 0 {
+		t.Fatalf("expected no matches when filtering to a resource type not in this capture, got %d", len(result.Matches))
+	}
+}
+
+func TestRunQuery_BadExpression(t *testing.T) {
+	arch := buildDiffArchive(t, queryPodList)
+	cmd := newTestQueryCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	if err := runQuery(cmd, []string{arch, "{.spec.["}); err == nil {
+		t.Error("expected error for invalid jsonpath expression")
+	}
+}
+
+func TestRunQuery_NoMatches(t *testing.T) {
+	arch := buildDiffArchive(t, queryPodList)
+	cmd := newTestQueryCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runQuery(cmd, []string{arch, "{.spec.replicas}"}); err != nil {
+		t.Fatalf("runQuery: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No matches.") {
+		t.Errorf("expected 'No matches.' message:\n%s", buf.String())
+	}
+}

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -16,6 +16,8 @@ func newTestQueryCommand() *cobra.Command {
 	cmd.Flags().String("at", "", "")
 	cmd.Flags().String("resource", "", "")
 	cmd.Flags().String("namespace", "", "")
+	cmd.Flags().Bool("text", false, "")
+	cmd.Flags().Bool("regex", false, "")
 	return cmd
 }
 
@@ -104,5 +106,68 @@ func TestRunQuery_NoMatches(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "No matches.") {
 		t.Errorf("expected 'No matches.' message:\n%s", buf.String())
+	}
+}
+
+func TestRunQuery_TextMode(t *testing.T) {
+	arch := buildDiffArchive(t, queryPodList)
+	cmd := newTestQueryCommand()
+	_ = cmd.Flags().Set("output", "json")
+	_ = cmd.Flags().Set("text", "true")
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runQuery(cmd, []string{arch, "nginx:alpine"}); err != nil {
+		t.Fatalf("runQuery: %v", err)
+	}
+	var result query.TextResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("output not valid JSON: %v\n%s", err, buf.String())
+	}
+	if len(result.Matches) != 2 {
+		t.Fatalf("expected 2 matches, got %d: %+v", len(result.Matches), result.Matches)
+	}
+	for _, m := range result.Matches {
+		if m.Field != "spec.containers[0].image" {
+			t.Errorf("unexpected field %q", m.Field)
+		}
+	}
+}
+
+func TestRunQuery_RegexMode_TableOutput(t *testing.T) {
+	arch := buildDiffArchive(t, queryPodList)
+	cmd := newTestQueryCommand()
+	_ = cmd.Flags().Set("regex", "true")
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runQuery(cmd, []string{arch, `nginx:\w+`}); err != nil {
+		t.Fatalf("runQuery: %v", err)
+	}
+	if !strings.Contains(buf.String(), "web-1") || !strings.Contains(buf.String(), "2 match(es)") {
+		t.Errorf("expected table output with both matches:\n%s", buf.String())
+	}
+}
+
+func TestRunQuery_TextAndRegexMutuallyExclusive(t *testing.T) {
+	arch := buildDiffArchive(t, queryPodList)
+	cmd := newTestQueryCommand()
+	_ = cmd.Flags().Set("text", "true")
+	_ = cmd.Flags().Set("regex", "true")
+	cmd.SetOut(&bytes.Buffer{})
+
+	if err := runQuery(cmd, []string{arch, "nginx"}); err == nil {
+		t.Error("expected error when --text and --regex are both set")
+	}
+}
+
+func TestRunQuery_InvalidRegex(t *testing.T) {
+	arch := buildDiffArchive(t, queryPodList)
+	cmd := newTestQueryCommand()
+	_ = cmd.Flags().Set("regex", "true")
+	cmd.SetOut(&bytes.Buffer{})
+
+	if err := runQuery(cmd, []string{arch, "(unclosed"}); err == nil {
+		t.Error("expected error for invalid regex")
 	}
 }

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -3,12 +3,52 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	archivepkg "github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
 	"github.com/phenixblue/k8shark/internal/query"
 	"github.com/spf13/cobra"
 )
+
+// buildMultiPathArchive writes an archive with one record per (path, body)
+// pair, for tests that need more than buildDiffArchive's single fixed path.
+func buildMultiPathArchive(t *testing.T, bodies map[string]string) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "capture.kshrk")
+	now := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	sw, err := archivepkg.NewStreamWriter(out)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	index := capture.Index{}
+	i := 0
+	for path, body := range bodies {
+		rec := &capture.Record{ID: path, CapturedAt: now, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body)}
+		if err := sw.WriteRecord(rec); err != nil {
+			t.Fatalf("WriteRecord: %v", err)
+		}
+		index[path] = &capture.IndexEntry{APIPath: path, Seqs: []int{0}, Times: []time.Time{now}}
+		i++
+	}
+	meta := &capture.CaptureMetadata{CaptureID: "test-capture", CapturedAt: now, CapturedUntil: now, RecordCount: i}
+	if err := sw.Finish(meta, index, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	return out
+}
+
+func mustJSONQueryString(t *testing.T, s string) string {
+	t.Helper()
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	return string(b)
+}
 
 func newTestQueryCommand() *cobra.Command {
 	cmd := &cobra.Command{}
@@ -172,6 +212,29 @@ func TestRunQuery_RegexMode_TableOutput(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "web-1") || !strings.Contains(buf.String(), "2 match(es)") {
 		t.Errorf("expected table output with both matches:\n%s", buf.String())
+	}
+}
+
+func TestRunQuery_TextMode_TableShowsGenericLogLocationWithoutContainer(t *testing.T) {
+	// A legacy log record with no ?container= param must still render as a
+	// log row (LOCATION "log"), not a blank LOCATION.
+	arch := buildMultiPathArchive(t, map[string]string{
+		"/api/v1/namespaces/crash-demo/pods/flaky-1/log": mustJSONQueryString(t, "fatal: connection refused"),
+	})
+	cmd := newTestQueryCommand()
+	_ = cmd.Flags().Set("text", "true")
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runQuery(cmd, []string{arch, "connection refused"}); err != nil {
+		t.Fatalf("runQuery: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "  log  ") {
+		t.Errorf("expected a generic 'log' LOCATION for a container-less log match:\n%s", out)
+	}
+	if strings.Contains(out, "log:") {
+		t.Errorf("did not expect a container suffix when none was captured:\n%s", out)
 	}
 }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -620,7 +620,7 @@ kshrk query capture.kshrk '{.spec.replicas}' --resource deployments -o json
 | `--resource` | (all) | Limit the query to one resource type, e.g. `pods` |
 | `--namespace` | (all) | Limit the query to one namespace |
 
-Expressions follow the same JSONPath syntax as `kubectl get -o jsonpath=`, including wildcards (`[*]`) and filters (`[?(@.key==value)]`). Only structured JSONPath queries are supported today; full-text search across object bodies and captured logs is planned as a follow-up.
+Expressions follow the same JSONPath syntax as `kubectl get -o jsonpath=`, including wildcards (`[*]`) and filters (`[?(@.key=="value")]`). Only structured JSONPath queries are supported today; full-text search across object bodies and captured logs is planned as a follow-up.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -619,8 +619,37 @@ kshrk query capture.kshrk '{.spec.replicas}' --resource deployments -o json
 | `--at` | latest | Query state at a timestamp (RFC3339 or relative duration like `-5m`); must be within the capture window |
 | `--resource` | (all) | Limit the query to one resource type, e.g. `pods` |
 | `--namespace` | (all) | Limit the query to one namespace |
+| `--text` | (off) | Treat the expression as a plain substring instead of JSONPath (see [Full-text search](#full-text-search) below) |
+| `--regex` | (off) | Treat the expression as a regular expression instead of JSONPath — mutually exclusive with `--text` |
 
-Expressions follow the same JSONPath syntax as `kubectl get -o jsonpath=`, including wildcards (`[*]`) and filters (`[?(@.key=="value")]`). Only structured JSONPath queries are supported today; full-text search across object bodies and captured logs is planned as a follow-up.
+Expressions follow the same JSONPath syntax as `kubectl get -o jsonpath=`, including wildcards (`[*]`) and filters (`[?(@.key=="value")]`).
+
+### Full-text search
+
+With `--text` or `--regex`, the expression is no longer JSONPath — it's searched as plain text across **every string value in every captured object**, and across captured pod logs (current and `--previous`). This answers "where does this error string appear?" without knowing in advance whether it's in an annotation, a container command, an event message, or a log line.
+
+```sh
+kshrk query capture.kshrk 'connection refused' --text
+```
+
+```
+RESOURCE     NAMESPACE   NAME                          LOCATION                                      SNIPPET
+pods         crash-demo  flaky-worker-897c5486c-lfk2f  spec.containers[0].command[2]                 echo starting up; sleep 3; echo 'fatal: connection refused to db:5432'; exit 1
+pods         crash-demo  flaky-worker-897c5486c-lfk2f  log:worker                                     fatal: connection refused to db:5432
+pods         crash-demo  flaky-worker-897c5486c-lfk2f  log:worker (previous)                           fatal: connection refused to db:5432
+deployments  crash-demo  flaky-worker                  metadata.annotations.kubectl.kubernetes.io/last-applied-configuration  …echo starting up; sleep 3; echo 'fatal: connection refused to db:5432'; exit 1"],"image":"busybox:…
+deployments  crash-demo  flaky-worker                  spec.template.spec.containers[0].command[2]   echo starting up; sleep 3; echo 'fatal: connection refused to db:5432'; exit 1
+
+5 match(es)
+```
+
+`--regex` accepts a Go regular expression (RE2 syntax) instead of a literal substring:
+
+```sh
+kshrk query capture.kshrk 'connection (refused|reset)' --regex
+```
+
+For object matches, `LOCATION` is the dotted JSON field path of the matched string (e.g. `spec.containers[0].command[2]`). For log matches, it's `log:<container>`, with `(previous)` appended for `kubectl logs --previous` content. `--resource`/`--namespace` scope full-text search the same way they scope JSONPath queries; `--resource` values other than `pods` exclude log content entirely, since only pods have logs.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -633,12 +633,12 @@ kshrk query capture.kshrk 'connection refused' --text
 ```
 
 ```
-RESOURCE     NAMESPACE   NAME                          LOCATION                                      SNIPPET
-pods         crash-demo  flaky-worker-897c5486c-lfk2f  spec.containers[0].command[2]                 echo starting up; sleep 3; echo 'fatal: connection refused to db:5432'; exit 1
-pods         crash-demo  flaky-worker-897c5486c-lfk2f  log:worker                                     fatal: connection refused to db:5432
-pods         crash-demo  flaky-worker-897c5486c-lfk2f  log:worker (previous)                           fatal: connection refused to db:5432
-deployments  crash-demo  flaky-worker                  metadata.annotations.kubectl.kubernetes.io/last-applied-configuration  …echo starting up; sleep 3; echo 'fatal: connection refused to db:5432'; exit 1"],"image":"busybox:…
-deployments  crash-demo  flaky-worker                  spec.template.spec.containers[0].command[2]   echo starting up; sleep 3; echo 'fatal: connection refused to db:5432'; exit 1
+RESOURCE     NAMESPACE   NAME                          LOCATION                                                                  SNIPPET
+pods         crash-demo  flaky-worker-897c5486c-lfk2f  spec.containers[0].command[2]                                             echo starting up; sleep 3; echo 'fatal: connection refused to db:5432'; exit 1
+pods         crash-demo  flaky-worker-897c5486c-lfk2f  log:worker                                                                fatal: connection refused to db:5432
+pods         crash-demo  flaky-worker-897c5486c-lfk2f  log:worker (previous)                                                     fatal: connection refused to db:5432
+deployments  crash-demo  flaky-worker                  metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"]  …echo starting up; sleep 3; echo 'fatal: connection refused to db:5432'; exit 1"],"image":"busybox:…
+deployments  crash-demo  flaky-worker                  spec.template.spec.containers[0].command[2]                               echo starting up; sleep 3; echo 'fatal: connection refused to db:5432'; exit 1
 
 5 match(es)
 ```
@@ -649,7 +649,7 @@ deployments  crash-demo  flaky-worker                  spec.template.spec.contai
 kshrk query capture.kshrk 'connection (refused|reset)' --regex
 ```
 
-For object matches, `LOCATION` is the dotted JSON field path of the matched string (e.g. `spec.containers[0].command[2]`). For log matches, it's `log:<container>`, with `(previous)` appended for `kubectl logs --previous` content. `--resource`/`--namespace` scope full-text search the same way they scope JSONPath queries; `--resource` values other than `pods` exclude log content entirely, since only pods have logs.
+For object matches, `LOCATION` is the JSON field path of the matched string (e.g. `spec.containers[0].command[2]`). A map key that isn't a simple identifier — common for annotations/labels, which routinely contain `.` and `/` — is bracket-quoted so the path stays unambiguous: `metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"]`, not the misleading `metadata.annotations.kubectl.kubernetes.io/last-applied-configuration`. For log matches, `LOCATION` is `log:<container>`, with `(previous)` appended for `kubectl logs --previous` content. `--resource`/`--namespace` scope full-text search the same way they scope JSONPath queries; `--resource` values other than `pods` exclude log content entirely, since only pods have logs.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -578,6 +578,52 @@ Exit codes follow the usual diff convention:
 
 ---
 
+## Query
+
+`kshrk query` evaluates a kubectl-style JSONPath expression against **every** object captured in the archive — across all resource types and namespaces at once — instead of one list at a time. Useful for questions like "every container image in this capture" or "every pod's phase" without knowing in advance which resource types to look at.
+
+```sh
+kshrk query capture.kshrk '{.spec.containers[*].image}'
+```
+
+Example table output:
+
+```
+RESOURCE     NAMESPACE  NAME    VALUE
+pods         default    web-1   "nginx:alpine"
+pods         default    web-2   "nginx:alpine"
+deployments  default    web     "nginx:alpine"
+
+3 match(es)
+```
+
+Objects that don't have the queried field are skipped rather than reported as errors, so one expression can safely run across dissimilar resource types.
+
+Scope the query and pin it to a point in time:
+
+```sh
+kshrk query capture.kshrk '{.status.phase}' --resource pods --at -5m
+```
+
+Emit machine-readable JSON instead of a table:
+
+```sh
+kshrk query capture.kshrk '{.spec.replicas}' --resource deployments -o json
+```
+
+### Query flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output`, `-o` | `table` | Output format: `table` or `json` |
+| `--at` | latest | Query state at a timestamp (RFC3339 or relative duration like `-5m`); must be within the capture window |
+| `--resource` | (all) | Limit the query to one resource type, e.g. `pods` |
+| `--namespace` | (all) | Limit the query to one namespace |
+
+Expressions follow the same JSONPath syntax as `kubectl get -o jsonpath=`, including wildcards (`[*]`) and filters (`[?(@.key==value)]`). Only structured JSONPath queries are supported today; full-text search across object bodies and captured logs is planned as a follow-up.
+
+---
+
 ## Redact
 
 Sensitive values can be removed from a capture archive in two ways.

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -44,8 +44,10 @@ type Result struct {
 }
 
 // Run evaluates opts.Expression against every captured object in store at
-// the resolved snapshot, returning one Match per non-empty JSONPath result.
-// Objects that don't have the queried field are skipped, not treated as errors.
+// the resolved snapshot, returning one Match per JSONPath result found on an
+// object — including zero-value results like "" or null, since those mean
+// the field exists. Objects that don't have the queried field at all produce
+// no results (via AllowMissingKeys) and are skipped, not treated as errors.
 func Run(store *server.CaptureStore, opts Options) (*Result, error) {
 	jp := jsonpath.New("query").AllowMissingKeys(true)
 	if err := jp.Parse(opts.Expression); err != nil {

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -1,0 +1,176 @@
+// Package query evaluates a JSONPath expression against every captured
+// object in an archive, across all resource types and namespaces, at a
+// chosen point in time.
+package query
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/server"
+	"k8s.io/client-go/util/jsonpath"
+)
+
+// Options configures a Run.
+type Options struct {
+	// Expression is a kubectl-style JSONPath template, e.g. "{.spec.containers[*].image}".
+	Expression string
+	// At selects the snapshot to query. Zero means the latest captured state.
+	At time.Time
+	// Resource limits the query to one resource type, e.g. "pods". Empty means all.
+	Resource string
+	// Namespace limits the query to one namespace. Empty means all.
+	Namespace string
+}
+
+// Match is one JSONPath result found on one captured object.
+type Match struct {
+	Path      string          `json:"path"`
+	Group     string          `json:"group,omitempty"`
+	Version   string          `json:"version,omitempty"`
+	Resource  string          `json:"resource,omitempty"`
+	Namespace string          `json:"namespace,omitempty"`
+	Name      string          `json:"name"`
+	Value     json.RawMessage `json:"value"`
+}
+
+// Result is the full set of matches for one query.
+type Result struct {
+	Matches []Match `json:"matches"`
+}
+
+// Run evaluates opts.Expression against every captured object in store at
+// the resolved snapshot, returning one Match per non-empty JSONPath result.
+// Objects that don't have the queried field are skipped, not treated as errors.
+func Run(store *server.CaptureStore, opts Options) (*Result, error) {
+	jp := jsonpath.New("query").AllowMissingKeys(true)
+	if err := jp.Parse(opts.Expression); err != nil {
+		return nil, fmt.Errorf("parsing jsonpath expression %q: %w", opts.Expression, err)
+	}
+
+	at := opts.At
+	if at.IsZero() {
+		at = store.Metadata.CapturedUntil
+	}
+
+	paths := make([]string, 0, len(store.Index))
+	for path := range store.Index {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	matches := make([]Match, 0)
+	for _, path := range paths {
+		if strings.Contains(path, "?") {
+			continue // Table/query-param variants of a path already covered plainly
+		}
+		g, v, r, ns := parseAPIPath(path)
+		if r == "" {
+			continue // discovery/openapi/other non-resource paths
+		}
+		if opts.Resource != "" && r != opts.Resource {
+			continue
+		}
+		if opts.Namespace != "" && ns != opts.Namespace {
+			continue
+		}
+		body, code, err := store.ReconstructAt(path, at)
+		if err != nil || code != 200 || len(body) == 0 {
+			continue
+		}
+		for _, item := range extractItems(body) {
+			var data any
+			if json.Unmarshal(item, &data) != nil {
+				continue
+			}
+			results, err := jp.FindResults(data)
+			if err != nil {
+				continue
+			}
+			name := itemName(item)
+			for _, set := range results {
+				for _, rv := range set {
+					value, ok := marshalValue(rv)
+					if !ok {
+						continue
+					}
+					matches = append(matches, Match{
+						Path: path, Group: g, Version: v, Resource: r,
+						Namespace: ns, Name: name, Value: value,
+					})
+				}
+			}
+		}
+	}
+	return &Result{Matches: matches}, nil
+}
+
+// extractItems returns the objects to query in body: a list's items, or the
+// body itself when it isn't list-shaped.
+func extractItems(body []byte) []json.RawMessage {
+	var list struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(body, &list); err != nil || list.Items == nil {
+		return []json.RawMessage{body}
+	}
+	return list.Items
+}
+
+func itemName(item json.RawMessage) string {
+	var meta struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+	if json.Unmarshal(item, &meta) != nil {
+		return ""
+	}
+	return meta.Metadata.Name
+}
+
+func marshalValue(rv reflect.Value) (json.RawMessage, bool) {
+	if !rv.IsValid() {
+		return nil, false
+	}
+	b, err := json.Marshal(rv.Interface())
+	if err != nil {
+		return nil, false
+	}
+	return json.RawMessage(b), true
+}
+
+// parseAPIPath extracts group, version, resource, and namespace from a canonical
+// API list path. Cluster-scoped paths return an empty namespace.
+func parseAPIPath(path string) (group, version, resource, namespace string) {
+	p := path
+	if i := strings.IndexByte(p, '?'); i >= 0 {
+		p = p[:i]
+	}
+	parts := strings.Split(strings.TrimPrefix(p, "/"), "/")
+	switch {
+	case len(parts) >= 3 && parts[0] == "api": // /api/v1/...
+		version = parts[1]
+		rest := parts[2:]
+		if len(rest) >= 3 && rest[0] == "namespaces" {
+			namespace = rest[1]
+			resource = rest[2]
+		} else if len(rest) >= 1 {
+			resource = rest[0]
+		}
+	case len(parts) >= 4 && parts[0] == "apis": // /apis/<group>/<version>/...
+		group, version = parts[1], parts[2]
+		rest := parts[3:]
+		if len(rest) >= 3 && rest[0] == "namespaces" {
+			namespace = rest[1]
+			resource = rest[2]
+		} else if len(rest) >= 1 {
+			resource = rest[0]
+		}
+	}
+	return
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -89,12 +89,12 @@ func Run(store *server.CaptureStore, opts Options) (*Result, error) {
 			continue
 		}
 		for _, item := range extractItems(body) {
-			meta := itemMeta(item, pathNS)
-			if opts.Namespace != "" && meta.Namespace != opts.Namespace {
-				continue
-			}
 			var data any
 			if json.Unmarshal(item, &data) != nil {
+				continue
+			}
+			meta := metaFromData(data, pathNS)
+			if opts.Namespace != "" && meta.Namespace != opts.Namespace {
 				continue
 			}
 			results, err := jp.FindResults(data)
@@ -138,21 +138,23 @@ type objectMeta struct {
 	Namespace string
 }
 
-func itemMeta(item json.RawMessage, fallbackNamespace string) objectMeta {
-	var m struct {
-		Metadata struct {
-			Name      string `json:"name"`
-			Namespace string `json:"namespace"`
-		} `json:"metadata"`
+// metaFromData reads name/namespace out of data — an object already decoded
+// via json.Unmarshal(item, &data) — instead of re-unmarshaling the item's raw
+// bytes. Callers need the decoded value anyway (for JSONPath evaluation or
+// string-walking), so deriving metadata from it avoids double-decoding every
+// object in the archive.
+func metaFromData(data any, fallbackNamespace string) objectMeta {
+	obj, ok := data.(map[string]any)
+	if !ok {
+		return objectMeta{Namespace: fallbackNamespace}
 	}
-	if json.Unmarshal(item, &m) != nil {
-		return objectMeta{}
-	}
-	ns := m.Metadata.Namespace
+	metadata, _ := obj["metadata"].(map[string]any)
+	name, _ := metadata["name"].(string)
+	ns, _ := metadata["namespace"].(string)
 	if ns == "" {
 		ns = fallbackNamespace
 	}
-	return objectMeta{Name: m.Metadata.Name, Namespace: ns}
+	return objectMeta{Name: name, Namespace: ns}
 }
 
 func marshalValue(rv reflect.Value) (json.RawMessage, bool) {

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -67,8 +67,11 @@ func Run(store *server.CaptureStore, opts Options) (*Result, error) {
 
 	matches := make([]Match, 0)
 	for _, path := range paths {
-		if strings.Contains(path, "?") {
-			continue // Table/query-param variants of a path already covered plainly
+		if isDuplicateView(path) {
+			continue // ?as=Table / ?as=TableSchema alternate representations of a path already covered plainly
+		}
+		if isLogPath(path) {
+			continue // plain-text pod logs aren't JSON objects; searched by SearchText instead
 		}
 		g, v, r, pathNS := parseAPIPath(path)
 		if r == "" {
@@ -161,6 +164,15 @@ func marshalValue(rv reflect.Value) (json.RawMessage, bool) {
 		return nil, false
 	}
 	return json.RawMessage(b), true
+}
+
+// isDuplicateView reports whether path is an alternate representation of a
+// resource already captured plainly under the same base path — the Table
+// (?as=Table) and TableSchema (?as=TableSchema) views used by `kubectl -o
+// wide`. Other query-param variants (pagination like ?limit=500, log paths)
+// are real, distinct captured data and must not be skipped.
+func isDuplicateView(path string) bool {
+	return strings.Contains(path, "?as=Table")
 }
 
 // parseAPIPath extracts group, version, resource, and namespace from a canonical

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -70,21 +70,26 @@ func Run(store *server.CaptureStore, opts Options) (*Result, error) {
 		if strings.Contains(path, "?") {
 			continue // Table/query-param variants of a path already covered plainly
 		}
-		g, v, r, ns := parseAPIPath(path)
+		g, v, r, pathNS := parseAPIPath(path)
 		if r == "" {
 			continue // discovery/openapi/other non-resource paths
 		}
 		if opts.Resource != "" && r != opts.Resource {
 			continue
 		}
-		if opts.Namespace != "" && ns != opts.Namespace {
-			continue
-		}
+		// Namespace filtering happens per-item below, not here: a cluster-wide
+		// list path (e.g. /api/v1/pods, captured when a namespaced resource has
+		// no namespaces: in its config) has no namespace segment of its own,
+		// but its items each carry their own metadata.namespace.
 		body, code, err := store.ReconstructAt(path, at)
 		if err != nil || code != 200 || len(body) == 0 {
 			continue
 		}
 		for _, item := range extractItems(body) {
+			meta := itemMeta(item, pathNS)
+			if opts.Namespace != "" && meta.Namespace != opts.Namespace {
+				continue
+			}
 			var data any
 			if json.Unmarshal(item, &data) != nil {
 				continue
@@ -93,7 +98,6 @@ func Run(store *server.CaptureStore, opts Options) (*Result, error) {
 			if err != nil {
 				continue
 			}
-			name := itemName(item)
 			for _, set := range results {
 				for _, rv := range set {
 					value, ok := marshalValue(rv)
@@ -102,7 +106,7 @@ func Run(store *server.CaptureStore, opts Options) (*Result, error) {
 					}
 					matches = append(matches, Match{
 						Path: path, Group: g, Version: v, Resource: r,
-						Namespace: ns, Name: name, Value: value,
+						Namespace: meta.Namespace, Name: meta.Name, Value: value,
 					})
 				}
 			}
@@ -123,16 +127,29 @@ func extractItems(body []byte) []json.RawMessage {
 	return list.Items
 }
 
-func itemName(item json.RawMessage) string {
-	var meta struct {
+// objectMeta is an object's resolved identity: its own name and namespace,
+// falling back to the enclosing list path's namespace for cluster-scoped
+// resources (nodes, PVs, …) that have no metadata.namespace of their own.
+type objectMeta struct {
+	Name      string
+	Namespace string
+}
+
+func itemMeta(item json.RawMessage, fallbackNamespace string) objectMeta {
+	var m struct {
 		Metadata struct {
-			Name string `json:"name"`
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
 		} `json:"metadata"`
 	}
-	if json.Unmarshal(item, &meta) != nil {
-		return ""
+	if json.Unmarshal(item, &m) != nil {
+		return objectMeta{}
 	}
-	return meta.Metadata.Name
+	ns := m.Metadata.Namespace
+	if ns == "" {
+		ns = fallbackNamespace
+	}
+	return objectMeta{Name: m.Metadata.Name, Namespace: ns}
 }
 
 func marshalValue(rv reflect.Value) (json.RawMessage, bool) {

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -157,6 +157,23 @@ func TestRun_SkipsTableViews(t *testing.T) {
 	}
 }
 
+func TestRun_DoesNotMisrouteNonPodLogPathsEndingInLog(t *testing.T) {
+	// A resource literally named "log" (e.g. a CRD) under a path that isn't
+	// shaped like the real pod-log subresource must still be queried as a
+	// normal JSON object, not silently skipped as a pod log.
+	store := buildQueryStore(t, map[string]string{
+		"/apis/example.io/v1/namespaces/prod/log": `{"kind":"LogList","apiVersion":"example.io/v1","items":[{"metadata":{"name":"needle"}}]}`,
+	})
+
+	result, err := Run(store, Options{Expression: "{.metadata.name}"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result.Matches) != 1 || result.Matches[0].Resource != "log" {
+		t.Fatalf("expected the custom 'log' resource to be queried, got %+v", result.Matches)
+	}
+}
+
 func TestRun_ResourceFilterExcludesOtherTypes(t *testing.T) {
 	store := buildQueryStore(t, map[string]string{
 		"/api/v1/namespaces/prod/pods":     `{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"a"}}]}`,

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -123,6 +123,40 @@ func TestRun_ClusterWideListResolvesPerItemNamespace(t *testing.T) {
 	}
 }
 
+func TestRun_IncludesPaginatedListPaths(t *testing.T) {
+	// A resource captured via pagination (e.g. the engine's namespace-discovery
+	// fetch, or any list with more than one page) is stored under a query-param
+	// index key like /api/v1/namespaces?limit=500 — a real, distinct capture,
+	// not a duplicate view, and must not be skipped like ?as=Table is.
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/namespaces?limit=500": `{"kind":"NamespaceList","apiVersion":"v1","items":[{"metadata":{"name":"prod"}}]}`,
+	})
+
+	result, err := Run(store, Options{Expression: "{.metadata.name}"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result.Matches) != 1 || result.Matches[0].Resource != "namespaces" {
+		t.Fatalf("expected the paginated namespaces list to be queried, got %+v", result.Matches)
+	}
+}
+
+func TestRun_SkipsTableViews(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/namespaces/prod/pods":          `{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"a"}}]}`,
+		"/api/v1/namespaces/prod/pods?as=Table": `{"kind":"Table","rows":[{"cells":["a"]}]}`,
+		"/api/v1/pods?as=TableSchema&limit=1":   `{"kind":"Table","columnDefinitions":[]}`,
+	})
+
+	result, err := Run(store, Options{Expression: "{.metadata.name}"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result.Matches) != 1 {
+		t.Fatalf("expected only the plain pods list to match, got %+v", result.Matches)
+	}
+}
+
 func TestRun_ResourceFilterExcludesOtherTypes(t *testing.T) {
 	store := buildQueryStore(t, map[string]string{
 		"/api/v1/namespaces/prod/pods":     `{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"a"}}]}`,

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -1,0 +1,142 @@
+package query
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/server"
+)
+
+func buildQueryStore(t *testing.T, bodies map[string]string) *server.CaptureStore {
+	t.Helper()
+	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	out := filepath.Join(t.TempDir(), "query.kshrk")
+	sw, err := archive.NewStreamWriter(out)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	idx := capture.Index{}
+	i := 0
+	for path, body := range bodies {
+		rec := &capture.Record{ID: path, CapturedAt: now, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body)}
+		if err := sw.WriteRecord(rec); err != nil {
+			t.Fatalf("WriteRecord: %v", err)
+		}
+		idx[path] = &capture.IndexEntry{APIPath: path, Seqs: []int{0}, Times: []time.Time{now}}
+		i++
+	}
+	meta := &capture.CaptureMetadata{
+		FormatVersion: capture.CurrentFormatVersion, CaptureID: "query-test",
+		KubernetesVersion: "v1.30.0", CapturedAt: now.Add(-time.Minute), CapturedUntil: now, RecordCount: i,
+	}
+	if err := sw.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	ar, err := archive.Open(out)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = ar.Close() })
+	store, err := server.LoadStore(ar)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	return store
+}
+
+func TestRun_MatchesAcrossResourceTypes(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/namespaces/prod/pods": `{"kind":"PodList","apiVersion":"v1","items":[
+		  {"metadata":{"name":"web-1","namespace":"prod"},"spec":{"containers":[{"image":"nginx:alpine"}]}}
+		]}`,
+		"/apis/apps/v1/namespaces/prod/deployments": `{"kind":"DeploymentList","apiVersion":"apps/v1","items":[
+		  {"metadata":{"name":"web","namespace":"prod"},"spec":{"template":{"spec":{"containers":[{"image":"nginx:alpine"}]}}}}
+		]}`,
+	})
+
+	result, err := Run(store, Options{Expression: "{.metadata.name}"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result.Matches) != 2 {
+		t.Fatalf("expected 2 matches across resource types, got %d: %+v", len(result.Matches), result.Matches)
+	}
+	got := map[string]bool{}
+	for _, m := range result.Matches {
+		got[m.Resource+"/"+m.Name] = true
+	}
+	if !got["pods/web-1"] || !got["deployments/web"] {
+		t.Errorf("missing expected matches: %+v", result.Matches)
+	}
+}
+
+func TestRun_FiltersByResourceAndNamespace(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/namespaces/prod/pods": `{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"a","namespace":"prod"}}]}`,
+		"/api/v1/namespaces/dev/pods":  `{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"b","namespace":"dev"}}]}`,
+	})
+
+	result, err := Run(store, Options{Expression: "{.metadata.name}", Namespace: "dev"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result.Matches) != 1 || result.Matches[0].Name != "b" {
+		t.Fatalf("expected only dev/b, got %+v", result.Matches)
+	}
+}
+
+func TestRun_ResourceFilterExcludesOtherTypes(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/namespaces/prod/pods":     `{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"a"}}]}`,
+		"/api/v1/namespaces/prod/services": `{"kind":"ServiceList","apiVersion":"v1","items":[{"metadata":{"name":"svc"}}]}`,
+	})
+
+	result, err := Run(store, Options{Expression: "{.metadata.name}", Resource: "services"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result.Matches) != 1 || result.Matches[0].Resource != "services" {
+		t.Fatalf("expected only services, got %+v", result.Matches)
+	}
+}
+
+func TestRun_MissingFieldYieldsNoMatchNotError(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/namespaces/prod/services": `{"kind":"ServiceList","apiVersion":"v1","items":[{"metadata":{"name":"svc"}}]}`,
+	})
+
+	result, err := Run(store, Options{Expression: "{.spec.containers[*].image}"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result.Matches) != 0 {
+		t.Fatalf("expected no matches for a field the resource doesn't have, got %+v", result.Matches)
+	}
+}
+
+func TestRun_SkipsDiscoveryAndNonResourcePaths(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1":                      `{"kind":"APIResourceList"}`,
+		"/openapi/v2":                  `{"swagger":"2.0"}`,
+		"/api/v1/namespaces/prod/pods": `{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"a"}}]}`,
+	})
+
+	result, err := Run(store, Options{Expression: "{.metadata.name}"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result.Matches) != 1 {
+		t.Fatalf("expected only the pod match, got %+v", result.Matches)
+	}
+}
+
+func TestRun_InvalidExpression(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{})
+	if _, err := Run(store, Options{Expression: "{.spec.["}); err == nil {
+		t.Error("expected error for invalid jsonpath expression")
+	}
+}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -89,6 +89,40 @@ func TestRun_FiltersByResourceAndNamespace(t *testing.T) {
 	}
 }
 
+func TestRun_ClusterWideListResolvesPerItemNamespace(t *testing.T) {
+	// A namespaced resource captured with no `namespaces:` in its config lands
+	// at the cluster-wide path (e.g. /api/v1/pods), but its items still carry
+	// their own metadata.namespace. --namespace must filter by that, not by
+	// the (empty) path namespace, and Match.Namespace must reflect it.
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/pods": `{"kind":"PodList","apiVersion":"v1","items":[
+		  {"metadata":{"name":"a","namespace":"prod"}},
+		  {"metadata":{"name":"b","namespace":"dev"}}
+		]}`,
+	})
+
+	all, err := Run(store, Options{Expression: "{.metadata.name}"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(all.Matches) != 2 {
+		t.Fatalf("expected 2 matches from the cluster-wide list, got %+v", all.Matches)
+	}
+	for _, m := range all.Matches {
+		if m.Namespace == "" {
+			t.Errorf("expected per-item namespace to be populated, got %+v", m)
+		}
+	}
+
+	scoped, err := Run(store, Options{Expression: "{.metadata.name}", Namespace: "dev"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(scoped.Matches) != 1 || scoped.Matches[0].Name != "b" || scoped.Matches[0].Namespace != "dev" {
+		t.Fatalf("expected only dev/b, got %+v", scoped.Matches)
+	}
+}
+
 func TestRun_ResourceFilterExcludesOtherTypes(t *testing.T) {
 	store := buildQueryStore(t, map[string]string{
 		"/api/v1/namespaces/prod/pods":     `{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"a"}}]}`,

--- a/internal/query/text.go
+++ b/internal/query/text.go
@@ -155,12 +155,12 @@ func searchLogPath(store *server.CaptureStore, path string, at time.Time, find f
 
 // isLogPath reports whether path is a captured pod-log endpoint
 // (/api/v1/namespaces/<ns>/pods/<name>/log[?container=<c>[&previous=true]]).
+// Delegates to parseLogPath's full shape check rather than a bare "/log"
+// suffix match, so an unrelated resource whose name happens to end in "log"
+// isn't misrouted as a pod log.
 func isLogPath(path string) bool {
-	p := path
-	if i := strings.IndexByte(p, '?'); i >= 0 {
-		p = p[:i]
-	}
-	return strings.HasSuffix(p, "/log")
+	_, _, _, _, ok := parseLogPath(path)
+	return ok
 }
 
 // parseLogPath extracts the namespace, pod name, container, and previous-log

--- a/internal/query/text.go
+++ b/internal/query/text.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/phenixblue/k8shark/internal/server"
 )
@@ -240,20 +241,30 @@ func newFinder(pattern string, isRegex bool) (finder, error) {
 	}, nil
 }
 
-// snippetRadius is how many characters of context to keep on either side of
-// a match when the matched string is long.
+// snippetRadius is how many bytes of context to keep on either side of a
+// match when the matched string is long. The actual cut point is snapped
+// outward to the nearest UTF-8 rune boundary (see snippet), so this is
+// approximate rather than an exact byte or character count.
 const snippetRadius = 40
 
-// snippet returns s trimmed to snippetRadius characters of context around
-// [start, end), with ellipses marking trimmed content.
+// snippet returns s trimmed to roughly snippetRadius bytes of context around
+// [start, end) (byte offsets, as produced by strings.Index/regexp), with
+// ellipses marking trimmed content. Cut points are snapped outward to the
+// nearest UTF-8 rune boundary so a multi-byte character is never split.
 func snippet(s string, start, end int) string {
 	from := start - snippetRadius
 	if from < 0 {
 		from = 0
 	}
+	for from > 0 && !utf8.RuneStart(s[from]) {
+		from--
+	}
 	to := end + snippetRadius
 	if to > len(s) {
 		to = len(s)
+	}
+	for to < len(s) && !utf8.RuneStart(s[to]) {
+		to++
 	}
 	out := s[from:to]
 	if from > 0 {

--- a/internal/query/text.go
+++ b/internal/query/text.go
@@ -43,7 +43,14 @@ type TextMatch struct {
 	// metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"].
 	// Empty for log matches.
 	Field string `json:"field,omitempty"`
-	// Container and Previous are set only for matches found in a captured pod log.
+	// Log is true when this match came from a captured pod log rather than
+	// an object body. Container may still be empty on a Log match — legacy
+	// archives could store a single log record with no ?container= query
+	// param — so Log, not "Container != \"\"", is the reliable signal that
+	// this is a log match.
+	Log bool `json:"log,omitempty"`
+	// Container and Previous are set only for matches found in a captured pod
+	// log (Log == true); Container may be empty (see Log).
 	Container string `json:"container,omitempty"`
 	Previous  bool   `json:"previous,omitempty"`
 	// Snippet is the matched text with surrounding context.
@@ -150,7 +157,7 @@ func searchLogPath(store *server.CaptureStore, path string, at time.Time, find f
 		}
 		matches = append(matches, TextMatch{
 			Path: path, Resource: "pods", Namespace: ns, Name: name,
-			Container: container, Previous: previous,
+			Log: true, Container: container, Previous: previous,
 			Snippet: snippet(line, start, end),
 		})
 	}

--- a/internal/query/text.go
+++ b/internal/query/text.go
@@ -98,12 +98,12 @@ func SearchText(store *server.CaptureStore, opts TextOptions) (*TextResult, erro
 			continue
 		}
 		for _, item := range extractItems(body) {
-			meta := itemMeta(item, pathNS)
-			if opts.Namespace != "" && meta.Namespace != opts.Namespace {
-				continue
-			}
 			var data any
 			if json.Unmarshal(item, &data) != nil {
+				continue
+			}
+			meta := metaFromData(data, pathNS)
+			if opts.Namespace != "" && meta.Namespace != opts.Namespace {
 				continue
 			}
 			walkStrings(data, "", func(field, s string) {

--- a/internal/query/text.go
+++ b/internal/query/text.go
@@ -1,0 +1,266 @@
+package query
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/server"
+)
+
+// TextOptions configures a SearchText.
+type TextOptions struct {
+	// Pattern is the substring (default) or regular expression to search for.
+	Pattern string
+	// Regex treats Pattern as a Go regular expression instead of a plain substring.
+	Regex bool
+	// At selects the snapshot to search. Zero means the latest captured state.
+	At time.Time
+	// Resource limits the search to one resource type, e.g. "pods". Empty means all.
+	Resource string
+	// Namespace limits the search to one namespace. Empty means all.
+	Namespace string
+}
+
+// TextMatch is one substring/regex match found in a captured object body or
+// pod log.
+type TextMatch struct {
+	Path      string `json:"path"`
+	Group     string `json:"group,omitempty"`
+	Version   string `json:"version,omitempty"`
+	Resource  string `json:"resource,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+	// Field is the dotted JSON field path of the matched string, e.g.
+	// "metadata.annotations.note" or "spec.containers[0].image". Empty for log matches.
+	Field string `json:"field,omitempty"`
+	// Container and Previous are set only for matches found in a captured pod log.
+	Container string `json:"container,omitempty"`
+	Previous  bool   `json:"previous,omitempty"`
+	// Snippet is the matched text with surrounding context.
+	Snippet string `json:"snippet"`
+}
+
+// TextResult is the full set of matches for one full-text search.
+type TextResult struct {
+	Matches []TextMatch `json:"matches"`
+}
+
+// SearchText finds opts.Pattern across every captured object body and pod
+// log in store at the resolved snapshot.
+func SearchText(store *server.CaptureStore, opts TextOptions) (*TextResult, error) {
+	find, err := newFinder(opts.Pattern, opts.Regex)
+	if err != nil {
+		return nil, err
+	}
+
+	at := opts.At
+	if at.IsZero() {
+		at = store.Metadata.CapturedUntil
+	}
+
+	paths := make([]string, 0, len(store.Index))
+	for path := range store.Index {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	matches := make([]TextMatch, 0)
+	for _, path := range paths {
+		if isLogPath(path) {
+			m, ok := searchLogPath(store, path, at, find, opts)
+			if ok {
+				matches = append(matches, m...)
+			}
+			continue
+		}
+		if strings.Contains(path, "?") {
+			continue // Table/query-param variants of a path already covered plainly
+		}
+		g, v, r, pathNS := parseAPIPath(path)
+		if r == "" {
+			continue // discovery/openapi/other non-resource paths
+		}
+		if opts.Resource != "" && r != opts.Resource {
+			continue
+		}
+		body, code, err := store.ReconstructAt(path, at)
+		if err != nil || code != 200 || len(body) == 0 {
+			continue
+		}
+		for _, item := range extractItems(body) {
+			meta := itemMeta(item, pathNS)
+			if opts.Namespace != "" && meta.Namespace != opts.Namespace {
+				continue
+			}
+			var data any
+			if json.Unmarshal(item, &data) != nil {
+				continue
+			}
+			walkStrings(data, "", func(field, s string) {
+				start, end, ok := find(s)
+				if !ok {
+					return
+				}
+				matches = append(matches, TextMatch{
+					Path: path, Group: g, Version: v, Resource: r,
+					Namespace: meta.Namespace, Name: meta.Name,
+					Field: field, Snippet: snippet(s, start, end),
+				})
+			})
+		}
+	}
+	return &TextResult{Matches: matches}, nil
+}
+
+func searchLogPath(store *server.CaptureStore, path string, at time.Time, find finder, opts TextOptions) ([]TextMatch, bool) {
+	ns, name, container, previous, ok := parseLogPath(path)
+	if !ok {
+		return nil, false
+	}
+	if opts.Namespace != "" && ns != opts.Namespace {
+		return nil, false
+	}
+	if opts.Resource != "" && opts.Resource != "pods" {
+		return nil, false
+	}
+	body, code, err := store.ReconstructAt(path, at)
+	if err != nil || code != 200 || len(body) == 0 {
+		return nil, false
+	}
+	var logText string
+	if json.Unmarshal(body, &logText) != nil {
+		return nil, false
+	}
+
+	matches := make([]TextMatch, 0)
+	for _, line := range strings.Split(logText, "\n") {
+		start, end, ok := find(line)
+		if !ok {
+			continue
+		}
+		matches = append(matches, TextMatch{
+			Path: path, Resource: "pods", Namespace: ns, Name: name,
+			Container: container, Previous: previous,
+			Snippet: snippet(line, start, end),
+		})
+	}
+	return matches, true
+}
+
+// isLogPath reports whether path is a captured pod-log endpoint
+// (/api/v1/namespaces/<ns>/pods/<name>/log[?container=<c>[&previous=true]]).
+func isLogPath(path string) bool {
+	p := path
+	if i := strings.IndexByte(p, '?'); i >= 0 {
+		p = p[:i]
+	}
+	return strings.HasSuffix(p, "/log")
+}
+
+// parseLogPath extracts the namespace, pod name, container, and previous-log
+// flag from a captured pod-log index key.
+func parseLogPath(path string) (namespace, name, container string, previous, ok bool) {
+	base, query := path, ""
+	if i := strings.IndexByte(path, '?'); i >= 0 {
+		base, query = path[:i], path[i+1:]
+	}
+	parts := strings.Split(strings.TrimPrefix(base, "/"), "/")
+	if len(parts) != 7 || parts[0] != "api" || parts[1] != "v1" || parts[2] != "namespaces" ||
+		parts[4] != "pods" || parts[6] != "log" {
+		return "", "", "", false, false
+	}
+	values, err := url.ParseQuery(query)
+	if err != nil {
+		return "", "", "", false, false
+	}
+	return parts[3], parts[5], values.Get("container"), values.Get("previous") == "true", true
+}
+
+// walkStrings visits every string leaf in v (a JSON-decoded object graph),
+// calling fn with its dotted field path and value. Map keys are visited in
+// sorted order for deterministic results.
+func walkStrings(v any, path string, fn func(field, s string)) {
+	switch t := v.(type) {
+	case string:
+		fn(path, t)
+	case map[string]any:
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			walkStrings(t[k], joinField(path, k), fn)
+		}
+	case []any:
+		for i, vv := range t {
+			walkStrings(vv, fmt.Sprintf("%s[%d]", path, i), fn)
+		}
+	}
+}
+
+func joinField(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
+}
+
+// finder reports the [start, end) byte range of the first match in s.
+type finder func(s string) (start, end int, ok bool)
+
+func newFinder(pattern string, isRegex bool) (finder, error) {
+	if isRegex {
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("compiling regex %q: %w", pattern, err)
+		}
+		return func(s string) (int, int, bool) {
+			loc := re.FindStringIndex(s)
+			if loc == nil {
+				return 0, 0, false
+			}
+			return loc[0], loc[1], true
+		}, nil
+	}
+	if pattern == "" {
+		return nil, fmt.Errorf("search pattern must not be empty")
+	}
+	return func(s string) (int, int, bool) {
+		idx := strings.Index(s, pattern)
+		if idx < 0 {
+			return 0, 0, false
+		}
+		return idx, idx + len(pattern), true
+	}, nil
+}
+
+// snippetRadius is how many characters of context to keep on either side of
+// a match when the matched string is long.
+const snippetRadius = 40
+
+// snippet returns s trimmed to snippetRadius characters of context around
+// [start, end), with ellipses marking trimmed content.
+func snippet(s string, start, end int) string {
+	from := start - snippetRadius
+	if from < 0 {
+		from = 0
+	}
+	to := end + snippetRadius
+	if to > len(s) {
+		to = len(s)
+	}
+	out := s[from:to]
+	if from > 0 {
+		out = "…" + out
+	}
+	if to < len(s) {
+		out += "…"
+	}
+	return out
+}

--- a/internal/query/text.go
+++ b/internal/query/text.go
@@ -36,8 +36,12 @@ type TextMatch struct {
 	Resource  string `json:"resource,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
 	Name      string `json:"name"`
-	// Field is the dotted JSON field path of the matched string, e.g.
-	// "metadata.annotations.note" or "spec.containers[0].image". Empty for log matches.
+	// Field is the JSON field path of the matched string, e.g.
+	// "metadata.annotations.note" or "spec.containers[0].image". A map key
+	// that isn't a simple identifier (common for annotations/labels, e.g.
+	// "kubectl.kubernetes.io/last-applied-configuration") is bracket-quoted:
+	// metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"].
+	// Empty for log matches.
 	Field string `json:"field,omitempty"`
 	// Container and Previous are set only for matches found in a captured pod log.
 	Container string `json:"container,omitempty"`
@@ -183,8 +187,8 @@ func parseLogPath(path string) (namespace, name, container string, previous, ok 
 }
 
 // walkStrings visits every string leaf in v (a JSON-decoded object graph),
-// calling fn with its dotted field path and value. Map keys are visited in
-// sorted order for deterministic results.
+// calling fn with its field path and value. Map keys are visited in sorted
+// order for deterministic results.
 func walkStrings(v any, path string, fn func(field, s string)) {
 	switch t := v.(type) {
 	case string:
@@ -205,11 +209,40 @@ func walkStrings(v any, path string, fn func(field, s string)) {
 	}
 }
 
+// joinField appends key to path as a JSON field-path segment. Kubernetes
+// annotation/label keys routinely contain '.' and '/' (e.g.
+// "kubectl.kubernetes.io/last-applied-configuration"), so a plain
+// "path.key" would render as if key were itself several nested fields.
+// Simple identifier-like keys use dot notation; anything else is
+// bracket-quoted (path["key"]) so the result is an unambiguous field path.
 func joinField(path, key string) string {
+	if !isSimpleFieldKey(key) {
+		return path + `["` + strings.ReplaceAll(key, `"`, `\"`) + `"]`
+	}
 	if path == "" {
 		return key
 	}
 	return path + "." + key
+}
+
+// isSimpleFieldKey reports whether key can be rendered as a bare dotted
+// path segment: starts with a letter or underscore, and contains only
+// letters, digits, and underscores.
+func isSimpleFieldKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for i, r := range key {
+		switch {
+		case r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z'):
+			continue
+		case i > 0 && r >= '0' && r <= '9':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // finder reports the [start, end) byte range of the first match in s.

--- a/internal/query/text.go
+++ b/internal/query/text.go
@@ -224,7 +224,9 @@ func walkStrings(v any, path string, fn func(field, s string)) {
 // bracket-quoted (path["key"]) so the result is an unambiguous field path.
 func joinField(path, key string) string {
 	if !isSimpleFieldKey(key) {
-		return path + `["` + strings.ReplaceAll(key, `"`, `\"`) + `"]`
+		// %q escapes backslashes, quotes, and control characters (and adds
+		// the surrounding quotes), unlike a bare quote-only replacement.
+		return path + "[" + fmt.Sprintf("%q", key) + "]"
 	}
 	if path == "" {
 		return key

--- a/internal/query/text.go
+++ b/internal/query/text.go
@@ -78,8 +78,8 @@ func SearchText(store *server.CaptureStore, opts TextOptions) (*TextResult, erro
 			}
 			continue
 		}
-		if strings.Contains(path, "?") {
-			continue // Table/query-param variants of a path already covered plainly
+		if isDuplicateView(path) {
+			continue // ?as=Table / ?as=TableSchema alternate representations of a path already covered plainly
 		}
 		g, v, r, pathNS := parseAPIPath(path)
 		if r == "" {

--- a/internal/query/text.go
+++ b/internal/query/text.go
@@ -215,6 +215,9 @@ func joinField(path, key string) string {
 type finder func(s string) (start, end int, ok bool)
 
 func newFinder(pattern string, isRegex bool) (finder, error) {
+	if pattern == "" {
+		return nil, fmt.Errorf("search pattern must not be empty")
+	}
 	if isRegex {
 		re, err := regexp.Compile(pattern)
 		if err != nil {
@@ -227,9 +230,6 @@ func newFinder(pattern string, isRegex bool) (finder, error) {
 			}
 			return loc[0], loc[1], true
 		}, nil
-	}
-	if pattern == "" {
-		return nil, fmt.Errorf("search pattern must not be empty")
 	}
 	return func(s string) (int, int, bool) {
 		idx := strings.Index(s, pattern)

--- a/internal/query/text_test.go
+++ b/internal/query/text_test.go
@@ -119,6 +119,9 @@ func TestSearchText_MatchesCurrentAndPreviousLogs(t *testing.T) {
 	}
 	sawCurrent, sawPrevious := false, false
 	for _, m := range result.Matches {
+		if !m.Log {
+			t.Errorf("expected Log=true on a log match, got %+v", m)
+		}
 		if m.Container != "worker" || m.Namespace != "crash-demo" || m.Name != "flaky-1" {
 			t.Errorf("unexpected log match identity: %+v", m)
 		}
@@ -130,6 +133,29 @@ func TestSearchText_MatchesCurrentAndPreviousLogs(t *testing.T) {
 	}
 	if !sawCurrent || !sawPrevious {
 		t.Errorf("expected both current and previous log matches, got %+v", result.Matches)
+	}
+}
+
+func TestSearchText_MatchesLegacyLogPathWithNoContainerParam(t *testing.T) {
+	// Legacy archives could store a single log record at the bare path, with
+	// no ?container= query param (see internal/server/handler.go's serveLog
+	// fallback for this same shape). Log must still be true and the match
+	// must not be dropped just because Container is unknown.
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/namespaces/crash-demo/pods/flaky-1/log": mustJSONString(t,
+			"starting up\nfatal: connection refused to db:5432\n"),
+	})
+
+	result, err := SearchText(store, TextOptions{Pattern: "connection refused"})
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
+	}
+	if len(result.Matches) != 1 {
+		t.Fatalf("expected 1 match, got %+v", result.Matches)
+	}
+	m := result.Matches[0]
+	if !m.Log || m.Container != "" || m.Namespace != "crash-demo" || m.Name != "flaky-1" {
+		t.Errorf("unexpected legacy log match: %+v", m)
 	}
 }
 

--- a/internal/query/text_test.go
+++ b/internal/query/text_test.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -57,6 +58,45 @@ func TestSearchText_BracketQuotesNonIdentifierMapKeys(t *testing.T) {
 		t.Fatalf("expected 1 match, got %+v", result.Matches)
 	}
 	want := `metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"]`
+	if result.Matches[0].Field != want {
+		t.Errorf("expected field path %q, got %q", want, result.Matches[0].Field)
+	}
+}
+
+func TestSearchText_EscapesBackslashAndControlCharsInMapKeys(t *testing.T) {
+	// A quote-only replacement leaves backslashes and control characters
+	// (tabs, newlines) unescaped, which can make the bracket-quoted segment
+	// ambiguous or malformed. %q must escape all of it.
+	weirdKey := "weird\\key\twith\ncontrol chars"
+	body, err := json.Marshal(map[string]any{
+		"kind":       "PodList",
+		"apiVersion": "v1",
+		"items": []any{
+			map[string]any{
+				"metadata": map[string]any{
+					"name": "web-1",
+					"annotations": map[string]any{
+						weirdKey: "needle-value",
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/namespaces/prod/pods": string(body),
+	})
+
+	result, err := SearchText(store, TextOptions{Pattern: "needle-value"})
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
+	}
+	if len(result.Matches) != 1 {
+		t.Fatalf("expected 1 match, got %+v", result.Matches)
+	}
+	want := "metadata.annotations[" + fmt.Sprintf("%q", weirdKey) + "]"
 	if result.Matches[0].Field != want {
 		t.Errorf("expected field path %q, got %q", want, result.Matches[0].Field)
 	}

--- a/internal/query/text_test.go
+++ b/internal/query/text_test.go
@@ -2,7 +2,9 @@ package query
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func mustJSONString(t *testing.T, s string) string {
@@ -178,5 +180,24 @@ func TestSearchText_NoMatches(t *testing.T) {
 	}
 	if len(result.Matches) != 0 {
 		t.Fatalf("expected no matches, got %+v", result.Matches)
+	}
+}
+
+func TestSnippet_DoesNotSplitMultiByteRune(t *testing.T) {
+	// "€" is 3 bytes in UTF-8, so a 40-byte radius lands mid-rune (40 isn't a
+	// multiple of 3) unless the cut point is snapped to a rune boundary.
+	euro := "€"
+	prefix := strings.Repeat(euro, 20)
+	suffix := strings.Repeat(euro, 20)
+	s := prefix + "TARGET" + suffix
+	start := len(prefix)
+	end := start + len("TARGET")
+
+	out := snippet(s, start, end)
+	if !utf8.ValidString(out) {
+		t.Fatalf("snippet produced invalid UTF-8: %q", out)
+	}
+	if !strings.Contains(out, "TARGET") {
+		t.Fatalf("snippet lost the match: %q", out)
 	}
 }

--- a/internal/query/text_test.go
+++ b/internal/query/text_test.go
@@ -128,6 +128,35 @@ func TestSearchText_NamespaceFilterAppliesToLogs(t *testing.T) {
 	}
 }
 
+func TestSearchText_IncludesPaginatedListPaths(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/namespaces?limit=500": `{"kind":"NamespaceList","apiVersion":"v1","items":[{"metadata":{"name":"prod-east"}}]}`,
+	})
+
+	result, err := SearchText(store, TextOptions{Pattern: "prod-east"})
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
+	}
+	if len(result.Matches) != 1 || result.Matches[0].Resource != "namespaces" {
+		t.Fatalf("expected the paginated namespaces list to be searched, got %+v", result.Matches)
+	}
+}
+
+func TestSearchText_SkipsTableViews(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/namespaces/prod/pods":          `{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"needle-pod"}}]}`,
+		"/api/v1/namespaces/prod/pods?as=Table": `{"kind":"Table","rows":[{"cells":["needle-pod"]}]}`,
+	})
+
+	result, err := SearchText(store, TextOptions{Pattern: "needle-pod"})
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
+	}
+	if len(result.Matches) != 1 {
+		t.Fatalf("expected only the plain pods list to match, got %+v", result.Matches)
+	}
+}
+
 func TestSearchText_NoMatches(t *testing.T) {
 	store := buildQueryStore(t, map[string]string{
 		"/api/v1/namespaces/prod/pods": `{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"a"}}]}`,

--- a/internal/query/text_test.go
+++ b/internal/query/text_test.go
@@ -1,0 +1,143 @@
+package query
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func mustJSONString(t *testing.T, s string) string {
+	t.Helper()
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	return string(b)
+}
+
+func TestSearchText_SubstringMatchInObjectBody(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/namespaces/prod/pods": `{"kind":"PodList","apiVersion":"v1","items":[
+		  {"metadata":{"name":"web-1","namespace":"prod","annotations":{"note":"needs a db migration before rollout"}}}
+		]}`,
+	})
+
+	result, err := SearchText(store, TextOptions{Pattern: "db migration"})
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
+	}
+	if len(result.Matches) != 1 {
+		t.Fatalf("expected 1 match, got %+v", result.Matches)
+	}
+	m := result.Matches[0]
+	if m.Field != "metadata.annotations.note" {
+		t.Errorf("expected field path metadata.annotations.note, got %q", m.Field)
+	}
+	if m.Name != "web-1" || m.Namespace != "prod" || m.Resource != "pods" {
+		t.Errorf("unexpected object identity: %+v", m)
+	}
+}
+
+func TestSearchText_RegexMatch(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/namespaces/prod/pods": `{"kind":"PodList","apiVersion":"v1","items":[
+		  {"metadata":{"name":"web-1"},"spec":{"containers":[{"image":"nginx:1.25-alpine"}]}}
+		]}`,
+	})
+
+	result, err := SearchText(store, TextOptions{Pattern: `nginx:1\.\d+`, Regex: true})
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
+	}
+	if len(result.Matches) != 1 || result.Matches[0].Field != "spec.containers[0].image" {
+		t.Fatalf("expected one match on spec.containers[0].image, got %+v", result.Matches)
+	}
+}
+
+func TestSearchText_InvalidRegex(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{})
+	if _, err := SearchText(store, TextOptions{Pattern: "(unclosed", Regex: true}); err == nil {
+		t.Error("expected error for invalid regex")
+	}
+}
+
+func TestSearchText_EmptyPattern(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{})
+	if _, err := SearchText(store, TextOptions{Pattern: ""}); err == nil {
+		t.Error("expected error for empty substring pattern")
+	}
+}
+
+func TestSearchText_MatchesCurrentAndPreviousLogs(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/namespaces/crash-demo/pods/flaky-1/log?container=worker": mustJSONString(t,
+			"starting up\nfatal: connection refused to db:5432\n"),
+		"/api/v1/namespaces/crash-demo/pods/flaky-1/log?container=worker&previous=true": mustJSONString(t,
+			"starting up\nfatal: connection refused to db:5432 (attempt 2)\n"),
+	})
+
+	result, err := SearchText(store, TextOptions{Pattern: "connection refused"})
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
+	}
+	if len(result.Matches) != 2 {
+		t.Fatalf("expected 2 matches (current + previous), got %+v", result.Matches)
+	}
+	sawCurrent, sawPrevious := false, false
+	for _, m := range result.Matches {
+		if m.Container != "worker" || m.Namespace != "crash-demo" || m.Name != "flaky-1" {
+			t.Errorf("unexpected log match identity: %+v", m)
+		}
+		if m.Previous {
+			sawPrevious = true
+		} else {
+			sawCurrent = true
+		}
+	}
+	if !sawCurrent || !sawPrevious {
+		t.Errorf("expected both current and previous log matches, got %+v", result.Matches)
+	}
+}
+
+func TestSearchText_ResourceFilterExcludesLogs(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/namespaces/crash-demo/pods/flaky-1/log?container=worker": mustJSONString(t, "connection refused"),
+		"/api/v1/namespaces/crash-demo/services":                          `{"kind":"ServiceList","apiVersion":"v1","items":[{"metadata":{"name":"connection-svc"}}]}`,
+	})
+
+	result, err := SearchText(store, TextOptions{Pattern: "connection", Resource: "services"})
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
+	}
+	if len(result.Matches) != 1 || result.Matches[0].Resource != "services" {
+		t.Fatalf("expected only the services match, got %+v", result.Matches)
+	}
+}
+
+func TestSearchText_NamespaceFilterAppliesToLogs(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/namespaces/prod/pods/a/log?container=c": mustJSONString(t, "boom"),
+		"/api/v1/namespaces/dev/pods/b/log?container=c":  mustJSONString(t, "boom"),
+	})
+
+	result, err := SearchText(store, TextOptions{Pattern: "boom", Namespace: "dev"})
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
+	}
+	if len(result.Matches) != 1 || result.Matches[0].Namespace != "dev" {
+		t.Fatalf("expected only the dev namespace log match, got %+v", result.Matches)
+	}
+}
+
+func TestSearchText_NoMatches(t *testing.T) {
+	store := buildQueryStore(t, map[string]string{
+		"/api/v1/namespaces/prod/pods": `{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"a"}}]}`,
+	})
+
+	result, err := SearchText(store, TextOptions{Pattern: "not-present-anywhere"})
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
+	}
+	if len(result.Matches) != 0 {
+		t.Fatalf("expected no matches, got %+v", result.Matches)
+	}
+}

--- a/internal/query/text_test.go
+++ b/internal/query/text_test.go
@@ -39,6 +39,29 @@ func TestSearchText_SubstringMatchInObjectBody(t *testing.T) {
 	}
 }
 
+func TestSearchText_BracketQuotesNonIdentifierMapKeys(t *testing.T) {
+	// Annotation/label keys routinely contain '.' and '/' (the group prefix
+	// convention), so a plain dotted path would render as if the key were
+	// itself several nested fields. Such keys must be bracket-quoted.
+	store := buildQueryStore(t, map[string]string{
+		"/apis/apps/v1/namespaces/prod/deployments": `{"kind":"DeploymentList","apiVersion":"apps/v1","items":[
+		  {"metadata":{"name":"web","namespace":"prod","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"needle-value"}}}
+		]}`,
+	})
+
+	result, err := SearchText(store, TextOptions{Pattern: "needle-value"})
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
+	}
+	if len(result.Matches) != 1 {
+		t.Fatalf("expected 1 match, got %+v", result.Matches)
+	}
+	want := `metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"]`
+	if result.Matches[0].Field != want {
+		t.Errorf("expected field path %q, got %q", want, result.Matches[0].Field)
+	}
+}
+
 func TestSearchText_RegexMatch(t *testing.T) {
 	store := buildQueryStore(t, map[string]string{
 		"/api/v1/namespaces/prod/pods": `{"kind":"PodList","apiVersion":"v1","items":[

--- a/internal/query/text_test.go
+++ b/internal/query/text_test.go
@@ -183,6 +183,23 @@ func TestSearchText_NoMatches(t *testing.T) {
 	}
 }
 
+func TestSearchText_DoesNotMisrouteNonPodLogPathsEndingInLog(t *testing.T) {
+	// A resource literally named "log" (e.g. a CRD) under a path that isn't
+	// shaped like the real pod-log subresource must be searched as a normal
+	// object, not misdetected as a pod log just because its path ends in "/log".
+	store := buildQueryStore(t, map[string]string{
+		"/apis/example.io/v1/namespaces/prod/log": `{"kind":"LogList","apiVersion":"example.io/v1","items":[{"metadata":{"name":"needle"}}]}`,
+	})
+
+	result, err := SearchText(store, TextOptions{Pattern: "needle"})
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
+	}
+	if len(result.Matches) != 1 || result.Matches[0].Resource != "log" {
+		t.Fatalf("expected the custom 'log' resource to be searched as a normal object, got %+v", result.Matches)
+	}
+}
+
 func TestSnippet_DoesNotSplitMultiByteRune(t *testing.T) {
 	// "€" is 3 bytes in UTF-8, so a 40-byte radius lands mid-rune (40 isn't a
 	// multiple of 3) unless the cut point is snapped to a rune boundary.

--- a/internal/query/text_test.go
+++ b/internal/query/text_test.go
@@ -67,6 +67,16 @@ func TestSearchText_EmptyPattern(t *testing.T) {
 	}
 }
 
+func TestSearchText_EmptyRegexPattern(t *testing.T) {
+	// regexp.Compile("") succeeds and matches everything at position 0 — an
+	// empty pattern must be rejected before it reaches regexp.Compile, in
+	// both modes, not just substring mode.
+	store := buildQueryStore(t, map[string]string{})
+	if _, err := SearchText(store, TextOptions{Pattern: "", Regex: true}); err == nil {
+		t.Error("expected error for empty regex pattern")
+	}
+}
+
 func TestSearchText_MatchesCurrentAndPreviousLogs(t *testing.T) {
 	store := buildQueryStore(t, map[string]string{
 		"/api/v1/namespaces/crash-demo/pods/flaky-1/log?container=worker": mustJSONString(t,


### PR DESCRIPTION
## Summary
- Adds `internal/query`, a JSONPath engine that walks **every** captured resource type and namespace in an archive (via `store.ReconstructAt`) and evaluates a kubectl-style JSONPath expression against each object, at a chosen point in time.
- Adds `internal/query/text.go`: full-text search (plain substring or Go regex) across every string value in every captured object (reporting the dotted JSON field path of each match) and across captured pod logs, current and `--previous`.
- Adds the `kshrk query <capture.kshrk> <expression>` CLI command: JSONPath by default, or `--text`/`--regex` (mutually exclusive) for full-text search — with `--at`/`--resource`/`--namespace` scoping and `table`/`json` output, mirroring `kshrk diagnose`'s structure and flag conventions.
- Uses `k8s.io/client-go/util/jsonpath` — already vendored transitively via the existing `k8s.io/client-go` dependency, so **no new go.mod/go.sum entries** (confirmed via `go mod tidy`).
- Renames `cmd/diagnose.go`'s `parseDiagnoseAt` → `parseAtFlag` and reuses it in `cmd/query.go`, since the `--at` timestamp/relative-duration parsing logic has nothing diagnose-specific about it.
- Adds a `## Query` section (with a `### Full-text search` subsection) to `docs/usage.md`, following the `Diagnose`/`Diff` section format.

This covers phases 1 and 2 of #112 ("structured query engine + CLI", then "full-text: objects + logs", per the issue's own suggested phasing). The UI global search box (phase 3) is a follow-up, not included here.

### Design notes
- Objects/values that don't match are skipped, not errors — the whole point is running one query across dissimilar resource types (a Service has no `.spec.containers`, and that's fine).
- Non-resource paths (discovery documents, `/openapi/*`, Table-format query-param variants) are filtered out before evaluation; pod-log paths are specifically detected and included for full-text search even though they carry `?container=...` query params.
- `Match.Name`/`Match.Namespace` are resolved **per item** (from `metadata.name`/`metadata.namespace`), not from the enclosing API path alone — a namespaced resource captured with no `namespaces:` in its config lands at a cluster-wide list path (e.g. `/api/v1/pods`) with no namespace segment, but its items still carry their own namespace. This was caught by review feedback and fixed with a regression test.
- For full-text matches, `LOCATION` is the dotted JSON field path (`spec.containers[0].command[2]`) for object matches, or `log:<container>[ (previous)]` for log matches.

## Test plan
- [x] `internal/query` unit tests: cross-resource-type matches, `--resource`/`--namespace` filtering (including the cluster-wide-list-path case), missing-field-is-not-an-error, discovery/non-resource path skipping, invalid-expression error
- [x] `internal/query/text_test.go`: substring + regex matches on object bodies with correct field paths, current + previous log matches, resource/namespace filters (including that a non-`pods` `--resource` filter excludes logs), invalid regex, empty pattern, no-matches
- [x] `cmd/query_test.go`: JSON/table output for both JSONPath and full-text modes, resource filter, bad expression, `--text`/`--regex` mutual exclusivity, invalid regex, no-matches message
- [x] `make test`, `make lint-ci`, `make fmt` all clean; `go mod tidy` produces no diff
- [x] Manually verified against real captures in `examples/`: `basic-workloads` (container images), `multi-namespace` (namespace-scoped query across pods/services/deployments), `crash-loop` (JSONPath into `containerStatuses[*].state.waiting.reason`, plus `--text 'connection refused'` finding the string in the pod's container command, current log, previous log, and the Deployment's spec + last-applied-configuration annotation), `rolling-update` (pod phases)