### PR TITLE
feat(cli): encrypt to age public-key recipients (M4 of #117)

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -24,8 +24,9 @@ single .kshrk capture file for later replay.
 Resources, namespaces, and intervals come from the --config file. Use
 --auto-discover to capture every available API resource without listing them,
 --output - to stream records as NDJSON to stdout, --redact-secrets to scrub
-Secret values from the archive after capture, and --encrypt to write the
-archive as an encrypted (age) envelope.`,
+Secret values from the archive after capture, and --encrypt (passphrase) or
+--encrypt-recipient (age public keys) to write the archive as an encrypted
+(age) envelope.`,
 	Example: `  # Capture using a config file
   kshrk capture --config k8shark.yaml
 
@@ -42,7 +43,10 @@ archive as an encrypted (age) envelope.`,
   kshrk capture --config k8shark.yaml --encrypt
 
   # Encrypt using a passphrase read from a file (no prompt)
-  kshrk capture --config k8shark.yaml --encrypt-passphrase-file ./pass.txt`,
+  kshrk capture --config k8shark.yaml --encrypt-passphrase-file ./pass.txt
+
+  # Encrypt to one or more age recipient public keys (shareable)
+  kshrk capture --config k8shark.yaml --encrypt-recipient age1abc... --encrypt-recipient age1def...`,
 	RunE: runCapture,
 }
 
