### PR TITLE
docs(encryption): threat model, format/usage docs, final edge-case tests (M5 of #117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ timeline, and a time-travel scrubber. See **[docs/web-ui.md](docs/web-ui.md)** f
 | [docs/releases.md](docs/releases.md) | How to cut a release, GoReleaser pipeline, signing, Homebrew tap |
 | [docs/development.md](docs/development.md) | Building, testing, linting, KinD dev cluster, E2E tests, package layout |
 | [docs/archive-format.md](docs/archive-format.md) | Internal `.kshrk` (ZIP+Zstd) layout, record and index JSON schemas, and the format-compatibility guarantee |
+| [docs/encryption-threat-model.md](docs/encryption-threat-model.md) | What `--encrypt` protects (and doesn't), key-handling rules, passphrase vs. recipient keys |
 
 ## License
 

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"filippo.io/age"
 	archivepkg "github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
 	"github.com/spf13/cobra"
@@ -77,7 +79,72 @@ func newTestDiffCommand() *cobra.Command {
 	cmd.Flags().String("resource", "", "")
 	cmd.Flags().String("namespace", "", "")
 	cmd.Flags().StringP("output", "o", "text", "")
+	addDecryptFlags(cmd)
+	// PersistentFlags on a standalone command aren't merged into Flags() until
+	// execution via cmd.Execute(); since tests call runDiff directly, merge
+	// them explicitly so resolveDecryptIdentities can read them.
+	cmd.Flags().AddFlagSet(cmd.PersistentFlags())
 	return cmd
+}
+
+// buildEncryptedDiffArchive mirrors buildDiffArchive but writes an
+// age-encrypted archive using a low-work-factor passphrase recipient.
+func buildEncryptedDiffArchive(t *testing.T, body, passphrase string) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "capture.kshrk")
+	now := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	rec := &capture.Record{ID: "rec-1", CapturedAt: now, APIPath: "/api/v1/namespaces/default/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body)}
+	meta := &capture.CaptureMetadata{CaptureID: "test-capture", CapturedAt: now, CapturedUntil: now, RecordCount: 1, Encrypted: true}
+	index := capture.Index{
+		"/api/v1/namespaces/default/pods": {APIPath: "/api/v1/namespaces/default/pods", Seqs: []int{0}, Times: []time.Time{now}},
+	}
+	r, err := age.NewScryptRecipient(passphrase)
+	if err != nil {
+		t.Fatalf("NewScryptRecipient: %v", err)
+	}
+	r.SetWorkFactor(10)
+	sw, err := archivepkg.NewEncryptedStreamWriter(out, []age.Recipient{r})
+	if err != nil {
+		t.Fatalf("NewEncryptedStreamWriter: %v", err)
+	}
+	if err := sw.WriteRecord(rec); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+	if err := sw.Finish(meta, index, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	return out
+}
+
+// TestRunDiff_EncryptedBeforeOnly exercises the M3 fix where only one side of
+// a two-archive diff is encrypted: --before is encrypted, --after is
+// plaintext. The shared --decrypt-passphrase-file must still be tried against
+// the encrypted side and the diff must run end to end.
+func TestRunDiff_EncryptedBeforeOnly(t *testing.T) {
+	const passphrase = "diff-encrypt-test-passphrase"
+	before := buildEncryptedDiffArchive(t, `{"kind":"PodList","items":[{"metadata":{"name":"before"}}]}`, passphrase)
+	after := buildDiffArchive(t, `{"kind":"PodList","items":[{"metadata":{"name":"after"}}]}`)
+
+	passFile := filepath.Join(t.TempDir(), "pass.txt")
+	if err := os.WriteFile(passFile, []byte(passphrase), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmd := newTestDiffCommand()
+	_ = cmd.Flags().Set("before", before)
+	_ = cmd.Flags().Set("after", after)
+	_ = cmd.Flags().Set("output", "json")
+	_ = cmd.Flags().Set("decrypt-passphrase-file", passFile)
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+
+	err := runDiff(cmd, nil)
+	if err == nil {
+		t.Fatal("expected a diff (exit error) between before/after pod names")
+	}
+	if _, ok := err.(exitError); !ok {
+		t.Fatalf("expected exitError (a real diff was found), got %T: %v", err, err)
+	}
 }
 
 func buildDiffArchive(t *testing.T, body string) string {

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -107,6 +107,10 @@ func buildEncryptedDiffArchive(t *testing.T, body, passphrase string) string {
 	if err != nil {
 		t.Fatalf("NewEncryptedStreamWriter: %v", err)
 	}
+	// Release the file handle even if WriteRecord/Finish below t.Fatalf's, so
+	// TempDir cleanup can't be blocked by an open file. Abort is a no-op after
+	// a successful Finish.
+	defer func() { _ = sw.Abort() }()
 	if err := sw.WriteRecord(rec); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -131,10 +131,18 @@ func TestRunDiff_EncryptedBeforeOnly(t *testing.T) {
 	}
 
 	cmd := newTestDiffCommand()
-	_ = cmd.Flags().Set("before", before)
-	_ = cmd.Flags().Set("after", after)
-	_ = cmd.Flags().Set("output", "json")
-	_ = cmd.Flags().Set("decrypt-passphrase-file", passFile)
+	if err := cmd.Flags().Set("before", before); err != nil {
+		t.Fatalf("set before flag: %v", err)
+	}
+	if err := cmd.Flags().Set("after", after); err != nil {
+		t.Fatalf("set after flag: %v", err)
+	}
+	if err := cmd.Flags().Set("output", "json"); err != nil {
+		t.Fatalf("set output flag: %v", err)
+	}
+	if err := cmd.Flags().Set("decrypt-passphrase-file", passFile); err != nil {
+		t.Fatalf("set decrypt-passphrase-file flag: %v", err)
+	}
 	buf := &bytes.Buffer{}
 	cmd.SetOut(buf)
 

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -79,6 +79,11 @@ func runReplay(cmd *cobra.Command, args []string) error {
 		writable = true
 	}
 
+	identities, err := resolveDecryptIdentities(cmd, args[0])
+	if err != nil {
+		return err
+	}
+
 	srv, err := server.Replay(server.ReplayOptions{
 		ArchivePath:       args[0],
 		Port:              port,
@@ -91,6 +96,7 @@ func runReplay(cmd *cobra.Command, args []string) error {
 		Writable:          writable,
 		DisableScheduling: !schedulePods,
 		Verbose:           verbose,
+		Identities:        identities,
 	})
 	if err != nil {
 		return fmt.Errorf("starting replay: %w", err)

--- a/cmd/replay_test.go
+++ b/cmd/replay_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -16,6 +18,11 @@ func newTestReplayCommand() *cobra.Command {
 	cmd.Flags().String("to", "", "")
 	cmd.Flags().Bool("loop", false, "")
 	cmd.Flags().Bool("start-paused", false, "")
+	addDecryptFlags(cmd)
+	// PersistentFlags on a standalone command aren't merged into Flags() until
+	// execution via cmd.Execute(); tests call runReplay directly, so merge
+	// them explicitly (matches the pattern in decrypt_flags_test.go / diff_test.go).
+	cmd.Flags().AddFlagSet(cmd.PersistentFlags())
 	return cmd
 }
 
@@ -49,5 +56,36 @@ func TestRunReplay_InvalidWindow(t *testing.T) {
 
 	if err := runReplay(cmd, []string{arch}); err == nil {
 		t.Fatal("expected error when --to precedes --from")
+	}
+}
+
+// TestRunReplay_EncryptedArchiveWrongPassphrase is a regression guard for a
+// gap where `replay` never resolved --decrypt-* flags: server.Replay was
+// always called with nil Identities, so ANY archive.OpenWithIdentities call
+// against an encrypted archive failed with the same "supply a decryption
+// key" error regardless of what --decrypt-passphrase-file contained — a
+// wrong passphrase and no passphrase were indistinguishable. Asserting the
+// error specifically mentions "incorrect passphrase" (not "supply a
+// decryption key") proves the flag is actually read and passed through to
+// the decrypt attempt.
+func TestRunReplay_EncryptedArchiveWrongPassphrase(t *testing.T) {
+	arch := buildEncryptedDiffArchive(t, healthyPodList, "replay-encrypt-test-passphrase")
+
+	passFile := filepath.Join(t.TempDir(), "wrong.txt")
+	if err := os.WriteFile(passFile, []byte("not-the-passphrase"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmd := newTestReplayCommand()
+	if err := cmd.Flags().Set("decrypt-passphrase-file", passFile); err != nil {
+		t.Fatalf("set decrypt-passphrase-file flag: %v", err)
+	}
+
+	err := runReplay(cmd, []string{arch})
+	if err == nil {
+		t.Fatal("expected an error for a wrong passphrase")
+	}
+	if !strings.Contains(err.Error(), "incorrect passphrase") {
+		t.Errorf("error = %q, want it to mention an incorrect passphrase (proving the flag was actually used), not a generic \"encrypted\" error", err)
 	}
 }

--- a/docs/archive-format.md
+++ b/docs/archive-format.md
@@ -3,9 +3,9 @@
 A k8shark capture is a `.kshrk` file: a ZIP container whose entries are
 individually Zstandard-compressed JSON (except `metadata.json`, which is stored
 uncompressed for fast header reads). It can be listed with any ZIP tool —
-unless it was written with any of `capture`'s encryption flags
-(`--encrypt`, `--encrypt-passphrase-file`, `--encrypt-recipient`, or
-`--encrypt-recipients-file`), in which case the whole file is a single
+unless it was written with any of the `--encrypt`, `--encrypt-passphrase-file`,
+`--encrypt-recipient`, or `--encrypt-recipients-file` flags (available on both
+`kshrk capture` and `kshrk redact`), in which case the whole file is a single
 [age](https://age-encryption.org/v1) envelope around this same ZIP layout; see
 [Encryption](#encryption) below.
 

--- a/docs/archive-format.md
+++ b/docs/archive-format.md
@@ -3,9 +3,11 @@
 A k8shark capture is a `.kshrk` file: a ZIP container whose entries are
 individually Zstandard-compressed JSON (except `metadata.json`, which is stored
 uncompressed for fast header reads). It can be listed with any ZIP tool —
-unless it was written with `--encrypt`/`--encrypt-recipient`, in which case the
-whole file is a single [age](https://age-encryption.org/v1) envelope around
-this same ZIP layout; see [Encryption](#encryption) below.
+unless it was written with any of `capture`'s encryption flags
+(`--encrypt`, `--encrypt-passphrase-file`, `--encrypt-recipient`, or
+`--encrypt-recipients-file`), in which case the whole file is a single
+[age](https://age-encryption.org/v1) envelope around this same ZIP layout; see
+[Encryption](#encryption) below.
 
 ```sh
 unzip -l capture.kshrk
@@ -229,8 +231,9 @@ kshrk redact --in capture.kshrk --out capture-redacted.kshrk
 
 ## Encryption
 
-`kshrk capture --encrypt` / `--encrypt-recipient` (and the equivalent flags on
-`kshrk redact`) can write a `.kshrk` file as a single
+`kshrk capture`'s encryption flags (`--encrypt`, `--encrypt-passphrase-file`,
+`--encrypt-recipient`, `--encrypt-recipients-file` — and the equivalent flags
+on `kshrk redact`) write a `.kshrk` file as a single
 [age](https://age-encryption.org/v1) envelope wrapping the entire ZIP
 container described above — not per-entry encryption. On write, the ZIP
 writer streams into `age.Encrypt`'s writer instead of directly into the

--- a/docs/archive-format.md
+++ b/docs/archive-format.md
@@ -2,7 +2,10 @@
 
 A k8shark capture is a `.kshrk` file: a ZIP container whose entries are
 individually Zstandard-compressed JSON (except `metadata.json`, which is stored
-uncompressed for fast header reads). It can be listed with any ZIP tool.
+uncompressed for fast header reads). It can be listed with any ZIP tool —
+unless it was written with `--encrypt`/`--encrypt-recipient`, in which case the
+whole file is a single [age](https://age-encryption.org/v1) envelope around
+this same ZIP layout; see [Encryption](#encryption) below.
 
 ```sh
 unzip -l capture.kshrk
@@ -223,6 +226,54 @@ types, but all values will be `REDACTED`.
 ```sh
 kshrk redact --in capture.kshrk --out capture-redacted.kshrk
 ```
+
+## Encryption
+
+`kshrk capture --encrypt` / `--encrypt-recipient` (and the equivalent flags on
+`kshrk redact`) can write a `.kshrk` file as a single
+[age](https://age-encryption.org/v1) envelope wrapping the entire ZIP
+container described above — not per-entry encryption. On write, the ZIP
+writer streams into `age.Encrypt`'s writer instead of directly into the
+output file. On read, `age.DecryptReaderAt` gives back a seekable
+`io.ReaderAt` over the decrypted plaintext, which `zip.NewReader` reads from
+directly — so an encrypted archive gets the same random-access reads as a
+plaintext one (used by `open`/`ui`), with nothing ever decrypted to a
+plaintext temp file or fully buffered in memory. `DecryptReaderAt`'s `ReadAt`
+is safe for concurrent use and internally caches only the most-recently
+decrypted chunk.
+
+**Detection, not a metadata field.** An encrypted archive is recognized by
+sniffing the file's first bytes for the literal, public age spec header
+(`age-encryption.org/v1\n`) — not by a flag inside `metadata.json`, since
+metadata.json is itself inside the ciphertext and unreadable without a key.
+This also means `format_version` is untouched by encryption: it's a
+transparent outer envelope, and `CheckFormatVersion` keeps governing only the
+*decrypted* payload structure exactly as documented above. A pre-encryption
+`kshrk` build has no way to recognize an age-wrapped file and will fail with a
+raw, unhelpful zip-parsing error rather than a clear message — there's no way
+to retrofit that for binaries already in the wild.
+
+**What's hidden vs. what leaks.** Because the whole ZIP is inside one
+ciphertext, entry names (the SHA-256-derived `pathDir` directories), the ZIP
+central directory, and per-entry sizes/counts are all hidden — not just
+record payloads. The residual leak is the ciphertext's approximate total size
+(rounded to the age STREAM chunk boundary) and the fact that it's an
+age-encrypted file at all (the header is a public part of the spec, not a
+secret). See [encryption-threat-model.md](encryption-threat-model.md) for the
+full threat model, key-handling rules, and what's explicitly out of scope.
+
+Key modes: a passphrase (age `ScryptRecipient`/`ScryptIdentity`) or one or
+more X25519 recipient public keys — never both for the same archive (age
+requires a passphrase recipient to be the file's only recipient).
+Passphrase/identity material is read from files, `$KSHRK_ENCRYPT_PASSPHRASE`
+/ `$KSHRK_DECRYPT_PASSPHRASE`, or an interactive prompt — never through Viper
+or the YAML config file.
+
+Since an encrypted archive can't be listed with a plain ZIP tool (unlike the
+plaintext archives described above), use `kshrk inspect` with the appropriate
+`--decrypt-*` flag to summarize one, or age-decrypt it first
+(`age --decrypt -i key.txt capture.kshrk > capture-plain.kshrk`) to poke at it
+with the manual ZIP/Zstd commands shown below.
 
 ## Streaming mode (NDJSON stdout)
 

--- a/docs/encryption-threat-model.md
+++ b/docs/encryption-threat-model.md
@@ -1,10 +1,12 @@
 # Encryption threat model
 
 `.kshrk` captures can contain Kubernetes Secret values, tokens, and other
-cluster PII. `kshrk capture --encrypt` / `--encrypt-recipient` (and the
-equivalent `kshrk redact` flags) let you write an archive as a single
-[age](https://age-encryption.org/v1) envelope. This page states plainly what
-that protects, what it doesn't, and the key-handling rules the CLI enforces.
+cluster PII. `kshrk capture`'s encryption flags (`--encrypt`,
+`--encrypt-passphrase-file`, `--encrypt-recipient`,
+`--encrypt-recipients-file` — and the equivalent `kshrk redact` flags) let you
+write an archive as a single [age](https://age-encryption.org/v1) envelope.
+This page states plainly what that protects, what it doesn't, and the
+key-handling rules the CLI enforces.
 See [archive-format.md](archive-format.md#encryption) for how the envelope is
 built; see [usage.md](usage.md#encryption) for command examples.
 

--- a/docs/encryption-threat-model.md
+++ b/docs/encryption-threat-model.md
@@ -1,0 +1,108 @@
+# Encryption threat model
+
+`.kshrk` captures can contain Kubernetes Secret values, tokens, and other
+cluster PII. `kshrk capture --encrypt` / `--encrypt-recipient` (and the
+equivalent `kshrk redact` flags) let you write an archive as a single
+[age](https://age-encryption.org/v1) envelope. This page states plainly what
+that protects, what it doesn't, and the key-handling rules the CLI enforces.
+See [archive-format.md](archive-format.md#encryption) for how the envelope is
+built; see [usage.md](usage.md#encryption) for command examples.
+
+## What is protected
+
+- **Everything inside the archive at rest**: record bodies (including Secret
+  data), the index, the watch index, and `metadata.json` are all inside a
+  single age ciphertext. There is no partial-plaintext archive — either you
+  have a working key or you have opaque bytes.
+- **Archive structure**, not just content: because encryption wraps the whole
+  ZIP container rather than individual entries, an attacker who obtains the
+  file cannot see entry names (which would otherwise be SHA-256-derived
+  directory names), per-record sizes, or the record count from the ZIP
+  central directory. This is deliberately stronger than a per-entry encryption
+  design would have been, at the cost described below.
+- **Tamper detection**: age's AEAD construction (ChaCha20-Poly1305 under the
+  STREAM chunking) authenticates every chunk. Any bit flipped in the
+  ciphertext — accidental corruption or deliberate tampering — causes
+  decryption to fail outright rather than silently returning corrupted data.
+- **In-transit copies**: since the whole file is one opaque envelope, copying
+  it over email, object storage, a support ticket attachment, etc. carries no
+  additional exposure beyond having the ciphertext bytes.
+
+## What is NOT protected (explicitly out of scope)
+
+- **File existence and approximate size.** Anyone with filesystem or network
+  access to the `.kshrk` file can see that it exists, its approximate size
+  (rounded to the age STREAM chunk boundary, ~64 KiB), and its modification
+  time. Encryption hides content and structure, not the fact of the file.
+- **That it's an age-encrypted file.** The first line of the file is the
+  literal, public spec string `age-encryption.org/v1` — this is how `kshrk`
+  itself detects an encrypted archive and prompts for a key. It is not a
+  secret and isn't intended to be.
+- **A compromised host while the archive is open.** `kshrk ui`/`kshrk open`
+  decrypt chunks on demand into process memory as they're browsed (see
+  [archive-format.md](archive-format.md#encryption)); a compromised machine
+  with the process running, or an attacker who captures the passphrase as
+  it's typed, defeats the encryption regardless of the archive itself. This
+  is the same trust boundary as any local decryption tool.
+- **Recipient revocation.** age has no built-in mechanism to revoke a
+  recipient key. If a private key or passphrase may have been exposed, the
+  only remedy is to re-encrypt to a new key/recipient set (see
+  [Rotating keys](#rotating-keys-today) below) — there is no way to
+  retroactively deny that key access to copies already handed out.
+- **Old `kshrk` binaries.** A `kshrk` build from before encryption support
+  (anything prior to this feature) will fail with a raw, unhelpful
+  `zip: not a valid zip file`-style error on an encrypted archive rather than
+  a clear "this archive is encrypted" message — there's no way to retrofit
+  clearer errors into binaries already in the wild. Current builds detect the
+  age header and give a specific error instead.
+
+## Key handling rules
+
+- **Passphrase material never touches the YAML config file or Viper.** The
+  `--encrypt-passphrase-file` / `--decrypt-passphrase-file` flags and the
+  `$KSHRK_ENCRYPT_PASSPHRASE` / `$KSHRK_DECRYPT_PASSPHRASE` environment
+  variables are read directly (`os.Getenv`, file reads) and are never bound
+  through Viper — so a passphrase can't accidentally end up committed in
+  `config.yaml` or a config file shared alongside a capture. There is
+  deliberately no bare `--encrypt-passphrase <string>` flag, since CLI
+  arguments are visible in shell history and to other users via `ps`.
+- **Treat an age identity (private key) file exactly like an SSH private
+  key**: restrict its file permissions (`chmod 600`), never commit it to
+  version control, and don't attach it to the same channel you send the
+  encrypted archive through.
+- **Passphrase mode and recipient mode are mutually exclusive per archive.**
+  This is an age library constraint (a passphrase/scrypt recipient must be
+  the file's only recipient), not a k8shark design choice — `kshrk` rejects
+  the combination before any prompt runs.
+- **Prefer recipient (public-key) encryption for anything automated or
+  multi-party.** A passphrase is simplest for a single ad-hoc share, but has
+  no forward secrecy or per-recipient accountability. Recipient keys let you
+  encrypt once to multiple people, and support key rotation without
+  re-distributing a shared secret.
+
+## Choosing passphrase vs. recipients
+
+| | Passphrase (`--encrypt`) | Recipients (`--encrypt-recipient`) |
+|---|---|---|
+| Setup | None — just a shared secret | Recipients generate an age keypair once (`age-keygen`) |
+| Sharing model | Whoever has the passphrase can decrypt | Encrypt to specific people's public keys |
+| Automation | Passphrase must be distributed to every consumer (file/env) | Encrypt to a public key with no secret material on the encrypting side |
+| Rotation | Requires a new shared secret and re-encryption | Add/remove recipients by re-encrypting to a different key set |
+
+## Rotating keys today
+
+There's no dedicated `kshrk encrypt`/`kshrk decrypt` command yet (tracked for
+a later milestone). In the meantime, `kshrk redact` can serve as a re-encrypt
+tool even with no redaction rules — pass `--decrypt-*` for the source key and
+`--encrypt-*` for the new key/recipients:
+
+```sh
+kshrk redact --in old.kshrk --out new.kshrk \
+  --decrypt-passphrase-file old-pass.txt \
+  --encrypt-recipient age1newrecipient...
+```
+
+**Caveat**: this always marks the output archive's metadata as `redacted:
+true`, even if no redaction actually occurred, since `kshrk redact` doesn't
+distinguish "re-key only" from "redact" today. Treat this as a workaround,
+not the intended long-term interface.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -747,8 +747,9 @@ See [config.md](config.md#redaction) for the full `redaction:` config block refe
 Captures can contain Secret values and other sensitive cluster data.
 `kshrk capture` (and `kshrk redact`) can write the archive as a single
 encrypted [age](https://age-encryption.org/v1) envelope, and every command
-that reads a `.kshrk` archive — `inspect`, `open`, `ui`, `diff`, `query`,
-`transitions`, `diagnose`, `redact` — decrypts it transparently given a key.
+that reads a `.kshrk` archive — `inspect`, `open`, `ui`, `replay`, `diff`,
+`query`, `transitions`, `diagnose`, `redact` — decrypts it transparently
+given a key.
 See [encryption-threat-model.md](encryption-threat-model.md) for what this
 does and doesn't protect against, and
 [archive-format.md#encryption](archive-format.md#encryption) for how the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -114,6 +114,12 @@ Capture complete
 | `--redact-secrets` | | false | Redact Secret `data`/`stringData` values from the archive after capture |
 | `--allow-secret` | | | `namespace/name` of secret to preserve when `--redact-secrets` is set (repeatable) |
 | `--redact-field` | | | Field redaction rule applied after capture: `<path>:<Kind>:<replacement>[:<type>]` (repeatable) |
+| `--encrypt` | | false | Encrypt the output archive with a passphrase (prompts if no source is given) |
+| `--encrypt-passphrase-file` | | | Read the encryption passphrase from this file instead of prompting |
+| `--encrypt-recipient` | | | age recipient public key (`age1...`) to encrypt to (repeatable) |
+| `--encrypt-recipients-file` | | | File of age recipient public keys, one per line |
+
+See [Encryption](#encryption) below for the full picture, including decrypting on read and combining with redaction.
 
 If `--config` is not specified, k8shark looks for `./config.yaml` in the current directory first, then falls back to `~/.config/kshrk/config.yaml`.
 
@@ -727,10 +733,97 @@ Examples:
 | `--allow-secret` | both | | `namespace/name` of secret to preserve (repeatable) |
 | `--redact-field` | both | | Field redaction rule (repeatable). Format: `<path>:<Kind>:<replacement>[:<type>]` |
 | `--config` | `redact` | | Capture config file — applies `redaction.rules` and `redaction.redactSecrets` |
+| `--encrypt`, `--encrypt-passphrase-file`, `--encrypt-recipient`, `--encrypt-recipients-file` | `redact` | | Encrypt the output archive — see [Encryption](#encryption) |
+| `--decrypt-passphrase-file`, `--decrypt-identity-file` | `redact` | | Decrypt an encrypted `--in` archive — see [Encryption](#encryption) |
 
 Secret metadata (name, namespace, labels, annotations, type) is always preserved so you can still count and identify secrets by kind.
 
 See [config.md](config.md#redaction) for the full `redaction:` config block reference with type-aware examples.
+
+---
+
+## Encryption
+
+Captures can contain Secret values and other sensitive cluster data.
+`kshrk capture` (and `kshrk redact`) can write the archive as a single
+encrypted [age](https://age-encryption.org/v1) envelope, and every command
+that reads a `.kshrk` archive — `inspect`, `open`, `ui`, `diff`, `query`,
+`transitions`, `diagnose`, `redact` — decrypts it transparently given a key.
+See [encryption-threat-model.md](encryption-threat-model.md) for what this
+does and doesn't protect against, and
+[archive-format.md#encryption](archive-format.md#encryption) for how the
+envelope is built.
+
+### Encrypting at capture time
+
+Two key modes, mutually exclusive per archive:
+
+```sh
+# Passphrase — prompts interactively (with confirmation) if no source is given
+kshrk capture --config k8shark.yaml --encrypt
+
+# Passphrase from a file, for scripts/CI (no prompt)
+kshrk capture --config k8shark.yaml --encrypt-passphrase-file ./pass.txt
+
+# Or via environment variable
+KSHRK_ENCRYPT_PASSPHRASE=hunter2 kshrk capture --config k8shark.yaml --encrypt
+
+# Recipient public keys — encrypt to one or more age keypairs
+age-keygen -o key.txt          # generates a private key; prints the public key
+kshrk capture --config k8shark.yaml --encrypt-recipient age1abc...
+
+# Or a file of recipients (one per line, '#' comments allowed)
+kshrk capture --config k8shark.yaml --encrypt-recipients-file recipients.txt
+```
+
+There is deliberately no `--encrypt-passphrase <string>` flag — passing a
+passphrase as a bare CLI argument would leak it into shell history and `ps`
+output. Use `--encrypt-passphrase-file`, the environment variable, or the
+interactive prompt instead.
+
+### Decrypting on read
+
+Every read command accepts the same decrypt flags:
+
+| Flag | Description |
+|------|-------------|
+| `--decrypt-passphrase-file` | Read the passphrase from this file (first line) |
+| `--decrypt-identity-file` | An age identity (private key) file, e.g. from `age-keygen` |
+| `$KSHRK_DECRYPT_PASSPHRASE` | Passphrase via environment variable |
+
+If none of these are given and the archive turns out to be encrypted, `kshrk`
+prompts for a passphrase on a terminal, or fails with a clear error instead of
+hanging if stdin isn't a terminal. A plaintext archive is unaffected either
+way — no key is ever required to open one.
+
+```sh
+kshrk inspect capture.kshrk --decrypt-passphrase-file ./pass.txt
+kshrk ui capture.kshrk --decrypt-passphrase-file ./pass.txt
+kshrk open capture.kshrk --decrypt-identity-file ./key.txt
+kshrk diff --before a.kshrk --after b.kshrk --decrypt-passphrase-file ./pass.txt
+```
+
+A wrong passphrase or key produces a clean error (`incorrect passphrase or
+key`), not a raw crypto failure.
+
+### Combining with redaction
+
+`kshrk redact` reads an encrypted source with the flags above and can
+re-encrypt the output with `--encrypt*`:
+
+```sh
+kshrk redact --in capture.kshrk --redact-secrets \
+  --decrypt-passphrase-file old-pass.txt \
+  --encrypt-recipient age1abc...
+```
+
+`kshrk capture --encrypt --redact-secrets` (redacting inline right after
+capture) works the same way and keeps the archive encrypted end to end — no
+plaintext copy is ever written to disk in between.
+
+If a source archive is encrypted but `redact` isn't given any `--encrypt*`
+flags, it warns and writes the redacted output in plaintext rather than
+silently downgrading it without telling you.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -810,7 +810,7 @@ key`), not a raw crypto failure.
 ### Combining with redaction
 
 `kshrk redact` reads an encrypted source with the flags above and can
-re-encrypt the output with `--encrypt*`:
+re-encrypt the output with `--encrypt-*`:
 
 ```sh
 kshrk redact --in capture.kshrk --redact-secrets \
@@ -822,7 +822,7 @@ kshrk redact --in capture.kshrk --redact-secrets \
 capture) works the same way and keeps the archive encrypted end to end — no
 plaintext copy is ever written to disk in between.
 
-If a source archive is encrypted but `redact` isn't given any `--encrypt*`
+If a source archive is encrypted but `redact` isn't given any `--encrypt-*`
 flags, it warns and writes the redacted output in plaintext rather than
 silently downgrading it without telling you.
 

--- a/internal/server/encrypt_test.go
+++ b/internal/server/encrypt_test.go
@@ -2,10 +2,12 @@ package server
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -60,6 +62,21 @@ func buildEncryptedTestArchive(t *testing.T) string {
 	return outPath
 }
 
+// pinnedClient builds an http.Client that verifies srv's self-signed
+// certificate via its RootCAs pool, rather than skipping TLS verification.
+func pinnedClient(t *testing.T, srv *Server) *http.Client {
+	t.Helper()
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(srv.CertPEM()) {
+		t.Fatal("failed to parse server cert PEM into a pool")
+	}
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool},
+		},
+	}
+}
+
 // TestServer_Open_EncryptedArchive mirrors TestServer_Open_EndToEnd but against
 // an encrypted archive: this is the long-lived-holder path (open/ui hold the
 // archive for the whole server lifetime), so it's worth a full HTTP round trip
@@ -82,11 +99,7 @@ func TestServer_Open_EncryptedArchive(t *testing.T) {
 	}
 	defer srv.Shutdown()
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402 — test only
-		},
-	}
+	client := pinnedClient(t, srv)
 
 	url := fmt.Sprintf("%s/api/v1/namespaces/default/pods", srv.Address())
 	resp, err := client.Get(url)
@@ -105,8 +118,14 @@ func TestServer_Open_EncryptedArchive(t *testing.T) {
 	if !ok || len(items) == 0 {
 		t.Fatal("expected at least one pod in items")
 	}
-	item := items[0].(map[string]any)
-	meta := item["metadata"].(map[string]any)
+	item, ok := items[0].(map[string]any)
+	if !ok {
+		t.Fatalf("items[0] is not an object: %#v", items[0])
+	}
+	meta, ok := item["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata is not an object: %#v", item["metadata"])
+	}
 	if meta["name"] != "nginx" {
 		t.Errorf("expected pod name=nginx, got %v", meta["name"])
 	}
@@ -121,6 +140,9 @@ func TestServer_Open_EncryptedArchiveNoIdentities(t *testing.T) {
 	_, err := Open(OpenOptions{ArchivePath: archivePath})
 	if err == nil {
 		t.Fatal("server.Open on encrypted archive with no identities succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "is encrypted") {
+		t.Errorf("error = %q, want it to mention the archive is encrypted", err)
 	}
 }
 
@@ -143,11 +165,7 @@ func TestServer_Replay_EncryptedArchive(t *testing.T) {
 	}
 	defer srv.Shutdown()
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402 — test only
-		},
-	}
+	client := pinnedClient(t, srv)
 	resp, err := client.Get(srv.Address() + "/api/v1/namespaces/default/pods")
 	if err != nil {
 		t.Fatalf("GET pods: %v", err)

--- a/internal/server/encrypt_test.go
+++ b/internal/server/encrypt_test.go
@@ -53,6 +53,10 @@ func buildEncryptedTestArchive(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("NewEncryptedStreamWriter: %v", err)
 	}
+	// Release the file handle even if WriteRecord/Finish below t.Fatalf's, so
+	// TempDir cleanup can't be blocked by an open file. Abort is a no-op after
+	// a successful Finish.
+	defer func() { _ = sw.Abort() }()
 	if err := sw.WriteRecord(rec); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}

--- a/internal/server/encrypt_test.go
+++ b/internal/server/encrypt_test.go
@@ -1,0 +1,159 @@
+package server
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"filippo.io/age"
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// serverEncryptTestPassphrase is a fixed test-only passphrase; not a real secret.
+const serverEncryptTestPassphrase = "server-encrypt-test-passphrase" //nolint:gosec // test fixture
+
+// buildEncryptedTestArchive mirrors buildTestArchive but writes an
+// age-encrypted archive using a low-work-factor passphrase recipient (fast
+// scrypt for tests; decryption reads the work factor from the file header, so
+// the standard passphrase identity still decrypts it).
+func buildEncryptedTestArchive(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "test.kshrk")
+
+	podList := `{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":{"name":"nginx","namespace":"default"}}]}`
+	now := time.Now().UTC()
+	rec := &capture.Record{
+		ID: "rec-001", CapturedAt: now, APIPath: "/api/v1/namespaces/default/pods",
+		HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(podList),
+	}
+	meta := &capture.CaptureMetadata{
+		CaptureID: "e2e-encrypted-capture", KubernetesVersion: "v1.29.0",
+		CapturedAt: now.Add(-time.Minute), CapturedUntil: now, RecordCount: 1, Encrypted: true,
+	}
+	idx := capture.Index{
+		"/api/v1/namespaces/default/pods": {
+			APIPath: "/api/v1/namespaces/default/pods", Seqs: []int{0}, Times: []time.Time{now},
+		},
+	}
+
+	r, err := age.NewScryptRecipient(serverEncryptTestPassphrase)
+	if err != nil {
+		t.Fatalf("NewScryptRecipient: %v", err)
+	}
+	r.SetWorkFactor(10)
+	sw, err := archive.NewEncryptedStreamWriter(outPath, []age.Recipient{r})
+	if err != nil {
+		t.Fatalf("NewEncryptedStreamWriter: %v", err)
+	}
+	if err := sw.WriteRecord(rec); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+	if err := sw.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("archive Finish: %v", err)
+	}
+	return outPath
+}
+
+// TestServer_Open_EncryptedArchive mirrors TestServer_Open_EndToEnd but against
+// an encrypted archive: this is the long-lived-holder path (open/ui hold the
+// archive for the whole server lifetime), so it's worth a full HTTP round trip
+// rather than just testing the decrypt resolver in isolation.
+func TestServer_Open_EncryptedArchive(t *testing.T) {
+	archivePath := buildEncryptedTestArchive(t)
+	identities, err := archive.IdentitiesFromPassphrase(serverEncryptTestPassphrase)
+	if err != nil {
+		t.Fatalf("IdentitiesFromPassphrase: %v", err)
+	}
+
+	kubeconfigOut := filepath.Join(t.TempDir(), "kubeconfig.yaml")
+	srv, err := Open(OpenOptions{
+		ArchivePath:   archivePath,
+		KubeconfigOut: kubeconfigOut,
+		Identities:    identities,
+	})
+	if err != nil {
+		t.Fatalf("server.Open: %v", err)
+	}
+	defer srv.Shutdown()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402 — test only
+		},
+	}
+
+	url := fmt.Sprintf("%s/api/v1/namespaces/default/pods", srv.Address())
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET pods: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var pods map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&pods); err != nil {
+		t.Fatal(err)
+	}
+	items, ok := pods["items"].([]any)
+	if !ok || len(items) == 0 {
+		t.Fatal("expected at least one pod in items")
+	}
+	item := items[0].(map[string]any)
+	meta := item["metadata"].(map[string]any)
+	if meta["name"] != "nginx" {
+		t.Errorf("expected pod name=nginx, got %v", meta["name"])
+	}
+}
+
+// TestServer_Open_EncryptedArchiveNoIdentities confirms Open fails clearly
+// (not a raw zip-parse error) when the archive is encrypted and no key is
+// supplied.
+func TestServer_Open_EncryptedArchiveNoIdentities(t *testing.T) {
+	archivePath := buildEncryptedTestArchive(t)
+
+	_, err := Open(OpenOptions{ArchivePath: archivePath})
+	if err == nil {
+		t.Fatal("server.Open on encrypted archive with no identities succeeded, want error")
+	}
+}
+
+// TestServer_Replay_EncryptedArchive confirms the replay path (used by
+// `kshrk ui` in replay mode) also decrypts correctly.
+func TestServer_Replay_EncryptedArchive(t *testing.T) {
+	archivePath := buildEncryptedTestArchive(t)
+	identities, err := archive.IdentitiesFromPassphrase(serverEncryptTestPassphrase)
+	if err != nil {
+		t.Fatalf("IdentitiesFromPassphrase: %v", err)
+	}
+
+	srv, err := Replay(ReplayOptions{
+		ArchivePath:   archivePath,
+		KubeconfigOut: filepath.Join(t.TempDir(), "kubeconfig.yaml"),
+		Identities:    identities,
+	})
+	if err != nil {
+		t.Fatalf("server.Replay: %v", err)
+	}
+	defer srv.Shutdown()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402 — test only
+		},
+	}
+	resp, err := client.Get(srv.Address() + "/api/v1/namespaces/default/pods")
+	if err != nil {
+		t.Fatalf("GET pods: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary

Fifth milestone of optional archive encryption-at-rest ([#117](https://github.com/phenixblue/k8shark/issues/117)): **documentation and a final edge-case test pass.** M1–M4 already shipped the full feature (core crypto, `capture --encrypt`, reader-side `--decrypt-*`, and public-key recipients); this closes the gap where encryption existed but wasn't documented anywhere. **Update:** review of this PR surfaced one genuine, user-visible bug fix along the way — see below.

## Docs

- **New `docs/encryption-threat-model.md`** — what's protected (contents, structure, tamper detection via AEAD) vs. explicitly out of scope (file existence/approximate size, a compromised host while the archive is open, recipient revocation, old `kshrk` binaries getting a raw error), the key-handling rules the CLI enforces (passphrase material never through Viper/`config.yaml`, treat identity files like SSH keys, passphrase/recipient mutual exclusion), a passphrase-vs-recipients comparison table, and today's re-key workaround via `kshrk redact` (with its `metadata.redacted=true` mislabeling caveat, pending the planned M6 `encrypt`/`decrypt` commands).
- **`docs/archive-format.md`** — new "Encryption" section: the whole-archive age envelope design, the header-sniff detection mechanism (not a metadata field, since `metadata.json` is itself ciphertext), why `format_version` is untouched, and what the envelope hides vs. its residual leak (ciphertext size, that it's an age file at all). Cross-linked with the threat-model doc.
- **`docs/usage.md`** — new "Encryption" section with capture examples for both key modes, the shared `--decrypt-*` flags that work identically across every read command, and combining encryption with redaction — plus `--encrypt-*`/`--decrypt-*` rows added to the existing Capture/Redact flags tables.
- **README** — doc-index table gains the threat-model doc.

## Bug fix found during review: `kshrk replay` never decrypted

Writing "every read command decrypts transparently" in the docs prompted a check against the actual code, which turned up a real gap: `kshrk replay` (distinct from `kshrk ui`'s `--ui` replay mode, which *was* wired in M3) never called the identity resolver, so `server.Replay` always ran with `nil` identities. Any encrypted archive failed with a generic "supply a decryption key" error regardless of what `--decrypt-passphrase-file`/`--decrypt-identity-file`/`$KSHRK_DECRYPT_PASSPHRASE` contained — the flags were silently ignored.

Fixed in `cmd/replay.go` (now resolves and passes identities, matching every other read command), confirmed no other command has the same gap by sweeping all `archive.Open`/`server.Open`/`server.Replay` call sites in `cmd/`, and added a regression test that specifically distinguishes "wrong passphrase" from "no passphrase" — the signal that proves the flag is actually being read rather than discarded.

## Tests

The feature was already heavily tested through M1–M4 (round-trips, tamper detection, wrong-key, non-TTY, concurrency, passphrase↔recipient re-keying, etc.). This fills the two real gaps rather than padding coverage:

- **`internal/server/encrypt_test.go`** — full HTTP round trips through an encrypted archive via `server.Open` and `server.Replay`. This is the long-lived-holder path behind `open`/`ui`; prior coverage only unit-tested the CLI resolver and single-shot commands like `inspect`, so the actual "decrypt once at launch, serve many requests" flow was untested. Includes a clean-failure case with no identities.
- **`cmd/diff_test.go`** — an end-to-end two-archive diff with only `--before` encrypted, exercising the M3 multi-path-prompt fix through the *full* diff pipeline (not just the resolver in isolation, which is all the original fix's test covered).

`make fmt`, `make lint-ci`, full `make test`, and `go mod tidy` (idempotent) all clean.

## Note for reviewers

Does **not** close #117 — M5 of 5 in the original plan. A follow-up **M6** (standalone `kshrk encrypt`/`kshrk decrypt` commands, agreed with the maintainer after M4) remains, referenced in the threat-model doc's "Rotating keys today" section as the reason today's re-key path is a `redact`-based workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
