### PR TITLE
feat(ui): turn global search into an icon-triggered command palette

### DIFF
--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -138,12 +138,13 @@ shares a chip/token filter bar with type-ahead completion:
 
 ## Global search
 
-The search box in the top bar searches the **whole capture** at once — every resource type and
-namespace, not just the list you're currently viewing — using the same engine as
-[`kshrk query`](usage.md#query). Type a query and press **Enter**; each result links straight to
-its object view.
+The 🔍 icon in the top bar opens a command palette that searches the **whole capture** at once —
+every resource type and namespace, not just the list you're currently viewing — using the same
+engine as [`kshrk query`](usage.md#query). Click the icon, or press **/** anywhere the focus isn't
+already in another text field, to open it; **Esc** or clicking outside the palette closes it.
 
-The mode dropdown next to the search box selects how the query text is interpreted:
+Type a query and matches appear inline as you type (a short debounce, not on every keystroke). The
+mode dropdown next to the input selects how the query text is interpreted:
 
 - **JSONPath** (default) — a kubectl-style expression, e.g. `{.spec.containers[*].image}`, evaluated
   against every captured object. Matches show the resource, object, and the matched value.
@@ -151,6 +152,10 @@ The mode dropdown next to the search box selects how the query text is interpret
   captured pod log (current and `--previous`). Matches show the field path (or `log:<container>`
   for a log line) and a snippet of context.
 - **Regex** — same as Text, but the query is a Go regular expression.
+
+The palette previews the first few matches; **↑ / ↓** move the selection and **Enter** opens the
+highlighted result directly. With nothing selected, Enter instead takes you to the full `#/search`
+results page — the same one you'd land on if there are more matches than the palette previews.
 
 This is the tool for "where does this error string appear?" — across annotations, container
 commands, event messages, and logs — without knowing in advance which resource type or namespace

--- a/internal/ui/v2/static/app.css
+++ b/internal/ui/v2/static/app.css
@@ -104,6 +104,9 @@ a { color: inherit; }
 .search-palette-input-row input {
   flex: 1; background: transparent; border: none; outline: none; color: var(--fg); font-size: 15px;
 }
+.search-palette-input-row input:focus-visible {
+  outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px;
+}
 .search-palette-status {
   padding: 6px 14px; color: var(--fg-faint); font-size: 11.5px; flex: none;
 }

--- a/internal/ui/v2/static/app.css
+++ b/internal/ui/v2/static/app.css
@@ -76,18 +76,58 @@ a { color: inherit; }
 .grow { flex: 1; }
 #capture-meta { font-size: 11px; color: var(--fg-faint); }
 
-/* Global search (topbar) */
-.search-form {
-  display: flex; align-items: center; gap: 6px; margin-right: 8px;
+/* Global search — topbar trigger + command-palette overlay */
+.search-trigger {
+  background: var(--bg-row); color: var(--fg-dim); border: 1px solid var(--border-strong);
+  border-radius: 6px; width: 30px; height: 30px; display: flex; align-items: center; justify-content: center;
+  font-size: 14px; line-height: 1; cursor: pointer; flex: none; margin-right: 8px;
 }
-.search-input {
-  background: var(--bg-row); color: var(--fg); border: 1px solid var(--border-strong);
-  padding: 5px 10px; border-radius: 6px; font-size: 12.5px; outline: none; width: 220px;
-}
-.search-input:focus { border-color: var(--accent); }
+.search-trigger:hover { color: var(--fg); border-color: var(--accent); }
 .search-mode {
   background: var(--bg-row); color: var(--fg); border: 1px solid var(--border-strong);
   padding: 4px 6px; border-radius: 6px; font-size: 12px; cursor: pointer;
+}
+
+.search-palette-backdrop {
+  position: fixed; inset: 0; z-index: 200; background: rgba(3, 6, 12, .6);
+  display: flex; align-items: flex-start; justify-content: center; padding-top: 12vh;
+}
+.search-palette {
+  width: 560px; max-width: calc(100vw - 32px); max-height: 70vh;
+  background: var(--bg-panel); border: 1px solid var(--border-strong); border-radius: 10px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, .5); overflow: hidden; display: flex; flex-direction: column;
+}
+.search-palette-input-row {
+  display: flex; align-items: center; gap: 8px; padding: 12px 14px; flex: none;
+  border-bottom: 1px solid var(--border);
+}
+.search-palette-input-row input {
+  flex: 1; background: transparent; border: none; outline: none; color: var(--fg); font-size: 15px;
+}
+.search-palette-status {
+  padding: 6px 14px; color: var(--fg-faint); font-size: 11.5px; flex: none;
+}
+.search-palette-results { overflow: auto; flex: 1; }
+.search-palette-row {
+  display: flex; flex-direction: column; gap: 2px; padding: 9px 14px;
+  border-bottom: 1px solid var(--border); text-decoration: none; color: inherit; cursor: pointer;
+}
+.search-palette-row:hover, .search-palette-row.selected { background: var(--bg-row-hover); }
+.search-palette-row .top { display: flex; gap: 8px; align-items: baseline; }
+.search-palette-row .kind {
+  font: 10.5px var(--mono); color: var(--fg-dim); text-transform: uppercase;
+  border: 1px solid var(--border-strong); border-radius: 5px; padding: 1px 6px;
+}
+.search-palette-row .name { font-size: 13px; }
+.search-palette-row .detail { font: 12px var(--mono); color: var(--fg-faint); word-break: break-all; }
+.search-palette-empty { padding: 22px 14px; color: var(--fg-dim); font-size: 13px; text-align: center; }
+.search-palette-footer {
+  display: flex; gap: 14px; padding: 8px 14px; color: var(--fg-faint); font-size: 11px;
+  border-top: 1px solid var(--border); flex: none;
+}
+.search-palette-footer kbd {
+  background: var(--bg-row); border: 1px solid var(--border-strong); border-radius: 4px;
+  padding: 1px 5px; font: 10px var(--mono);
 }
 
 /* Scrubber */

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -2290,10 +2290,13 @@
       backdrop.style.display = 'none';
       clearTimeout(debounceTimer);
       requestSeq++; // invalidate any in-flight request so its response is discarded on arrival
+      // Return focus to the trigger rather than leaving it on the now-hidden
+      // input, which would otherwise strand keyboard/AT navigation.
+      trigger.focus();
     }
 
     const trigger = el('button', {
-      class: 'search-trigger', type: 'button', title: 'Search (press / )',
+      class: 'search-trigger', type: 'button', title: 'Search (press /)',
       'aria-label': 'Search', 'aria-keyshortcuts': '/',
       onclick: () => open(),
     }, '🔍');

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -2251,9 +2251,16 @@
       const preview = all.slice(0, SEARCH_PALETTE_PREVIEW);
       renderRows(preview);
       const total = data.total || 0;
-      status.textContent = total > preview.length
-        ? `Showing ${preview.length} of ${total} — press Enter for the full list`
-        : `${total} match${total === 1 ? '' : 'es'} · mode: ${data.mode}`;
+      if (total <= preview.length) {
+        status.textContent = `${total} match${total === 1 ? '' : 'es'} · mode: ${data.mode}`;
+      } else if (data.truncated) {
+        // /v2/api/search itself caps the response — the "full list" on
+        // #/search is really just the first `all.length` matches, not all
+        // `total` of them, so say so instead of promising a full list.
+        status.textContent = `Showing ${preview.length} of ${total} — press Enter to see the first ${all.length} (results are capped)`;
+      } else {
+        status.textContent = `Showing ${preview.length} of ${total} — press Enter for the full list`;
+      }
     }
 
     input.addEventListener('input', () => {
@@ -2263,9 +2270,20 @@
     modeSel.addEventListener('change', runSearch);
     // Escape is handled on the panel (not just the input) so it dismisses the
     // palette no matter which element inside it — input, mode select, or a
-    // result row — currently has focus.
+    // result row — currently has focus. Tab is trapped the same way, cycling
+    // through input -> mode select -> result rows -> input, so focus can't
+    // leak out to the page behind an aria-modal dialog.
     panel.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape') { e.preventDefault(); close(); }
+      if (e.key === 'Escape') { e.preventDefault(); close(); return; }
+      if (e.key === 'Tab') {
+        const focusable = [input, modeSel, ...rows];
+        if (!focusable.length) return;
+        e.preventDefault();
+        const idx = focusable.indexOf(document.activeElement);
+        const step = e.shiftKey ? -1 : 1;
+        const next = ((idx === -1 ? 0 : idx) + step + focusable.length) % focusable.length;
+        focusable[next].focus();
+      }
     });
     input.addEventListener('keydown', (e) => {
       if (e.key === 'ArrowDown') { e.preventDefault(); moveSelection(1); return; }

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -2229,7 +2229,12 @@
     async function runSearch() {
       const seq = ++requestSeq;
       const val = input.value.trim();
-      if (!val) { status.textContent = ''; renderRows([]); return; }
+      if (!val) {
+        status.textContent = '';
+        resultsBox.innerHTML = '';
+        rows = []; selected = -1;
+        return;
+      }
       let data;
       try {
         data = await getJSON('/v2/api/search?q=' + encodeURIComponent(val) + '&mode=' + encodeURIComponent(modeSel.value));
@@ -2256,8 +2261,13 @@
       debounceTimer = setTimeout(runSearch, 200);
     });
     modeSel.addEventListener('change', runSearch);
+    // Escape is handled on the panel (not just the input) so it dismisses the
+    // palette no matter which element inside it — input, mode select, or a
+    // result row — currently has focus.
+    panel.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') { e.preventDefault(); close(); }
+    });
     input.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape') { e.preventDefault(); close(); return; }
       if (e.key === 'ArrowDown') { e.preventDefault(); moveSelection(1); return; }
       if (e.key === 'ArrowUp') { e.preventDefault(); moveSelection(-1); return; }
       if (e.key === 'Enter') {
@@ -2282,6 +2292,7 @@
 
     const trigger = el('button', {
       class: 'search-trigger', type: 'button', title: 'Search (press / )',
+      'aria-label': 'Search', 'aria-keyshortcuts': '/',
       onclick: () => open(),
     }, '🔍');
     const bar = $('topbar');

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -2186,11 +2186,17 @@
     let requestSeq = 0;  // guards against a slower, older request clobbering a newer one's results
 
     function setSelected(idx) {
+      // If focus already landed in the results list (e.g. via Tab), move it
+      // along with the highlight so Enter's native anchor activation and the
+      // visual "selected" row never disagree. While typing, focus stays in
+      // the input and only the highlight moves.
+      const focusOnARow = rows.includes(document.activeElement);
       if (rows[selected]) rows[selected].classList.remove('selected');
       selected = idx;
       if (rows[selected]) {
         rows[selected].classList.add('selected');
         rows[selected].scrollIntoView({ block: 'nearest' });
+        if (focusOnARow) rows[selected].focus();
       }
     }
 

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -2267,7 +2267,10 @@
       clearTimeout(debounceTimer);
       debounceTimer = setTimeout(runSearch, 200);
     });
