### PR TITLE
feat(capture): --encrypt for passphrase-encrypted archives (M2 of #117)

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -101,7 +101,7 @@ func runCapture(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if encrypt && cfg.Output == "-" {
-		return fmt.Errorf("--encrypt cannot be combined with --output - (NDJSON streaming to stdout is not encrypted)")
+		return fmt.Errorf("archive encryption (--encrypt / --encrypt-passphrase-file) cannot be combined with --output - (NDJSON streaming to stdout is not encrypted)")
 	}
 	var encRecipients []age.Recipient
 	var encIdentities []age.Identity

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -94,14 +94,26 @@ func runCapture(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid config: %w", err)
 	}
 
+	// When streaming NDJSON to stdout, stdout must carry only records, so all
+	// human-oriented output (spinner, status, summary) goes to stderr instead.
+	streamingStdout := cfg.Output == "-"
+	msgOut := os.Stdout
+	if streamingStdout {
+		msgOut = os.Stderr
+	}
+
+	// Reject incompatible flag combinations before any interactive passphrase
+	// prompt so users aren't asked for a secret only to be told it can't be
+	// used. encryptRequested checks the flags without prompting.
+	if encryptRequested(cmd) && streamingStdout {
+		return fmt.Errorf("archive encryption (--encrypt / --encrypt-passphrase-file) cannot be combined with --output - (NDJSON streaming to stdout is not encrypted)")
+	}
+
 	// Resolve encryption before the (potentially long) capture starts so a bad
 	// or missing passphrase fails fast rather than after minutes of polling.
 	passphrase, encrypt, err := resolveEncryptPassphrase(cmd)
 	if err != nil {
 		return err
-	}
-	if encrypt && cfg.Output == "-" {
-		return fmt.Errorf("archive encryption (--encrypt / --encrypt-passphrase-file) cannot be combined with --output - (NDJSON streaming to stdout is not encrypted)")
 	}
 	var encRecipients []age.Recipient
 	var encIdentities []age.Identity
@@ -120,10 +132,10 @@ func runCapture(cmd *cobra.Command, args []string) error {
 	}
 	engine.SetEncryption(encRecipients)
 
-	fmt.Fprintf(os.Stdout, "Starting capture -> %s\n", cfg.Output)
+	fmt.Fprintf(msgOut, "Starting capture -> %s\n", cfg.Output)
 
 	// Spinner runs until capture finishes.
-	stopSpinner := startSpinner(os.Stdout)
+	stopSpinner := startSpinner(msgOut)
 	sum, err := engine.Run()
 	stopSpinner()
 
@@ -131,30 +143,30 @@ func runCapture(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("capture failed: %w", err)
 	}
 
-	fmt.Fprintf(os.Stdout, "\nCapture complete\n")
-	fmt.Fprintf(os.Stdout, "  Output:    %s (%s)\n", sum.OutputPath, formatBytes(sum.OutputSize))
+	fmt.Fprintf(msgOut, "\nCapture complete\n")
+	fmt.Fprintf(msgOut, "  Output:    %s (%s)\n", sum.OutputPath, formatBytes(sum.OutputSize))
 	if encrypt {
-		fmt.Fprintf(os.Stdout, "  Encrypted: yes (age passphrase)\n")
+		fmt.Fprintf(msgOut, "  Encrypted: yes (age passphrase)\n")
 	}
-	fmt.Fprintf(os.Stdout, "  Records:   %d across %d resource path(s)\n", sum.RecordCount, sum.ResourceCount)
-	fmt.Fprintf(os.Stdout, "  Duration:  %s\n", sum.Duration)
+	fmt.Fprintf(msgOut, "  Records:   %d across %d resource path(s)\n", sum.RecordCount, sum.ResourceCount)
+	fmt.Fprintf(msgOut, "  Duration:  %s\n", sum.Duration)
 	if sum.PodLogs.Attempted > 0 {
-		fmt.Fprintf(os.Stdout, "  Pod logs:  %d/%d captured", sum.PodLogs.Captured, sum.PodLogs.Attempted)
+		fmt.Fprintf(msgOut, "  Pod logs:  %d/%d captured", sum.PodLogs.Captured, sum.PodLogs.Attempted)
 		if sum.PodLogs.Skipped > 0 {
-			fmt.Fprintf(os.Stdout, " (%d skipped)", sum.PodLogs.Skipped)
+			fmt.Fprintf(msgOut, " (%d skipped)", sum.PodLogs.Skipped)
 		}
 		if sum.PodLogs.CapturedPrevious > 0 {
-			fmt.Fprintf(os.Stdout, ", %d previous", sum.PodLogs.CapturedPrevious)
+			fmt.Fprintf(msgOut, ", %d previous", sum.PodLogs.CapturedPrevious)
 		}
-		fmt.Fprintln(os.Stdout)
+		fmt.Fprintln(msgOut)
 		if len(sum.PodLogs.Failures) > 0 {
-			fmt.Fprintln(os.Stdout, "  Skipped (sample):")
+			fmt.Fprintln(msgOut, "  Skipped (sample):")
 			for _, f := range sum.PodLogs.Failures {
-				fmt.Fprintf(os.Stdout, "    - %s/%s [container=%s]: %s\n",
+				fmt.Fprintf(msgOut, "    - %s/%s [container=%s]: %s\n",
 					f.Namespace, f.Pod, f.Container, f.Reason)
 			}
 			if sum.PodLogs.Skipped > len(sum.PodLogs.Failures) {
-				fmt.Fprintf(os.Stdout, "    ... and %d more (run with --verbose for full list)\n",
+				fmt.Fprintf(msgOut, "    ... and %d more (run with --verbose for full list)\n",
 					sum.PodLogs.Skipped-len(sum.PodLogs.Failures))
 			}
 		}
@@ -205,7 +217,7 @@ func runCapture(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("replacing archive with redacted version: %w", err)
 		}
 		if result.SecretsRedacted > 0 || result.FieldsRedacted > 0 {
-			fmt.Fprintf(os.Stdout, "  Redacted:  %d secret(s), %d record(s) with field rules applied\n",
+			fmt.Fprintf(msgOut, "  Redacted:  %d secret(s), %d record(s) with field rules applied\n",
 				result.SecretsRedacted, result.FieldsRedacted)
 		}
 	}

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/capture"
 	"github.com/phenixblue/k8shark/internal/config"
 	"github.com/phenixblue/k8shark/internal/redact"
@@ -22,8 +23,9 @@ single .kshrk capture file for later replay.
 
 Resources, namespaces, and intervals come from the --config file. Use
 --auto-discover to capture every available API resource without listing them,
---output - to stream records as NDJSON to stdout, and --redact-secrets to
-scrub Secret values from the archive after capture.`,
+--output - to stream records as NDJSON to stdout, --redact-secrets to scrub
+Secret values from the archive after capture, and --encrypt to write the
+archive as an encrypted (age) envelope.`,
 	Example: `  # Capture using a config file
   kshrk capture --config k8shark.yaml
 
@@ -34,7 +36,13 @@ scrub Secret values from the archive after capture.`,
   kshrk capture --config k8shark.yaml --output -
 
   # Capture, then redact Secret values from the archive
-  kshrk capture --config k8shark.yaml --redact-secrets`,
+  kshrk capture --config k8shark.yaml --redact-secrets
+
+  # Capture and encrypt the archive, prompting for a passphrase
+  kshrk capture --config k8shark.yaml --encrypt
+
+  # Encrypt using a passphrase read from a file (no prompt)
+  kshrk capture --config k8shark.yaml --encrypt-passphrase-file ./pass.txt`,
 	RunE: runCapture,
 }
 
@@ -47,6 +55,7 @@ func init() {
 	captureCmd.Flags().Bool("redact-secrets", false, "redact Secret data and stringData values from the archive after capture")
 	captureCmd.Flags().StringArray("allow-secret", nil, "namespace/name of secret to preserve when --redact-secrets is set (repeatable)")
 	captureCmd.Flags().StringArray("redact-field", nil, "field redaction rule applied after capture: <fieldPath>:<Kind>:<replacement>[:<valueType>] (repeatable)")
+	addEncryptFlags(captureCmd)
 	_ = viper.BindPFlag("output", captureCmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag("kubeconfig", captureCmd.Flags().Lookup("kubeconfig"))
 	_ = viper.BindPFlag("duration", captureCmd.Flags().Lookup("duration"))
@@ -85,12 +94,31 @@ func runCapture(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid config: %w", err)
 	}
 
+	// Resolve encryption before the (potentially long) capture starts so a bad
+	// or missing passphrase fails fast rather than after minutes of polling.
+	passphrase, encrypt, err := resolveEncryptPassphrase(cmd)
+	if err != nil {
+		return err
+	}
+	if encrypt && cfg.Output == "-" {
+		return fmt.Errorf("--encrypt cannot be combined with --output - (NDJSON streaming to stdout is not encrypted)")
+	}
+	var encRecipients []age.Recipient
+	var encIdentities []age.Identity
+	if encrypt {
+		encRecipients, encIdentities, err = encryptOptionsFromPassphrase(passphrase)
+		if err != nil {
+			return err
+		}
+	}
+
 	verbose, _ := cmd.Root().PersistentFlags().GetBool("verbose")
 
 	engine, err := capture.NewEngine(cfg, verbose)
 	if err != nil {
 		return fmt.Errorf("initializing capture engine: %w", err)
 	}
+	engine.SetEncryption(encRecipients)
 
 	fmt.Fprintf(os.Stdout, "Starting capture -> %s\n", cfg.Output)
 
@@ -105,6 +133,9 @@ func runCapture(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(os.Stdout, "\nCapture complete\n")
 	fmt.Fprintf(os.Stdout, "  Output:    %s (%s)\n", sum.OutputPath, formatBytes(sum.OutputSize))
+	if encrypt {
+		fmt.Fprintf(os.Stdout, "  Encrypted: yes (age passphrase)\n")
+	}
 	fmt.Fprintf(os.Stdout, "  Records:   %d across %d resource path(s)\n", sum.RecordCount, sum.ResourceCount)
 	fmt.Fprintf(os.Stdout, "  Duration:  %s\n", sum.Duration)
 	if sum.PodLogs.Attempted > 0 {
@@ -160,6 +191,10 @@ func runCapture(cmd *cobra.Command, args []string) error {
 			RedactSecrets: doRedactSecrets,
 			AllowList:     allowList,
 			Rules:         fieldRules,
+			// When the capture was encrypted, decrypt it to redact and re-encrypt
+			// the result so the redacted archive stays encrypted end to end.
+			Identities: encIdentities,
+			Recipients: encRecipients,
 		})
 		if err != nil {
 			_ = os.Remove(tmpPath)

--- a/cmd/encrypt_flags.go
+++ b/cmd/encrypt_flags.go
@@ -34,13 +34,21 @@ func addEncryptFlags(cmd *cobra.Command) {
 //
 // It returns (passphrase, enabled, error). passphrase is empty when enabled
 // is false.
-func resolveEncryptPassphrase(cmd *cobra.Command) (string, bool, error) {
+// encryptRequested reports whether the user asked for output encryption
+// (via --encrypt or --encrypt-passphrase-file), without resolving or
+// prompting for the passphrase. Callers use it to reject incompatible flag
+// combinations before any interactive prompt runs.
+func encryptRequested(cmd *cobra.Command) bool {
 	encrypt, _ := cmd.Flags().GetBool("encrypt")
 	passphraseFile, _ := cmd.Flags().GetString("encrypt-passphrase-file")
-	enabled := encrypt || passphraseFile != ""
-	if !enabled {
+	return encrypt || passphraseFile != ""
+}
+
+func resolveEncryptPassphrase(cmd *cobra.Command) (string, bool, error) {
+	if !encryptRequested(cmd) {
 		return "", false, nil
 	}
+	passphraseFile, _ := cmd.Flags().GetString("encrypt-passphrase-file")
 
 	if passphraseFile != "" {
 		pass, err := readPassphraseFile(passphraseFile)

--- a/cmd/encrypt_flags.go
+++ b/cmd/encrypt_flags.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"filippo.io/age"
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+// encryptPassphraseEnv is the environment variable consulted for the archive
+// encryption passphrase when no --encrypt-passphrase-file is given. It is read
+// directly via os.Getenv, never through Viper, so the passphrase can never be
+// bound from (or leak into) the YAML config file.
+const encryptPassphraseEnv = "KSHRK_ENCRYPT_PASSPHRASE"
+
+// addEncryptFlags registers the write-side encryption flags on cmd.
+func addEncryptFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("encrypt", false, "encrypt the output archive (age); passphrase from --encrypt-passphrase-file, $"+encryptPassphraseEnv+", or an interactive prompt")
+	cmd.Flags().String("encrypt-passphrase-file", "", "read the encryption passphrase from this file (first line) instead of prompting")
+	_ = cmd.MarkFlagFilename("encrypt-passphrase-file")
+}
+
+// resolveEncryptPassphrase determines whether the command should encrypt its
+// output and, if so, resolves the passphrase. Encryption is enabled when
+// --encrypt is set or a --encrypt-passphrase-file is given. The passphrase is
+// resolved in priority order: the file, then $KSHRK_ENCRYPT_PASSPHRASE, then
+// an interactive TTY prompt (with confirmation). When encryption is requested
+// but no passphrase source is available and stdin is not a TTY, it fails
+// loudly rather than hanging on a prompt that can never be answered.
+//
+// It returns (passphrase, enabled, error). passphrase is empty when enabled
+// is false.
+func resolveEncryptPassphrase(cmd *cobra.Command) (string, bool, error) {
+	encrypt, _ := cmd.Flags().GetBool("encrypt")
+	passphraseFile, _ := cmd.Flags().GetString("encrypt-passphrase-file")
+	enabled := encrypt || passphraseFile != ""
+	if !enabled {
+		return "", false, nil
+	}
+
+	if passphraseFile != "" {
+		pass, err := readPassphraseFile(passphraseFile)
+		if err != nil {
+			return "", true, err
+		}
+		return pass, true, nil
+	}
+
+	if pass := os.Getenv(encryptPassphraseEnv); pass != "" {
+		return pass, true, nil
+	}
+
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return "", true, fmt.Errorf("encryption requested but no passphrase provided: set --encrypt-passphrase-file or $%s (an interactive prompt requires a terminal)", encryptPassphraseEnv)
+	}
+
+	pass, err := promptNewPassphrase(cmd)
+	if err != nil {
+		return "", true, err
+	}
+	return pass, true, nil
+}
+
+// readPassphraseFile reads a passphrase from the first line of path, trimming
+// a single trailing newline (and any \r) so a file created with a trailing
+// newline works as expected. An empty passphrase is rejected.
+func readPassphraseFile(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading passphrase file %q: %w", path, err)
+	}
+	pass := string(b)
+	if i := strings.IndexAny(pass, "\r\n"); i >= 0 {
+		pass = pass[:i]
+	}
+	if pass == "" {
+		return "", fmt.Errorf("passphrase file %q is empty", path)
+	}
+	return pass, nil
+}
+
+// promptNewPassphrase interactively reads a passphrase twice from the
+// terminal and confirms the two entries match. The typed characters are not
+// echoed.
+func promptNewPassphrase(cmd *cobra.Command) (string, error) {
+	fd := int(os.Stdin.Fd())
+	out := cmd.OutOrStdout()
+
+	fmt.Fprint(out, "Enter passphrase for archive encryption: ")
+	first, err := term.ReadPassword(fd)
+	fmt.Fprintln(out)
+	if err != nil {
+		return "", fmt.Errorf("reading passphrase: %w", err)
+	}
+	if len(first) == 0 {
+		return "", fmt.Errorf("passphrase must not be empty")
+	}
+
+	fmt.Fprint(out, "Confirm passphrase: ")
+	second, err := term.ReadPassword(fd)
+	fmt.Fprintln(out)
+	if err != nil {
+		return "", fmt.Errorf("reading passphrase confirmation: %w", err)
+	}
+
+	if string(first) != string(second) {
+		return "", fmt.Errorf("passphrases do not match")
+	}
+	return string(first), nil
+}
+
+// encryptOptionsFromPassphrase builds the age recipients and identities for a
+// passphrase. Recipients encrypt the output; identities decrypt an existing
+// encrypted archive (needed when redacting an encrypted capture in place).
+func encryptOptionsFromPassphrase(passphrase string) (recipients []age.Recipient, identities []age.Identity, err error) {
+	recipients, err = archive.RecipientsFromPassphrase(passphrase)
+	if err != nil {
+		return nil, nil, err
+	}
+	identities, err = archive.IdentitiesFromPassphrase(passphrase)
+	if err != nil {
+		return nil, nil, err
+	}
+	return recipients, identities, nil
+}

--- a/cmd/encrypt_flags.go
+++ b/cmd/encrypt_flags.go
@@ -88,7 +88,9 @@ func readPassphraseFile(path string) (string, error) {
 // echoed.
 func promptNewPassphrase(cmd *cobra.Command) (string, error) {
 	fd := int(os.Stdin.Fd())
-	out := cmd.OutOrStdout()
+	// Prompts go to stderr so they never corrupt machine-readable output on
+	// stdout (or a stdout redirect).
+	out := cmd.ErrOrStderr()
 
 	fmt.Fprint(out, "Enter passphrase for archive encryption: ")
 	first, err := term.ReadPassword(fd)

--- a/cmd/encrypt_flags_test.go
+++ b/cmd/encrypt_flags_test.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newTestEncryptCommand builds a command with just the encryption flags so
+// resolveEncryptPassphrase can be exercised in isolation.
+func newTestEncryptCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	addEncryptFlags(cmd)
+	return cmd
+}
+
+func TestResolveEncryptPassphrase_Disabled(t *testing.T) {
+	cmd := newTestEncryptCommand()
+	pass, enabled, err := resolveEncryptPassphrase(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enabled {
+		t.Error("enabled = true with no flags, want false")
+	}
+	if pass != "" {
+		t.Errorf("pass = %q, want empty", pass)
+	}
+}
+
+func TestResolveEncryptPassphrase_FromFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pass.txt")
+	if err := os.WriteFile(path, []byte("hunter2\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cmd := newTestEncryptCommand()
+	_ = cmd.Flags().Set("encrypt-passphrase-file", path)
+
+	pass, enabled, err := resolveEncryptPassphrase(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !enabled {
+		t.Error("enabled = false, want true (passphrase file implies encryption)")
+	}
+	// The trailing newline must be trimmed.
+	if pass != "hunter2" {
+		t.Errorf("pass = %q, want %q", pass, "hunter2")
+	}
+}
+
+func TestResolveEncryptPassphrase_EmptyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty.txt")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cmd := newTestEncryptCommand()
+	_ = cmd.Flags().Set("encrypt-passphrase-file", path)
+
+	if _, _, err := resolveEncryptPassphrase(cmd); err == nil {
+		t.Fatal("expected error for empty passphrase file, got nil")
+	}
+}
+
+func TestResolveEncryptPassphrase_FromEnv(t *testing.T) {
+	t.Setenv(encryptPassphraseEnv, "env-secret")
+	cmd := newTestEncryptCommand()
+	_ = cmd.Flags().Set("encrypt", "true")
+
+	pass, enabled, err := resolveEncryptPassphrase(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !enabled {
+		t.Error("enabled = false, want true")
+	}
+	if pass != "env-secret" {
+		t.Errorf("pass = %q, want %q", pass, "env-secret")
+	}
+}
+
+// TestResolveEncryptPassphrase_NonTTYNoSource verifies the loud-failure path:
+// encryption requested, no file and no env, and stdin is not a terminal (as
+// in `go test`), so it must return an error rather than block on a prompt.
+func TestResolveEncryptPassphrase_NonTTYNoSource(t *testing.T) {
+	// Ensure the env var is unset for this test regardless of the outer env.
+	t.Setenv(encryptPassphraseEnv, "")
+	cmd := newTestEncryptCommand()
+	_ = cmd.Flags().Set("encrypt", "true")
+
+	_, _, err := resolveEncryptPassphrase(cmd)
+	if err == nil {
+		t.Fatal("expected an error when no passphrase source and no TTY, got nil")
+	}
+	if !strings.Contains(err.Error(), "no passphrase provided") {
+		t.Errorf("error = %q, want it to mention no passphrase provided", err)
+	}
+}

--- a/cmd/encrypt_flags_test.go
+++ b/cmd/encrypt_flags_test.go
@@ -83,15 +83,30 @@ func TestResolveEncryptPassphrase_FromEnv(t *testing.T) {
 }
 
 // TestResolveEncryptPassphrase_NonTTYNoSource verifies the loud-failure path:
-// encryption requested, no file and no env, and stdin is not a terminal (as
-// in `go test`), so it must return an error rather than block on a prompt.
+// encryption requested, no file and no env, and stdin is not a terminal, so
+// it must return an error rather than block on a prompt.
 func TestResolveEncryptPassphrase_NonTTYNoSource(t *testing.T) {
 	// Ensure the env var is unset for this test regardless of the outer env.
 	t.Setenv(encryptPassphraseEnv, "")
+
+	// Force stdin to a pipe (never a TTY) so the test is deterministic even
+	// when `go test` is run from an interactive terminal — otherwise
+	// term.IsTerminal could be true and the resolver would block on the
+	// interactive prompt.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
 	cmd := newTestEncryptCommand()
 	_ = cmd.Flags().Set("encrypt", "true")
 
-	_, _, err := resolveEncryptPassphrase(cmd)
+	_, _, err = resolveEncryptPassphrase(cmd)
 	if err == nil {
 		t.Fatal("expected an error when no passphrase source and no TTY, got nil")
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
+	golang.org/x/term v0.44.0
 	gopkg.in/evanphx/json-patch.v4 v4.13.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.3
@@ -51,7 +52,6 @@ require (
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -93,6 +93,7 @@ type StreamWriter struct {
 	n       int
 	bytes   int64          // running total of uncompressed record JSON bytes
 	pathSeq map[string]int // apiPath → next seq number for that path's directory
+	closed  bool           // set once Finish or Abort has run the close sequence
 }
 
 // NewStreamWriter creates a new StreamWriter writing to outputPath.
@@ -209,6 +210,10 @@ func (w *StreamWriter) Finish(meta, index, watchIndex any) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
+	if w.closed {
+		return fmt.Errorf("archive writer already closed")
+	}
+
 	// metadata.json stored uncompressed for fast header reads.
 	if meta != nil {
 		b, err := json.MarshalIndent(meta, "", "  ")
@@ -229,6 +234,7 @@ func (w *StreamWriter) Finish(meta, index, watchIndex any) error {
 			return err
 		}
 	}
+	w.closed = true
 	// Close the layers from outermost to innermost, but always attempt every
 	// close so a failure partway through can't leak the file descriptor: zw
 	// wraps ageW (when encrypting) which wraps f. Return the first error.
@@ -245,6 +251,30 @@ func (w *StreamWriter) Finish(meta, index, watchIndex any) error {
 		firstErr = fmt.Errorf("closing output file: %w", err)
 	}
 	return firstErr
+}
+
+// Abort releases the writer's underlying handles without finalizing the
+// archive. It is a no-op once Finish (or a prior Abort) has run, so it is safe
+// to defer as error-path cleanup alongside a normal Finish. Closing the file
+// handle also lets the caller remove or rename a partially-written output
+// (e.g. capture's ".redacting" temp) on platforms where an open handle blocks
+// that (Windows).
+func (w *StreamWriter) Abort() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+	// Best-effort close of each layer. zw.Close may error (e.g. nothing
+	// written yet); we still close the remaining layers and only surface the
+	// file-close error, which is the one that matters for handle release.
+	_ = w.zw.Close()
+	if w.ageW != nil {
+		_ = w.ageW.Close()
+	}
+	return w.f.Close()
 }
 
 // RecordCount returns the number of records written so far.

--- a/internal/capture/encrypt_test.go
+++ b/internal/capture/encrypt_test.go
@@ -6,12 +6,30 @@ import (
 	"testing"
 	"time"
 
+	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/config"
 )
 
 // encryptTestPassphrase is a fixed test-only passphrase; not a real secret.
 const encryptTestPassphrase = "capture-encrypt-test-passphrase" //nolint:gosec // test fixture
+
+// fastScryptRecipients builds a passphrase recipient with a deliberately low
+// scrypt work factor. The production default (logN=18) is CPU-heavy and, when
+// several package test binaries run in parallel under CI, can starve the
+// capture goroutines enough that the short poll window elapses with no
+// records — making an otherwise-correct round-trip test flaky. Decryption
+// reads the work factor from the file header, so the standard passphrase
+// identity still decrypts these archives.
+func fastScryptRecipients(t *testing.T, passphrase string) []age.Recipient {
+	t.Helper()
+	r, err := age.NewScryptRecipient(passphrase)
+	if err != nil {
+		t.Fatalf("NewScryptRecipient: %v", err)
+	}
+	r.SetWorkFactor(10)
+	return []age.Recipient{r}
+}
 
 // TestEngine_CaptureEncrypted verifies that a capture run with encryption
 // recipients writes an age-encrypted archive: a plain Open must fail because
@@ -31,13 +49,8 @@ func TestEngine_CaptureEncrypted(t *testing.T) {
 		},
 	}
 
-	recipients, err := archive.RecipientsFromPassphrase(encryptTestPassphrase)
-	if err != nil {
-		t.Fatalf("RecipientsFromPassphrase: %v", err)
-	}
-
 	eng := newEngineWith(cfg, fake.Client(), fake.URL, false)
-	eng.SetEncryption(recipients)
+	eng.SetEncryption(fastScryptRecipients(t, encryptTestPassphrase))
 	if _, err := eng.Run(); err != nil {
 		t.Fatalf("engine.Run() error: %v", err)
 	}
@@ -92,12 +105,8 @@ func TestEngine_CaptureEncrypted_WrongPassphrase(t *testing.T) {
 			{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "500ms", Interval: 500 * time.Millisecond},
 		},
 	}
-	recipients, err := archive.RecipientsFromPassphrase(encryptTestPassphrase)
-	if err != nil {
-		t.Fatalf("RecipientsFromPassphrase: %v", err)
-	}
 	eng := newEngineWith(cfg, fake.Client(), fake.URL, false)
-	eng.SetEncryption(recipients)
+	eng.SetEncryption(fastScryptRecipients(t, encryptTestPassphrase))
 	if _, err := eng.Run(); err != nil {
 		t.Fatalf("engine.Run() error: %v", err)
 	}

--- a/internal/capture/encrypt_test.go
+++ b/internal/capture/encrypt_test.go
@@ -1,0 +1,112 @@
+package capture
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/config"
+)
+
+// encryptTestPassphrase is a fixed test-only passphrase; not a real secret.
+const encryptTestPassphrase = "capture-encrypt-test-passphrase" //nolint:gosec // test fixture
+
+// TestEngine_CaptureEncrypted verifies that a capture run with encryption
+// recipients writes an age-encrypted archive: a plain Open must fail because
+// the archive is encrypted, OpenWithIdentities with the matching passphrase
+// must succeed, and the decrypted metadata must record Encrypted=true.
+func TestEngine_CaptureEncrypted(t *testing.T) {
+	fake := fakeK8sServer(t)
+	defer fake.Close()
+
+	outFile := filepath.Join(t.TempDir(), "capture.kshrk")
+	cfg := &config.Config{
+		DurationRaw: "2s",
+		Duration:    2 * time.Second,
+		Output:      outFile,
+		Resources: []config.Resource{
+			{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "500ms", Interval: 500 * time.Millisecond},
+		},
+	}
+
+	recipients, err := archive.RecipientsFromPassphrase(encryptTestPassphrase)
+	if err != nil {
+		t.Fatalf("RecipientsFromPassphrase: %v", err)
+	}
+
+	eng := newEngineWith(cfg, fake.Client(), fake.URL, false)
+	eng.SetEncryption(recipients)
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	if fi, err := os.Stat(outFile); err != nil || fi.Size() == 0 {
+		t.Fatalf("output archive missing or empty: %v", err)
+	}
+
+	// A plain Open must refuse the encrypted archive with a clear message.
+	if _, err := archive.Open(outFile); err == nil {
+		t.Fatal("archive.Open on encrypted capture succeeded, want error")
+	}
+
+	identities, err := archive.IdentitiesFromPassphrase(encryptTestPassphrase)
+	if err != nil {
+		t.Fatalf("IdentitiesFromPassphrase: %v", err)
+	}
+	ar, err := archive.OpenWithIdentities(outFile, identities)
+	if err != nil {
+		t.Fatalf("OpenWithIdentities: %v", err)
+	}
+	defer ar.Close()
+
+	var meta CaptureMetadata
+	if err := ar.ReadMetadata(&meta); err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if !meta.Encrypted {
+		t.Error("decrypted metadata.Encrypted = false, want true")
+	}
+	var idx Index
+	if err := ar.ReadIndex(&idx); err != nil {
+		t.Fatalf("ReadIndex: %v", err)
+	}
+	if _, ok := idx["/api/v1/namespaces/default/pods"]; !ok {
+		t.Error("pod path missing from decrypted index")
+	}
+}
+
+// TestEngine_CaptureEncrypted_WrongPassphrase confirms that opening an
+// encrypted capture with the wrong passphrase fails with a clean message.
+func TestEngine_CaptureEncrypted_WrongPassphrase(t *testing.T) {
+	fake := fakeK8sServer(t)
+	defer fake.Close()
+
+	outFile := filepath.Join(t.TempDir(), "capture.kshrk")
+	cfg := &config.Config{
+		DurationRaw: "1s",
+		Duration:    1 * time.Second,
+		Output:      outFile,
+		Resources: []config.Resource{
+			{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "500ms", Interval: 500 * time.Millisecond},
+		},
+	}
+	recipients, err := archive.RecipientsFromPassphrase(encryptTestPassphrase)
+	if err != nil {
+		t.Fatalf("RecipientsFromPassphrase: %v", err)
+	}
+	eng := newEngineWith(cfg, fake.Client(), fake.URL, false)
+	eng.SetEncryption(recipients)
+	if _, err := eng.Run(); err != nil {
+		t.Fatalf("engine.Run() error: %v", err)
+	}
+
+	wrong, err := archive.IdentitiesFromPassphrase("not-the-passphrase")
+	if err != nil {
+		t.Fatalf("IdentitiesFromPassphrase: %v", err)
+	}
+	if _, err := archive.OpenWithIdentities(outFile, wrong); err == nil {
+		t.Fatal("OpenWithIdentities with wrong passphrase succeeded, want error")
+	}
+}

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -356,7 +356,10 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 		WatchEnabled:      anyWatchEnabled(e.cfg.Resources),
 		Intervals:         distinctIntervals(e.cfg.Resources),
 		UncompressedBytes: e.sink.UncompressedBytes(),
-		Encrypted:         len(e.recipients) > 0,
+		// Mirror the sink-selection condition: recipients are ignored for
+		// "-" (NDJSON to stdout), so the archive is only actually encrypted
+		// when writing to a file.
+		Encrypted: len(e.recipients) > 0 && e.cfg.Output != "-",
 	}
 
 	if e.verbose {

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -239,16 +239,22 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 	if e.sink == nil {
 		if e.cfg.Output == "-" {
 			e.sink = archive.NewNDJSONWriter(os.Stdout)
-		} else if len(e.recipients) > 0 {
-			e.sink, err = archive.NewEncryptedStreamWriter(e.cfg.Output, e.recipients)
-			if err != nil {
-				return nil, err
-			}
 		} else {
-			e.sink, err = archive.NewStreamWriter(e.cfg.Output)
+			var sw *archive.StreamWriter
+			if len(e.recipients) > 0 {
+				sw, err = archive.NewEncryptedStreamWriter(e.cfg.Output, e.recipients)
+			} else {
+				sw, err = archive.NewStreamWriter(e.cfg.Output)
+			}
 			if err != nil {
 				return nil, err
 			}
+			e.sink = sw
+			// Release the writer's file handle on any early-return error path
+			// between here and Finish (e.g. namespace expansion or watch
+			// validation below). Abort is a no-op once Finish has run, so the
+			// success path is unaffected.
+			defer func() { _ = sw.Abort() }()
 		}
 	}
 

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"filippo.io/age"
 	"github.com/google/uuid"
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/config"
@@ -97,6 +98,10 @@ type Engine struct {
 	index      Index
 	watchIndex WatchIndex
 	sink       archive.RecordSink // set by Run(); exposed for tests
+	// recipients, when non-empty, makes Run() write the output archive as an
+	// age-encrypted envelope. Set via SetEncryption before Run(). Ignored when
+	// output is "-" (NDJSON streaming to stdout is never encrypted).
+	recipients []age.Recipient
 	// pollPasses, when non-zero, makes pollResource fetch exactly this many
 	// times back-to-back instead of waiting on a real time.Ticker paced by
 	// res.Interval and bounded by the capture context's timeout (e.cfg.Duration).
@@ -171,6 +176,14 @@ func NewEngine(cfg *config.Config, verbose bool) (*Engine, error) {
 	}, nil
 }
 
+// SetEncryption makes Run() write the output archive as an age-encrypted
+// envelope to the given recipients. It must be called before Run(). Passing
+// no recipients leaves the archive unencrypted. Has no effect when output is
+// "-" (NDJSON streaming to stdout is never encrypted).
+func (e *Engine) SetEncryption(recipients []age.Recipient) {
+	e.recipients = recipients
+}
+
 // newEngineWith constructs an Engine with a pre-built HTTP client and base URL.
 // Used in tests to inject a fake API server.
 func newEngineWith(cfg *config.Config, client *http.Client, baseURL string, verbose bool) *Engine {
@@ -226,6 +239,11 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 	if e.sink == nil {
 		if e.cfg.Output == "-" {
 			e.sink = archive.NewNDJSONWriter(os.Stdout)
+		} else if len(e.recipients) > 0 {
+			e.sink, err = archive.NewEncryptedStreamWriter(e.cfg.Output, e.recipients)
+			if err != nil {
+				return nil, err
+			}
 		} else {
 			e.sink, err = archive.NewStreamWriter(e.cfg.Output)
 			if err != nil {
@@ -338,6 +356,7 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 		WatchEnabled:      anyWatchEnabled(e.cfg.Resources),
 		Intervals:         distinctIntervals(e.cfg.Resources),
 		UncompressedBytes: e.sink.UncompressedBytes(),
+		Encrypted:         len(e.recipients) > 0,
 	}
 
 	if e.verbose {

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -369,7 +369,13 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 	}
 
 	if e.verbose {
-		fmt.Fprintf(os.Stdout, "  captured %d records\n", e.sink.RecordCount())
+		// When records stream to stdout as NDJSON, keep stdout pure and send
+		// this diagnostic to stderr instead.
+		w := os.Stdout
+		if e.cfg.Output == "-" {
+			w = os.Stderr
+		}
+		fmt.Fprintf(w, "  captured %d records\n", e.sink.RecordCount())
 	}
 
 	if err := e.sink.Finish(meta, e.index, e.watchIndex); err != nil {

--- a/internal/capture/record.go
+++ b/internal/capture/record.go
@@ -63,7 +63,7 @@ type CaptureMetadata struct {
 	Redacted          bool     `json:"redacted,omitempty"`
 	SecretsRedacted   int      `json:"secrets_redacted,omitempty"`
 	FieldsRedacted    int      `json:"fields_redacted,omitempty"`
-	// Encrypted records that the archive was written as an encrypted (age)
+	// Encrypted is true when the archive was written as an encrypted (age)
 	// envelope. It is informational only: encryption is detected structurally
 	// by sniffing the file, not from this field (which lives inside the
 	// ciphertext and so is only readable after decryption). Omitted for

--- a/internal/capture/record.go
+++ b/internal/capture/record.go
@@ -63,6 +63,12 @@ type CaptureMetadata struct {
 	Redacted          bool     `json:"redacted,omitempty"`
 	SecretsRedacted   int      `json:"secrets_redacted,omitempty"`
 	FieldsRedacted    int      `json:"fields_redacted,omitempty"`
+	// Encrypted records that the archive was written as an encrypted (age)
+	// envelope. It is informational only: encryption is detected structurally
+	// by sniffing the file, not from this field (which lives inside the
+	// ciphertext and so is only readable after decryption). Omitted for
+	// plaintext archives.
+	Encrypted bool `json:"encrypted,omitempty"`
 }
 
 // IndexEntry maps an API path to the ordered list of record sequence numbers.

--- a/internal/redact/encrypt_test.go
+++ b/internal/redact/encrypt_test.go
@@ -49,6 +49,10 @@ func buildEncryptedArchive(t *testing.T, records []*capture.Record, recipients [
 	if err != nil {
 		t.Fatalf("buildEncryptedArchive NewEncryptedStreamWriter: %v", err)
 	}
+	// Release the file handle even if a WriteRecord/Finish below t.Fatalf's,
+	// so TempDir cleanup can't be blocked by an open file. Abort is a no-op
+	// after a successful Finish.
+	defer func() { _ = sw.Abort() }()
 	for _, r := range records {
 		if err := sw.WriteRecord(r); err != nil {
 			t.Fatalf("buildEncryptedArchive WriteRecord: %v", err)

--- a/internal/redact/encrypt_test.go
+++ b/internal/redact/encrypt_test.go
@@ -1,0 +1,137 @@
+package redact
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"filippo.io/age"
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// redactEncryptTestPassphrase is a fixed test-only passphrase; not a real secret.
+const redactEncryptTestPassphrase = "redact-encrypt-test-passphrase" //nolint:gosec // test fixture
+
+// buildEncryptedArchive mirrors buildTestArchive but writes the records as an
+// age-encrypted archive using recipients.
+func buildEncryptedArchive(t *testing.T, records []*capture.Record, recipients []age.Recipient) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	idx := capture.Index{}
+	pathSeq := map[string]int{}
+	for _, r := range records {
+		seq := pathSeq[r.APIPath]
+		pathSeq[r.APIPath] = seq + 1
+		e := idx[r.APIPath]
+		if e == nil {
+			e = &capture.IndexEntry{APIPath: r.APIPath}
+			idx[r.APIPath] = e
+		}
+		e.Seqs = append(e.Seqs, seq)
+		e.Times = append(e.Times, r.CapturedAt)
+	}
+
+	meta := &capture.CaptureMetadata{
+		CaptureID:     "test-id",
+		CapturedAt:    time.Now().Add(-time.Minute),
+		CapturedUntil: time.Now(),
+		RecordCount:   len(records),
+		Encrypted:     true,
+	}
+
+	outPath := filepath.Join(dir, "test.kshrk")
+	sw, err := archive.NewEncryptedStreamWriter(outPath, recipients)
+	if err != nil {
+		t.Fatalf("buildEncryptedArchive NewEncryptedStreamWriter: %v", err)
+	}
+	for _, r := range records {
+		if err := sw.WriteRecord(r); err != nil {
+			t.Fatalf("buildEncryptedArchive WriteRecord: %v", err)
+		}
+	}
+	if err := sw.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("buildEncryptedArchive Finish: %v", err)
+	}
+	return outPath
+}
+
+// TestRedact_EncryptedRoundTrip redacts an encrypted source archive in place:
+// the source is decrypted with Identities, redacted, and re-encrypted with
+// Recipients. The redacted output must itself be encrypted (a plain Open
+// fails) and, once decrypted, must have the Secret value scrubbed and record
+// Encrypted=true.
+func TestRedact_EncryptedRoundTrip(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("my-password"))
+	records := []*capture.Record{
+		secretRecord("r1", "default", "db-creds", map[string]string{"password": encoded}, nil),
+	}
+
+	recipients, err := archive.RecipientsFromPassphrase(redactEncryptTestPassphrase)
+	if err != nil {
+		t.Fatalf("RecipientsFromPassphrase: %v", err)
+	}
+	identities, err := archive.IdentitiesFromPassphrase(redactEncryptTestPassphrase)
+	if err != nil {
+		t.Fatalf("IdentitiesFromPassphrase: %v", err)
+	}
+
+	src := buildEncryptedArchive(t, records, recipients)
+	dst := src + "-redacted.kshrk"
+	t.Cleanup(func() { os.Remove(dst) })
+
+	result, err := Archive(src, dst, Options{
+		RedactSecrets: true,
+		Identities:    identities,
+		Recipients:    recipients,
+	})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if result.SecretsRedacted != 1 {
+		t.Errorf("expected 1 redacted record, got %d", result.SecretsRedacted)
+	}
+
+	// Output must be encrypted: a plain Open fails.
+	if _, err := archive.Open(dst); err == nil {
+		t.Fatal("archive.Open on redacted encrypted archive succeeded, want error")
+	}
+
+	ar, err := archive.OpenWithIdentities(dst, identities)
+	if err != nil {
+		t.Fatalf("OpenWithIdentities: %v", err)
+	}
+	defer ar.Close()
+
+	var meta capture.CaptureMetadata
+	if err := ar.ReadMetadata(&meta); err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if !meta.Encrypted {
+		t.Error("redacted metadata.Encrypted = false, want true")
+	}
+	if !meta.Redacted {
+		t.Error("redacted metadata.Redacted = false, want true")
+	}
+
+	data, err := ar.ReadRecord("/api/v1/namespaces/default/secrets", 0)
+	if err != nil {
+		t.Fatalf("ReadRecord: %v", err)
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatalf("parsing record: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	_ = json.Unmarshal(rec.ResponseBody, &obj)
+	var dataMap map[string]string
+	_ = json.Unmarshal(obj["data"], &dataMap)
+	want := base64.StdEncoding.EncodeToString([]byte("REDACTED"))
+	if dataMap["password"] != want {
+		t.Errorf("data[password] = %q, want %q", dataMap["password"], want)
+	}
+}

--- a/internal/redact/encrypt_test.go
+++ b/internal/redact/encrypt_test.go
@@ -71,10 +71,14 @@ func TestRedact_EncryptedRoundTrip(t *testing.T) {
 		secretRecord("r1", "default", "db-creds", map[string]string{"password": encoded}, nil),
 	}
 
-	recipients, err := archive.RecipientsFromPassphrase(redactEncryptTestPassphrase)
+	// Low scrypt work factor keeps the test fast; decryption reads the factor
+	// from the file header, so the standard passphrase identity still works.
+	scryptR, err := age.NewScryptRecipient(redactEncryptTestPassphrase)
 	if err != nil {
-		t.Fatalf("RecipientsFromPassphrase: %v", err)
+		t.Fatalf("NewScryptRecipient: %v", err)
 	}
+	scryptR.SetWorkFactor(10)
+	recipients := []age.Recipient{scryptR}
 	identities, err := archive.IdentitiesFromPassphrase(redactEncryptTestPassphrase)
 	if err != nil {
 		t.Fatalf("IdentitiesFromPassphrase: %v", err)

--- a/internal/redact/encrypt_test.go
+++ b/internal/redact/encrypt_test.go
@@ -127,9 +127,13 @@ func TestRedact_EncryptedRoundTrip(t *testing.T) {
 		t.Fatalf("parsing record: %v", err)
 	}
 	var obj map[string]json.RawMessage
-	_ = json.Unmarshal(rec.ResponseBody, &obj)
+	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+		t.Fatalf("parsing response body: %v", err)
+	}
 	var dataMap map[string]string
-	_ = json.Unmarshal(obj["data"], &dataMap)
+	if err := json.Unmarshal(obj["data"], &dataMap); err != nil {
+		t.Fatalf("parsing secret data: %v", err)
+	}
 	want := base64.StdEncoding.EncodeToString([]byte("REDACTED"))
 	if dataMap["password"] != want {
 		t.Errorf("data[password] = %q, want %q", dataMap["password"], want)

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -81,6 +81,10 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	if err != nil {
 		return Result{}, fmt.Errorf("creating output archive: %w", err)
 	}
+	// Ensure the output writer's file handle is released if we return early
+	// (e.g. a malformed record) before Finish. Abort is a no-op once Finish
+	// has run, so the success path is unaffected.
+	defer func() { _ = sw.Abort() }()
 
 	// newIdx / newWI will be built with corrected seq numbers as we write.
 	newIdx := make(capture.Index, len(idx))

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
 	"github.com/phenixblue/k8shark/internal/config"
@@ -25,6 +26,14 @@ type Options struct {
 	AllowList map[string]bool
 	// Rules is the list of field-level redaction rules to apply to every record.
 	Rules []config.RedactionRule
+	// Identities, when non-empty, are used to decrypt an encrypted source
+	// archive before redacting. Required when srcPath is an encrypted archive.
+	Identities []age.Identity
+	// Recipients, when non-empty, cause the redacted output archive to be
+	// written as an age-encrypted envelope. Typically the caller supplies both
+	// Identities and Recipients derived from the same passphrase so a redacted
+	// encrypted archive stays encrypted.
+	Recipients []age.Recipient
 }
 
 // Result reports how many redactions were performed.
@@ -36,7 +45,7 @@ type Result struct {
 // Archive reads srcPath, applies redaction options, and writes to dstPath.
 // The original archive is not modified.
 func Archive(srcPath, dstPath string, opts Options) (Result, error) {
-	ar, err := archive.Open(srcPath)
+	ar, err := archive.OpenWithIdentities(srcPath, opts.Identities)
 	if err != nil {
 		return Result{}, fmt.Errorf("opening archive: %w", err)
 	}
@@ -63,7 +72,12 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 
 	result := Result{}
 
-	sw, err := archive.NewStreamWriter(dstPath)
+	var sw *archive.StreamWriter
+	if len(opts.Recipients) > 0 {
+		sw, err = archive.NewEncryptedStreamWriter(dstPath, opts.Recipients)
+	} else {
+		sw, err = archive.NewStreamWriter(dstPath)
+	}
 	if err != nil {
 		return Result{}, fmt.Errorf("creating output archive: %w", err)
 	}
@@ -163,6 +177,7 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	meta.Redacted = true
 	meta.SecretsRedacted = result.SecretsRedacted
 	meta.FieldsRedacted = result.FieldsRedacted
+	meta.Encrypted = len(opts.Recipients) > 0
 
 	if err := sw.Finish(&meta, newIdx, newWI); err != nil {
 		return Result{}, fmt.Errorf("finishing output archive: %w", err)


### PR DESCRIPTION
## Summary

Second milestone of optional archive encryption-at-rest ([#117](https://github.com/phenixblue/k8shark/issues/117)): **writer-side integration, passphrase only.** Builds on the M1 crypto core (#204) to make `kshrk capture --encrypt` produce an encrypted `.kshrk` archive. Public-key recipients come in M4; the read commands (`inspect`/`open`/`ui`/`diff`/…) get their own `--decrypt-*` flags in M3 — for now an encrypted archive is read back via the library API (which is what the tests exercise).

## What's in this PR

- **New flags on `capture`:** `--encrypt` and `--encrypt-passphrase-file <path>`. Encryption is enabled when either is given.
- **Passphrase resolution** (priority order): the file → `$KSHRK_ENCRYPT_PASSPHRASE` → interactive TTY prompt with confirmation. Resolved *before* the (potentially long) capture starts, so a bad/missing passphrase fails fast rather than after minutes of polling. When encryption is requested with no passphrase source and stdin isn't a terminal, it **fails loudly** instead of hanging on an unanswerable prompt.
- **Secrets stay out of config:** the env var is read via `os.Getenv` directly and the flags are deliberately *not* `viper.BindPFlag`'d, so passphrase material can never be bound from — or leak into — `config.yaml`. (This is the hard rule that'll be documented in M5's threat model.)
- **Engine wiring:** `Engine.SetEncryption(recipients)` threads recipients into `Run()`, which now uses `archive.NewEncryptedStreamWriter` for on-disk output. `--output -` (NDJSON to stdout) is never encrypted and is rejected in combination with `--encrypt`.
- **Redaction stays encrypted end to end:** `capture --encrypt --redact-secrets` works — `redact.Options` gains `Identities`/`Recipients` so the post-capture pass decrypts, redacts, and re-encrypts with the same passphrase, with **no plaintext intermediate on disk** (the `.redacting` temp is itself encrypted).
- **Metadata:** `CaptureMetadata` gains an informational `encrypted` (`omitempty`) field. Additive — **no `format_version` bump**. Encryption is still detected structurally by sniffing the file header, not from this field (which lives inside the ciphertext).

## Tests

- `internal/capture/encrypt_test.go` — capture round-trip (encrypted write → plain `Open` refuses it → `OpenWithIdentities` succeeds → `metadata.Encrypted == true` → index intact), plus wrong-passphrase failure. Runs through the production engine against the existing fake API server.
- `internal/redact/encrypt_test.go` — redact an encrypted archive in place: output is encrypted (plain `Open` fails), decrypts to a scrubbed Secret with `Encrypted`+`Redacted` both set.
- `cmd/encrypt_flags_test.go` — passphrase resolution: file (trailing newline trimmed), empty file rejected, env var, and the non-TTY loud-failure path.

Verified locally: `make fmt`, `make lint-ci`, full `make test`, and `go mod tidy` (idempotent — `golang.org/x/term` promoted to a direct dep) all clean.

## Note for reviewers

Does **not** close #117 — this is M2 of 5. A full binary capture needs a live cluster; the fake-API-server engine tests stand in for that and exercise the real encrypt-write → decrypt-read path through the archive code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)