@@ -104,23 +108,46 @@ func runCapture(cmd *cobra.Command, args []string) error {
 
 	// Reject incompatible flag combinations before any interactive passphrase
 	// prompt so users aren't asked for a secret only to be told it can't be
-	// used. encryptRequested checks the flags without prompting.
-	if encryptRequested(cmd) && streamingStdout {
-		return fmt.Errorf("archive encryption (--encrypt / --encrypt-passphrase-file) cannot be combined with --output - (NDJSON streaming to stdout is not encrypted)")
+	// used. These helpers check the flags without prompting.
+	if (encryptRequested(cmd) || recipientsRequested(cmd)) && streamingStdout {
+		return fmt.Errorf("archive encryption cannot be combined with --output - (NDJSON streaming to stdout is not encrypted)")
 	}
 
-	// Resolve encryption before the (potentially long) capture starts so a bad
-	// or missing passphrase fails fast rather than after minutes of polling.
-	passphrase, encrypt, err := resolveEncryptPassphrase(cmd)
+	// Resolve redaction inputs up front: whether the capture will be redacted
+	// determines how the archive is encrypted (see below).
+	doRedactSecrets, allowList, fieldRules, err := resolveRedaction(cmd, cfg)
 	if err != nil {
 		return err
 	}
-	var encRecipients []age.Recipient
-	var encIdentities []age.Identity
-	if encrypt {
-		encRecipients, encIdentities, err = encryptOptionsFromPassphrase(passphrase)
-		if err != nil {
-			return err
+	willRedact := doRedactSecrets || len(fieldRules) > 0
+
+	// Resolve encryption before the (potentially long) capture starts so a bad
+	// or missing passphrase fails fast rather than after minutes of polling.
+	enc, err := resolveEncryption(cmd)
+	if err != nil {
+		return err
+	}
+
+	// Decide what the engine encrypts the on-disk archive to. When the capture
+	// will be redacted afterwards, the engine encrypts the intermediate to an
+	// ephemeral key so the redact pass can decrypt it in memory and re-encrypt
+	// to the real recipients — without ever writing plaintext to disk and
+	// without needing the recipients' private keys (which we don't have in
+	// recipient mode). Otherwise the engine encrypts directly to the final
+	// recipients.
+	var engineRecipients, redactRecipients []age.Recipient
+	var redactIdentities []age.Identity
+	if enc.enabled {
+		redactRecipients = enc.recipients
+		if willRedact {
+			eph, gerr := age.GenerateX25519Identity()
+			if gerr != nil {
+				return fmt.Errorf("generating ephemeral encryption key: %w", gerr)
+			}
+			engineRecipients = []age.Recipient{eph.Recipient()}
+			redactIdentities = []age.Identity{eph}
+		} else {
+			engineRecipients = enc.recipients
 		}
 	}
 
@@ -130,7 +157,7 @@ func runCapture(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("initializing capture engine: %w", err)
 	}
-	engine.SetEncryption(encRecipients)
+	engine.SetEncryption(engineRecipients)
 
 	fmt.Fprintf(msgOut, "Starting capture -> %s\n", cfg.Output)
 
@@ -145,8 +172,8 @@ func runCapture(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(msgOut, "\nCapture complete\n")
 	fmt.Fprintf(msgOut, "  Output:    %s (%s)\n", sum.OutputPath, formatBytes(sum.OutputSize))
-	if encrypt {
-		fmt.Fprintf(msgOut, "  Encrypted: yes (age passphrase)\n")
+	if enc.enabled {
+		fmt.Fprintf(msgOut, "  Encrypted: yes (age %s)\n", enc.mode)
 	}
 	fmt.Fprintf(msgOut, "  Records:   %d across %d resource path(s)\n", sum.RecordCount, sum.ResourceCount)
 	fmt.Fprintf(msgOut, "  Duration:  %s\n", sum.Duration)
@@ -172,41 +199,18 @@ func runCapture(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Post-capture redaction: merge --redact-secrets / --redact-field CLI flags
-	// with any redaction.rules defined in the config file.
-	doRedactSecrets, _ := cmd.Flags().GetBool("redact-secrets")
-	if cfg.Redaction.RedactSecrets {
-		doRedactSecrets = true
-	}
-	allows, _ := cmd.Flags().GetStringArray("allow-secret")
-	allowList := make(map[string]bool, len(allows))
-	for _, a := range allows {
-		allowList[a] = true
-	}
-	for _, a := range cfg.Redaction.AllowSecrets {
-		allowList[a] = true
-	}
-	redactFields, _ := cmd.Flags().GetStringArray("redact-field")
-	var fieldRules []config.RedactionRule
-	fieldRules = append(fieldRules, cfg.Redaction.Rules...)
-	for _, rf := range redactFields {
-		rule, err := parseRedactField(rf)
-		if err != nil {
-			return err
-		}
-		fieldRules = append(fieldRules, rule)
-	}
-
-	if doRedactSecrets || len(fieldRules) > 0 {
+	// Post-capture redaction (inputs resolved before the capture started).
+	if willRedact {
 		tmpPath := sum.OutputPath + ".redacting"
 		result, err := redact.Archive(sum.OutputPath, tmpPath, redact.Options{
 			RedactSecrets: doRedactSecrets,
 			AllowList:     allowList,
 			Rules:         fieldRules,
-			// When the capture was encrypted, decrypt it to redact and re-encrypt
-			// the result so the redacted archive stays encrypted end to end.
-			Identities: encIdentities,
-			Recipients: encRecipients,
+			// Decrypt the (ephemerally-encrypted) intermediate and re-encrypt to
+			// the real recipients so the redacted archive stays encrypted end to
+			// end; both are nil for a plaintext capture.
+			Identities: redactIdentities,
+			Recipients: redactRecipients,
 		})
 		if err != nil {
 			_ = os.Remove(tmpPath)
@@ -223,6 +227,36 @@ func runCapture(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// resolveRedaction merges the --redact-secrets / --allow-secret / --redact-field
+// CLI flags with any redaction block in the config file into the effective
+// redaction inputs for a capture.
+func resolveRedaction(cmd *cobra.Command, cfg *config.Config) (doRedactSecrets bool, allowList map[string]bool, fieldRules []config.RedactionRule, err error) {
+	doRedactSecrets, _ = cmd.Flags().GetBool("redact-secrets")
+	if cfg.Redaction.RedactSecrets {
+		doRedactSecrets = true
+	}
+
+	allows, _ := cmd.Flags().GetStringArray("allow-secret")
+	allowList = make(map[string]bool, len(allows))
+	for _, a := range allows {
+		allowList[a] = true
+	}
+	for _, a := range cfg.Redaction.AllowSecrets {
+		allowList[a] = true
+	}
+
+	fieldRules = append(fieldRules, cfg.Redaction.Rules...)
+	redactFields, _ := cmd.Flags().GetStringArray("redact-field")
+	for _, rf := range redactFields {
+		rule, perr := parseRedactField(rf)
+		if perr != nil {
+			return false, nil, nil, perr
+		}
+		fieldRules = append(fieldRules, rule)
+	}
+	return doRedactSecrets, allowList, fieldRules, nil
 }
 
 // startSpinner prints a rotating spinner on w until the returned stop function

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -214,11 +214,19 @@ func runCapture(cmd *cobra.Command, args []string) error {
 		})
 		if err != nil {
 			_ = os.Remove(tmpPath)
+			// When the intermediate was encrypted to the ephemeral in-memory key
+			// (redactIdentities is set), sum.OutputPath can't be decrypted by any
+			// user key — remove it rather than leave an unrecoverable file where
+			// the user expects their capture.
+			if len(redactIdentities) > 0 {
+				_ = os.Remove(sum.OutputPath)
+			}
 			return fmt.Errorf("redacting archive: %w", err)
 		}
 		if err := os.Rename(tmpPath, sum.OutputPath); err != nil {
-			_ = os.Remove(tmpPath)
-			return fmt.Errorf("replacing archive with redacted version: %w", err)
+			// Don't delete tmpPath: it holds the fully-redacted archive, so leave
+			// it for manual recovery instead of destroying the only good copy.
+			return fmt.Errorf("replacing archive with redacted version (redacted output left at %s): %w", tmpPath, err)
 		}
 		if result.SecretsRedacted > 0 || result.FieldsRedacted > 0 {
 			fmt.Fprintf(msgOut, "  Redacted:  %d secret(s), %d record(s) with field rules applied\n",

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -170,13 +170,65 @@ func runCapture(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("capture failed: %w", err)
 	}
 
+	// Post-capture redaction runs before the summary so the summary reflects
+	// the final on-disk archive. While redaction is pending, the archive at
+	// sum.OutputPath is only the ephemerally-encrypted intermediate — not yet
+	// decryptable by the user's key — so we must not report it as encrypted
+	// until this completes.
+	var redactResult redact.Result
+	if willRedact {
+		tmpPath := sum.OutputPath + ".redacting"
+		result, rerr := redact.Archive(sum.OutputPath, tmpPath, redact.Options{
+			RedactSecrets: doRedactSecrets,
+			AllowList:     allowList,
+			Rules:         fieldRules,
+			// Decrypt the (ephemerally-encrypted) intermediate and re-encrypt to
+			// the real recipients so the redacted archive stays encrypted end to
+			// end; both are nil for a plaintext capture.
+			Identities: redactIdentities,
+			Recipients: redactRecipients,
+		})
+		if rerr != nil {
+			_ = os.Remove(tmpPath)
+			// When the intermediate was encrypted to the ephemeral in-memory key
+			// (redactIdentities is set), sum.OutputPath can't be decrypted by any
+			// user key — remove it rather than leave an unrecoverable file where
+			// the user expects their capture.
+			if len(redactIdentities) > 0 {
+				_ = os.Remove(sum.OutputPath)
+			}
+			return fmt.Errorf("redacting archive: %w", rerr)
+		}
+		if err := os.Rename(tmpPath, sum.OutputPath); err != nil {
+			// The fully-redacted archive is at tmpPath; keep it for recovery
+			// rather than destroying the only good copy. Remove the ephemerally-
+			// encrypted intermediate still sitting at sum.OutputPath, since no
+			// user key can decrypt it.
+			if len(redactIdentities) > 0 {
+				_ = os.Remove(sum.OutputPath)
+			}
+			return fmt.Errorf("replacing archive with redacted version (redacted output left at %s): %w", tmpPath, err)
+		}
+		redactResult = result
+	}
+
+	// Re-stat: redaction rewrites the archive, so report the final size.
+	outputSize := sum.OutputSize
+	if fi, serr := os.Stat(sum.OutputPath); serr == nil {
+		outputSize = fi.Size()
+	}
+
 	fmt.Fprintf(msgOut, "\nCapture complete\n")
-	fmt.Fprintf(msgOut, "  Output:    %s (%s)\n", sum.OutputPath, formatBytes(sum.OutputSize))
+	fmt.Fprintf(msgOut, "  Output:    %s (%s)\n", sum.OutputPath, formatBytes(outputSize))
 	if enc.enabled {
 		fmt.Fprintf(msgOut, "  Encrypted: yes (age %s)\n", enc.mode)
 	}
 	fmt.Fprintf(msgOut, "  Records:   %d across %d resource path(s)\n", sum.RecordCount, sum.ResourceCount)
 	fmt.Fprintf(msgOut, "  Duration:  %s\n", sum.Duration)
+	if redactResult.SecretsRedacted > 0 || redactResult.FieldsRedacted > 0 {
+		fmt.Fprintf(msgOut, "  Redacted:  %d secret(s), %d record(s) with field rules applied\n",
+			redactResult.SecretsRedacted, redactResult.FieldsRedacted)
+	}
 	if sum.PodLogs.Attempted > 0 {
 		fmt.Fprintf(msgOut, "  Pod logs:  %d/%d captured", sum.PodLogs.Captured, sum.PodLogs.Attempted)
 		if sum.PodLogs.Skipped > 0 {
@@ -196,41 +248,6 @@ func runCapture(cmd *cobra.Command, args []string) error {
 				fmt.Fprintf(msgOut, "    ... and %d more (run with --verbose for full list)\n",
 					sum.PodLogs.Skipped-len(sum.PodLogs.Failures))
 			}
-		}
-	}
-
-	// Post-capture redaction (inputs resolved before the capture started).
-	if willRedact {
-		tmpPath := sum.OutputPath + ".redacting"
-		result, err := redact.Archive(sum.OutputPath, tmpPath, redact.Options{
-			RedactSecrets: doRedactSecrets,
-			AllowList:     allowList,
-			Rules:         fieldRules,
-			// Decrypt the (ephemerally-encrypted) intermediate and re-encrypt to
-			// the real recipients so the redacted archive stays encrypted end to
-			// end; both are nil for a plaintext capture.
-			Identities: redactIdentities,
-			Recipients: redactRecipients,
-		})
-		if err != nil {
-			_ = os.Remove(tmpPath)
-			// When the intermediate was encrypted to the ephemeral in-memory key
-			// (redactIdentities is set), sum.OutputPath can't be decrypted by any
-			// user key — remove it rather than leave an unrecoverable file where
-			// the user expects their capture.
-			if len(redactIdentities) > 0 {
-				_ = os.Remove(sum.OutputPath)
-			}
-			return fmt.Errorf("redacting archive: %w", err)
-		}
-		if err := os.Rename(tmpPath, sum.OutputPath); err != nil {
-			// Don't delete tmpPath: it holds the fully-redacted archive, so leave
-			// it for manual recovery instead of destroying the only good copy.
-			return fmt.Errorf("replacing archive with redacted version (redacted output left at %s): %w", tmpPath, err)
-		}
-		if result.SecretsRedacted > 0 || result.FieldsRedacted > 0 {
-			fmt.Fprintf(msgOut, "  Redacted:  %d secret(s), %d record(s) with field rules applied\n",
-				result.SecretsRedacted, result.FieldsRedacted)
 		}
 	}
 

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -120,6 +120,9 @@ func runCapture(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	willRedact := doRedactSecrets || len(fieldRules) > 0
+	if willRedact && streamingStdout {
+		return fmt.Errorf("redaction (--redact-secrets / --redact-field) cannot be combined with --output - (redaction rewrites the archive file, which NDJSON streaming to stdout does not produce)")
+	}
 
 	// Resolve encryption before the (potentially long) capture starts so a bad
 	// or missing passphrase fails fast rather than after minutes of polling.

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -215,10 +215,14 @@ func runCapture(cmd *cobra.Command, args []string) error {
 		redactResult = result
 	}
 
-	// Re-stat: redaction rewrites the archive, so report the final size.
+	// Re-stat: redaction rewrites the archive, so report the final size. Skip
+	// in streaming mode, where OutputPath is "-" (no file) and a stray file
+	// named "-" would otherwise report a misleading size.
 	outputSize := sum.OutputSize
-	if fi, serr := os.Stat(sum.OutputPath); serr == nil {
-		outputSize = fi.Size()
+	if !streamingStdout {
+		if fi, serr := os.Stat(sum.OutputPath); serr == nil {
+			outputSize = fi.Size()
+		}
 	}
 
 	fmt.Fprintf(msgOut, "\nCapture complete\n")

--- a/cmd/encrypt_flags.go
+++ b/cmd/encrypt_flags.go
@@ -143,11 +143,14 @@ type encryptConfig struct {
 }
 
 // resolveEncryption determines how (if at all) a command should encrypt its
-// output. Passphrase mode (--encrypt / --encrypt-passphrase-file / env / prompt)
-// and recipient mode (--encrypt-recipient / --encrypt-recipients-file) are
-// mutually exclusive: age requires a passphrase (scrypt) recipient to be the
-// file's only recipient. The conflict is reported before any interactive
-// passphrase prompt so the user isn't asked for a secret that can't be used.
+// output. Passphrase mode is enabled only by --encrypt or
+// --encrypt-passphrase-file; once enabled, the passphrase itself comes from the
+// file, $KSHRK_ENCRYPT_PASSPHRASE, or an interactive prompt (none of those
+// sources enable encryption on their own). Recipient mode is enabled by
+// --encrypt-recipient / --encrypt-recipients-file. The two modes are mutually
+// exclusive: age requires a passphrase (scrypt) recipient to be the file's only
+// recipient. The conflict is reported before any interactive passphrase prompt
+// so the user isn't asked for a secret that can't be used.
 func resolveEncryption(cmd *cobra.Command) (encryptConfig, error) {
 	passphraseMode := encryptRequested(cmd)
 	recipientMode := recipientsRequested(cmd)

--- a/cmd/encrypt_flags.go
+++ b/cmd/encrypt_flags.go
@@ -19,9 +19,21 @@ const encryptPassphraseEnv = "KSHRK_ENCRYPT_PASSPHRASE"
 
 // addEncryptFlags registers the write-side encryption flags on cmd.
 func addEncryptFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool("encrypt", false, "encrypt the output archive (age); passphrase from --encrypt-passphrase-file, $"+encryptPassphraseEnv+", or an interactive prompt")
+	cmd.Flags().Bool("encrypt", false, "encrypt the output archive with a passphrase (age); from --encrypt-passphrase-file, $"+encryptPassphraseEnv+", or an interactive prompt")
 	cmd.Flags().String("encrypt-passphrase-file", "", "read the encryption passphrase from this file (first line) instead of prompting")
+	cmd.Flags().StringArray("encrypt-recipient", nil, "age recipient public key (age1...) to encrypt to (repeatable); mutually exclusive with passphrase encryption")
+	cmd.Flags().String("encrypt-recipients-file", "", "file of age recipient public keys (one per line) to encrypt to")
 	_ = cmd.MarkFlagFilename("encrypt-passphrase-file")
+	_ = cmd.MarkFlagFilename("encrypt-recipients-file")
+}
+
+// recipientsRequested reports whether the user asked for public-key (recipient)
+// encryption, without parsing the keys. Used to detect the passphrase/recipient
+// conflict before any interactive prompt runs.
+func recipientsRequested(cmd *cobra.Command) bool {
+	inline, _ := cmd.Flags().GetStringArray("encrypt-recipient")
+	file, _ := cmd.Flags().GetString("encrypt-recipients-file")
+	return len(inline) > 0 || file != ""
 }
 
 // resolveEncryptPassphrase determines whether the command should encrypt its
@@ -123,17 +135,78 @@ func promptNewPassphrase(cmd *cobra.Command) (string, error) {
 	return string(first), nil
 }
 
-// encryptOptionsFromPassphrase builds the age recipients and identities for a
-// passphrase. Recipients encrypt the output; identities decrypt an existing
-// encrypted archive (needed when redacting an encrypted capture in place).
-func encryptOptionsFromPassphrase(passphrase string) (recipients []age.Recipient, identities []age.Identity, err error) {
-	recipients, err = archive.RecipientsFromPassphrase(passphrase)
-	if err != nil {
-		return nil, nil, err
+// encryptConfig is the resolved write-side encryption for a command.
+type encryptConfig struct {
+	enabled    bool
+	mode       string // "passphrase" or "recipients" (for display); empty when disabled
+	recipients []age.Recipient
+}
+
+// resolveEncryption determines how (if at all) a command should encrypt its
+// output. Passphrase mode (--encrypt / --encrypt-passphrase-file / env / prompt)
+// and recipient mode (--encrypt-recipient / --encrypt-recipients-file) are
+// mutually exclusive: age requires a passphrase (scrypt) recipient to be the
+// file's only recipient. The conflict is reported before any interactive
+// passphrase prompt so the user isn't asked for a secret that can't be used.
+func resolveEncryption(cmd *cobra.Command) (encryptConfig, error) {
+	passphraseMode := encryptRequested(cmd)
+	recipientMode := recipientsRequested(cmd)
+
+	if passphraseMode && recipientMode {
+		return encryptConfig{}, fmt.Errorf("passphrase encryption (--encrypt / --encrypt-passphrase-file) cannot be combined with recipient encryption (--encrypt-recipient / --encrypt-recipients-file): age requires a passphrase to be the only recipient")
 	}
-	identities, err = archive.IdentitiesFromPassphrase(passphrase)
-	if err != nil {
-		return nil, nil, err
+
+	switch {
+	case recipientMode:
+		recips, err := recipientsFromFlags(cmd)
+		if err != nil {
+			return encryptConfig{}, err
+		}
+		if len(recips) == 0 {
+			return encryptConfig{}, fmt.Errorf("no age recipients found in --encrypt-recipient / --encrypt-recipients-file")
+		}
+		return encryptConfig{enabled: true, mode: "recipients", recipients: recips}, nil
+	case passphraseMode:
+		passphrase, _, err := resolveEncryptPassphrase(cmd)
+		if err != nil {
+			return encryptConfig{}, err
+		}
+		recips, err := archive.RecipientsFromPassphrase(passphrase)
+		if err != nil {
+			return encryptConfig{}, err
+		}
+		return encryptConfig{enabled: true, mode: "passphrase", recipients: recips}, nil
+	default:
+		return encryptConfig{}, nil
 	}
-	return recipients, identities, nil
+}
+
+// recipientsFromFlags parses all age recipients from --encrypt-recipient
+// (inline age1... keys) and --encrypt-recipients-file (a recipients file).
+func recipientsFromFlags(cmd *cobra.Command) ([]age.Recipient, error) {
+	var recips []age.Recipient
+
+	inline, _ := cmd.Flags().GetStringArray("encrypt-recipient")
+	for _, s := range inline {
+		r, err := age.ParseX25519Recipient(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --encrypt-recipient %q: %w", s, err)
+		}
+		recips = append(recips, r)
+	}
+
+	if file, _ := cmd.Flags().GetString("encrypt-recipients-file"); file != "" {
+		f, err := os.Open(file)
+		if err != nil {
+			return nil, fmt.Errorf("opening recipients file %q: %w", file, err)
+		}
+		defer f.Close()
+		fileRecips, err := age.ParseRecipients(f)
+		if err != nil {
+			return nil, fmt.Errorf("parsing recipients file %q: %w", file, err)
+		}
+		recips = append(recips, fileRecips...)
+	}
+
+	return recips, nil
 }

--- a/cmd/encrypt_flags.go
+++ b/cmd/encrypt_flags.go
@@ -208,6 +208,15 @@ func recipientsFromFlags(cmd *cobra.Command) ([]age.Recipient, error) {
 		if err != nil {
 			return nil, fmt.Errorf("parsing recipients file %q: %w", file, err)
 		}
+		// age.ParseRecipients also accepts post-quantum "age1pq1..." (Hybrid)
+		// keys, but --encrypt-recipient parses X25519 (age1...) only. Keep the
+		// two flag variants consistent — and interoperable with age-keygen — by
+		// rejecting non-X25519 recipients here too.
+		for _, r := range fileRecips {
+			if _, ok := r.(*age.X25519Recipient); !ok {
+				return nil, fmt.Errorf("recipients file %q contains a non-X25519 recipient; only age1... public keys are supported", file)
+			}
+		}
 		recips = append(recips, fileRecips...)
 	}
 

--- a/cmd/encrypt_flags_test.go
+++ b/cmd/encrypt_flags_test.go
@@ -71,6 +71,32 @@ func TestResolveEncryption_RecipientsFile(t *testing.T) {
 	}
 }
 
+// TestResolveEncryption_RecipientsFileRejectsNonX25519 keeps the two recipient
+// flag variants consistent: age.ParseRecipients accepts post-quantum Hybrid
+// (age1pq1...) keys, but --encrypt-recipient is X25519-only, so the file
+// variant must reject non-X25519 recipients too.
+func TestResolveEncryption_RecipientsFileRejectsNonX25519(t *testing.T) {
+	hybrid, err := age.GenerateHybridIdentity()
+	if err != nil {
+		t.Fatalf("GenerateHybridIdentity: %v", err)
+	}
+	dir := t.TempDir()
+	recipFile := filepath.Join(dir, "recipients.txt")
+	if err := os.WriteFile(recipFile, []byte(hybrid.Recipient().String()+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cmd := newTestEncryptCommand()
+	_ = cmd.Flags().Set("encrypt-recipients-file", recipFile)
+
+	_, err = resolveEncryption(cmd)
+	if err == nil {
+		t.Fatal("expected an error for a non-X25519 (Hybrid) recipient in the file")
+	}
+	if !strings.Contains(err.Error(), "non-X25519") {
+		t.Errorf("error = %q, want it to mention a non-X25519 recipient", err)
+	}
+}
+
 func TestResolveEncryption_PassphraseAndRecipientConflict(t *testing.T) {
 	id, err := age.GenerateX25519Identity()
 	if err != nil {

--- a/cmd/encrypt_flags_test.go
+++ b/cmd/encrypt_flags_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"filippo.io/age"
 	"github.com/spf13/cobra"
 )
 
@@ -15,6 +16,104 @@ func newTestEncryptCommand() *cobra.Command {
 	cmd := &cobra.Command{}
 	addEncryptFlags(cmd)
 	return cmd
+}
+
+func TestResolveEncryption_Disabled(t *testing.T) {
+	cmd := newTestEncryptCommand()
+	enc, err := resolveEncryption(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enc.enabled {
+		t.Error("enabled = true with no flags, want false")
+	}
+}
+
+func TestResolveEncryption_RecipientInline(t *testing.T) {
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("GenerateX25519Identity: %v", err)
+	}
+	cmd := newTestEncryptCommand()
+	_ = cmd.Flags().Set("encrypt-recipient", id.Recipient().String())
+
+	enc, err := resolveEncryption(cmd)
+	if err != nil {
+		t.Fatalf("resolveEncryption: %v", err)
+	}
+	if !enc.enabled || enc.mode != "recipients" {
+		t.Errorf("enc = %+v, want enabled recipients", enc)
+	}
+	if len(enc.recipients) != 1 {
+		t.Errorf("recipients len = %d, want 1", len(enc.recipients))
+	}
+}
+
+func TestResolveEncryption_RecipientsFile(t *testing.T) {
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("GenerateX25519Identity: %v", err)
+	}
+	dir := t.TempDir()
+	recipFile := filepath.Join(dir, "recipients.txt")
+	if err := os.WriteFile(recipFile, []byte("# a recipient\n"+id.Recipient().String()+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cmd := newTestEncryptCommand()
+	_ = cmd.Flags().Set("encrypt-recipients-file", recipFile)
+
+	enc, err := resolveEncryption(cmd)
+	if err != nil {
+		t.Fatalf("resolveEncryption: %v", err)
+	}
+	if !enc.enabled || len(enc.recipients) != 1 {
+		t.Errorf("enc = %+v, want enabled with 1 recipient", enc)
+	}
+}
+
+func TestResolveEncryption_PassphraseAndRecipientConflict(t *testing.T) {
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("GenerateX25519Identity: %v", err)
+	}
+	cmd := newTestEncryptCommand()
+	_ = cmd.Flags().Set("encrypt", "true")
+	_ = cmd.Flags().Set("encrypt-recipient", id.Recipient().String())
+
+	_, err = resolveEncryption(cmd)
+	if err == nil {
+		t.Fatal("expected an error combining passphrase and recipient encryption")
+	}
+	if !strings.Contains(err.Error(), "cannot be combined") {
+		t.Errorf("error = %q, want it to mention the combination is disallowed", err)
+	}
+}
+
+func TestResolveEncryption_InvalidRecipient(t *testing.T) {
+	cmd := newTestEncryptCommand()
+	_ = cmd.Flags().Set("encrypt-recipient", "not-a-valid-age-key")
+
+	if _, err := resolveEncryption(cmd); err == nil {
+		t.Fatal("expected an error for an invalid --encrypt-recipient")
+	}
+}
+
+func TestResolveEncrypt_PassphraseMode(t *testing.T) {
+	dir := t.TempDir()
+	passFile := filepath.Join(dir, "pass.txt")
+	if err := os.WriteFile(passFile, []byte("hunter2\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cmd := newTestEncryptCommand()
+	_ = cmd.Flags().Set("encrypt-passphrase-file", passFile)
+
+	enc, err := resolveEncryption(cmd)
+	if err != nil {
+		t.Fatalf("resolveEncryption: %v", err)
+	}
+	if !enc.enabled || enc.mode != "passphrase" || len(enc.recipients) != 1 {
+		t.Errorf("enc = %+v, want enabled passphrase with 1 recipient", enc)
+	}
 }
 
 func TestResolveEncryptPassphrase_Disabled(t *testing.T) {

--- a/cmd/redact.go
+++ b/cmd/redact.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/config"
 	"github.com/phenixblue/k8shark/internal/redact"
@@ -31,7 +30,11 @@ Rules may also be loaded from a config file's redaction.rules block via --config
   kshrk redact --in capture.kshrk --redact-field "data.api-key:ConfigMap:REDACTED"
 
   # Use redaction.rules from a config file, writing to a chosen path
-  kshrk redact --in capture.kshrk --out safe.kshrk --config k8shark.yaml`,
+  kshrk redact --in capture.kshrk --out safe.kshrk --config k8shark.yaml
+
+  # Redact and encrypt the output to an age recipient (decrypt an encrypted
+  # source with --decrypt-passphrase-file / --decrypt-identity-file)
+  kshrk redact --in capture.kshrk --redact-secrets --encrypt-recipient age1abc...`,
 	RunE: runRedact,
 }
 
@@ -129,23 +132,20 @@ func runRedact(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// Write-side: optionally re-encrypt the redacted output.
-	passphrase, encrypt, err := resolveEncryptPassphrase(cmd)
+	// Write-side: optionally re-encrypt the redacted output (passphrase or
+	// recipient keys).
+	enc, err := resolveEncryption(cmd)
 	if err != nil {
 		return err
 	}
-	var recipients []age.Recipient
-	if encrypt {
-		recipients, err = archive.RecipientsFromPassphrase(passphrase)
-		if err != nil {
-			return err
+	if !enc.enabled {
+		if srcEncrypted, _ := archive.IsEncrypted(in); srcEncrypted {
+			// The source is encrypted but no output encryption was requested —
+			// warn that the redacted copy will be written in plaintext so an
+			// encrypted capture isn't silently downgraded.
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"warning: source archive is encrypted but the redacted output %q will be written in plaintext; pass --encrypt or --encrypt-recipient to keep it encrypted\n", out)
 		}
-	} else if srcEncrypted, _ := archive.IsEncrypted(in); srcEncrypted {
-		// The source is encrypted but no output encryption was requested — warn
-		// that the redacted copy will be written in plaintext so an encrypted
-		// capture isn't silently downgraded.
-		fmt.Fprintf(cmd.ErrOrStderr(),
-			"warning: source archive is encrypted but the redacted output %q will be written in plaintext; pass --encrypt to keep it encrypted\n", out)
 	}
 
 	result, err := redact.Archive(in, out, redact.Options{
@@ -153,7 +153,7 @@ func runRedact(cmd *cobra.Command, _ []string) error {
 		AllowList:     allowList,
 		Rules:         rules,
 		Identities:    identities,
-		Recipients:    recipients,
+		Recipients:    enc.recipients,
 	})
 	if err != nil {
 		return err

--- a/cmd/redact.go
+++ b/cmd/redact.go
@@ -144,7 +144,7 @@ func runRedact(cmd *cobra.Command, _ []string) error {
 			// warn that the redacted copy will be written in plaintext so an
 			// encrypted capture isn't silently downgraded.
 			fmt.Fprintf(cmd.ErrOrStderr(),
-				"warning: source archive is encrypted but the redacted output %q will be written in plaintext; pass --encrypt or --encrypt-recipient to keep it encrypted\n", out)
+				"warning: source archive is encrypted but the redacted output %q will be written in plaintext; pass a passphrase (--encrypt / --encrypt-passphrase-file) or recipient (--encrypt-recipient / --encrypt-recipients-file) flag to keep it encrypted\n", out)
 		}
 	}
 

--- a/internal/redact/encrypt_test.go
+++ b/internal/redact/encrypt_test.go
@@ -147,3 +147,46 @@ func TestRedact_EncryptedRoundTrip(t *testing.T) {
 		t.Errorf("data[password] = %q, want %q", dataMap["password"], want)
 	}
 }
+
+// TestRedact_ReKeyAcrossIdentities exercises the asymmetric read/write key path
+// that capture's ephemeral-identity redaction relies on: read an archive
+// encrypted to identity A, write the redacted result encrypted to a *different*
+// recipient B. The output must be decryptable only by B, not A.
+func TestRedact_ReKeyAcrossIdentities(t *testing.T) {
+	idA, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("GenerateX25519Identity A: %v", err)
+	}
+	idB, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("GenerateX25519Identity B: %v", err)
+	}
+
+	encoded := base64.StdEncoding.EncodeToString([]byte("my-password"))
+	records := []*capture.Record{
+		secretRecord("r1", "default", "db-creds", map[string]string{"password": encoded}, nil),
+	}
+	src := buildEncryptedArchive(t, records, []age.Recipient{idA.Recipient()})
+	dst := src + "-rekeyed.kshrk"
+	t.Cleanup(func() { os.Remove(dst) })
+
+	if _, err := Archive(src, dst, Options{
+		RedactSecrets: true,
+		Identities:    []age.Identity{idA},              // read with A
+		Recipients:    []age.Recipient{idB.Recipient()}, // write to B
+	}); err != nil {
+		t.Fatalf("Archive re-key: %v", err)
+	}
+
+	// B decrypts.
+	arB, err := archive.OpenWithIdentities(dst, []age.Identity{idB})
+	if err != nil {
+		t.Fatalf("OpenWithIdentities(B): %v", err)
+	}
+	_ = arB.Close()
+
+	// A must NOT decrypt the re-keyed output.
+	if _, err := archive.OpenWithIdentities(dst, []age.Identity{idA}); err == nil {
+		t.Fatal("OpenWithIdentities(A) on re-keyed archive succeeded, want failure")
+	}
+}

--- a/internal/redact/encrypt_test.go
+++ b/internal/redact/encrypt_test.go
@@ -183,10 +183,13 @@ func TestRedact_ReKeyAcrossIdentities(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenWithIdentities(B): %v", err)
 	}
-	_ = arB.Close()
+	if err := arB.Close(); err != nil {
+		t.Errorf("closing B-decrypted archive: %v", err)
+	}
 
 	// A must NOT decrypt the re-keyed output.
-	if _, err := archive.OpenWithIdentities(dst, []age.Identity{idA}); err == nil {
+	if arA, err := archive.OpenWithIdentities(dst, []age.Identity{idA}); err == nil {
+		_ = arA.Close()
 		t.Fatal("OpenWithIdentities(A) on re-keyed archive succeeded, want failure")
 	}
 }


### PR DESCRIPTION
## Summary

Fourth milestone of optional archive encryption-at-rest ([#117](https://github.com/phenixblue/k8shark/issues/117)): **write-side public-key encryption** — the symmetric counterpart to M3's `--decrypt-identity-file`. You can now encrypt a capture to age recipient public keys (the natural "share with a teammate" flow), not just a passphrase.

## What's in this PR

- **New flags on `capture` and `redact`:** `--encrypt-recipient` (repeatable `age1...` key) and `--encrypt-recipients-file` (an age recipients file, via `age.ParseRecipients`). Presence enables encryption, mirroring `--encrypt-passphrase-file`.
- **Passphrase and recipient modes are mutually exclusive**, enforced at flag-parse time *before* any prompt — age requires a passphrase (scrypt) recipient to be the file's only recipient. A unified `resolveEncryption()` returns the recipient set for either mode plus a display label.
- **No reader-side change** — M3 already decrypts X25519 identity files, so `--decrypt-identity-file` opens these archives as-is.

## Capture + redaction + encryption, both modes, no plaintext spillage

Redaction is a post-capture pass that re-reads the archive, which is a problem for recipient mode: we hold the *public* key, not the private one, so we can't decrypt the intermediate. Solution: when a capture will be redacted, the engine encrypts the intermediate to an **ephemeral X25519 key held only in memory**, and the redact pass decrypts it and re-encrypts to the real recipients. This:
- works uniformly for passphrase and recipient modes,
- never writes plaintext to disk,
- needs no access to the recipients' private keys,
- and, as a bonus, replaces M2's *three* scrypt runs (passphrase + redact) with a **single** KDF at the final write.

`redact` standalone gets the same flags; it reads an encrypted source via the M3 `--decrypt-*` flags and warns (rather than silently downgrading) if a source is encrypted but no output encryption is requested.

## Verified end to end (built binary, no cluster needed via `redact`)

```
$ kshrk redact --in plain.kshrk --out enc.kshrk --redact-secrets --encrypt-recipient age1fehq…   # ✓
$ kshrk inspect enc.kshrk --decrypt-identity-file key.txt                                          # ✓ decrypts
$ kshrk inspect enc.kshrk                                                                          # clear "is encrypted" error
$ kshrk redact … --encrypt-recipients-file recip.txt                                               # ✓ (file variant)
$ kshrk redact … --encrypt --encrypt-recipient age1…                                               # rejected:
Error: passphrase encryption (…) cannot be combined with recipient encryption (…): age requires a passphrase to be the only recipient
```

## Tests

- `cmd/encrypt_flags_test.go`: `resolveEncryption` for recipient (inline + file), passphrase, the mutual-exclusion error, and an invalid recipient key.
- `internal/redact/encrypt_test.go`: an **asymmetric read-A / write-B re-key** test that mirrors capture's ephemeral path — output decryptable only by B, not A.

`make fmt`, `make lint-ci`, full `make test`, and `go mod tidy` (idempotent) all clean.

## Note for reviewers

Does **not** close #117 — M4 of 5. Only **M5** (docs + threat model + final edge-case pass) remains in the original plan; a follow-up **M6** (standalone `kshrk encrypt`/`decrypt`) was since agreed with the maintainer. Uses X25519 recipients (not the SSH or post-quantum Hybrid types) for `age-keygen` interoperability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)