### PR TITLE
feat(ui): add global search box to the v2 dashboard

### DIFF
--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -136,6 +136,26 @@ shares a chip/token filter bar with type-ahead completion:
 
 ![Chip/token filter in action](images/v2/chip-filter.png)
 
+## Global search
+
+The search box in the top bar searches the **whole capture** at once — every resource type and
+namespace, not just the list you're currently viewing — using the same engine as
+[`kshrk query`](usage.md#query). Type a query and press **Enter**; each result links straight to
+its object view.
+
+The mode dropdown next to the search box selects how the query text is interpreted:
+
+- **JSONPath** (default) — a kubectl-style expression, e.g. `{.spec.containers[*].image}`, evaluated
+  against every captured object. Matches show the resource, object, and the matched value.
+- **Text** — a plain substring, searched across every string field in every object *and* every
+  captured pod log (current and `--previous`). Matches show the field path (or `log:<container>`
+  for a log line) and a snippet of context.
+- **Regex** — same as Text, but the query is a Go regular expression.
+
+This is the tool for "where does this error string appear?" — across annotations, container
+commands, event messages, and logs — without knowing in advance which resource type or namespace
+holds the answer.
+
 ## Timeline and watch events
 
 If the capture was taken with `watch: true` on its resource entries, the **Timeline** plots watch events

--- a/internal/ui/v2/search.go
+++ b/internal/ui/v2/search.go
@@ -1,0 +1,106 @@
+package v2
+
+import (
+	"net/http"
+
+	"github.com/phenixblue/k8shark/internal/query"
+)
+
+// maxSearchResults caps how many rows /v2/api/search returns in one response,
+// so a broad pattern against a large archive can't send an enormous payload
+// to the browser. Truncated is set on the response when the cap was hit.
+const maxSearchResults = 500
+
+// SearchResult is one row in the dashboard's global search results: a
+// deep-linkable object identity, plus either a JSONPath value or a full-text
+// match location/snippet depending on the request's mode.
+type SearchResult struct {
+	Path      string `json:"path"`
+	Group     string `json:"group,omitempty"`
+	Version   string `json:"version,omitempty"`
+	Resource  string `json:"resource,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+	// Value is the JSONPath result (mode=jsonpath only).
+	Value string `json:"value,omitempty"`
+	// Field/Snippet/Log/Container/Previous are set for full-text matches
+	// (mode=text/regex only) — see internal/query.TextMatch.
+	Field     string `json:"field,omitempty"`
+	Snippet   string `json:"snippet,omitempty"`
+	Log       bool   `json:"log,omitempty"`
+	Container string `json:"container,omitempty"`
+	Previous  bool   `json:"previous,omitempty"`
+}
+
+// SearchResponse is the /v2/api/search response body.
+type SearchResponse struct {
+	Mode      string         `json:"mode"`
+	Query     string         `json:"query"`
+	Results   []SearchResult `json:"results"`
+	Total     int            `json:"total"`
+	Truncated bool           `json:"truncated"`
+}
+
+// serveSearch runs the same query engine as `kshrk query` (internal/query)
+// against the capture, for the dashboard's global search box. mode selects
+// the query language: "jsonpath" (default), "text" (substring), or "regex".
+func (h *Handler) serveSearch(w http.ResponseWriter, r *http.Request) {
+	if h.Store == nil {
+		writeError(w, http.StatusInternalServerError, "store not initialized")
+		return
+	}
+	q := r.URL.Query().Get("q")
+	if q == "" {
+		writeError(w, http.StatusBadRequest, "missing q query parameter")
+		return
+	}
+	mode := r.URL.Query().Get("mode")
+	if mode == "" {
+		mode = "jsonpath"
+	}
+	resource := r.URL.Query().Get("resource")
+	namespace := r.URL.Query().Get("namespace")
+	at := h.resolveAt(r)
+
+	var rows []SearchResult
+	switch mode {
+	case "jsonpath":
+		result, err := query.Run(h.Store, query.Options{Expression: q, At: at, Resource: resource, Namespace: namespace})
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		for _, m := range result.Matches {
+			rows = append(rows, SearchResult{
+				Path: m.Path, Group: m.Group, Version: m.Version, Resource: m.Resource,
+				Namespace: m.Namespace, Name: m.Name, Value: string(m.Value),
+			})
+		}
+	case "text", "regex":
+		result, err := query.SearchText(h.Store, query.TextOptions{
+			Pattern: q, Regex: mode == "regex", At: at, Resource: resource, Namespace: namespace,
+		})
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		for _, m := range result.Matches {
+			rows = append(rows, SearchResult{
+				Path: m.Path, Group: m.Group, Version: m.Version, Resource: m.Resource,
+				Namespace: m.Namespace, Name: m.Name, Field: m.Field, Snippet: m.Snippet,
+				Log: m.Log, Container: m.Container, Previous: m.Previous,
+			})
+		}
+	default:
+		writeError(w, http.StatusBadRequest, "mode must be jsonpath, text, or regex (got "+mode+")")
+		return
+	}
+
+	resp := SearchResponse{Mode: mode, Query: q, Total: len(rows)}
+	if len(rows) > maxSearchResults {
+		resp.Truncated = true
+		rows = rows[:maxSearchResults]
+	}
+	resp.Results = rows
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/ui/v2/search.go
+++ b/internal/ui/v2/search.go
@@ -63,6 +63,7 @@ func (h *Handler) serveSearch(w http.ResponseWriter, r *http.Request) {
 	at := h.resolveAt(r)
 
 	var rows []SearchResult
+	var total int
 	switch mode {
 	case "jsonpath":
 		result, err := query.Run(h.Store, query.Options{Expression: q, At: at, Resource: resource, Namespace: namespace})
@@ -70,7 +71,12 @@ func (h *Handler) serveSearch(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
+		total = len(result.Matches)
+		rows = make([]SearchResult, 0, min(total, maxSearchResults))
 		for _, m := range result.Matches {
+			if len(rows) >= maxSearchResults {
+				break
+			}
 			rows = append(rows, SearchResult{
 				Path: m.Path, Group: m.Group, Version: m.Version, Resource: m.Resource,
 				Namespace: m.Namespace, Name: m.Name, Value: string(m.Value),
@@ -84,7 +90,12 @@ func (h *Handler) serveSearch(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
+		total = len(result.Matches)
+		rows = make([]SearchResult, 0, min(total, maxSearchResults))
 		for _, m := range result.Matches {
+			if len(rows) >= maxSearchResults {
+				break
+			}
 			rows = append(rows, SearchResult{
 				Path: m.Path, Group: m.Group, Version: m.Version, Resource: m.Resource,
 				Namespace: m.Namespace, Name: m.Name, Field: m.Field, Snippet: m.Snippet,
@@ -96,11 +107,7 @@ func (h *Handler) serveSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := SearchResponse{Mode: mode, Query: q, Total: len(rows)}
-	if len(rows) > maxSearchResults {
-		resp.Truncated = true
-		rows = rows[:maxSearchResults]
-	}
-	resp.Results = rows
-	writeJSON(w, http.StatusOK, resp)
+	writeJSON(w, http.StatusOK, SearchResponse{
+		Mode: mode, Query: q, Results: rows, Total: total, Truncated: total > maxSearchResults,
+	})
 }

--- a/internal/ui/v2/search_test.go
+++ b/internal/ui/v2/search_test.go
@@ -1,0 +1,159 @@
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+func newSearchTestHandler(t *testing.T) *Handler {
+	t.Helper()
+	now := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	pods := `{"kind":"PodList","apiVersion":"v1","items":[` +
+		`{"metadata":{"name":"web-1","namespace":"default","annotations":{"note":"needs a db migration"}},"spec":{"containers":[{"image":"nginx:alpine"}]}}]}`
+	recs := []*capture.Record{
+		{ID: "p1", CapturedAt: now, APIPath: "/api/v1/namespaces/default/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(pods)},
+	}
+	idx := capture.Index{
+		"/api/v1/namespaces/default/pods": {APIPath: "/api/v1/namespaces/default/pods", Seqs: []int{0}, Times: []time.Time{now}},
+	}
+	meta := &capture.CaptureMetadata{CaptureID: "search-ui", CapturedAt: now, CapturedUntil: now, RecordCount: 1}
+	return &Handler{Store: buildV2TestStore(t, recs, idx, meta), At: now}
+}
+
+func searchRequest(query string) *http.Request {
+	return httptest.NewRequest(http.MethodGet, "/v2/api/search?"+query, nil)
+}
+
+func TestServeSearch_JSONPathMode(t *testing.T) {
+	h := newSearchTestHandler(t)
+	w := httptest.NewRecorder()
+	h.serveSearch(w, searchRequest("q="+url.QueryEscape("{.spec.containers[*].image}")))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", w.Code, w.Body.String())
+	}
+	var resp SearchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Mode != "jsonpath" || resp.Total != 1 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if resp.Results[0].Value != `"nginx:alpine"` || resp.Results[0].Name != "web-1" {
+		t.Errorf("unexpected result: %+v", resp.Results[0])
+	}
+}
+
+func TestServeSearch_TextMode(t *testing.T) {
+	h := newSearchTestHandler(t)
+	w := httptest.NewRecorder()
+	h.serveSearch(w, searchRequest("mode=text&q="+url.QueryEscape("db migration")))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", w.Code, w.Body.String())
+	}
+	var resp SearchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Mode != "text" || resp.Total != 1 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if resp.Results[0].Field != "metadata.annotations.note" {
+		t.Errorf("unexpected field: %+v", resp.Results[0])
+	}
+}
+
+func TestServeSearch_RegexMode(t *testing.T) {
+	h := newSearchTestHandler(t)
+	w := httptest.NewRecorder()
+	h.serveSearch(w, searchRequest("mode=regex&q="+url.QueryEscape(`nginx:\w+`)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", w.Code, w.Body.String())
+	}
+	var resp SearchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Mode != "regex" || resp.Total != 1 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestServeSearch_MissingQuery(t *testing.T) {
+	h := newSearchTestHandler(t)
+	w := httptest.NewRecorder()
+	h.serveSearch(w, searchRequest(""))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestServeSearch_BadMode(t *testing.T) {
+	h := newSearchTestHandler(t)
+	w := httptest.NewRecorder()
+	h.serveSearch(w, searchRequest("mode=bogus&q=x"))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestServeSearch_InvalidRegex(t *testing.T) {
+	h := newSearchTestHandler(t)
+	w := httptest.NewRecorder()
+	h.serveSearch(w, searchRequest("mode=regex&q="+url.QueryEscape("(unclosed")))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestServeSearch_NilStore(t *testing.T) {
+	h := &Handler{}
+	w := httptest.NewRecorder()
+	h.serveSearch(w, searchRequest("q=x"))
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestServeSearch_Truncates(t *testing.T) {
+	now := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	items := make([]string, 0, maxSearchResults+50)
+	for i := 0; i < maxSearchResults+50; i++ {
+		items = append(items, fmt.Sprintf(`{"metadata":{"name":"pod-%d","namespace":"default"}}`, i))
+	}
+	body := `{"kind":"PodList","apiVersion":"v1","items":[` + strings.Join(items, ",") + `]}`
+	recs := []*capture.Record{
+		{ID: "p1", CapturedAt: now, APIPath: "/api/v1/namespaces/default/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body)},
+	}
+	idx := capture.Index{
+		"/api/v1/namespaces/default/pods": {APIPath: "/api/v1/namespaces/default/pods", Seqs: []int{0}, Times: []time.Time{now}},
+	}
+	meta := &capture.CaptureMetadata{CaptureID: "search-truncate", CapturedAt: now, CapturedUntil: now, RecordCount: 1}
+	h := &Handler{Store: buildV2TestStore(t, recs, idx, meta), At: now}
+
+	w := httptest.NewRecorder()
+	h.serveSearch(w, searchRequest("mode=text&q="+url.QueryEscape("pod-")))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", w.Code, w.Body.String())
+	}
+	var resp SearchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Truncated {
+		t.Errorf("expected truncated=true for %d matches, got %+v", resp.Total, resp)
+	}
+	if resp.Total != maxSearchResults+50 {
+		t.Errorf("Total = %d, want %d (untruncated count)", resp.Total, maxSearchResults+50)
+	}
+	if len(resp.Results) != maxSearchResults {
+		t.Errorf("len(Results) = %d, want %d (capped)", len(resp.Results), maxSearchResults)
+	}
+}

--- a/internal/ui/v2/static/app.css
+++ b/internal/ui/v2/static/app.css
@@ -76,6 +76,20 @@ a { color: inherit; }
 .grow { flex: 1; }
 #capture-meta { font-size: 11px; color: var(--fg-faint); }
 
+/* Global search (topbar) */
+.search-form {
+  display: flex; align-items: center; gap: 6px; margin-right: 8px;
+}
+.search-input {
+  background: var(--bg-row); color: var(--fg); border: 1px solid var(--border-strong);
+  padding: 5px 10px; border-radius: 6px; font-size: 12.5px; outline: none; width: 220px;
+}
+.search-input:focus { border-color: var(--accent); }
+.search-mode {
+  background: var(--bg-row); color: var(--fg); border: 1px solid var(--border-strong);
+  padding: 4px 6px; border-radius: 6px; font-size: 12px; cursor: pointer;
+}
+
 /* Scrubber */
 .scrubber {
   display: flex; align-items: center; gap: 8px; padding: 4px 10px;

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -2133,7 +2133,9 @@
       const link = '#/object?path=' + encodeURIComponent(m.path) + (m.name ? '&name=' + encodeURIComponent(m.name) : '');
       const loc = m.log ? ('log' + (m.container ? ':' + m.container : '') + (m.previous ? ' (previous)' : '')) : (m.field || '');
       const detail = m.snippet || m.value || '';
-      const row = el('div', { style: 'display:flex; gap:12px; padding:10px 4px; border-bottom:1px solid var(--border); cursor:pointer;', onclick: () => go(link) });
+      // A real <a href> (not a <div onclick>) so results are keyboard-focusable
+      // and activate with Enter, like any other link.
+      const row = el('a', { href: link, style: 'display:flex; gap:12px; padding:10px 4px; border-bottom:1px solid var(--border); text-decoration:none; color:inherit;' });
       row.appendChild(el('span', { style: 'flex:none; align-self:flex-start; font-size:10.5px; font-weight:600; text-transform:uppercase; color:var(--fg-dim); border:1px solid var(--border-strong); border-radius:5px; padding:1px 6px;' }, m.resource || ''));
       row.appendChild(el('div', { style: 'min-width:0;' },
         el('div', { style: 'font-size:13px;' }, obj),

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -111,6 +111,7 @@
   //   #/ns/<name>/pod/<pod>   pod drilldown
   //   #/timeline              timeline
   //   #/logs                  logs full-screen
+  //   #/search?q=..&mode=..   global search results (see the topbar search box)
   function parseRoute() {
     let h = (location.hash || '#/overview').replace(/^#/, '');
     // Strip any ?query=... before splitting on slashes; route params live in
@@ -119,7 +120,7 @@
     if (qIdx >= 0) h = h.slice(0, qIdx);
     const parts = h.split('/').filter(Boolean);
     if (parts.length === 0) return { name: 'overview' };
-    if (parts[0] === 'overview' || parts[0] === 'namespaces' || parts[0] === 'pods' || parts[0] === 'workloads' || parts[0] === 'resources' || parts[0] === 'resource' || parts[0] === 'object' || parts[0] === 'timeline' || parts[0] === 'logs' || parts[0] === 'diff' || parts[0] === 'diagnostics') {
+    if (parts[0] === 'overview' || parts[0] === 'namespaces' || parts[0] === 'pods' || parts[0] === 'workloads' || parts[0] === 'resources' || parts[0] === 'resource' || parts[0] === 'object' || parts[0] === 'timeline' || parts[0] === 'logs' || parts[0] === 'diff' || parts[0] === 'diagnostics' || parts[0] === 'search') {
       return { name: parts[0] };
     }
     if (parts[0] === 'ns' && parts[1]) {
@@ -2090,6 +2091,89 @@
     setContent(root);
   }
 
+  // ── Global search ────────────────────────────────────────────────────────
+  // Backed by the same internal/query engine as `kshrk query`. mode is
+  // "jsonpath" (default), "text" (substring), or "regex".
+  async function renderSearch() {
+    const q = hashQuery();
+    const query = q.get('q') || '';
+    const mode = q.get('mode') || 'jsonpath';
+    if (searchEls) {
+      searchEls.input.value = query;
+      searchEls.modeSel.value = mode;
+    }
+    if (!query) {
+      setContent(el('div', { class: 'state', style: 'padding:24px;' }, 'Type a query and press Enter to search — JSONPath by default, or switch the mode to search plain text/regex across every object body and pod log.'));
+      return;
+    }
+    setContent(loadingState('Searching…'));
+    let data;
+    try {
+      data = await getJSON('/v2/api/search?q=' + encodeURIComponent(query) + '&mode=' + encodeURIComponent(mode));
+    } catch (e) {
+      setContent(errorState(e.message));
+      return;
+    }
+    const results = data.results || [];
+    const root = el('div', {});
+    root.appendChild(el('div', { class: 'section-title', style: 'font-size:15px; margin-bottom:2px;' }, 'Search results'));
+    root.appendChild(el('div', { style: 'color:var(--fg-dim); font-size:12px; margin-bottom:14px;' },
+      data.total + ' match' + (data.total === 1 ? '' : 'es') + ' · mode: ' + data.mode +
+      (data.truncated ? ' · showing first ' + results.length : '')));
+
+    if (!results.length) {
+      root.appendChild(el('div', { class: 'state', style: 'padding:24px;' }, 'No matches.'));
+      setContent(root);
+      return;
+    }
+
+    const card = el('div', { class: 'card' });
+    for (const m of results) {
+      const obj = (m.namespace ? m.namespace + '/' : '') + m.name;
+      const link = '#/object?path=' + encodeURIComponent(m.path) + (m.name ? '&name=' + encodeURIComponent(m.name) : '');
+      const loc = m.log ? ('log' + (m.container ? ':' + m.container : '') + (m.previous ? ' (previous)' : '')) : (m.field || '');
+      const detail = m.snippet || m.value || '';
+      const row = el('div', { style: 'display:flex; gap:12px; padding:10px 4px; border-bottom:1px solid var(--border); cursor:pointer;', onclick: () => go(link) });
+      row.appendChild(el('span', { style: 'flex:none; align-self:flex-start; font-size:10.5px; font-weight:600; text-transform:uppercase; color:var(--fg-dim); border:1px solid var(--border-strong); border-radius:5px; padding:1px 6px;' }, m.resource || ''));
+      row.appendChild(el('div', { style: 'min-width:0;' },
+        el('div', { style: 'font-size:13px;' }, obj),
+        loc ? el('div', { style: 'font-size:12px; color:var(--fg-dim);' }, loc) : null,
+        detail ? el('div', { style: 'font-size:12px; color:var(--fg-faint); margin-top:2px; word-break:break-all;' }, detail) : null));
+      card.appendChild(row);
+    }
+    root.appendChild(card);
+    setContent(root);
+  }
+
+  // searchEls caches the topbar search box elements — built once (like
+  // transportEls) so typing doesn't get wiped out by an unrelated re-render.
+  let searchEls = null;
+  function setupSearchBox() {
+    const modeSel = el('select', { class: 'search-mode', title: 'Search mode' },
+      el('option', { value: 'jsonpath' }, 'JSONPath'),
+      el('option', { value: 'text' }, 'Text'),
+      el('option', { value: 'regex' }, 'Regex'));
+    const input = el('input', {
+      type: 'search', class: 'search-input',
+      placeholder: 'Search captured objects & logs…',
+      title: 'Global search across every captured object and pod log (see mode selector)',
+    });
+    const form = el('form', {
+      class: 'search-form',
+      onsubmit: (e) => {
+        e.preventDefault();
+        const val = input.value.trim();
+        if (!val) return;
+        go('#/search?q=' + encodeURIComponent(val) + '&mode=' + encodeURIComponent(modeSel.value));
+      },
+    }, input, modeSel);
+    searchEls = { form, input, modeSel };
+    const bar = $('topbar');
+    const scrub = $('scrubber');
+    if (bar && scrub) bar.insertBefore(form, scrub);
+    else if (bar) bar.appendChild(form);
+  }
+
   async function renderTimeline() {
     setContent(loadingState('Loading timeline…'));
     let data;
@@ -2332,6 +2416,7 @@
     if (r.name === 'timeline') return renderTimeline();
     if (r.name === 'logs') return renderLogs();
     if (r.name === 'diff') return renderDiff();
+    if (r.name === 'search') return renderSearch();
     return setContent(errorState('Unknown route'));
   }
 
@@ -2364,6 +2449,7 @@
   async function init() {
     applyTheme(currentTheme());
     setupThemeToggle();
+    setupSearchBox();
     state.route = parseRoute();
     try {
       const ts = await getJSON('/v2/api/timestamps');

--- a/internal/ui/v2/v2.go
+++ b/internal/ui/v2/v2.go
@@ -57,6 +57,7 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 
 	mux.HandleFunc("/v2/api/overview", h.serveOverview)
 	mux.HandleFunc("/v2/api/diagnostics", h.serveDiagnostics)
+	mux.HandleFunc("/v2/api/search", h.serveSearch)
 	mux.HandleFunc("/v2/api/capture", h.serveCaptureInfo)
 	mux.HandleFunc("/v2/api/namespace", h.serveNamespace)
 	mux.HandleFunc("/v2/api/pods", h.serveAllPods)


### PR DESCRIPTION
## Summary
- Adds a persistent search box to the v2 dashboard's top bar, wired to `internal/query` — the same engine that backs `kshrk query` (#197).
- New endpoint `/v2/api/search?q=<expr>&mode=jsonpath|text|regex[&resource=][&namespace=]`, honoring the dashboard's existing time-travel (`at`) via the shared `resolveAt` helper.
- New `#/search?q=..&mode=..` route and results view: each row shows the object identity plus either the JSONPath value or the full-text match location/snippet, and links straight into the existing object-view URL scheme (`#/object?path=..&name=..`).
- Results are capped at 500 with a `truncated` flag, so a broad pattern against a large archive can't send an unbounded payload to the browser.

This is phase 3 (final) of #112 — phases 1–2 (the JSONPath/full-text query engine and the `kshrk query` CLI) merged in #197.

### Design notes
- The search input + mode `<select>` are built once during `init()` (like the replay transport controls in `renderTransport`), not recreated on every `render()` — otherwise typing would get wiped out by an unrelated route change.
- Reuses `#/object?path=..&name=..` verbatim as the deep-link target — no new object-view addressing scheme.
- `mode` defaults to `jsonpath` to match `kshrk query`'s own default.

## Test plan
- [x] `internal/ui/v2/search_test.go`: JSONPath/text/regex modes, missing `q`, bad `mode`, invalid regex, nil store, truncation (600-item synthetic capture → `Truncated=true`, `len(Results)==500`)
- [x] `make test`, `make lint-ci`, `make fmt` all clean; `go mod tidy` produces no diff
- [x] Manually verified in a real browser against `examples/crash-loop/capture.kshrk`:
  - JSONPath `{.spec.containers[*].image}` → 1 match, correct value, click-through to the pod's object view (confirmed via the actual `#/object?path=..&name=..` navigation, not just a code read)
  - Text mode `connection refused` → 5 matches, identical to `kshrk query`'s CLI output (container command, current + previous log, bracket-quoted annotation field, deployment spec)
  - Regex mode `connection (refused|reset)` → same 5 matches
  - No-match state, and an invalid-regex error state surfacing the real Go error message
  - Search box persists (and resets correctly) across navigating to other tabs and back
  - No console errors at any point

Closes #112