### PR TITLE
feat(cli): decrypt encrypted archives across all read commands (M3 of #117)

### DIFF
--- a/cmd/decrypt_flags.go
+++ b/cmd/decrypt_flags.go
@@ -25,16 +25,18 @@ func addDecryptFlags(cmd *cobra.Command) {
 	_ = cmd.MarkPersistentFlagFilename("decrypt-identity-file")
 }
 
-// resolveDecryptIdentities returns the age identities needed to open the
-// archive at path, or nil when no key is required. Key material is gathered
+// resolveDecryptIdentities returns the age identities needed to open the given
+// archive path(s), or nil when no key is required. Key material is gathered
 // from --decrypt-identity-file, --decrypt-passphrase-file, and
 // $KSHRK_DECRYPT_PASSPHRASE (all optional and combinable — age tries each
-// identity until one succeeds). When none is supplied, it peeks whether path
-// is encrypted: a plaintext archive needs no key (returns nil, so plaintext
-// archives open with zero interaction), while an encrypted one triggers an
-// interactive passphrase prompt on a TTY, or a clear error when stdin is not a
-// terminal (rather than hanging on an unanswerable prompt).
-func resolveDecryptIdentities(cmd *cobra.Command, path string) ([]age.Identity, error) {
+// identity until one succeeds). When none is supplied, it peeks whether any
+// path is encrypted: if none are, no key is needed (returns nil, so plaintext
+// archives open with zero interaction); if any is, it triggers an interactive
+// passphrase prompt on a TTY, or a clear error when stdin is not a terminal
+// (rather than hanging on an unanswerable prompt). Multiple paths matter for
+// diff, where a single shared key covers both archives and either side may be
+// the encrypted one.
+func resolveDecryptIdentities(cmd *cobra.Command, paths ...string) ([]age.Identity, error) {
 	passphraseFile, _ := cmd.Flags().GetString("decrypt-passphrase-file")
 	identityFile, _ := cmd.Flags().GetString("decrypt-identity-file")
 
@@ -70,22 +72,30 @@ func resolveDecryptIdentities(cmd *cobra.Command, path string) ([]age.Identity, 
 		return identities, nil
 	}
 
-	// No explicit key was given: only prompt if the archive actually needs
-	// one, so plaintext archives (the common case) open untouched.
-	encrypted, err := archive.IsEncrypted(path)
-	if err != nil {
-		// A stat/read failure here (e.g. missing file) is better surfaced by
-		// the subsequent open with its own clear message; don't preempt it.
-		return nil, nil //nolint:nilerr // intentional: defer the error to Open
+	// No explicit key was given: only prompt if some archive actually needs
+	// one, so plaintext archives (the common case) open untouched. In
+	// two-archive diff mode either side may be the encrypted one, so check
+	// them all and prompt against the first encrypted path.
+	encPath := ""
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		// A stat/read failure here (e.g. a missing file) is better surfaced by
+		// the subsequent open with its own clear message; skip it.
+		if enc, err := archive.IsEncrypted(p); err == nil && enc {
+			encPath = p
+			break
+		}
 	}
-	if !encrypted {
+	if encPath == "" {
 		return nil, nil
 	}
 
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
-		return nil, fmt.Errorf("archive %q is encrypted: provide --decrypt-passphrase-file, --decrypt-identity-file, or $%s (an interactive prompt requires a terminal)", path, decryptPassphraseEnv)
+		return nil, fmt.Errorf("archive %q is encrypted: provide --decrypt-passphrase-file, --decrypt-identity-file, or $%s (an interactive prompt requires a terminal)", encPath, decryptPassphraseEnv)
 	}
-	pass, err := promptDecryptPassphrase(cmd, path)
+	pass, err := promptDecryptPassphrase(cmd, encPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/decrypt_flags.go
+++ b/cmd/decrypt_flags.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"filippo.io/age"
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+// decryptPassphraseEnv is the environment variable consulted for the passphrase
+// to decrypt an encrypted archive when no --decrypt-passphrase-file is given.
+// It is read directly via os.Getenv, never through Viper, so secret material
+// can never be bound from (or leak into) the YAML config file.
+const decryptPassphraseEnv = "KSHRK_DECRYPT_PASSPHRASE"
+
+// addDecryptFlags registers the read-side decryption flags as persistent flags
+// on cmd, so every archive-reading subcommand accepts them.
+func addDecryptFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().String("decrypt-passphrase-file", "", "read the passphrase for an encrypted archive from this file (first line)")
+	cmd.PersistentFlags().String("decrypt-identity-file", "", "age identity (key) file to decrypt an encrypted archive")
+	_ = cmd.MarkPersistentFlagFilename("decrypt-passphrase-file")
+	_ = cmd.MarkPersistentFlagFilename("decrypt-identity-file")
+}
+
+// resolveDecryptIdentities returns the age identities needed to open the
+// archive at path, or nil when no key is required. Key material is gathered
+// from --decrypt-identity-file, --decrypt-passphrase-file, and
+// $KSHRK_DECRYPT_PASSPHRASE (all optional and combinable — age tries each
+// identity until one succeeds). When none is supplied, it peeks whether path
+// is encrypted: a plaintext archive needs no key (returns nil, so plaintext
+// archives open with zero interaction), while an encrypted one triggers an
+// interactive passphrase prompt on a TTY, or a clear error when stdin is not a
+// terminal (rather than hanging on an unanswerable prompt).
+func resolveDecryptIdentities(cmd *cobra.Command, path string) ([]age.Identity, error) {
+	passphraseFile, _ := cmd.Flags().GetString("decrypt-passphrase-file")
+	identityFile, _ := cmd.Flags().GetString("decrypt-identity-file")
+
+	var identities []age.Identity
+
+	if identityFile != "" {
+		ids, err := parseIdentityFile(identityFile)
+		if err != nil {
+			return nil, err
+		}
+		identities = append(identities, ids...)
+	}
+
+	passphrase := ""
+	if passphraseFile != "" {
+		p, err := readPassphraseFile(passphraseFile)
+		if err != nil {
+			return nil, err
+		}
+		passphrase = p
+	} else if env := os.Getenv(decryptPassphraseEnv); env != "" {
+		passphrase = env
+	}
+	if passphrase != "" {
+		ids, err := archive.IdentitiesFromPassphrase(passphrase)
+		if err != nil {
+			return nil, err
+		}
+		identities = append(identities, ids...)
+	}
+
+	if len(identities) > 0 {
+		return identities, nil
+	}
+
+	// No explicit key was given: only prompt if the archive actually needs
+	// one, so plaintext archives (the common case) open untouched.
+	encrypted, err := archive.IsEncrypted(path)
+	if err != nil {
+		// A stat/read failure here (e.g. missing file) is better surfaced by
+		// the subsequent open with its own clear message; don't preempt it.
+		return nil, nil //nolint:nilerr // intentional: defer the error to Open
+	}
+	if !encrypted {
+		return nil, nil
+	}
+
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return nil, fmt.Errorf("archive %q is encrypted: provide --decrypt-passphrase-file, --decrypt-identity-file, or $%s (an interactive prompt requires a terminal)", path, decryptPassphraseEnv)
+	}
+	pass, err := promptDecryptPassphrase(cmd, path)
+	if err != nil {
+		return nil, err
+	}
+	return archive.IdentitiesFromPassphrase(pass)
+}
+
+// parseIdentityFile parses an age identity (key) file into identities.
+func parseIdentityFile(path string) ([]age.Identity, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening identity file %q: %w", path, err)
+	}
+	defer f.Close()
+	ids, err := age.ParseIdentities(f)
+	if err != nil {
+		return nil, fmt.Errorf("parsing identity file %q: %w", path, err)
+	}
+	return ids, nil
+}
+
+// promptDecryptPassphrase reads a single passphrase from the terminal (no
+// confirmation — the user is supplying an existing key, not setting a new
+// one). The prompt goes to stderr so it never corrupts machine-readable
+// stdout, and the typed characters are not echoed.
+func promptDecryptPassphrase(cmd *cobra.Command, path string) (string, error) {
+	out := cmd.ErrOrStderr()
+	fmt.Fprintf(out, "Enter passphrase to decrypt %s: ", path)
+	pass, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Fprintln(out)
+	if err != nil {
+		return "", fmt.Errorf("reading passphrase: %w", err)
+	}
+	if len(pass) == 0 {
+		return "", fmt.Errorf("passphrase must not be empty")
+	}
+	return string(pass), nil
+}

--- a/cmd/decrypt_flags_test.go
+++ b/cmd/decrypt_flags_test.go
@@ -204,6 +204,38 @@ func TestResolveDecryptIdentities_EncryptedNonTTY(t *testing.T) {
 	}
 }
 