-    modeSel.addEventListener('change', runSearch);
+    modeSel.addEventListener('change', () => {
+      clearTimeout(debounceTimer); // don't let a still-pending debounced search also fire
+      runSearch();
+    });
     // Escape is handled on the panel (not just the input) so it dismisses the
     // palette no matter which element inside it — input, mode select, or a
     // result row — currently has focus. Tab is trapped the same way, cycling

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -2169,7 +2169,7 @@
     });
     const status = el('div', { class: 'search-palette-status' });
     const resultsBox = el('div', { class: 'search-palette-results' });
-    const panel = el('div', { class: 'search-palette' },
+    const panel = el('div', { class: 'search-palette', role: 'dialog', 'aria-modal': 'true', 'aria-label': 'Search captured objects & logs' },
       el('div', { class: 'search-palette-input-row' }, input, modeSel),
       status, resultsBox,
       el('div', { class: 'search-palette-footer' },
@@ -2288,6 +2288,8 @@
     }
     function close() {
       backdrop.style.display = 'none';
+      clearTimeout(debounceTimer);
+      requestSeq++; // invalidate any in-flight request so its response is discarded on arrival
     }
 
     const trigger = el('button', {

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -2271,13 +2271,18 @@
       clearTimeout(debounceTimer); // don't let a still-pending debounced search also fire
       runSearch();
     });
-    // Escape is handled on the panel (not just the input) so it dismisses the
-    // palette no matter which element inside it — input, mode select, or a
-    // result row — currently has focus. Tab is trapped the same way, cycling
-    // through input -> mode select -> result rows -> input, so focus can't
-    // leak out to the page behind an aria-modal dialog.
+    // Escape and ↑/↓ are handled on the panel (not just the input) so they
+    // work no matter which focusable element inside it — input, mode select,
+    // or a result row — currently has focus, since Tab (trapped the same
+    // way below) can move focus to any of them. ↑/↓ skip the mode <select>
+    // so its own native up/down value-changing behavior still works.
     panel.addEventListener('keydown', (e) => {
       if (e.key === 'Escape') { e.preventDefault(); close(); return; }
+      if ((e.key === 'ArrowDown' || e.key === 'ArrowUp') && document.activeElement !== modeSel) {
+        e.preventDefault();
+        moveSelection(e.key === 'ArrowDown' ? 1 : -1);
+        return;
+      }
       if (e.key === 'Tab') {
         const focusable = [input, modeSel, ...rows];
         if (!focusable.length) return;
@@ -2289,8 +2294,6 @@
       }
     });
     input.addEventListener('keydown', (e) => {
-      if (e.key === 'ArrowDown') { e.preventDefault(); moveSelection(1); return; }
-      if (e.key === 'ArrowUp') { e.preventDefault(); moveSelection(-1); return; }
       if (e.key === 'Enter') {
         e.preventDefault();
         if (selected >= 0 && rows[selected]) { rows[selected].click(); return; }

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -2098,9 +2098,9 @@
     const q = hashQuery();
     const query = q.get('q') || '';
     const mode = q.get('mode') || 'jsonpath';
-    if (searchEls) {
-      searchEls.input.value = query;
-      searchEls.modeSel.value = mode;
+    if (searchPalette) {
+      searchPalette.input.value = query;
+      searchPalette.modeSel.value = mode;
     }
     if (!query) {
       setContent(el('div', { class: 'state', style: 'padding:24px;' }, 'Type a query and press Enter to search — JSONPath by default, or switch the mode to search plain text/regex across every object body and pod log.'));
@@ -2147,33 +2147,161 @@
     setContent(root);
   }
 
-  // searchEls caches the topbar search box elements — built once (like
-  // transportEls) so typing doesn't get wiped out by an unrelated re-render.
-  let searchEls = null;
-  function setupSearchBox() {
+  // How many results the palette previews inline before pointing at the
+  // full #/search page (which shows everything /v2/api/search returned, up
+  // to its own server-side cap).
+  const SEARCH_PALETTE_PREVIEW = 8;
+
+  // searchPalette caches the command-palette overlay's elements and state —
+  // built once (like transportEls) and appended to <body> so it renders
+  // above whatever view is on screen without living inside any view's
+  // re-render. The topbar only ever holds the small trigger icon.
+  let searchPalette = null;
+  function setupSearchPalette() {
     const modeSel = el('select', { class: 'search-mode', title: 'Search mode' },
       el('option', { value: 'jsonpath' }, 'JSONPath'),
       el('option', { value: 'text' }, 'Text'),
       el('option', { value: 'regex' }, 'Regex'));
     const input = el('input', {
-      type: 'search', class: 'search-input',
+      type: 'search',
       placeholder: 'Search captured objects & logs…',
-      title: 'Global search across every captured object and pod log (see mode selector)',
+      title: 'Global search across every captured object and pod log',
     });
-    const form = el('form', {
-      class: 'search-form',
-      onsubmit: (e) => {
+    const status = el('div', { class: 'search-palette-status' });
+    const resultsBox = el('div', { class: 'search-palette-results' });
+    const panel = el('div', { class: 'search-palette' },
+      el('div', { class: 'search-palette-input-row' }, input, modeSel),
+      status, resultsBox,
+      el('div', { class: 'search-palette-footer' },
+        el('span', {}, el('kbd', {}, '↑'), el('kbd', {}, '↓'), ' navigate'),
+        el('span', {}, el('kbd', {}, '↵'), ' open'),
+        el('span', {}, el('kbd', {}, 'esc'), ' close')));
+    const backdrop = el('div', { class: 'search-palette-backdrop', style: 'display:none;' }, panel);
+    backdrop.addEventListener('click', (e) => { if (e.target === backdrop) close(); });
+    document.body.appendChild(backdrop);
+
+    let rows = [];       // rendered result <a> elements, in display order
+    let selected = -1;   // keyboard-selected row index, -1 = none
+    let debounceTimer = null;
+    let requestSeq = 0;  // guards against a slower, older request clobbering a newer one's results
+
+    function setSelected(idx) {
+      if (rows[selected]) rows[selected].classList.remove('selected');
+      selected = idx;
+      if (rows[selected]) {
+        rows[selected].classList.add('selected');
+        rows[selected].scrollIntoView({ block: 'nearest' });
+      }
+    }
+
+    function moveSelection(delta) {
+      if (!rows.length) return;
+      let idx = selected + delta;
+      if (idx < 0) idx = rows.length - 1;
+      if (idx >= rows.length) idx = 0;
+      setSelected(idx);
+    }
+
+    function renderRows(matches) {
+      resultsBox.innerHTML = '';
+      rows = [];
+      selected = -1;
+      if (!matches.length) {
+        resultsBox.appendChild(el('div', { class: 'search-palette-empty' }, 'No matches.'));
+        return;
+      }
+      for (const m of matches) {
+        const obj = (m.namespace ? m.namespace + '/' : '') + m.name;
+        const link = '#/object?path=' + encodeURIComponent(m.path) + (m.name ? '&name=' + encodeURIComponent(m.name) : '');
+        const loc = m.log ? ('log' + (m.container ? ':' + m.container : '') + (m.previous ? ' (previous)' : '')) : (m.field || '');
+        const detail = m.snippet || m.value || '';
+        const row = el('a', { href: link, class: 'search-palette-row', onclick: () => close() },
+          el('div', { class: 'top' },
+            el('span', { class: 'kind' }, m.resource || ''),
+            el('span', { class: 'name' }, obj)),
+          loc ? el('div', { class: 'detail' }, loc) : null,
+          detail ? el('div', { class: 'detail' }, detail) : null);
+        rows.push(row);
+        resultsBox.appendChild(row);
+      }
+    }
+
+    async function runSearch() {
+      const seq = ++requestSeq;
+      const val = input.value.trim();
+      if (!val) { status.textContent = ''; renderRows([]); return; }
+      let data;
+      try {
+        data = await getJSON('/v2/api/search?q=' + encodeURIComponent(val) + '&mode=' + encodeURIComponent(modeSel.value));
+      } catch (e) {
+        if (seq !== requestSeq) return; // a newer request has since started — discard this stale one
+        rows = []; selected = -1;
+        resultsBox.innerHTML = '';
+        resultsBox.appendChild(el('div', { class: 'search-palette-empty' }, e.message));
+        status.textContent = '';
+        return;
+      }
+      if (seq !== requestSeq) return; // a newer request has since started — discard this stale one
+      const all = data.results || [];
+      const preview = all.slice(0, SEARCH_PALETTE_PREVIEW);
+      renderRows(preview);
+      const total = data.total || 0;
+      status.textContent = total > preview.length
+        ? `Showing ${preview.length} of ${total} — press Enter for the full list`
+        : `${total} match${total === 1 ? '' : 'es'} · mode: ${data.mode}`;
+    }
+
+    input.addEventListener('input', () => {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(runSearch, 200);
+    });
+    modeSel.addEventListener('change', runSearch);
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') { e.preventDefault(); close(); return; }
+      if (e.key === 'ArrowDown') { e.preventDefault(); moveSelection(1); return; }
+      if (e.key === 'ArrowUp') { e.preventDefault(); moveSelection(-1); return; }
+      if (e.key === 'Enter') {
         e.preventDefault();
+        if (selected >= 0 && rows[selected]) { rows[selected].click(); return; }
         const val = input.value.trim();
         if (!val) return;
+        close();
         go('#/search?q=' + encodeURIComponent(val) + '&mode=' + encodeURIComponent(modeSel.value));
-      },
-    }, input, modeSel);
-    searchEls = { form, input, modeSel };
+      }
+    });
+
+    function open() {
+      backdrop.style.display = 'flex';
+      input.focus();
+      input.select();
+      if (input.value.trim()) runSearch();
+    }
+    function close() {
+      backdrop.style.display = 'none';
+    }
+
+    const trigger = el('button', {
+      class: 'search-trigger', type: 'button', title: 'Search (press / )',
+      onclick: () => open(),
+    }, '🔍');
     const bar = $('topbar');
     const scrub = $('scrubber');
-    if (bar && scrub) bar.insertBefore(form, scrub);
-    else if (bar) bar.appendChild(form);
+    if (bar && scrub) bar.insertBefore(trigger, scrub);
+    else if (bar) bar.appendChild(trigger);
+
+    // Global "/" shortcut, ignored while typing in any other field so it
+    // doesn't hijack the per-list filter bars.
+    window.addEventListener('keydown', (e) => {
+      if (e.key !== '/' || e.metaKey || e.ctrlKey || e.altKey) return;
+      if (backdrop.style.display !== 'none') return;
+      const ae = document.activeElement;
+      const tag = ae && ae.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || (ae && ae.isContentEditable)) return;
+      e.preventDefault();
+      open();
+    });
+
+    searchPalette = { input, modeSel, open, close };
   }
 
   async function renderTimeline() {
@@ -2451,7 +2579,7 @@
   async function init() {
     applyTheme(currentTheme());
     setupThemeToggle();
-    setupSearchBox();
+    setupSearchPalette();
     state.route = parseRoute();
     try {
       const ts = await getJSON('/v2/api/timestamps');


### PR DESCRIPTION
## Summary
- Replaces the always-visible topbar search input + mode dropdown (added in #202) with a small 🔍 icon, restoring the topbar to its pre-search footprint at normal window widths (the scrubber was getting squeezed off-screen with everything crammed into one row).
- Clicking the icon (or pressing `/` when focus isn't already in another field) opens a command-palette overlay: a larger input, mode selector, and a live debounced preview of the first few matches from `/v2/api/search`.
- Keyboard nav in the palette: ↑/↓ moves the selection, Enter opens the highlighted result, Esc or a backdrop click dismisses it. Enter with nothing selected falls through to the full `#/search` results page (same page as before, unchanged) for the complete/truncated list.
- Fixed a race found during manual testing: a slower, older `/v2/api/search` response (e.g. from a request made before a mode switch) could land after a newer one and clobber the rendered results/selection. Guarded with a per-call sequence number so only the latest request's response is applied.
- Updated `docs/web-ui.md`'s "Global search" section for the new interaction.

This was scoped from a design review — see the three alternatives considered (two-row split, this command palette, and search-promoted-to-row-1) before picking this one.

## Test plan
- [x] `make fmt && make lint && go test ./internal/ui/...` all clean
- [x] Manual browser verification against `examples/crash-loop/capture.kshrk`:
  - [x] Icon opens the palette; topbar is back to its pre-search width
  - [x] `/` opens the palette from a non-input focus, and is ignored while another input (e.g. a list's filter bar) is focused
  - [x] Typing shows a live, debounced preview in Text/JSONPath/Regex modes
  - [x] ↑/↓ selects a row; Enter on a selected row navigates to the object and closes the palette
  - [x] Enter with no selection navigates to the full `#/search` page
  - [x] Esc and backdrop-click both close the palette
  - [x] No console errors