+// TestResolveDecryptIdentities_MultiPathEncryptedSecond guards the diff
+// two-archive case: when the first path is plaintext but a later one is
+// encrypted, the resolver must still detect the need for a key (here, error
+// on a non-TTY) rather than returning nil because only the first was checked.
+func TestResolveDecryptIdentities_MultiPathEncryptedSecond(t *testing.T) {
+	dir := t.TempDir()
+	plain := filepath.Join(dir, "plain.kshrk")
+	writePlaintextArchive(t, plain)
+	enc := filepath.Join(dir, "enc.kshrk")
+	writeEncryptedArchive(t, enc, "whatever")
+
+	t.Setenv(decryptPassphraseEnv, "")
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	cmd := newTestDecryptCommand()
+	_, err = resolveDecryptIdentities(cmd, plain, enc)
+	if err == nil {
+		t.Fatal("expected an error: second path is encrypted, no key, no TTY")
+	}
+	if !strings.Contains(err.Error(), "enc.kshrk") || !strings.Contains(err.Error(), "is encrypted") {
+		t.Errorf("error = %q, want it to name the encrypted (second) archive", err)
+	}
+}
+
 // TestResolveDecryptIdentities_WrongPassphrase confirms the resolver succeeds
 // (it can't know the key is wrong) but the subsequent open fails cleanly.
 func TestResolveDecryptIdentities_WrongPassphrase(t *testing.T) {

--- a/cmd/decrypt_flags_test.go
+++ b/cmd/decrypt_flags_test.go
@@ -1,0 +1,228 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"filippo.io/age"
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/spf13/cobra"
+)
+
+// newTestDecryptCommand builds a command carrying the persistent decrypt
+// flags (which live on the root command in production).
+func newTestDecryptCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	addDecryptFlags(cmd)
+	// PersistentFlags on a standalone command aren't merged into Flags() until
+	// execution, so expose them for GetString in these unit tests.
+	cmd.Flags().AddFlagSet(cmd.PersistentFlags())
+	return cmd
+}
+
+// writeEncryptedArchive writes a minimal passphrase-encrypted archive at path.
+func writeEncryptedArchive(t *testing.T, path, passphrase string) {
+	t.Helper()
+	r, err := age.NewScryptRecipient(passphrase)
+	if err != nil {
+		t.Fatalf("NewScryptRecipient: %v", err)
+	}
+	r.SetWorkFactor(10) // fast KDF for tests
+	sw, err := archive.NewEncryptedStreamWriter(path, []age.Recipient{r})
+	if err != nil {
+		t.Fatalf("NewEncryptedStreamWriter: %v", err)
+	}
+	rec := map[string]any{"id": "r1", "api_path": "/api/v1/nodes"}
+	if err := sw.WriteRecord(rec); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+	if err := sw.Finish(map[string]any{"capture_id": "enc"}, map[string]any{}, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+}
+
+func writePlaintextArchive(t *testing.T, path string) {
+	t.Helper()
+	sw, err := archive.NewStreamWriter(path)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	rec := map[string]any{"id": "r1", "api_path": "/api/v1/nodes"}
+	if err := sw.WriteRecord(rec); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+	if err := sw.Finish(map[string]any{"capture_id": "plain"}, map[string]any{}, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+}
+
+// TestResolveDecryptIdentities_PlaintextNeedsNoKey is the key regression guard:
+// a plaintext archive with no decrypt flags resolves to nil identities (no
+// prompt, no error) and opens normally.
+func TestResolveDecryptIdentities_PlaintextNeedsNoKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plain.kshrk")
+	writePlaintextArchive(t, path)
+
+	cmd := newTestDecryptCommand()
+	ids, err := resolveDecryptIdentities(cmd, path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ids != nil {
+		t.Errorf("identities = %v, want nil for a plaintext archive", ids)
+	}
+	// And it must actually open with those (nil) identities.
+	ar, err := archive.OpenWithIdentities(path, ids)
+	if err != nil {
+		t.Fatalf("OpenWithIdentities(plaintext): %v", err)
+	}
+	_ = ar.Close()
+}
+
+func TestResolveDecryptIdentities_PassphraseFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "enc.kshrk")
+	const pass = "decrypt-test-passphrase"
+	writeEncryptedArchive(t, path, pass)
+
+	passFile := filepath.Join(dir, "pass.txt")
+	if err := os.WriteFile(passFile, []byte(pass+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmd := newTestDecryptCommand()
+	_ = cmd.Flags().Set("decrypt-passphrase-file", passFile)
+
+	ids, err := resolveDecryptIdentities(cmd, path)
+	if err != nil {
+		t.Fatalf("resolveDecryptIdentities: %v", err)
+	}
+	ar, err := archive.OpenWithIdentities(path, ids)
+	if err != nil {
+		t.Fatalf("OpenWithIdentities: %v", err)
+	}
+	defer ar.Close()
+	var meta map[string]any
+	if err := ar.ReadMetadata(&meta); err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if meta["capture_id"] != "enc" {
+		t.Errorf("capture_id = %v, want enc", meta["capture_id"])
+	}
+}
+
+func TestResolveDecryptIdentities_Env(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "enc.kshrk")
+	const pass = "env-decrypt-passphrase"
+	writeEncryptedArchive(t, path, pass)
+
+	t.Setenv(decryptPassphraseEnv, pass)
+	cmd := newTestDecryptCommand()
+
+	ids, err := resolveDecryptIdentities(cmd, path)
+	if err != nil {
+		t.Fatalf("resolveDecryptIdentities: %v", err)
+	}
+	ar, err := archive.OpenWithIdentities(path, ids)
+	if err != nil {
+		t.Fatalf("OpenWithIdentities: %v", err)
+	}
+	_ = ar.Close()
+}
+
+// TestResolveDecryptIdentities_IdentityFile exercises the X25519 identity-file
+// path end to end, even before M4 adds CLI flags to write such archives: the
+// test encrypts to an X25519 recipient directly and decrypts via the parsed
+// identity file.
+func TestResolveDecryptIdentities_IdentityFile(t *testing.T) {
+	dir := t.TempDir()
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("GenerateX25519Identity: %v", err)
+	}
+	path := filepath.Join(dir, "enc.kshrk")
+	sw, err := archive.NewEncryptedStreamWriter(path, []age.Recipient{id.Recipient()})
+	if err != nil {
+		t.Fatalf("NewEncryptedStreamWriter: %v", err)
+	}
+	if err := sw.WriteRecord(map[string]any{"id": "r1", "api_path": "/api/v1/nodes"}); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+	if err := sw.Finish(map[string]any{"capture_id": "x25519"}, map[string]any{}, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	identFile := filepath.Join(dir, "key.txt")
+	if err := os.WriteFile(identFile, []byte(id.String()+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile identity: %v", err)
+	}
+
+	cmd := newTestDecryptCommand()
+	_ = cmd.Flags().Set("decrypt-identity-file", identFile)
+
+	ids, err := resolveDecryptIdentities(cmd, path)
+	if err != nil {
+		t.Fatalf("resolveDecryptIdentities: %v", err)
+	}
+	ar, err := archive.OpenWithIdentities(path, ids)
+	if err != nil {
+		t.Fatalf("OpenWithIdentities: %v", err)
+	}
+	_ = ar.Close()
+}
+
+// TestResolveDecryptIdentities_EncryptedNonTTY verifies the loud-failure path:
+// an encrypted archive, no key flags/env, and a non-TTY stdin must error
+// instead of blocking on a prompt.
+func TestResolveDecryptIdentities_EncryptedNonTTY(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "enc.kshrk")
+	writeEncryptedArchive(t, path, "whatever")
+
+	t.Setenv(decryptPassphraseEnv, "")
+
+	// Force stdin to a pipe so the terminal check is deterministic.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	cmd := newTestDecryptCommand()
+	_, err = resolveDecryptIdentities(cmd, path)
+	if err == nil {
+		t.Fatal("expected an error for an encrypted archive with no key and no TTY")
+	}
+	if !strings.Contains(err.Error(), "is encrypted") {
+		t.Errorf("error = %q, want it to mention the archive is encrypted", err)
+	}
+}
+
+// TestResolveDecryptIdentities_WrongPassphrase confirms the resolver succeeds
+// (it can't know the key is wrong) but the subsequent open fails cleanly.
+func TestResolveDecryptIdentities_WrongPassphrase(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "enc.kshrk")
+	writeEncryptedArchive(t, path, "correct-pass")
+
+	passFile := filepath.Join(dir, "pass.txt")
+	if err := os.WriteFile(passFile, []byte("wrong-pass"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cmd := newTestDecryptCommand()
+	_ = cmd.Flags().Set("decrypt-passphrase-file", passFile)
+
+	ids, err := resolveDecryptIdentities(cmd, path)
+	if err != nil {
+		t.Fatalf("resolveDecryptIdentities: %v", err)
+	}
+	if _, err := archive.OpenWithIdentities(path, ids); err == nil {
+		t.Fatal("OpenWithIdentities with wrong passphrase succeeded, want error")
+	}
+}

--- a/cmd/diagnose.go
+++ b/cmd/diagnose.go
@@ -56,7 +56,11 @@ func runDiagnose(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	ar, err := archive.Open(args[0])
+	identities, err := resolveDecryptIdentities(cmd, args[0])
+	if err != nil {
+		return err
+	}
+	ar, err := archive.OpenWithIdentities(args[0], identities)
 	if err != nil {
 		return fmt.Errorf("opening archive: %w", err)
 	}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -65,6 +65,17 @@ func runDiff(cmd *cobra.Command, _ []string) error {
 	namespace, _ := cmd.Flags().GetString("namespace")
 	output, _ := cmd.Flags().GetString("output")
 
+	// A single key source is shared across both archives (documented v1.0
+	// limitation). Peek/prompt against whichever archive path is set.
+	keyPath := archivePath
+	if keyPath == "" {
+		keyPath = beforeArchive
+	}
+	identities, err := resolveDecryptIdentities(cmd, keyPath)
+	if err != nil {
+		return err
+	}
+
 	result, err := diffpkg.Run(diffpkg.Options{
 		BeforeArchive: beforeArchive,
 		AfterArchive:  afterArchive,
@@ -73,6 +84,7 @@ func runDiff(cmd *cobra.Command, _ []string) error {
 		AfterAt:       afterAt,
 		Resource:      resource,
 		Namespace:     namespace,
+		Identities:    identities,
 	})
 	if err != nil {
 		return err

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -66,12 +66,9 @@ func runDiff(cmd *cobra.Command, _ []string) error {
 	output, _ := cmd.Flags().GetString("output")
 
 	// A single key source is shared across both archives (documented v1.0
-	// limitation). Peek/prompt against whichever archive path is set.
-	keyPath := archivePath
-	if keyPath == "" {
-		keyPath = beforeArchive
-	}
-	identities, err := resolveDecryptIdentities(cmd, keyPath)
+	// limitation). Pass every candidate path so an encrypted archive on either
+	// side triggers the prompt, even if the other side is plaintext.
+	identities, err := resolveDecryptIdentities(cmd, archivePath, beforeArchive, afterArchive)
 	if err != nil {
 		return err
 	}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -41,7 +41,11 @@ func init() {
 func runInspect(cmd *cobra.Command, args []string) error {
 	output, _ := cmd.Flags().GetString("output")
 
-	report, err := inspect.Run(args[0])
+	identities, err := resolveDecryptIdentities(cmd, args[0])
+	if err != nil {
+		return err
+	}
+	report, err := inspect.Run(args[0], identities)
 	if err != nil {
 		return err
 	}

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -42,12 +42,18 @@ func runOpen(cmd *cobra.Command, args []string) error {
 	at, _ := cmd.Flags().GetString("at")
 	verbose, _ := cmd.Root().PersistentFlags().GetBool("verbose")
 
+	identities, err := resolveDecryptIdentities(cmd, archivePath)
+	if err != nil {
+		return err
+	}
+
 	opts := server.OpenOptions{
 		ArchivePath:   archivePath,
 		Port:          port,
 		KubeconfigOut: kubeconfigOut,
 		At:            at,
 		Verbose:       verbose,
+		Identities:    identities,
 	}
 
 	srv, err := server.Open(opts)

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -63,7 +63,11 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--text and --regex are mutually exclusive")
 	}
 
-	ar, err := archive.Open(args[0])
+	identities, err := resolveDecryptIdentities(cmd, args[0])
+	if err != nil {
+		return err
+	}
+	ar, err := archive.OpenWithIdentities(args[0], identities)
 	if err != nil {
 		return fmt.Errorf("opening archive: %w", err)
 	}

--- a/cmd/redact.go
+++ b/cmd/redact.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"filippo.io/age"
+	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/config"
 	"github.com/phenixblue/k8shark/internal/redact"
 	"github.com/spf13/cobra"
@@ -45,6 +47,9 @@ func init() {
 	_ = redactCmd.MarkFlagFilename("in", captureExt)
 	_ = redactCmd.MarkFlagFilename("out", captureExt)
 	_ = redactCmd.MarkFlagFilename("config", configExts...)
+	// Write-side encryption for the redacted output (read-side --decrypt-* are
+	// persistent flags from the root command).
+	addEncryptFlags(redactCmd)
 }
 
 // parseRedactField parses a --redact-field flag value of the form:
@@ -118,10 +123,37 @@ func runRedact(cmd *cobra.Command, _ []string) error {
 		rules = append(rules, rule)
 	}
 
+	// Read-side: decrypt an encrypted source archive if a key was supplied.
+	identities, err := resolveDecryptIdentities(cmd, in)
+	if err != nil {
+		return err
+	}
+
+	// Write-side: optionally re-encrypt the redacted output.
+	passphrase, encrypt, err := resolveEncryptPassphrase(cmd)
+	if err != nil {
+		return err
+	}
+	var recipients []age.Recipient
+	if encrypt {
+		recipients, err = archive.RecipientsFromPassphrase(passphrase)
+		if err != nil {
+			return err
+		}
+	} else if srcEncrypted, _ := archive.IsEncrypted(in); srcEncrypted {
+		// The source is encrypted but no output encryption was requested — warn
+		// that the redacted copy will be written in plaintext so an encrypted
+		// capture isn't silently downgraded.
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"warning: source archive is encrypted but the redacted output %q will be written in plaintext; pass --encrypt to keep it encrypted\n", out)
+	}
+
 	result, err := redact.Archive(in, out, redact.Options{
 		RedactSecrets: doRedactSecrets,
 		AllowList:     allowList,
 		Rules:         rules,
+		Identities:    identities,
+		Recipients:    recipients,
 	})
 	if err != nil {
 		return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,9 @@ func init() {
 	_ = rootCmd.MarkPersistentFlagFilename("config", configExts...)
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "enable verbose output")
 	_ = viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
+	// Read-side decryption flags. Deliberately NOT viper-bound: passphrase
+	// material is read via os.Getenv / files only, never from config.yaml.
+	addDecryptFlags(rootCmd)
 }
 
 func initConfig() {

--- a/cmd/transitions.go
+++ b/cmd/transitions.go
@@ -81,7 +81,11 @@ func runTransitions(cmd *cobra.Command, args []string) error {
 		opts.Until = t
 	}
 
-	ts, err := transitions.LoadTransitions(args[0], opts)
+	identities, err := resolveDecryptIdentities(cmd, args[0])
+	if err != nil {
+		return err
+	}
+	ts, err := transitions.LoadTransitions(args[0], opts, identities)
 	if err != nil {
 		return err
 	}

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -104,17 +104,22 @@ func runUI(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--at cannot be combined with replay flags (--speed/--from/--to/--loop/--start-paused/--writable/--with-kwok/--with-controller-manager); use --from/--to to set the replay window")
 	}
 
+	identities, err := resolveDecryptIdentities(cmd, archivePath)
+	if err != nil {
+		return err
+	}
+
 	var mockSrv *server.Server
-	var err error
 	if replayMode {
 		mockSrv, err = server.Replay(server.ReplayOptions{
 			ArchivePath: archivePath, Port: apiPort, KubeconfigOut: kubeconfigOut,
 			Speed: speed, From: from, To: to, Loop: loop, StartPaused: startPaused, PauseAtWindowEnd: true,
-			Writable: writable, Verbose: verbose,
+			Writable: writable, Verbose: verbose, Identities: identities,
 		})
 	} else {
 		mockSrv, err = server.Open(server.OpenOptions{
 			ArchivePath: archivePath, Port: apiPort, KubeconfigOut: kubeconfigOut, At: at, Verbose: verbose,
+			Identities: identities,
 		})
 	}
 	if err != nil {

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -26,6 +26,19 @@ func isAgeEncrypted(f *os.File) (bool, error) {
 	return n == len(buf) && string(buf) == ageIntro, nil
 }
 
+// IsEncrypted reports whether the archive at path is an age-encrypted k8shark
+// archive (as written by NewEncryptedStreamWriter), reading only the file
+// header. A plaintext ZIP archive returns false. Callers use it to decide
+// whether a decryption key is needed before opening.
+func IsEncrypted(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	return isAgeEncrypted(f)
+}
+
 // RecipientsFromPassphrase returns a recipient set for passphrase-based
 // archive encryption. Per the age spec a ScryptRecipient must be the only
 // recipient for a file, so this is always a single-element slice.

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"filippo.io/age"
 	archivepkg "github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
 	"github.com/phenixblue/k8shark/internal/server"
@@ -22,6 +23,10 @@ type Options struct {
 	AfterAt       string
 	Resource      string
 	Namespace     string
+	// Identities decrypts encrypted archive(s); ignored for plaintext ones.
+	// A single key source is shared across both archives in the two-archive
+	// mode (a documented v1.0 limitation).
+	Identities []age.Identity
 }
 
 type Result struct {
@@ -146,11 +151,11 @@ func loadSnapshots(opts Options) (*archiveSnapshot, *archiveSnapshot, error) {
 		if opts.Archive != "" || opts.BeforeAt != "" || opts.AfterAt != "" {
 			return nil, nil, fmt.Errorf("use either --before/--after or --archive with --before-at/--after-at")
 		}
-		before, err := loadArchiveSnapshot(opts.BeforeArchive, time.Time{})
+		before, err := loadArchiveSnapshot(opts.BeforeArchive, time.Time{}, opts.Identities)
 		if err != nil {
 			return nil, nil, err
 		}
-		after, err := loadArchiveSnapshot(opts.AfterArchive, time.Time{})
+		after, err := loadArchiveSnapshot(opts.AfterArchive, time.Time{}, opts.Identities)
 		if err != nil {
 			before.cleanup()
 			return nil, nil, err
@@ -160,7 +165,7 @@ func loadSnapshots(opts Options) (*archiveSnapshot, *archiveSnapshot, error) {
 		if opts.BeforeAt == "" || opts.AfterAt == "" {
 			return nil, nil, fmt.Errorf("--before-at and --after-at are required with --archive")
 		}
-		base, err := loadArchiveSnapshot(opts.Archive, time.Time{})
+		base, err := loadArchiveSnapshot(opts.Archive, time.Time{}, opts.Identities)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -174,12 +179,12 @@ func loadSnapshots(opts Options) (*archiveSnapshot, *archiveSnapshot, error) {
 			base.cleanup()
 			return nil, nil, err
 		}
-		before, err := loadArchiveSnapshot(opts.Archive, beforeAt)
+		before, err := loadArchiveSnapshot(opts.Archive, beforeAt, opts.Identities)
 		if err != nil {
 			base.cleanup()
 			return nil, nil, err
 		}
-		after, err := loadArchiveSnapshot(opts.Archive, afterAt)
+		after, err := loadArchiveSnapshot(opts.Archive, afterAt, opts.Identities)
 		if err != nil {
 			base.cleanup()
 			before.cleanup()
@@ -192,8 +197,8 @@ func loadSnapshots(opts Options) (*archiveSnapshot, *archiveSnapshot, error) {
 	}
 }
 
-func loadArchiveSnapshot(archivePath string, at time.Time) (*archiveSnapshot, error) {
-	ar, err := archivepkg.Open(archivePath)
+func loadArchiveSnapshot(archivePath string, at time.Time, identities []age.Identity) (*archiveSnapshot, error) {
+	ar, err := archivepkg.OpenWithIdentities(archivePath, identities)
 	if err != nil {
 		return nil, fmt.Errorf("opening archive %q: %w", archivePath, err)
 	}

--- a/internal/inspect/encrypt_test.go
+++ b/internal/inspect/encrypt_test.go
@@ -1,0 +1,54 @@
+package inspect
+
+import (
+	"path/filepath"
+	"testing"
+
+	"filippo.io/age"
+	"github.com/phenixblue/k8shark/internal/archive"
+)
+
+// TestRun_Encrypted verifies inspect.Run threads identities through to the
+// archive open: an encrypted archive is refused without a key and summarized
+// with one.
+func TestRun_Encrypted(t *testing.T) {
+	const pass = "inspect-encrypt-test"
+	r, err := age.NewScryptRecipient(pass)
+	if err != nil {
+		t.Fatalf("NewScryptRecipient: %v", err)
+	}
+	r.SetWorkFactor(10)
+
+	path := filepath.Join(t.TempDir(), "enc.kshrk")
+	sw, err := archive.NewEncryptedStreamWriter(path, []age.Recipient{r})
+	if err != nil {
+		t.Fatalf("NewEncryptedStreamWriter: %v", err)
+	}
+	rec := map[string]any{"id": "r1", "api_path": "/api/v1/nodes", "response_code": 200,
+		"response_body": map[string]any{"apiVersion": "v1", "kind": "NodeList", "items": []any{}}}
+	if err := sw.WriteRecord(rec); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+	meta := map[string]any{"format_version": 1, "capture_id": "enc", "record_count": 1}
+	idx := map[string]any{"/api/v1/nodes": map[string]any{"api_path": "/api/v1/nodes", "seqs": []int{0}}}
+	if err := sw.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// Without a key, Run must fail (not silently misread the ciphertext).
+	if _, err := Run(path, nil); err == nil {
+		t.Fatal("Run on encrypted archive without identities succeeded, want error")
+	}
+
+	ids, err := archive.IdentitiesFromPassphrase(pass)
+	if err != nil {
+		t.Fatalf("IdentitiesFromPassphrase: %v", err)
+	}
+	report, err := Run(path, ids)
+	if err != nil {
+		t.Fatalf("Run with identities: %v", err)
+	}
+	if report.CaptureID != "enc" {
+		t.Errorf("CaptureID = %q, want enc", report.CaptureID)
+	}
+}

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
 )
@@ -37,8 +38,10 @@ type ResourceSummary struct {
 }
 
 // Run opens archivePath and returns a Report without extracting to disk.
-func Run(archivePath string) (*Report, error) {
-	ar, err := archive.Open(archivePath)
+// identities decrypts an encrypted archive; it is ignored for plaintext
+// archives, so callers may pass nil.
+func Run(archivePath string, identities []age.Identity) (*Report, error) {
+	ar, err := archive.OpenWithIdentities(archivePath, identities)
 	if err != nil {
 		return nil, fmt.Errorf("opening archive: %w", err)
 	}

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -93,7 +93,7 @@ func TestRun_BasicSummary(t *testing.T) {
 		secretRec("r5", "default", "my-secret"),
 	})
 
-	report, err := Run(archivePath)
+	report, err := Run(archivePath, nil)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestRun_ArchiveSize(t *testing.T) {
 	archivePath := buildArchive(t, []*capture.Record{
 		rec("r1", "/api/v1/namespaces/default/pods"),
 	})
-	report, err := Run(archivePath)
+	report, err := Run(archivePath, nil)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestRun_SortedOutput(t *testing.T) {
 		rec("r2", "/api/v1/namespaces/default/pods"),
 		rec("r3", "/api/v1/nodes"),
 	})
-	report, err := Run(archivePath)
+	report, err := Run(archivePath, nil)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/internal/inspect/version_test.go
+++ b/internal/inspect/version_test.go
@@ -13,7 +13,7 @@ func TestRun_ReportsFormatVersion_LegacyNormalizedToOne(t *testing.T) {
 	// buildArchive writes no format_version (pre-versioning archive); inspect
 	// should report it as version 1.
 	path := buildArchive(t, []*capture.Record{rec("r1", "/api/v1/namespaces/default/pods")})
-	report, err := Run(path)
+	report, err := Run(path, nil)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -24,7 +24,7 @@ func TestRun_ReportsFormatVersion_LegacyNormalizedToOne(t *testing.T) {
 
 func TestRun_RejectsFutureFormatVersion(t *testing.T) {
 	path := buildArchiveWithVersion(t, capture.CurrentFormatVersion+1)
-	if _, err := Run(path); err == nil {
+	if _, err := Run(path, nil); err == nil {
 		t.Fatal("expected Run to reject an archive with a newer format version")
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
 )
@@ -23,6 +24,8 @@ type OpenOptions struct {
 	KubeconfigOut string
 	At            string
 	Verbose       bool
+	// Identities decrypts an encrypted archive; ignored for plaintext archives.
+	Identities []age.Identity
 }
 
 // ReplayOptions holds parameters for replaying a capture forward through time.
@@ -35,6 +38,8 @@ type ReplayOptions struct {
 	To            string // window end: RFC3339 or relative like -1m (empty = capture end)
 	Loop          bool
 	StartPaused   bool
+	// Identities decrypts an encrypted archive; ignored for plaintext archives.
+	Identities []age.Identity
 	// PauseAtWindowEnd, when StartPaused is set, parks the clock at the window
 	// end (the most complete captured state) instead of the window start. The
 	// Web UI sets this: a capture's opening moments are typically sparse
@@ -70,7 +75,7 @@ type Server struct {
 // Open opens a capture archive, starts the mock HTTPS server, and writes
 // a kubeconfig pointing at it.
 func Open(opts OpenOptions) (*Server, error) {
-	ar, err := archive.Open(opts.ArchivePath)
+	ar, err := archive.OpenWithIdentities(opts.ArchivePath, opts.Identities)
 	if err != nil {
 		return nil, fmt.Errorf("opening archive: %w", err)
 	}
@@ -91,7 +96,7 @@ func Open(opts OpenOptions) (*Server, error) {
 // clock advances through the [from, to] window at the given speed, streaming
 // captured watch events over time. LIST/GET return state as-of the clock.
 func Replay(opts ReplayOptions) (*Server, error) {
-	ar, err := archive.Open(opts.ArchivePath)
+	ar, err := archive.OpenWithIdentities(opts.ArchivePath, opts.Identities)
 	if err != nil {
 		return nil, fmt.Errorf("opening archive: %w", err)
 	}

--- a/internal/transitions/transitions.go
+++ b/internal/transitions/transitions.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
 )
@@ -43,8 +44,11 @@ type FilterOpts struct {
 //     (ADDED/MODIFIED/DELETED labels captured at watch-stream time).
 //   - Poll-only paths: consecutive snapshot pairs are diff'd by object identity
 //     to detect additions, modifications, and deletions.
-func LoadTransitions(archivePath string, opts FilterOpts) ([]Transition, error) {
-	ar, err := archive.Open(archivePath)
+//
+// identities decrypts an encrypted archive; it is ignored for plaintext
+// archives, so callers may pass nil.
+func LoadTransitions(archivePath string, opts FilterOpts, identities []age.Identity) ([]Transition, error) {
+	ar, err := archive.OpenWithIdentities(archivePath, identities)
 	if err != nil {
 		return nil, fmt.Errorf("opening archive: %w", err)
 	}

--- a/internal/transitions/transitions_test.go
+++ b/internal/transitions/transitions_test.go
@@ -147,7 +147,7 @@ func TestPollTransitions_Added(t *testing.T) {
 	snap2 := `{"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
 	archivePath := buildPollArchive(t, "/api/v1/namespaces/default/pods", []string{snap1, snap2})
 
-	ts, err := LoadTransitions(archivePath, FilterOpts{})
+	ts, err := LoadTransitions(archivePath, FilterOpts{}, nil)
 	if err != nil {
 		t.Fatalf("LoadTransitions: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestPollTransitions_Modified(t *testing.T) {
 	snap2 := `{"items":[{"metadata":{"name":"nginx","namespace":"default"},"status":{"phase":"Running"}}]}`
 	archivePath := buildPollArchive(t, "/api/v1/namespaces/default/pods", []string{snap1, snap2})
 
-	ts, err := LoadTransitions(archivePath, FilterOpts{})
+	ts, err := LoadTransitions(archivePath, FilterOpts{}, nil)
 	if err != nil {
 		t.Fatalf("LoadTransitions: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestPollTransitions_Deleted(t *testing.T) {
 	snap2 := `{"items":[]}`
 	archivePath := buildPollArchive(t, "/api/v1/namespaces/default/pods", []string{snap1, snap2})
 
-	ts, err := LoadTransitions(archivePath, FilterOpts{})
+	ts, err := LoadTransitions(archivePath, FilterOpts{}, nil)
 	if err != nil {
 		t.Fatalf("LoadTransitions: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestPollTransitions_NoChange(t *testing.T) {
 	body := `{"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
 	archivePath := buildPollArchive(t, "/api/v1/namespaces/default/pods", []string{body, body})
 
-	ts, err := LoadTransitions(archivePath, FilterOpts{})
+	ts, err := LoadTransitions(archivePath, FilterOpts{}, nil)
 	if err != nil {
 		t.Fatalf("LoadTransitions: %v", err)
 	}
@@ -227,7 +227,7 @@ func TestWatchTransitions_Direct(t *testing.T) {
 	}
 	archivePath := buildWatchArchive(t, "/api/v1/namespaces/default/pods", snap, events)
 
-	ts, err := LoadTransitions(archivePath, FilterOpts{})
+	ts, err := LoadTransitions(archivePath, FilterOpts{}, nil)
 	if err != nil {
 		t.Fatalf("LoadTransitions: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestFilterByName(t *testing.T) {
 	snap2 := `{"items":[{"metadata":{"name":"nginx","namespace":"default"}},{"metadata":{"name":"redis","namespace":"default"}}]}`
 	archivePath := buildPollArchive(t, "/api/v1/namespaces/default/pods", []string{snap1, snap2})
 
-	ts, err := LoadTransitions(archivePath, FilterOpts{Name: "nginx"})
+	ts, err := LoadTransitions(archivePath, FilterOpts{Name: "nginx"}, nil)
 	if err != nil {
 		t.Fatalf("LoadTransitions: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestFilterByResource(t *testing.T) {
 	archive1 := buildPollArchive(t, "/api/v1/namespaces/default/pods", []string{snap1, snap2})
 
 	// Only match pods, not services.
-	ts, err := LoadTransitions(archive1, FilterOpts{Resource: "pods"})
+	ts, err := LoadTransitions(archive1, FilterOpts{Resource: "pods"}, nil)
 	if err != nil {
 		t.Fatalf("LoadTransitions: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestFilterByResource(t *testing.T) {
 		t.Errorf("expected 1 pod transition, got %d: %+v", len(ts), ts)
 	}
 
-	ts2, err := LoadTransitions(archive1, FilterOpts{Resource: "services"})
+	ts2, err := LoadTransitions(archive1, FilterOpts{Resource: "services"}, nil)
 	if err != nil {
 		t.Fatalf("LoadTransitions (services): %v", err)
 	}
@@ -300,7 +300,7 @@ func TestFilterByTimeWindow(t *testing.T) {
 	// Use --since after snap2 timestamp → only snap3 change (redis ADDED) visible.
 	since := t0.Add(90 * time.Second)
 
-	ts, err := LoadTransitions(archivePath, FilterOpts{Since: since})
+	ts, err := LoadTransitions(archivePath, FilterOpts{Since: since}, nil)
 	if err != nil {
 		t.Fatalf("LoadTransitions: %v", err)
 	}
@@ -344,7 +344,7 @@ func TestLoadTransitions_OldArchiveNoWatchIndex(t *testing.T) {
 	body := `{"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
 	archivePath := buildPollArchive(t, "/api/v1/namespaces/default/pods", []string{body})
 
-	ts, err := LoadTransitions(archivePath, FilterOpts{})
+	ts, err := LoadTransitions(archivePath, FilterOpts{}, nil)
 	if err != nil {
 		t.Fatalf("LoadTransitions: %v", err)
 	}


### PR DESCRIPTION
## Summary

Third milestone of optional archive encryption-at-rest ([#117](https://github.com/phenixblue/k8shark/issues/117)): **the reader side.** Builds on M1 (crypto core, #204) and M2 (`capture --encrypt`, #205). Every archive-reading command can now open an encrypted `.kshrk` transparently, given a key — so the round trip `capture --encrypt` → hand off → `kshrk ui file.kshrk` finally works end to end.

## What's in this PR

- **New persistent flags** on the root command (so every subcommand accepts them): `--decrypt-passphrase-file` and `--decrypt-identity-file` (an age identity/key file), plus `$KSHRK_DECRYPT_PASSPHRASE`. As on the write side, these are **never viper-bound** — passphrase material can't be bound from or leak into `config.yaml`.
- **Smart resolution** (`resolveDecryptIdentities`): gathers key material from the flags/env; when none is given it **peeks** whether the archive is encrypted (`archive.IsEncrypted`). A plaintext archive needs no key and opens with **zero interaction**; an encrypted one prompts once on a TTY (no confirmation — you're supplying an existing key) or **fails loudly on a non-TTY** instead of hanging.
- **Threaded `[]age.Identity`** through every read path, swapping `archive.Open` → `archive.OpenWithIdentities`:
  - `inspect`, `query`, `diagnose`, `transitions`
  - `diff` — single shared key across both archives (documented v1.0 limitation)
  - the mock server behind `open`/`ui` (`Identities` added to `OpenOptions`/`ReplayOptions`)
  - `OpenWithIdentities` ignores identities for plaintext archives, so each call site has one code path.
- **`redact`** gains `--decrypt-*` to read an encrypted source and reuses M2's write-side `--encrypt` flags to re-encrypt the output — fulfilling the issue's `redact --encrypt`. If a source is encrypted but no `--encrypt` is given, it **warns** that the redacted copy is plaintext rather than silently downgrading.

## Reader UX (verified with the built binary)

```
$ kshrk inspect enc.kshrk                          # no key, non-TTY
Error: archive "enc.kshrk" is encrypted: provide --decrypt-passphrase-file,
--decrypt-identity-file, or $KSHRK_DECRYPT_PASSPHRASE (an interactive prompt
requires a terminal)

$ kshrk inspect enc.kshrk --decrypt-passphrase-file pass.txt   # ✓ summarizes
$ KSHRK_DECRYPT_PASSPHRASE=… kshrk inspect enc.kshrk           # ✓ summarizes
$ kshrk inspect enc.kshrk --decrypt-passphrase-file wrong.txt  # clean error:
Error: opening archive: failed to decrypt archive "enc.kshrk": incorrect passphrase or key

$ kshrk inspect plaintext.kshrk                    # ✓ opens, zero flags, no prompt
```

For `kshrk ui`/`open` (long-lived holders) the key is resolved once at launch; the archive stays encrypted at rest and only transient chunks are decrypted on demand via `age.DecryptReaderAt` (the M1 design property), with the fd closed on shutdown.

## Tests

- `cmd/decrypt_flags_test.go`: passphrase file (trailing newline trimmed), env, **X25519 identity file** (exercised end to end even before M4 adds write flags, by encrypting to a generated recipient directly), wrong passphrase, non-TTY loud failure, and the **regression guard** — a plaintext archive resolves to `nil` identities and opens untouched.
- `internal/inspect/encrypt_test.go`: encrypted round-trip through `inspect.Run` (refused without a key, summarized with one).

`make fmt`, `make lint-ci`, full `make test`, and `go mod tidy` (idempotent) all clean.

## Note for reviewers

Does **not** close #117 — M3 of 5. Remaining: M4 (public-key recipient flags on the write side; the read side already handles X25519 identities here) and M5 (docs + threat model). The `redact --encrypt` inclusion is a small scope addition beyond pure reader-side, made to avoid a silent plaintext downgrade when redacting an encrypted capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)