### PR TITLE
feat(cli): standalone kshrk encrypt/decrypt commands (M6 of #117)

### DIFF
--- a/cmd/decrypt.go
+++ b/cmd/decrypt.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/spf13/cobra"
+)
+
+var decryptCmd = &cobra.Command{
+	Use:   "decrypt <capture.kshrk>",
+	Short: "Decrypt an encrypted capture archive back to plaintext",
+	Long: `Writes a plaintext copy of an age-encrypted .kshrk archive. The
+original encrypted archive is not modified; the output defaults to
+<in>-decrypted.kshrk.
+
+Every other kshrk command (inspect, open, ui, replay, diff, query,
+transitions, diagnose, redact) already reads an encrypted archive
+transparently given a key — this command is for producing a standalone
+plaintext copy, e.g. to hand off to a tool that can't decrypt, or before
+re-encrypting to a different key/recipient set.`,
+	Example: `  # Decrypt using a passphrase read from a file
+  kshrk decrypt capture.kshrk --decrypt-passphrase-file ./pass.txt
+
+  # Decrypt using an age identity (private key) file
+  kshrk decrypt capture.kshrk --decrypt-identity-file ./key.txt
+
+  # Choose the output path explicitly
+  kshrk decrypt capture.kshrk --output plain.kshrk --decrypt-passphrase-file ./pass.txt`,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeArchiveArg,
+	RunE:              runDecrypt,
+}
+
+func init() {
+	rootCmd.AddCommand(decryptCmd)
+	decryptCmd.Flags().StringP("output", "o", "", "output archive path (default: <in>-decrypted.kshrk)")
+	_ = decryptCmd.MarkFlagFilename("output", captureExt)
+}
+
+func runDecrypt(cmd *cobra.Command, args []string) error {
+	in := args[0]
+	out, _ := cmd.Flags().GetString("output")
+	if out == "" {
+		out = defaultCryptOutput(in, "decrypted")
+	}
+
+	if err := rejectSamePath(in, out); err != nil {
+		return err
+	}
+
+	identities, err := resolveDecryptIdentities(cmd, in)
+	if err != nil {
+		return err
+	}
+
+	if err := archive.DecryptFile(in, out, identities); err != nil {
+		return err
+	}
+
+	fi, _ := os.Stat(out)
+	var size int64
+	if fi != nil {
+		size = fi.Size()
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Decrypted -> %s (%s)\n", out, formatBytes(size))
+	return nil
+}

--- a/cmd/decrypt_test.go
+++ b/cmd/decrypt_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,6 +18,9 @@ func newTestDecryptCmdCommand() *cobra.Command {
 	// execution via cmd.Execute(); tests call runDecrypt directly, so merge
 	// them explicitly (matches the pattern used elsewhere in this package).
 	cmd.Flags().AddFlagSet(cmd.PersistentFlags())
+	// These tests assert on disk state and returned errors, not the printed
+	// summary, so discard stdout rather than letting it leak to os.Stdout.
+	cmd.SetOut(io.Discard)
 	return cmd
 }
 

--- a/cmd/decrypt_test.go
+++ b/cmd/decrypt_test.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newTestDecryptCmdCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().StringP("output", "o", "", "")
+	addDecryptFlags(cmd)
+	// PersistentFlags on a standalone command aren't merged into Flags() until
+	// execution via cmd.Execute(); tests call runDecrypt directly, so merge
+	// them explicitly (matches the pattern used elsewhere in this package).
+	cmd.Flags().AddFlagSet(cmd.PersistentFlags())
+	return cmd
+}
+
+func TestRunDecrypt_DefaultOutputAndRoundTrip(t *testing.T) {
+	const passphrase = "decrypt-cmd-test-passphrase"
+	in := buildEncryptedDiffArchive(t, healthyPodList, passphrase)
+
+	passFile := filepath.Join(t.TempDir(), "pass.txt")
+	if err := os.WriteFile(passFile, []byte(passphrase), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmd := newTestDecryptCmdCommand()
+	if err := cmd.Flags().Set("decrypt-passphrase-file", passFile); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+	if err := runDecrypt(cmd, []string{in}); err != nil {
+		t.Fatalf("runDecrypt: %v", err)
+	}
+
+	wantOut := strings.TrimSuffix(in, ".kshrk") + "-decrypted.kshrk"
+	fi, err := os.Stat(wantOut)
+	if err != nil {
+		t.Fatalf("default output %q not created: %v", wantOut, err)
+	}
+	if fi.Size() == 0 {
+		t.Fatal("decrypted output is empty")
+	}
+}
+
+func TestRunDecrypt_WrongPassphrase(t *testing.T) {
+	in := buildEncryptedDiffArchive(t, healthyPodList, "correct-passphrase")
+
+	passFile := filepath.Join(t.TempDir(), "wrong.txt")
+	if err := os.WriteFile(passFile, []byte("wrong-passphrase"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cmd := newTestDecryptCmdCommand()
+	if err := cmd.Flags().Set("decrypt-passphrase-file", passFile); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+
+	err := runDecrypt(cmd, []string{in})
+	if err == nil {
+		t.Fatal("expected an error for a wrong passphrase")
+	}
+	if !strings.Contains(err.Error(), "incorrect passphrase") {
+		t.Errorf("error = %q, want it to mention an incorrect passphrase", err)
+	}
+}
+
+func TestRunDecrypt_RejectsNotEncrypted(t *testing.T) {
+	in := buildDiffArchive(t, healthyPodList)
+	cmd := newTestDecryptCmdCommand()
+
+	err := runDecrypt(cmd, []string{in})
+	if err == nil {
+		t.Fatal("expected an error decrypting a plaintext archive")
+	}
+	if !strings.Contains(err.Error(), "not encrypted") {
+		t.Errorf("error = %q, want it to mention the archive is not encrypted", err)
+	}
+}
+
+func TestRunDecrypt_SameOutputRejected(t *testing.T) {
+	const passphrase = "decrypt-cmd-test-passphrase"
+	in := buildEncryptedDiffArchive(t, healthyPodList, passphrase)
+
+	passFile := filepath.Join(t.TempDir(), "pass.txt")
+	if err := os.WriteFile(passFile, []byte(passphrase), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cmd := newTestDecryptCmdCommand()
+	if err := cmd.Flags().Set("output", in); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+	if err := cmd.Flags().Set("decrypt-passphrase-file", passFile); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+
+	if err := runDecrypt(cmd, []string{in}); err == nil {
+		t.Fatal("expected an error when --output equals the input path")
+	}
+}

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/spf13/cobra"
+)
+
+var encryptCmd = &cobra.Command{
+	Use:   "encrypt <capture.kshrk>",
+	Short: "Encrypt an existing capture archive after the fact",
+	Long: `Writes an age-encrypted copy of an existing plaintext .kshrk archive.
+The original archive is not modified; the output defaults to
+<in>-encrypted.kshrk.
+
+This is a whole-file transform, not a new capture: use it to encrypt an
+archive you already have (e.g. before sharing it), as an alternative to
+'kshrk capture --encrypt' at capture time.`,
+	Example: `  # Encrypt with a passphrase, prompting for it
+  kshrk encrypt capture.kshrk
+
+  # Encrypt using a passphrase read from a file (no prompt)
+  kshrk encrypt capture.kshrk --encrypt-passphrase-file ./pass.txt
+
+  # Encrypt to one or more age recipient public keys
+  kshrk encrypt capture.kshrk --encrypt-recipient age1abc...
+
+  # Choose the output path explicitly
+  kshrk encrypt capture.kshrk --output shared.kshrk --encrypt-recipient age1abc...`,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeArchiveArg,
+	RunE:              runEncrypt,
+}
+
+func init() {
+	rootCmd.AddCommand(encryptCmd)
+	encryptCmd.Flags().StringP("output", "o", "", "output archive path (default: <in>-encrypted.kshrk)")
+	_ = encryptCmd.MarkFlagFilename("output", captureExt)
+	addEncryptFlags(encryptCmd)
+}
+
+func runEncrypt(cmd *cobra.Command, args []string) error {
+	in := args[0]
+	out, _ := cmd.Flags().GetString("output")
+	if out == "" {
+		out = defaultCryptOutput(in, "encrypted")
+	}
+
+	if err := rejectSamePath(in, out); err != nil {
+		return err
+	}
+
+	enc, err := resolveEncryption(cmd)
+	if err != nil {
+		return err
+	}
+	if !enc.enabled {
+		return fmt.Errorf("no encryption method given: use --encrypt, --encrypt-passphrase-file, --encrypt-recipient, or --encrypt-recipients-file")
+	}
+
+	if err := archive.EncryptFile(in, out, enc.recipients); err != nil {
+		return err
+	}
+
+	fi, _ := os.Stat(out)
+	var size int64
+	if fi != nil {
+		size = fi.Size()
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Encrypted (age %s) -> %s (%s)\n", enc.mode, out, formatBytes(size))
+	return nil
+}
+
+// defaultCryptOutput derives the default output path for encrypt/decrypt:
+// <in>-<suffix>.kshrk, trimming either the current or legacy archive
+// extension so "capture.khsrk" yields "capture-encrypted.kshrk", not
+// "capture.khsrk-encrypted.kshrk". Mirrors redact's default-output naming.
+func defaultCryptOutput(in, suffix string) string {
+	base := strings.TrimSuffix(strings.TrimSuffix(in, ".kshrk"), ".khsrk")
+	return base + "-" + suffix + ".kshrk"
+}
+
+// rejectSamePath refuses to let an output path overwrite its input,
+// comparing absolute paths so relative-vs-absolute spellings of the same file
+// are still caught.
+func rejectSamePath(in, out string) error {
+	inAbs, _ := filepath.Abs(in)
+	outAbs, _ := filepath.Abs(out)
+	if inAbs == outAbs {
+		return fmt.Errorf("output path must differ from the input archive")
+	}
+	return nil
+}

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -21,7 +21,7 @@ This is a whole-file transform, not a new capture: use it to encrypt an
 archive you already have (e.g. before sharing it), as an alternative to
 'kshrk capture --encrypt' at capture time.`,
 	Example: `  # Encrypt with a passphrase, prompting for it
-  kshrk encrypt capture.kshrk
+  kshrk encrypt capture.kshrk --encrypt
 
   # Encrypt using a passphrase read from a file (no prompt)
   kshrk encrypt capture.kshrk --encrypt-passphrase-file ./pass.txt

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -86,10 +86,19 @@ func defaultCryptOutput(in, suffix string) string {
 
 // rejectSamePath refuses to let an output path overwrite its input,
 // comparing absolute paths so relative-vs-absolute spellings of the same file
-// are still caught.
+// are still caught. A failure resolving either path is itself an error,
+// rather than silently comparing an unresolved path against a resolved one —
+// which could miss a genuine in==out overwrite (e.g. if only one of the two
+// paths is affected by an unresolvable working directory).
 func rejectSamePath(in, out string) error {
-	inAbs, _ := filepath.Abs(in)
-	outAbs, _ := filepath.Abs(out)
+	inAbs, err := filepath.Abs(in)
+	if err != nil {
+		return fmt.Errorf("resolving input path %q: %w", in, err)
+	}
+	outAbs, err := filepath.Abs(out)
+	if err != nil {
+		return fmt.Errorf("resolving output path %q: %w", out, err)
+	}
 	if inAbs == outAbs {
 		return fmt.Errorf("output path must differ from the input archive")
 	}

--- a/cmd/encrypt_test.go
+++ b/cmd/encrypt_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,9 @@ func newTestEncryptCmdCommand() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Flags().StringP("output", "o", "", "")
 	addEncryptFlags(cmd)
+	// These tests assert on disk state and returned errors, not the printed
+	// summary, so discard stdout rather than letting it leak to os.Stdout.
+	cmd.SetOut(io.Discard)
 	return cmd
 }
 

--- a/cmd/encrypt_test.go
+++ b/cmd/encrypt_test.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"filippo.io/age"
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/spf13/cobra"
+)
+
+func newTestEncryptCmdCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().StringP("output", "o", "", "")
+	addEncryptFlags(cmd)
+	return cmd
+}
+
+func TestRunEncrypt_DefaultOutputAndRoundTrip(t *testing.T) {
+	in := buildDiffArchive(t, healthyPodList)
+	passFile := filepath.Join(t.TempDir(), "pass.txt")
+	if err := os.WriteFile(passFile, []byte("encrypt-cmd-test-passphrase"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmd := newTestEncryptCmdCommand()
+	if err := cmd.Flags().Set("encrypt-passphrase-file", passFile); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+	if err := runEncrypt(cmd, []string{in}); err != nil {
+		t.Fatalf("runEncrypt: %v", err)
+	}
+
+	wantOut := strings.TrimSuffix(in, ".kshrk") + "-encrypted.kshrk"
+	if _, err := os.Stat(wantOut); err != nil {
+		t.Fatalf("default output %q not created: %v", wantOut, err)
+	}
+	if enc, err := archive.IsEncrypted(wantOut); err != nil || !enc {
+		t.Fatalf("IsEncrypted(output) = %v, %v; want true, nil", enc, err)
+	}
+
+	identities, err := archive.IdentitiesFromPassphrase("encrypt-cmd-test-passphrase")
+	if err != nil {
+		t.Fatalf("IdentitiesFromPassphrase: %v", err)
+	}
+	ar, err := archive.OpenWithIdentities(wantOut, identities)
+	if err != nil {
+		t.Fatalf("OpenWithIdentities: %v", err)
+	}
+	_ = ar.Close()
+}
+
+func TestRunEncrypt_ExplicitOutput(t *testing.T) {
+	in := buildDiffArchive(t, healthyPodList)
+	out := filepath.Join(filepath.Dir(in), "custom.kshrk")
+
+	cmd := newTestEncryptCmdCommand()
+	if err := cmd.Flags().Set("output", out); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+	if err := cmd.Flags().Set("encrypt-recipient", mustGenerateRecipient(t)); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+	if err := runEncrypt(cmd, []string{in}); err != nil {
+		t.Fatalf("runEncrypt: %v", err)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("explicit output %q not created: %v", out, err)
+	}
+}
+
+func TestRunEncrypt_NoMethodGiven(t *testing.T) {
+	in := buildDiffArchive(t, healthyPodList)
+	cmd := newTestEncryptCmdCommand()
+
+	err := runEncrypt(cmd, []string{in})
+	if err == nil {
+		t.Fatal("expected an error when no encryption method is given")
+	}
+	if !strings.Contains(err.Error(), "no encryption method given") {
+		t.Errorf("error = %q, want it to mention no encryption method given", err)
+	}
+}
+
+func TestRunEncrypt_RejectsAlreadyEncrypted(t *testing.T) {
+	in := buildDiffArchive(t, healthyPodList)
+	cmd := newTestEncryptCmdCommand()
+	if err := cmd.Flags().Set("encrypt-recipient", mustGenerateRecipient(t)); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+	if err := runEncrypt(cmd, []string{in}); err != nil {
+		t.Fatalf("runEncrypt (first pass): %v", err)
+	}
+	encOut := strings.TrimSuffix(in, ".kshrk") + "-encrypted.kshrk"
+
+	// Encrypting the already-encrypted output must be rejected, not silently
+	// double-wrap it.
+	cmd2 := newTestEncryptCmdCommand()
+	if err := cmd2.Flags().Set("encrypt-recipient", mustGenerateRecipient(t)); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+	err := runEncrypt(cmd2, []string{encOut})
+	if err == nil {
+		t.Fatal("expected an error encrypting an already-encrypted archive")
+	}
+	if !strings.Contains(err.Error(), "already encrypted") {
+		t.Errorf("error = %q, want it to mention already encrypted", err)
+	}
+}
+
+func TestRunEncrypt_SameOutputRejected(t *testing.T) {
+	in := buildDiffArchive(t, healthyPodList)
+	cmd := newTestEncryptCmdCommand()
+	if err := cmd.Flags().Set("output", in); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+	if err := cmd.Flags().Set("encrypt-recipient", mustGenerateRecipient(t)); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+	if err := runEncrypt(cmd, []string{in}); err == nil {
+		t.Fatal("expected an error when --output equals the input path")
+	}
+}
+
+// mustGenerateRecipient returns a freshly generated age1... public key string.
+func mustGenerateRecipient(t *testing.T) string {
+	t.Helper()
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("GenerateX25519Identity: %v", err)
+	}
+	return id.Recipient().String()
+}

--- a/docs/encryption-threat-model.md
+++ b/docs/encryption-threat-model.md
@@ -3,10 +3,11 @@
 `.kshrk` captures can contain Kubernetes Secret values, tokens, and other
 cluster PII. `kshrk capture`'s encryption flags (`--encrypt`,
 `--encrypt-passphrase-file`, `--encrypt-recipient`,
-`--encrypt-recipients-file` — and the equivalent `kshrk redact` flags) let you
-write an archive as a single [age](https://age-encryption.org/v1) envelope.
-This page states plainly what that protects, what it doesn't, and the
-key-handling rules the CLI enforces.
+`--encrypt-recipients-file` — and the equivalent `kshrk redact` flags), plus
+the standalone `kshrk encrypt`/`kshrk decrypt` commands for an existing
+archive, let you write an archive as a single
+[age](https://age-encryption.org/v1) envelope. This page states plainly what
+that protects, what it doesn't, and the key-handling rules the CLI enforces.
 See [archive-format.md](archive-format.md#encryption) for how the envelope is
 built; see [usage.md](usage.md#encryption) for command examples.
 
@@ -49,7 +50,7 @@ built; see [usage.md](usage.md#encryption) for command examples.
 - **Recipient revocation.** age has no built-in mechanism to revoke a
   recipient key. If a private key or passphrase may have been exposed, the
   only remedy is to re-encrypt to a new key/recipient set (see
-  [Rotating keys](#rotating-keys-today) below) — there is no way to
+  [Rotating keys](#rotating-keys) below) — there is no way to
   retroactively deny that key access to copies already handed out.
 - **Old `kshrk` binaries.** A `kshrk` build from before encryption support
   (anything prior to this feature) will fail with a raw, unhelpful
@@ -91,20 +92,21 @@ built; see [usage.md](usage.md#encryption) for command examples.
 | Automation | Passphrase must be distributed to every consumer (file/env) | Encrypt to a public key with no secret material on the encrypting side |
 | Rotation | Requires a new shared secret and re-encryption | Add/remove recipients by re-encrypting to a different key set |
 
-## Rotating keys today
+## Rotating keys
 
-There's no dedicated `kshrk encrypt`/`kshrk decrypt` command yet (tracked for
-a later milestone). In the meantime, `kshrk redact` can serve as a re-encrypt
-tool even with no redaction rules — pass `--decrypt-*` for the source key and
-`--encrypt-*` for the new key/recipients:
+Use `kshrk decrypt` followed by `kshrk encrypt` to rotate a passphrase, move
+from a passphrase to recipient keys, or add/remove recipients:
 
 ```sh
-kshrk redact --in old.kshrk --out new.kshrk \
-  --decrypt-passphrase-file old-pass.txt \
-  --encrypt-recipient age1newrecipient...
+kshrk decrypt old.kshrk --decrypt-passphrase-file old-pass.txt --output plain.kshrk
+kshrk encrypt plain.kshrk --encrypt-recipient age1newrecipient... --output new.kshrk
 ```
 
-**Caveat**: this always marks the output archive's metadata as `redacted:
-true`, even if no redaction actually occurred, since `kshrk redact` doesn't
-distinguish "re-key only" from "redact" today. Treat this as a workaround,
-not the intended long-term interface.
+The intermediate `plain.kshrk` is a real plaintext file on disk between the
+two commands — remove it once `new.kshrk` is confirmed good if that matters
+for your threat model (there's no combined "re-key without ever writing
+plaintext" command). `kshrk redact` is also usable as a re-encrypt tool even
+with no redaction rules (pass `--decrypt-*` for the source key and
+`--encrypt-*` for the new key/recipients), which avoids the plaintext
+intermediate, but always marks the output's metadata as `redacted: true`
+even when nothing was actually redacted.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -749,7 +749,10 @@ Captures can contain Secret values and other sensitive cluster data.
 encrypted [age](https://age-encryption.org/v1) envelope, and every command
 that reads a `.kshrk` archive — `inspect`, `open`, `ui`, `replay`, `diff`,
 `query`, `transitions`, `diagnose`, `redact` — decrypts it transparently
-given a key.
+given a key. `kshrk encrypt`/`kshrk decrypt` also let you encrypt or decrypt
+an existing archive standalone, after the fact (see
+[Encrypting or decrypting after the fact](#encrypting-or-decrypting-after-the-fact)
+below).
 See [encryption-threat-model.md](encryption-threat-model.md) for what this
 does and doesn't protect against, and
 [archive-format.md#encryption](archive-format.md#encryption) for how the
@@ -825,6 +828,35 @@ plaintext copy is ever written to disk in between.
 If a source archive is encrypted but `redact` isn't given any `--encrypt-*`
 flags, it warns and writes the redacted output in plaintext rather than
 silently downgrading it without telling you.
+
+### Encrypting or decrypting after the fact
+
+`kshrk encrypt` and `kshrk decrypt` are standalone whole-file commands for an
+archive you already have — no new capture, no redaction. Use them to encrypt
+an existing plaintext archive before sharing it, produce a plaintext copy for
+a tool that can't decrypt, or rotate keys (decrypt, then re-encrypt to a new
+passphrase or recipient set). Both take the same encrypt/decrypt flags shown
+above, and default their output to `<in>-encrypted.kshrk` /
+`<in>-decrypted.kshrk` — the original archive is never modified.
+
+```sh
+# Encrypt an archive you already captured
+kshrk encrypt capture.kshrk --encrypt-recipient age1abc...
+
+# Decrypt back to plaintext
+kshrk decrypt capture-encrypted.kshrk --decrypt-passphrase-file ./pass.txt
+
+# Rotate from a passphrase to a recipient key
+kshrk decrypt old.kshrk --decrypt-passphrase-file old-pass.txt --output plain.kshrk
+kshrk encrypt plain.kshrk --encrypt-recipient age1new... --output new.kshrk
+```
+
+`kshrk encrypt` refuses to run against an archive that's already encrypted,
+and `kshrk decrypt` refuses to run against one that isn't — both fail with a
+clear error rather than silently double-wrapping or no-op copying. See
+[encryption-threat-model.md#rotating-keys](encryption-threat-model.md#rotating-keys)
+for the trade-offs of this two-step rotation versus `redact`'s
+plaintext-free re-encrypt path.
 
 ---
 

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -75,18 +75,18 @@ func isNoIdentityMatch(err error) bool {
 // permissive than the original — this matters most for DecryptFile, whose
 // output is plaintext.
 //
-// The file is opened write-only (callers never read back from it) with the
-// owner-write bit guaranteed regardless of src's mode, covering two cases
-// where a restrictive source mode (e.g. read-only 0400/0444, or write-only
-// 0200 which O_RDWR would reject despite not needing read access) could
-// otherwise deny the write this function needs to perform: as defense in
-// depth for the create-a-new-file path, and, concretely, when dstPath
-// already exists — OpenFile's mode argument is ignored for an existing file,
-// so only its current on-disk mode governs the access check, and re-running
-// against the same restrictively-permissioned output (which this very
-// mode-preservation logic can produce) would otherwise fail. Callers must
-// restore the exact source mode (via (*os.File).Chmod, using the returned
-// FileMode) once they're done writing, before the final Close.
+// dstPath is locked to mode|0o200 (the source's permission bits, plus the
+// owner-write needed to populate it) before this function returns — never to
+// whatever an existing dstPath's own mode happened to be. That matters when
+// dstPath already exists more permissively than the source (e.g. a stale
+// 0644 file where the source is 0600): narrowing it only via a final Chmod
+// after writing (as an earlier version of this function did) would leave
+// plaintext sitting under the loose permissions for the entire duration of
+// the write. Permission failures here are fatal, not best-effort — if the
+// intended mode can't be set, no content is written under the wrong
+// permissions in the first place. Callers still restore the exact source
+// mode (dropping the extra owner-write bit, via (*os.File).Chmod using the
+// returned FileMode) once they're done writing, before the final Close.
 func createLike(dstPath string, src *os.File) (*os.File, os.FileMode, error) {
 	srcInfo, err := src.Stat()
 	if err != nil {
@@ -101,14 +101,31 @@ func createLike(dstPath string, src *os.File) (*os.File, os.FileMode, error) {
 		// Only touch the mode of a regular file — dstPath could be a
 		// directory or other special file (the caller passed a bad --output),
 		// and chmod'ing that isn't this function's business; let the
-		// OpenFile below report a clear error for it instead.
+		// OpenFile below report a clear error for it instead. This also
+		// narrows an existing, more-permissive dstPath down to the intended
+		// mode *before* opening it, so there is no window where it sits at
+		// looser-than-intended permissions while content is written.
 		if existing.Mode().IsRegular() {
-			_ = os.Chmod(dstPath, existing.Mode().Perm()|0o200) // best-effort; OpenFile below reports any real failure
+			if err := os.Chmod(dstPath, mode|0o200); err != nil {
+				return nil, 0, fmt.Errorf("setting permissions on %q: %w", dstPath, err)
+			}
 		}
 	}
 	dst, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode|0o200)
 	if err != nil {
 		return nil, 0, fmt.Errorf("creating %q: %w", dstPath, err)
+	}
+	// This is the call that actually closes the loose-permission window: an
+	// existing dstPath that was open()-able because it already had the
+	// owner-write bit (e.g. a stale, more-permissive 0644 where the source is
+	// 0600) is narrowed here, before any content is written — not left at its
+	// old, looser mode until the caller's chmod after writing finishes. It
+	// also covers OpenFile's create mode being subject to umask, for a
+	// freshly-created dstPath.
+	if err := dst.Chmod(mode | 0o200); err != nil {
+		dst.Close()
+		os.Remove(dstPath)
+		return nil, 0, fmt.Errorf("setting permissions on %q: %w", dstPath, err)
 	}
 	return dst, mode, nil
 }

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"filippo.io/age"
 )
@@ -68,73 +69,78 @@ func isNoIdentityMatch(err error) bool {
 	return errors.As(err, &noMatch)
 }
 
-// createLike creates dstPath and returns it along with src's permission bits,
-// instead of os.Create's fixed 0666&umask. EncryptFile/DecryptFile can turn a
-// source archive stored with restrictive permissions (e.g. 0600) into an
-// encrypted or plaintext copy, so the copy shouldn't silently end up more
-// permissive than the original — this matters most for DecryptFile, whose
-// output is plaintext.
+// createLike creates a fresh temporary file in dstPath's directory — never
+// dstPath itself — and returns it along with src's permission bits and a
+// commit function. The caller writes into the returned file, then, once
+// finished, calls commit to fix its permissions to match src exactly and
+// atomically rename it into place as dstPath (or removeTemp to discard it on
+// error). EncryptFile/DecryptFile use this so a source archive stored with
+// restrictive permissions (e.g. 0600) can't silently turn into a more
+// permissive encrypted or plaintext copy — this matters most for DecryptFile,
+// whose output is plaintext.
 //
-// dstPath is locked to mode|0o200 (the source's permission bits, plus the
-// owner-write needed to populate it) before this function returns — never to
-// whatever an existing dstPath's own mode happened to be. That matters when
-// dstPath already exists more permissively than the source (e.g. a stale
-// 0644 file where the source is 0600): narrowing it only via a final Chmod
-// after writing (as an earlier version of this function did) would leave
-// plaintext sitting under the loose permissions for the entire duration of
-// the write. Permission failures here are fatal, not best-effort — if the
-// intended mode can't be set, no content is written under the wrong
-// permissions in the first place. Callers still restore the exact source
-// mode (dropping the extra owner-write bit, via (*os.File).Chmod using the
-// returned FileMode) once they're done writing, before the final Close.
-func createLike(dstPath string, src *os.File) (*os.File, os.FileMode, error) {
+// Writing to a same-directory temp file and renaming into place, rather than
+// opening dstPath directly, closes two related gaps a direct-open approach
+// (an earlier version of this function used one) can't avoid:
+//   - Partially-written output is never observable at dstPath: on any
+//     failure the temp file is simply discarded, never having touched
+//     whatever (if anything) previously existed at dstPath.
+//   - Symlink-following, safely, even under a TOCTOU race: an Lstat-then-Open
+//     check on dstPath (what an earlier version of this function did) can
+//     still be raced — dstPath can be swapped for a symlink after the check
+//     and before the open, causing a direct write to follow the link and
+//     corrupt an unintended target. os.Rename doesn't have this problem:
+//     POSIX rename(2) atomically replaces whatever is *named* dstPath — if
+//     that's a symlink, the symlink itself is replaced, never its target —
+//     no matter when dstPath started (or stopped) being a symlink relative
+//     to this function's checks.
+//
+// An existing symlink or other non-regular file at dstPath is still rejected
+// up front with a clear error, rather than silently replacing it.
+func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, commit func() error, err error) {
 	srcInfo, err := src.Stat()
 	if err != nil {
-		return nil, 0, fmt.Errorf("stat %q: %w", src.Name(), err)
+		return nil, 0, nil, fmt.Errorf("stat %q: %w", src.Name(), err)
 	}
-	mode := srcInfo.Mode().Perm()
+	mode = srcInfo.Mode().Perm()
 
-	// Lstat, not Stat: dstPath must be rejected if IT is a symlink, without
-	// following it first. os.Stat/os.OpenFile both follow symlinks, so an
-	// existing symlink at dstPath (planted by an attacker, or left over from
-	// something else) would otherwise cause EncryptFile/DecryptFile to
-	// truncate and write through it to whatever it points at — and the
-	// deferred cleanup's os.Remove(dstPath) only removes the symlink itself
-	// on failure, not the target, silently leaving partially-written content
-	// behind in a file this function never meant to touch. Rejecting any
-	// non-regular existing path here (symlink, device, fifo, socket) is
-	// simpler and safer than trying to handle each case.
 	if existing, statErr := os.Lstat(dstPath); statErr == nil {
 		if !existing.Mode().IsRegular() {
-			return nil, 0, fmt.Errorf("output %q exists and is not a regular file (mode %s)", dstPath, existing.Mode())
+			return nil, 0, nil, fmt.Errorf("output %q exists and is not a regular file (mode %s)", dstPath, existing.Mode())
 		}
 		if os.SameFile(srcInfo, existing) {
-			return nil, 0, fmt.Errorf("output %q must not be the same file as the input", dstPath)
-		}
-		// Narrows an existing, more-permissive dstPath down to the intended
-		// mode *before* opening it, so there is no window where it sits at
-		// looser-than-intended permissions while content is written.
-		if err := os.Chmod(dstPath, mode|0o200); err != nil {
-			return nil, 0, fmt.Errorf("setting permissions on %q: %w", dstPath, err)
+			return nil, 0, nil, fmt.Errorf("output %q must not be the same file as the input", dstPath)
 		}
 	}
-	dst, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode|0o200)
+
+	tmp, err := os.CreateTemp(filepath.Dir(dstPath), "."+filepath.Base(dstPath)+".tmp-*")
 	if err != nil {
-		return nil, 0, fmt.Errorf("creating %q: %w", dstPath, err)
+		return nil, 0, nil, fmt.Errorf("creating temporary file for %q: %w", dstPath, err)
 	}
-	// This is the call that actually closes the loose-permission window: an
-	// existing dstPath that was open()-able because it already had the
-	// owner-write bit (e.g. a stale, more-permissive 0644 where the source is
-	// 0600) is narrowed here, before any content is written — not left at its
-	// old, looser mode until the caller's chmod after writing finishes. It
-	// also covers OpenFile's create mode being subject to umask, for a
-	// freshly-created dstPath.
-	if err := dst.Chmod(mode | 0o200); err != nil {
-		dst.Close()
-		os.Remove(dstPath)
-		return nil, 0, fmt.Errorf("setting permissions on %q: %w", dstPath, err)
+	tmpPath := tmp.Name()
+	// os.CreateTemp always uses 0600 regardless of src's mode; add the
+	// owner-write bit for good measure (0600 already has it) while we
+	// populate the file. commit narrows this to the exact source mode
+	// before the rename.
+	if err := tmp.Chmod(mode | 0o200); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return nil, 0, nil, fmt.Errorf("setting permissions on temporary file: %w", err)
 	}
-	return dst, mode, nil
+
+	commit = func() error {
+		if err := tmp.Chmod(mode); err != nil {
+			return fmt.Errorf("setting permissions on %q: %w", tmpPath, err)
+		}
+		if err := tmp.Close(); err != nil {
+			return fmt.Errorf("closing %q: %w", tmpPath, err)
+		}
+		if err := os.Rename(tmpPath, dstPath); err != nil {
+			return fmt.Errorf("renaming temporary file into place as %q: %w", dstPath, err)
+		}
+		return nil
+	}
+	return tmp, mode, commit, nil
 }
 
 // EncryptFile writes an age-encrypted copy of the plaintext file at srcPath to
@@ -161,17 +167,18 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 	}
 	defer src.Close()
 
-	dst, mode, err := createLike(dstPath, src)
+	dst, _, commit, err := createLike(dstPath, src)
 	if err != nil {
 		return err
 	}
-	// Every failure from here on removes the partially-written output, so
-	// each branch below only needs to set err and return — no repeated
-	// close/remove boilerplate to keep in sync.
+	tmpPath := dst.Name()
+	// Every failure from here on discards the temporary file, which never
+	// touched dstPath — so each branch below only needs to set err and
+	// return. Once commit succeeds this is a no-op (err is nil).
 	defer func() {
 		if err != nil {
 			dst.Close()
-			os.Remove(dstPath)
+			os.Remove(tmpPath)
 		}
 	}()
 
@@ -180,19 +187,14 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 		return fmt.Errorf("setting up encryption: %w", err)
 	}
 	if _, err = io.Copy(w, src); err != nil {
-		_ = w.Close() // best-effort: attempt to finalize before the deferred cleanup removes dstPath
+		_ = w.Close() // best-effort: attempt to finalize before the deferred cleanup discards the temp file
 		return fmt.Errorf("encrypting %q: %w", srcPath, err)
 	}
 	if err = w.Close(); err != nil {
 		return fmt.Errorf("finishing encryption of %q: %w", srcPath, err)
 	}
-	// Restore the source's exact mode now that writing is done — createLike
-	// forced the owner-write bit on so the writes above could happen at all.
-	if err = dst.Chmod(mode); err != nil {
-		return fmt.Errorf("setting permissions on %q: %w", dstPath, err)
-	}
-	if err = dst.Close(); err != nil {
-		return fmt.Errorf("closing %q: %w", dstPath, err)
+	if err = commit(); err != nil {
+		return err
 	}
 	return nil
 }
@@ -228,17 +230,18 @@ func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error)
 		return fmt.Errorf("decrypting %q: %w", srcPath, err)
 	}
 
-	dst, mode, err := createLike(dstPath, src)
+	dst, _, commit, err := createLike(dstPath, src)
 	if err != nil {
 		return err
 	}
-	// Every failure from here on removes the partially-written output, so
-	// each branch below only needs to set err and return — no repeated
-	// close/remove boilerplate to keep in sync.
+	tmpPath := dst.Name()
+	// Every failure from here on discards the temporary file, which never
+	// touched dstPath — so each branch below only needs to set err and
+	// return. Once commit succeeds this is a no-op (err is nil).
 	defer func() {
 		if err != nil {
 			dst.Close()
-			os.Remove(dstPath)
+			os.Remove(tmpPath)
 		}
 	}()
 
@@ -248,13 +251,8 @@ func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error)
 		// STREAM authentication rejected tampered or corrupt ciphertext.
 		return fmt.Errorf("decrypting %q: tampered or corrupt archive: %w", srcPath, err)
 	}
-	// Restore the source's exact mode now that writing is done — createLike
-	// forced the owner-write bit on so the write above could happen at all.
-	if err = dst.Chmod(mode); err != nil {
-		return fmt.Errorf("setting permissions on %q: %w", dstPath, err)
-	}
-	if err = dst.Close(); err != nil {
-		return fmt.Errorf("closing %q: %w", dstPath, err)
+	if err = commit(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -68,22 +68,39 @@ func isNoIdentityMatch(err error) bool {
 	return errors.As(err, &noMatch)
 }
 
-// createLike creates dstPath with src's permission bits, instead of
-// os.Create's fixed 0666&umask. EncryptFile/DecryptFile can turn a source
-// archive stored with restrictive permissions (e.g. 0600) into an encrypted
-// or plaintext copy, so the copy shouldn't silently end up more permissive
-// than the original — this matters most for DecryptFile, whose output is
-// plaintext.
-func createLike(dstPath string, src *os.File) (*os.File, error) {
+// createLike creates dstPath and returns it along with src's permission bits,
+// instead of os.Create's fixed 0666&umask. EncryptFile/DecryptFile can turn a
+// source archive stored with restrictive permissions (e.g. 0600) into an
+// encrypted or plaintext copy, so the copy shouldn't silently end up more
+// permissive than the original — this matters most for DecryptFile, whose
+// output is plaintext.
+//
+// The file is opened for writing with the owner-write bit guaranteed
+// regardless of src's mode, covering two cases where a restrictive source
+// mode (e.g. read-only 0400/0444) could otherwise deny the write this
+// function needs to perform: as defense in depth for the create-a-new-file
+// path, and, concretely, when dstPath already exists — OpenFile's mode
+// argument is ignored for an existing file, so only its current on-disk mode
+// governs the access check, and re-running against the same
+// restrictively-permissioned output (which this very mode-preservation logic
+// can produce) would otherwise fail. Callers must restore the exact source
+// mode (via (*os.File).Chmod, using the returned FileMode) once they're done
+// writing, before the final Close.
+func createLike(dstPath string, src *os.File) (*os.File, os.FileMode, error) {
 	srcInfo, err := src.Stat()
 	if err != nil {
-		return nil, fmt.Errorf("stat %q: %w", src.Name(), err)
+		return nil, 0, fmt.Errorf("stat %q: %w", src.Name(), err)
 	}
-	dst, err := os.OpenFile(dstPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcInfo.Mode().Perm())
+	mode := srcInfo.Mode().Perm()
+
+	if existing, statErr := os.Stat(dstPath); statErr == nil {
+		_ = os.Chmod(dstPath, existing.Mode().Perm()|0o200) // best-effort; OpenFile below reports any real failure
+	}
+	dst, err := os.OpenFile(dstPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode|0o200)
 	if err != nil {
-		return nil, fmt.Errorf("creating %q: %w", dstPath, err)
+		return nil, 0, fmt.Errorf("creating %q: %w", dstPath, err)
 	}
-	return dst, nil
+	return dst, mode, nil
 }
 
 // EncryptFile writes an age-encrypted copy of the plaintext file at srcPath to
@@ -110,7 +127,7 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 	}
 	defer src.Close()
 
-	dst, err := createLike(dstPath, src)
+	dst, mode, err := createLike(dstPath, src)
 	if err != nil {
 		return err
 	}
@@ -134,6 +151,11 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 	}
 	if err = w.Close(); err != nil {
 		return fmt.Errorf("finishing encryption of %q: %w", srcPath, err)
+	}
+	// Restore the source's exact mode now that writing is done — createLike
+	// forced the owner-write bit on so the writes above could happen at all.
+	if err = dst.Chmod(mode); err != nil {
+		return fmt.Errorf("setting permissions on %q: %w", dstPath, err)
 	}
 	if err = dst.Close(); err != nil {
 		return fmt.Errorf("closing %q: %w", dstPath, err)
@@ -172,7 +194,7 @@ func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error)
 		return fmt.Errorf("decrypting %q: %w", srcPath, err)
 	}
 
-	dst, err := createLike(dstPath, src)
+	dst, mode, err := createLike(dstPath, src)
 	if err != nil {
 		return err
 	}
@@ -191,6 +213,11 @@ func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error)
 		// age.Decrypt's header parsing. A failure here means age's per-chunk
 		// STREAM authentication rejected tampered or corrupt ciphertext.
 		return fmt.Errorf("decrypting %q: tampered or corrupt archive: %w", srcPath, err)
+	}
+	// Restore the source's exact mode now that writing is done — createLike
+	// forced the owner-write bit on so the write above could happen at all.
+	if err = dst.Chmod(mode); err != nil {
+		return fmt.Errorf("setting permissions on %q: %w", dstPath, err)
 	}
 	if err = dst.Close(); err != nil {
 		return fmt.Errorf("closing %q: %w", dstPath, err)

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -73,11 +73,12 @@ func isNoIdentityMatch(err error) bool {
 // dstPath itself — and returns it along with src's permission bits and a
 // commit function. The caller writes into the returned file, then, once
 // finished, calls commit to fix its permissions to match src exactly and
-// atomically rename it into place as dstPath (or removeTemp to discard it on
-// error). EncryptFile/DecryptFile use this so a source archive stored with
-// restrictive permissions (e.g. 0600) can't silently turn into a more
-// permissive encrypted or plaintext copy — this matters most for DecryptFile,
-// whose output is plaintext.
+// atomically rename it into place as dstPath; on error, the caller instead
+// closes the returned file and os.Remove's its Name() to discard it (dstPath
+// itself is never touched either way). EncryptFile/DecryptFile use this so a
+// source archive stored with restrictive permissions (e.g. 0600) can't
+// silently turn into a more permissive encrypted or plaintext copy — this
+// matters most for DecryptFile, whose output is plaintext.
 //
 // Writing to a same-directory temp file and renaming into place, rather than
 // opening dstPath directly, closes two related gaps a direct-open approach

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -83,7 +83,7 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 		return fmt.Errorf("%q is already encrypted", srcPath)
 	}
 	if len(recipients) == 0 {
-		return fmt.Errorf("EncryptFile: at least one recipient is required")
+		return fmt.Errorf("archive encryption requires at least one recipient")
 	}
 
 	src, err := os.Open(srcPath)
@@ -137,7 +137,7 @@ func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error)
 		return fmt.Errorf("%q is not encrypted", srcPath)
 	}
 	if len(identities) == 0 {
-		return fmt.Errorf("DecryptFile: at least one identity is required")
+		return fmt.Errorf("archive decryption requires at least one identity")
 	}
 
 	src, err := os.Open(srcPath)

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -67,3 +67,102 @@ func isNoIdentityMatch(err error) bool {
 	var noMatch *age.NoIdentityMatchError
 	return errors.As(err, &noMatch)
 }
+
+// EncryptFile writes an age-encrypted copy of the plaintext file at srcPath to
+// dstPath, encrypting to recipients. Unlike NewEncryptedStreamWriter (which
+// encrypts while writing a brand-new archive), this is a whole-file transform
+// for encrypting an archive that already exists on disk — used by
+// `kshrk encrypt`. It refuses to run if srcPath is already an age-encrypted
+// file, and removes a partially-written dstPath on any failure.
+func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) error {
+	encrypted, err := IsEncrypted(srcPath)
+	if err != nil {
+		return fmt.Errorf("reading %q: %w", srcPath, err)
+	}
+	if encrypted {
+		return fmt.Errorf("%q is already encrypted", srcPath)
+	}
+	if len(recipients) == 0 {
+		return fmt.Errorf("EncryptFile: at least one recipient is required")
+	}
+
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return fmt.Errorf("opening %q: %w", srcPath, err)
+	}
+	defer src.Close()
+
+	dst, err := os.Create(dstPath)
+	if err != nil {
+		return fmt.Errorf("creating %q: %w", dstPath, err)
+	}
+	w, err := age.Encrypt(dst, recipients...)
+	if err != nil {
+		dst.Close()
+		os.Remove(dstPath)
+		return fmt.Errorf("setting up encryption: %w", err)
+	}
+	if _, err := io.Copy(w, src); err != nil {
+		dst.Close()
+		os.Remove(dstPath)
+		return fmt.Errorf("encrypting %q: %w", srcPath, err)
+	}
+	if err := w.Close(); err != nil {
+		dst.Close()
+		os.Remove(dstPath)
+		return fmt.Errorf("finishing encryption of %q: %w", srcPath, err)
+	}
+	if err := dst.Close(); err != nil {
+		return fmt.Errorf("closing %q: %w", dstPath, err)
+	}
+	return nil
+}
+
+// DecryptFile writes a plaintext copy of the age-encrypted file at srcPath to
+// dstPath, decrypting with identities. It is the inverse whole-file transform
+// of EncryptFile, used by `kshrk decrypt`. It refuses to run if srcPath is not
+// an age-encrypted file, and removes a partially-written dstPath on any
+// failure.
+func DecryptFile(srcPath, dstPath string, identities []age.Identity) error {
+	encrypted, err := IsEncrypted(srcPath)
+	if err != nil {
+		return fmt.Errorf("reading %q: %w", srcPath, err)
+	}
+	if !encrypted {
+		return fmt.Errorf("%q is not encrypted", srcPath)
+	}
+	if len(identities) == 0 {
+		return fmt.Errorf("DecryptFile: at least one identity is required")
+	}
+
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return fmt.Errorf("opening %q: %w", srcPath, err)
+	}
+	defer src.Close()
+
+	r, err := age.Decrypt(src, identities...)
+	if err != nil {
+		if isNoIdentityMatch(err) {
+			return fmt.Errorf("failed to decrypt %q: incorrect passphrase or key", srcPath)
+		}
+		return fmt.Errorf("decrypting %q: %w", srcPath, err)
+	}
+
+	dst, err := os.Create(dstPath)
+	if err != nil {
+		return fmt.Errorf("creating %q: %w", dstPath, err)
+	}
+	if _, err := io.Copy(dst, r); err != nil {
+		dst.Close()
+		os.Remove(dstPath)
+		// A wrong identity/passphrase is always caught above, synchronously in
+		// age.Decrypt's header parsing. A failure here means age's per-chunk
+		// STREAM authentication rejected tampered or corrupt ciphertext.
+		return fmt.Errorf("decrypting %q: tampered or corrupt archive: %w", srcPath, err)
+	}
+	if err := dst.Close(); err != nil {
+		return fmt.Errorf("closing %q: %w", dstPath, err)
+	}
+	return nil
+}

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -159,7 +159,9 @@ func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, c
 // encrypts while writing a brand-new archive), this is a whole-file transform
 // for encrypting an archive that already exists on disk — used by
 // `kshrk encrypt`. It refuses to run if srcPath is already an age-encrypted
-// file, and removes a partially-written dstPath on any failure.
+// file. Writing happens via createLike's temp-file-then-rename, so dstPath is
+// never partially written: on any failure the discarded temp file is removed
+// and dstPath (whether or not it already existed) is left untouched.
 func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error) {
 	encrypted, err := IsEncrypted(srcPath)
 	if err != nil {
@@ -213,8 +215,10 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 // DecryptFile writes a plaintext copy of the age-encrypted file at srcPath to
 // dstPath, decrypting with identities. It is the inverse whole-file transform
 // of EncryptFile, used by `kshrk decrypt`. It refuses to run if srcPath is not
-// an age-encrypted file, and removes a partially-written dstPath on any
-// failure.
+// an age-encrypted file. Writing happens via createLike's
+// temp-file-then-rename, so dstPath is never partially written: on any
+// failure the discarded temp file is removed and dstPath (whether or not it
+// already existed) is left untouched.
 func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error) {
 	encrypted, err := IsEncrypted(srcPath)
 	if err != nil {

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -70,6 +70,23 @@ func isNoIdentityMatch(err error) bool {
 	return errors.As(err, &noMatch)
 }
 
+// classifyDecryptCopyError turns an io.Copy failure encountered while
+// decrypting into a clear error, distinguishing a genuine OS-level I/O
+// problem (disk full or a permission problem writing the temp file, a read
+// error on the source) from age's per-chunk STREAM authentication rejecting
+// tampered or corrupt ciphertext — conflating the two would make an ordinary
+// operational failure look like a security incident. A wrong
+// identity/passphrase is always caught earlier, synchronously in
+// age.Decrypt's header parsing, so anything reaching here that isn't an I/O
+// error is a tamper/corruption signal.
+func classifyDecryptCopyError(srcPath string, err error) error {
+	var pathErr *fs.PathError
+	if errors.As(err, &pathErr) {
+		return fmt.Errorf("decrypting %q: %w", srcPath, err)
+	}
+	return fmt.Errorf("decrypting %q: tampered or corrupt archive: %w", srcPath, err)
+}
+
 // createLike creates a fresh temporary file in dstPath's directory — never
 // dstPath itself — and returns it along with src's permission bits and a
 // commit function. The caller writes into the returned file, then, once
@@ -129,15 +146,15 @@ func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, c
 		return nil, 0, nil, fmt.Errorf("creating temporary file for %q: %w", dstPath, err)
 	}
 	tmpPath := tmp.Name()
-	// os.CreateTemp always uses 0600 regardless of src's mode; add the
-	// owner-write bit for good measure (0600 already has it) while we
-	// populate the file. commit narrows this to the exact source mode
-	// before the rename.
-	if err := tmp.Chmod(mode | 0o200); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
-		return nil, 0, nil, fmt.Errorf("setting permissions on temporary file: %w", err)
-	}
+	// Deliberately left at os.CreateTemp's default 0600 (not widened to
+	// src's mode) for the entire time the file is being populated: 0600
+	// already grants the owner-write this function needs regardless of what
+	// src's mode is, and NOT touching it here means a permissive source mode
+	// (e.g. 0644) can never cause partially-written content — plaintext, for
+	// DecryptFile — to sit exposed at that wider mode while being written or
+	// if cleanup runs after a failure. commit is the only place the file's
+	// mode changes, narrowing (or widening) it to the exact source mode in
+	// the same moment it's renamed into place.
 
 	commit = func() error {
 		if err := tmp.Chmod(mode); err != nil {
@@ -261,10 +278,7 @@ func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error)
 	}()
 
 	if _, err = io.Copy(dst, r); err != nil {
-		// A wrong identity/passphrase is always caught above, synchronously in
-		// age.Decrypt's header parsing. A failure here means age's per-chunk
-		// STREAM authentication rejected tampered or corrupt ciphertext.
-		return fmt.Errorf("decrypting %q: tampered or corrupt archive: %w", srcPath, err)
+		return classifyDecryptCopyError(srcPath, err)
 	}
 	if err = commit(); err != nil {
 		return err

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -74,7 +74,7 @@ func isNoIdentityMatch(err error) bool {
 // for encrypting an archive that already exists on disk — used by
 // `kshrk encrypt`. It refuses to run if srcPath is already an age-encrypted
 // file, and removes a partially-written dstPath on any failure.
-func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) error {
+func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error) {
 	encrypted, err := IsEncrypted(srcPath)
 	if err != nil {
 		return fmt.Errorf("reading %q: %w", srcPath, err)
@@ -96,23 +96,28 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) error {
 	if err != nil {
 		return fmt.Errorf("creating %q: %w", dstPath, err)
 	}
+	// Every failure from here on removes the partially-written output, so
+	// each branch below only needs to set err and return — no repeated
+	// close/remove boilerplate to keep in sync.
+	defer func() {
+		if err != nil {
+			dst.Close()
+			os.Remove(dstPath)
+		}
+	}()
+
 	w, err := age.Encrypt(dst, recipients...)
 	if err != nil {
-		dst.Close()
-		os.Remove(dstPath)
 		return fmt.Errorf("setting up encryption: %w", err)
 	}
-	if _, err := io.Copy(w, src); err != nil {
-		dst.Close()
-		os.Remove(dstPath)
+	if _, err = io.Copy(w, src); err != nil {
+		_ = w.Close() // best-effort: attempt to finalize before the deferred cleanup removes dstPath
 		return fmt.Errorf("encrypting %q: %w", srcPath, err)
 	}
-	if err := w.Close(); err != nil {
-		dst.Close()
-		os.Remove(dstPath)
+	if err = w.Close(); err != nil {
 		return fmt.Errorf("finishing encryption of %q: %w", srcPath, err)
 	}
-	if err := dst.Close(); err != nil {
+	if err = dst.Close(); err != nil {
 		return fmt.Errorf("closing %q: %w", dstPath, err)
 	}
 	return nil
@@ -123,7 +128,7 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) error {
 // of EncryptFile, used by `kshrk decrypt`. It refuses to run if srcPath is not
 // an age-encrypted file, and removes a partially-written dstPath on any
 // failure.
-func DecryptFile(srcPath, dstPath string, identities []age.Identity) error {
+func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error) {
 	encrypted, err := IsEncrypted(srcPath)
 	if err != nil {
 		return fmt.Errorf("reading %q: %w", srcPath, err)
@@ -153,15 +158,23 @@ func DecryptFile(srcPath, dstPath string, identities []age.Identity) error {
 	if err != nil {
 		return fmt.Errorf("creating %q: %w", dstPath, err)
 	}
-	if _, err := io.Copy(dst, r); err != nil {
-		dst.Close()
-		os.Remove(dstPath)
+	// Every failure from here on removes the partially-written output, so
+	// each branch below only needs to set err and return — no repeated
+	// close/remove boilerplate to keep in sync.
+	defer func() {
+		if err != nil {
+			dst.Close()
+			os.Remove(dstPath)
+		}
+	}()
+
+	if _, err = io.Copy(dst, r); err != nil {
 		// A wrong identity/passphrase is always caught above, synchronously in
 		// age.Decrypt's header parsing. A failure here means age's per-chunk
 		// STREAM authentication rejected tampered or corrupt ciphertext.
 		return fmt.Errorf("decrypting %q: tampered or corrupt archive: %w", srcPath, err)
 	}
-	if err := dst.Close(); err != nil {
+	if err = dst.Close(); err != nil {
 		return fmt.Errorf("closing %q: %w", dstPath, err)
 	}
 	return nil

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -75,17 +75,18 @@ func isNoIdentityMatch(err error) bool {
 // permissive than the original — this matters most for DecryptFile, whose
 // output is plaintext.
 //
-// The file is opened for writing with the owner-write bit guaranteed
-// regardless of src's mode, covering two cases where a restrictive source
-// mode (e.g. read-only 0400/0444) could otherwise deny the write this
-// function needs to perform: as defense in depth for the create-a-new-file
-// path, and, concretely, when dstPath already exists — OpenFile's mode
-// argument is ignored for an existing file, so only its current on-disk mode
-// governs the access check, and re-running against the same
-// restrictively-permissioned output (which this very mode-preservation logic
-// can produce) would otherwise fail. Callers must restore the exact source
-// mode (via (*os.File).Chmod, using the returned FileMode) once they're done
-// writing, before the final Close.
+// The file is opened write-only (callers never read back from it) with the
+// owner-write bit guaranteed regardless of src's mode, covering two cases
+// where a restrictive source mode (e.g. read-only 0400/0444, or write-only
+// 0200 which O_RDWR would reject despite not needing read access) could
+// otherwise deny the write this function needs to perform: as defense in
+// depth for the create-a-new-file path, and, concretely, when dstPath
+// already exists — OpenFile's mode argument is ignored for an existing file,
+// so only its current on-disk mode governs the access check, and re-running
+// against the same restrictively-permissioned output (which this very
+// mode-preservation logic can produce) would otherwise fail. Callers must
+// restore the exact source mode (via (*os.File).Chmod, using the returned
+// FileMode) once they're done writing, before the final Close.
 func createLike(dstPath string, src *os.File) (*os.File, os.FileMode, error) {
 	srcInfo, err := src.Stat()
 	if err != nil {
@@ -94,9 +95,18 @@ func createLike(dstPath string, src *os.File) (*os.File, os.FileMode, error) {
 	mode := srcInfo.Mode().Perm()
 
 	if existing, statErr := os.Stat(dstPath); statErr == nil {
-		_ = os.Chmod(dstPath, existing.Mode().Perm()|0o200) // best-effort; OpenFile below reports any real failure
+		if os.SameFile(srcInfo, existing) {
+			return nil, 0, fmt.Errorf("output %q must not be the same file as the input", dstPath)
+		}
+		// Only touch the mode of a regular file — dstPath could be a
+		// directory or other special file (the caller passed a bad --output),
+		// and chmod'ing that isn't this function's business; let the
+		// OpenFile below report a clear error for it instead.
+		if existing.Mode().IsRegular() {
+			_ = os.Chmod(dstPath, existing.Mode().Perm()|0o200) // best-effort; OpenFile below reports any real failure
+		}
 	}
-	dst, err := os.OpenFile(dstPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode|0o200)
+	dst, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode|0o200)
 	if err != nil {
 		return nil, 0, fmt.Errorf("creating %q: %w", dstPath, err)
 	}

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -105,13 +106,22 @@ func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, c
 	}
 	mode = srcInfo.Mode().Perm()
 
-	if existing, statErr := os.Lstat(dstPath); statErr == nil {
+	switch existing, statErr := os.Lstat(dstPath); {
+	case statErr == nil:
 		if !existing.Mode().IsRegular() {
 			return nil, 0, nil, fmt.Errorf("output %q exists and is not a regular file (mode %s)", dstPath, existing.Mode())
 		}
 		if os.SameFile(srcInfo, existing) {
 			return nil, 0, nil, fmt.Errorf("output %q must not be the same file as the input", dstPath)
 		}
+	case errors.Is(statErr, fs.ErrNotExist):
+		// The common case: no output exists yet, nothing to check.
+	default:
+		// Anything else (permission denied traversing a parent directory, an
+		// I/O error, ...) is a real failure — don't silently treat it the
+		// same as "doesn't exist" and proceed without having enforced the
+		// non-regular/same-file checks above.
+		return nil, 0, nil, fmt.Errorf("checking existing output %q: %w", dstPath, statErr)
 	}
 
 	tmp, err := os.CreateTemp(filepath.Dir(dstPath), "."+filepath.Base(dstPath)+".tmp-*")

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -94,21 +94,28 @@ func createLike(dstPath string, src *os.File) (*os.File, os.FileMode, error) {
 	}
 	mode := srcInfo.Mode().Perm()
 
-	if existing, statErr := os.Stat(dstPath); statErr == nil {
+	// Lstat, not Stat: dstPath must be rejected if IT is a symlink, without
+	// following it first. os.Stat/os.OpenFile both follow symlinks, so an
+	// existing symlink at dstPath (planted by an attacker, or left over from
+	// something else) would otherwise cause EncryptFile/DecryptFile to
+	// truncate and write through it to whatever it points at — and the
+	// deferred cleanup's os.Remove(dstPath) only removes the symlink itself
+	// on failure, not the target, silently leaving partially-written content
+	// behind in a file this function never meant to touch. Rejecting any
+	// non-regular existing path here (symlink, device, fifo, socket) is
+	// simpler and safer than trying to handle each case.
+	if existing, statErr := os.Lstat(dstPath); statErr == nil {
+		if !existing.Mode().IsRegular() {
+			return nil, 0, fmt.Errorf("output %q exists and is not a regular file (mode %s)", dstPath, existing.Mode())
+		}
 		if os.SameFile(srcInfo, existing) {
 			return nil, 0, fmt.Errorf("output %q must not be the same file as the input", dstPath)
 		}
-		// Only touch the mode of a regular file — dstPath could be a
-		// directory or other special file (the caller passed a bad --output),
-		// and chmod'ing that isn't this function's business; let the
-		// OpenFile below report a clear error for it instead. This also
-		// narrows an existing, more-permissive dstPath down to the intended
+		// Narrows an existing, more-permissive dstPath down to the intended
 		// mode *before* opening it, so there is no window where it sits at
 		// looser-than-intended permissions while content is written.
-		if existing.Mode().IsRegular() {
-			if err := os.Chmod(dstPath, mode|0o200); err != nil {
-				return nil, 0, fmt.Errorf("setting permissions on %q: %w", dstPath, err)
-			}
+		if err := os.Chmod(dstPath, mode|0o200); err != nil {
+			return nil, 0, fmt.Errorf("setting permissions on %q: %w", dstPath, err)
 		}
 	}
 	dst, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode|0o200)

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -68,6 +68,24 @@ func isNoIdentityMatch(err error) bool {
 	return errors.As(err, &noMatch)
 }
 
+// createLike creates dstPath with src's permission bits, instead of
+// os.Create's fixed 0666&umask. EncryptFile/DecryptFile can turn a source
+// archive stored with restrictive permissions (e.g. 0600) into an encrypted
+// or plaintext copy, so the copy shouldn't silently end up more permissive
+// than the original — this matters most for DecryptFile, whose output is
+// plaintext.
+func createLike(dstPath string, src *os.File) (*os.File, error) {
+	srcInfo, err := src.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat %q: %w", src.Name(), err)
+	}
+	dst, err := os.OpenFile(dstPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcInfo.Mode().Perm())
+	if err != nil {
+		return nil, fmt.Errorf("creating %q: %w", dstPath, err)
+	}
+	return dst, nil
+}
+
 // EncryptFile writes an age-encrypted copy of the plaintext file at srcPath to
 // dstPath, encrypting to recipients. Unlike NewEncryptedStreamWriter (which
 // encrypts while writing a brand-new archive), this is a whole-file transform
@@ -92,9 +110,9 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 	}
 	defer src.Close()
 
-	dst, err := os.Create(dstPath)
+	dst, err := createLike(dstPath, src)
 	if err != nil {
-		return fmt.Errorf("creating %q: %w", dstPath, err)
+		return err
 	}
 	// Every failure from here on removes the partially-written output, so
 	// each branch below only needs to set err and return — no repeated
@@ -154,9 +172,9 @@ func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error)
 		return fmt.Errorf("decrypting %q: %w", srcPath, err)
 	}
 
-	dst, err := os.Create(dstPath)
+	dst, err := createLike(dstPath, src)
 	if err != nil {
-		return fmt.Errorf("creating %q: %w", dstPath, err)
+		return err
 	}
 	// Every failure from here on removes the partially-written output, so
 	// each branch below only needs to set err and return — no repeated

--- a/internal/archive/crypto_test.go
+++ b/internal/archive/crypto_test.go
@@ -314,3 +314,151 @@ func TestPlaintextArchiveStillOpens(t *testing.T) {
 	}
 	defer ar2.Close()
 }
+
+// TestEncryptFile_DecryptFile_RoundTrip_Passphrase encrypts an existing
+// plaintext archive after the fact, confirms the result is an age-encrypted
+// file readable by OpenWithIdentities, then decrypts it back and confirms the
+// bytes are byte-for-byte identical to the original plaintext archive.
+func TestEncryptFile_DecryptFile_RoundTrip_Passphrase(t *testing.T) {
+	dir := t.TempDir()
+	plainPath := filepath.Join(dir, "plain.kshrk")
+	sampleArchive(t, plainPath)
+	original, err := os.ReadFile(plainPath)
+	if err != nil {
+		t.Fatalf("ReadFile(plain): %v", err)
+	}
+
+	recipients, err := RecipientsFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("RecipientsFromPassphrase: %v", err)
+	}
+	encPath := filepath.Join(dir, "enc.kshrk")
+	if err := EncryptFile(plainPath, encPath, recipients); err != nil {
+		t.Fatalf("EncryptFile: %v", err)
+	}
+
+	if enc, err := IsEncrypted(encPath); err != nil || !enc {
+		t.Fatalf("IsEncrypted(encrypted output) = %v, %v; want true, nil", enc, err)
+	}
+	// The source file must be untouched.
+	if unchanged, err := os.ReadFile(plainPath); err != nil || string(unchanged) != string(original) {
+		t.Fatalf("EncryptFile modified its source file")
+	}
+
+	identities, err := IdentitiesFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("IdentitiesFromPassphrase: %v", err)
+	}
+	ar, err := OpenWithIdentities(encPath, identities)
+	if err != nil {
+		t.Fatalf("OpenWithIdentities(encrypted output): %v", err)
+	}
+	_ = ar.Close()
+
+	decPath := filepath.Join(dir, "dec.kshrk")
+	if err := DecryptFile(encPath, decPath, identities); err != nil {
+		t.Fatalf("DecryptFile: %v", err)
+	}
+	decrypted, err := os.ReadFile(decPath)
+	if err != nil {
+		t.Fatalf("ReadFile(decrypted): %v", err)
+	}
+	if string(decrypted) != string(original) {
+		t.Error("DecryptFile output does not match the original plaintext archive byte-for-byte")
+	}
+}
+
+// TestEncryptFile_DecryptFile_RoundTrip_X25519 is the recipient-mode
+// equivalent of the passphrase round trip.
+func TestEncryptFile_DecryptFile_RoundTrip_X25519(t *testing.T) {
+	dir := t.TempDir()
+	plainPath := filepath.Join(dir, "plain.kshrk")
+	sampleArchive(t, plainPath)
+
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("GenerateX25519Identity: %v", err)
+	}
+	encPath := filepath.Join(dir, "enc.kshrk")
+	if err := EncryptFile(plainPath, encPath, []age.Recipient{id.Recipient()}); err != nil {
+		t.Fatalf("EncryptFile: %v", err)
+	}
+
+	decPath := filepath.Join(dir, "dec.kshrk")
+	if err := DecryptFile(encPath, decPath, []age.Identity{id}); err != nil {
+		t.Fatalf("DecryptFile: %v", err)
+	}
+	original, err := os.ReadFile(plainPath)
+	if err != nil {
+		t.Fatalf("ReadFile(plain): %v", err)
+	}
+	decrypted, err := os.ReadFile(decPath)
+	if err != nil {
+		t.Fatalf("ReadFile(decrypted): %v", err)
+	}
+	if string(decrypted) != string(original) {
+		t.Error("DecryptFile output does not match the original plaintext archive byte-for-byte")
+	}
+}
+
+// TestEncryptFile_RejectsAlreadyEncrypted guards against silently
+// double-wrapping an already-encrypted archive.
+func TestEncryptFile_RejectsAlreadyEncrypted(t *testing.T) {
+	dir := t.TempDir()
+	recipients, err := RecipientsFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("RecipientsFromPassphrase: %v", err)
+	}
+	encPath := filepath.Join(dir, "enc.kshrk")
+	sampleEncryptedArchive(t, encPath, recipients)
+
+	if err := EncryptFile(encPath, filepath.Join(dir, "double.kshrk"), recipients); err == nil {
+		t.Fatal("EncryptFile on an already-encrypted archive succeeded, want error")
+	} else if !strings.Contains(err.Error(), "already encrypted") {
+		t.Errorf("error = %q, want it to mention the archive is already encrypted", err)
+	}
+}
+
+// TestDecryptFile_RejectsNotEncrypted guards against silently passing a
+// plaintext archive through unchanged (or failing with a confusing
+// "at least one identity is required" error) when given to DecryptFile.
+func TestDecryptFile_RejectsNotEncrypted(t *testing.T) {
+	dir := t.TempDir()
+	plainPath := filepath.Join(dir, "plain.kshrk")
+	sampleArchive(t, plainPath)
+
+	identities, err := IdentitiesFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("IdentitiesFromPassphrase: %v", err)
+	}
+	err = DecryptFile(plainPath, filepath.Join(dir, "out.kshrk"), identities)
+	if err == nil {
+		t.Fatal("DecryptFile on a plaintext archive succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "not encrypted") {
+		t.Errorf("error = %q, want it to mention the archive is not encrypted", err)
+	}
+}
+
+// TestDecryptFile_WrongPassphrase confirms the clean, stable error message.
+func TestDecryptFile_WrongPassphrase(t *testing.T) {
+	dir := t.TempDir()
+	recipients, err := RecipientsFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("RecipientsFromPassphrase: %v", err)
+	}
+	encPath := filepath.Join(dir, "enc.kshrk")
+	sampleEncryptedArchive(t, encPath, recipients)
+
+	wrong, err := IdentitiesFromPassphrase("wrong-passphrase")
+	if err != nil {
+		t.Fatalf("IdentitiesFromPassphrase: %v", err)
+	}
+	err = DecryptFile(encPath, filepath.Join(dir, "out.kshrk"), wrong)
+	if err == nil {
+		t.Fatal("DecryptFile with wrong passphrase succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "incorrect passphrase or key") {
+		t.Errorf("error = %q, want a clean 'incorrect passphrase or key' message", err)
+	}
+}

--- a/internal/archive/crypto_test.go
+++ b/internal/archive/crypto_test.go
@@ -603,6 +603,52 @@ func TestEncryptFile_RejectsSameFileAsOutput(t *testing.T) {
 	}
 }
 
+// TestEncryptFile_RejectsSymlinkOutput guards against a symlink-following
+// arbitrary-file-write: if dstPath is a symlink, os.Stat/os.OpenFile would
+// follow it and truncate/write through to whatever it points at, while the
+// error-path cleanup's os.Remove(dstPath) only removes the symlink itself —
+// not the target — leaving partially-written content behind in a file this
+// function never meant to touch. createLike must reject an existing symlink
+// at dstPath outright (via os.Lstat, which does not follow it), rather than
+// silently writing through it.
+func TestEncryptFile_RejectsSymlinkOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+	dir := t.TempDir()
+	plainPath := filepath.Join(dir, "plain.kshrk")
+	sampleArchive(t, plainPath)
+
+	target := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(target, []byte("not meant to be touched"), 0o600); err != nil {
+		t.Fatalf("WriteFile(target): %v", err)
+	}
+	linkPath := filepath.Join(dir, "enc.kshrk")
+	if err := os.Symlink(target, linkPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	recipients, err := RecipientsFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("RecipientsFromPassphrase: %v", err)
+	}
+	if err := EncryptFile(plainPath, linkPath, recipients); err == nil {
+		t.Fatal("EncryptFile against a symlink output succeeded, want a rejection")
+	} else if !strings.Contains(err.Error(), "not a regular file") {
+		t.Errorf("error = %q, want it to mention the output is not a regular file", err)
+	}
+
+	// The symlink target must be untouched — this is the actual security
+	// property being guarded.
+	after, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile(target) after rejected EncryptFile: %v", err)
+	}
+	if string(after) != "not meant to be touched" {
+		t.Error("EncryptFile wrote through the symlink to its target despite being rejected")
+	}
+}
+
 func statMode(t *testing.T, path string) os.FileMode {
 	t.Helper()
 	fi, err := os.Stat(path)

--- a/internal/archive/crypto_test.go
+++ b/internal/archive/crypto_test.go
@@ -421,7 +421,7 @@ func TestEncryptFile_RejectsAlreadyEncrypted(t *testing.T) {
 
 // TestDecryptFile_RejectsNotEncrypted guards against silently passing a
 // plaintext archive through unchanged (or failing with a confusing
-// "at least one identity is required" error) when given to DecryptFile.
+// "requires at least one identity" error) when given to DecryptFile.
 func TestDecryptFile_RejectsNotEncrypted(t *testing.T) {
 	dir := t.TempDir()
 	plainPath := filepath.Join(dir, "plain.kshrk")

--- a/internal/archive/crypto_test.go
+++ b/internal/archive/crypto_test.go
@@ -419,15 +419,12 @@ func TestEncryptFile_DecryptFile_PreservesSourceMode(t *testing.T) {
 	}
 }
 
-// TestEncryptFile_DecryptFile_ReadOnlySourceMode is a regression guard for a
-// bug in an earlier version of createLike: creating the destination file
-// directly with the source's exact mode fails outright when that mode has no
-// owner-write bit (e.g. 0400/0444, a read-only source) — Unix applies the
-// create mode immediately, and the very open() call that's meant to write the
-// file is then denied write access to what it just created. createLike must
-// force the owner-write bit on while writing and chmod to the exact source
-// mode only once done, so a read-only source round-trips successfully with
-// its mode preserved rather than erroring.
+// TestEncryptFile_DecryptFile_ReadOnlySourceMode confirms a read-only source
+// (0400/0444 — no owner-write bit at all) round-trips successfully with its
+// mode preserved in the output: createLike's temp file is writable while
+// being populated regardless of the source's mode, and commit narrows it to
+// the exact source mode (dropping the extra write bit) only once done, via
+// the rename.
 func TestEncryptFile_DecryptFile_ReadOnlySourceMode(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix permission bits don't apply on Windows")
@@ -467,16 +464,14 @@ func TestEncryptFile_DecryptFile_ReadOnlySourceMode(t *testing.T) {
 	}
 }
 
-// TestCreateLike_NarrowsExistingLoosePermissionsBeforeWriting is a regression
-// guard for a gap in an earlier version of createLike: a pre-existing
-// dstPath that's MORE permissive than the source (e.g. a stale 0644 file
-// where the source is 0600) was only narrowed by the caller's final Chmod,
-// after all content had already been written — meaning plaintext/ciphertext
-// sat under the loose permissions for the entire write. createLike must
-// narrow dstPath to the source's mode *before* returning the open file, so
-// there is no window where content is written under looser-than-intended
-// permissions.
-func TestCreateLike_NarrowsExistingLoosePermissionsBeforeWriting(t *testing.T) {
+// TestCreateLike_DoesNotTouchDstPathUntilCommit confirms the core guarantee
+// of the temp-file+rename design: while the returned file is being written
+// to, a pre-existing dstPath (regardless of its permissions or content) is
+// completely untouched — no partial content, no permission change — right up
+// until commit() is called. This is what makes the design immune to both the
+// "loose permissions during write" and "symlink-following" issues an
+// earlier, direct-open version of createLike had to work around individually.
+func TestCreateLike_DoesNotTouchDstPathUntilCommit(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix permission bits don't apply on Windows")
 	}
@@ -492,35 +487,52 @@ func TestCreateLike_NarrowsExistingLoosePermissionsBeforeWriting(t *testing.T) {
 	defer src.Close()
 
 	dstPath := filepath.Join(dir, "dst.kshrk")
-	if err := os.WriteFile(dstPath, []byte("stale, loosely-permissioned prior output"), 0o644); err != nil {
+	const staleContent = "stale, loosely-permissioned prior output"
+	if err := os.WriteFile(dstPath, []byte(staleContent), 0o644); err != nil {
 		t.Fatalf("WriteFile(stale dst, 0644): %v", err)
 	}
 
-	dst, mode, err := createLike(dstPath, src)
+	dst, mode, commit, err := createLike(dstPath, src)
 	if err != nil {
 		t.Fatalf("createLike: %v", err)
 	}
-	defer dst.Close()
-
 	if mode != 0o600 {
 		t.Errorf("returned mode = %o, want 0600 (the source's mode)", mode)
 	}
-	// The critical assertion: by the time createLike returns — before any
-	// caller has written a single byte — dstPath must already be narrowed to
-	// the source's mode, not left at its old, looser 0644.
+	if dst.Name() == dstPath {
+		t.Fatalf("createLike returned a file at dstPath itself (%q); it must be a separate temp file", dstPath)
+	}
+
+	// Write into the returned file and confirm dstPath is still exactly the
+	// stale content/permissions from before — commit hasn't run yet.
+	if _, err := dst.WriteString("new content"); err != nil {
+		t.Fatalf("WriteString: %v", err)
+	}
+	if got := statMode(t, dstPath); got != 0o644 {
+		t.Errorf("dstPath mode before commit = %o, want unchanged 0644", got)
+	}
+	if content, err := os.ReadFile(dstPath); err != nil || string(content) != staleContent {
+		t.Errorf("dstPath content before commit = %q, %v; want unchanged %q", content, err, staleContent)
+	}
+
+	if err := commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
 	if got := statMode(t, dstPath); got != 0o600 {
-		t.Errorf("dstPath mode immediately after createLike = %o, want 0600 (narrowed before any write, not left at the stale 0644)", got)
+		t.Errorf("dstPath mode after commit = %o, want 0600 (the source's mode)", got)
+	}
+	if content, err := os.ReadFile(dstPath); err != nil || string(content) != "new content" {
+		t.Errorf("dstPath content after commit = %q, %v; want %q", content, err, "new content")
 	}
 }
 
-// TestEncryptFile_ExistingReadOnlyOutput covers the case createLike's
-// pre-chmod exists for: dstPath already exists with a restrictive mode (e.g.
-// left behind, with a read-only mode, by an earlier run of this very
-// mode-preservation logic). os.OpenFile's mode argument is ignored for a
-// file that already exists — only its current on-disk mode governs the
-// access check — so re-running EncryptFile against the same output path
-// must still succeed rather than failing with a permission error caused by
-// its own past output.
+// TestEncryptFile_ExistingReadOnlyOutput confirms overwriting an existing,
+// restrictively-permissioned output succeeds: createLike writes to a fresh
+// temp file and renames it into place, so the pre-existing dstPath's own
+// permissions (here, read-only 0400 — e.g. left behind by an earlier run of
+// this same mode-preservation logic) never block the operation. Unlike an
+// open()-based approach, a rename only needs write access to the *directory*
+// to replace the name, not to the file it's replacing.
 func TestEncryptFile_ExistingReadOnlyOutput(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix permission bits don't apply on Windows")
@@ -551,35 +563,6 @@ func TestEncryptFile_ExistingReadOnlyOutput(t *testing.T) {
 		t.Fatalf("OpenWithIdentities: %v", err)
 	}
 	_ = ar.Close()
-}
-
-// TestEncryptFile_ExistingWriteOnlyOutput confirms createLike opens the
-// destination O_WRONLY, not O_RDWR: an existing output file with a
-// write-only (0200) mode has no read bit, which O_RDWR would reject even
-// though EncryptFile never actually reads back from dst. This mirrors
-// TestEncryptFile_ExistingReadOnlyOutput, but for the destination's mode
-// rather than the source's (a 0200 *source* can never be processed at all,
-// independent of this fix, since encrypting it requires reading it).
-func TestEncryptFile_ExistingWriteOnlyOutput(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix permission bits don't apply on Windows")
-	}
-	dir := t.TempDir()
-	plainPath := filepath.Join(dir, "plain.kshrk")
-	sampleArchive(t, plainPath)
-
-	encPath := filepath.Join(dir, "enc.kshrk")
-	if err := os.WriteFile(encPath, []byte("stale output from a prior run"), 0o200); err != nil {
-		t.Fatalf("WriteFile(stale output, 0200): %v", err)
-	}
-
-	recipients, err := RecipientsFromPassphrase(testPassphrase)
-	if err != nil {
-		t.Fatalf("RecipientsFromPassphrase: %v", err)
-	}
-	if err := EncryptFile(plainPath, encPath, recipients); err != nil {
-		t.Fatalf("EncryptFile overwriting a pre-existing 0200 (write-only) output: %v", err)
-	}
 }
 
 // TestEncryptFile_RejectsSameFileAsOutput guards createLike's os.SameFile

--- a/internal/archive/crypto_test.go
+++ b/internal/archive/crypto_test.go
@@ -1,6 +1,8 @@
 package archive
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -768,5 +770,55 @@ func TestDecryptFile_WrongPassphrase(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "incorrect passphrase or key") {
 		t.Errorf("error = %q, want a clean 'incorrect passphrase or key' message", err)
+	}
+}
+
+// TestDecryptFile_TamperedCiphertext confirms a real, end-to-end tamper (a
+// flipped byte in the ciphertext payload, past the header) is classified as
+// "tampered or corrupt", not a generic decryption failure.
+func TestDecryptFile_TamperedCiphertext(t *testing.T) {
+	dir := t.TempDir()
+	recipients, err := RecipientsFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("RecipientsFromPassphrase: %v", err)
+	}
+	encPath := filepath.Join(dir, "enc.kshrk")
+	sampleEncryptedArchive(t, encPath, recipients)
+
+	data, err := os.ReadFile(encPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	data[len(data)-10] ^= 0xFF
+	if err := os.WriteFile(encPath, data, 0o600); err != nil {
+		t.Fatalf("WriteFile(tampered): %v", err)
+	}
+
+	identities, err := IdentitiesFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("IdentitiesFromPassphrase: %v", err)
+	}
+	err = DecryptFile(encPath, filepath.Join(dir, "out.kshrk"), identities)
+	if err == nil {
+		t.Fatal("DecryptFile against tampered ciphertext succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "tampered or corrupt") {
+		t.Errorf("error = %q, want it to mention tampered or corrupt content", err)
+	}
+}
+
+// TestClassifyDecryptCopyError unit-tests the I/O-vs-tamper distinction
+// directly with synthetic errors, since reliably forcing a genuine mid-copy
+// OS-level I/O failure (disk full, a permission error on an already-open fd)
+// isn't practical to reproduce deterministically and portably in a test.
+func TestClassifyDecryptCopyError(t *testing.T) {
+	ioErr := &fs.PathError{Op: "write", Path: "/tmp/whatever", Err: errors.New("no space left on device")}
+	if got := classifyDecryptCopyError("src.kshrk", ioErr).Error(); strings.Contains(got, "tampered or corrupt") {
+		t.Errorf("classifyDecryptCopyError(*fs.PathError) = %q, want it to NOT claim tampering for a plain I/O error", got)
+	}
+
+	otherErr := errors.New("chunk authentication failed")
+	if got := classifyDecryptCopyError("src.kshrk", otherErr).Error(); !strings.Contains(got, "tampered or corrupt") {
+		t.Errorf("classifyDecryptCopyError(non-PathError) = %q, want it to mention tampered or corrupt content", got)
 	}
 }

--- a/internal/archive/crypto_test.go
+++ b/internal/archive/crypto_test.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -370,6 +371,61 @@ func TestEncryptFile_DecryptFile_RoundTrip_Passphrase(t *testing.T) {
 	if string(decrypted) != string(original) {
 		t.Error("DecryptFile output does not match the original plaintext archive byte-for-byte")
 	}
+}
+
+// TestEncryptFile_DecryptFile_PreservesSourceMode confirms EncryptFile and
+// DecryptFile create their output with the source file's permission bits,
+// not os.Create's fixed 0666&umask — a restrictively-permissioned source
+// (e.g. 0600) must not silently become more permissive in the copy, which
+// matters most for DecryptFile since its output is plaintext.
+func TestEncryptFile_DecryptFile_PreservesSourceMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits don't apply on Windows")
+	}
+	dir := t.TempDir()
+	plainPath := filepath.Join(dir, "plain.kshrk")
+	sampleArchive(t, plainPath)
+	if err := os.Chmod(plainPath, 0o600); err != nil {
+		t.Fatalf("Chmod(plain, 0600): %v", err)
+	}
+
+	recipients, err := RecipientsFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("RecipientsFromPassphrase: %v", err)
+	}
+	encPath := filepath.Join(dir, "enc.kshrk")
+	if err := EncryptFile(plainPath, encPath, recipients); err != nil {
+		t.Fatalf("EncryptFile: %v", err)
+	}
+	if mode := statMode(t, encPath); mode != 0o600 {
+		t.Errorf("encrypted output mode = %o, want 0600 (matching the source)", mode)
+	}
+
+	// Re-permission the encrypted file differently to confirm DecryptFile
+	// independently preserves *its* source's mode, not a hardcoded default.
+	if err := os.Chmod(encPath, 0o640); err != nil {
+		t.Fatalf("Chmod(enc, 0640): %v", err)
+	}
+	identities, err := IdentitiesFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("IdentitiesFromPassphrase: %v", err)
+	}
+	decPath := filepath.Join(dir, "dec.kshrk")
+	if err := DecryptFile(encPath, decPath, identities); err != nil {
+		t.Fatalf("DecryptFile: %v", err)
+	}
+	if mode := statMode(t, decPath); mode != 0o640 {
+		t.Errorf("decrypted output mode = %o, want 0640 (matching the source)", mode)
+	}
+}
+
+func statMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%q): %v", path, err)
+	}
+	return fi.Mode().Perm()
 }
 
 // TestEncryptFile_DecryptFile_RoundTrip_X25519 is the recipient-mode

--- a/internal/archive/crypto_test.go
+++ b/internal/archive/crypto_test.go
@@ -507,6 +507,56 @@ func TestEncryptFile_ExistingReadOnlyOutput(t *testing.T) {
 	_ = ar.Close()
 }
 
+// TestEncryptFile_ExistingWriteOnlyOutput confirms createLike opens the
+// destination O_WRONLY, not O_RDWR: an existing output file with a
+// write-only (0200) mode has no read bit, which O_RDWR would reject even
+// though EncryptFile never actually reads back from dst. This mirrors
+// TestEncryptFile_ExistingReadOnlyOutput, but for the destination's mode
+// rather than the source's (a 0200 *source* can never be processed at all,
+// independent of this fix, since encrypting it requires reading it).
+func TestEncryptFile_ExistingWriteOnlyOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits don't apply on Windows")
+	}
+	dir := t.TempDir()
+	plainPath := filepath.Join(dir, "plain.kshrk")
+	sampleArchive(t, plainPath)
+
+	encPath := filepath.Join(dir, "enc.kshrk")
+	if err := os.WriteFile(encPath, []byte("stale output from a prior run"), 0o200); err != nil {
+		t.Fatalf("WriteFile(stale output, 0200): %v", err)
+	}
+
+	recipients, err := RecipientsFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("RecipientsFromPassphrase: %v", err)
+	}
+	if err := EncryptFile(plainPath, encPath, recipients); err != nil {
+		t.Fatalf("EncryptFile overwriting a pre-existing 0200 (write-only) output: %v", err)
+	}
+}
+
+// TestEncryptFile_RejectsSameFileAsOutput guards createLike's os.SameFile
+// check: encrypting a file onto itself (as opposed to the CLI-level
+// absolute-path comparison in cmd/encrypt.go, which a caller of this
+// exported library function directly wouldn't get for free) must be
+// rejected, not silently truncate the source while reading from it.
+func TestEncryptFile_RejectsSameFileAsOutput(t *testing.T) {
+	dir := t.TempDir()
+	plainPath := filepath.Join(dir, "plain.kshrk")
+	sampleArchive(t, plainPath)
+
+	recipients, err := RecipientsFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("RecipientsFromPassphrase: %v", err)
+	}
+	if err := EncryptFile(plainPath, plainPath, recipients); err == nil {
+		t.Fatal("EncryptFile(path, path, ...) succeeded, want a same-file error")
+	} else if !strings.Contains(err.Error(), "same file") {
+		t.Errorf("error = %q, want it to mention the same-file conflict", err)
+	}
+}
+
 func statMode(t *testing.T, path string) os.FileMode {
 	t.Helper()
 	fi, err := os.Stat(path)

--- a/internal/archive/crypto_test.go
+++ b/internal/archive/crypto_test.go
@@ -341,8 +341,12 @@ func TestEncryptFile_DecryptFile_RoundTrip_Passphrase(t *testing.T) {
 		t.Fatalf("IsEncrypted(encrypted output) = %v, %v; want true, nil", enc, err)
 	}
 	// The source file must be untouched.
-	if unchanged, err := os.ReadFile(plainPath); err != nil || string(unchanged) != string(original) {
-		t.Fatalf("EncryptFile modified its source file")
+	unchanged, err := os.ReadFile(plainPath)
+	if err != nil {
+		t.Fatalf("ReadFile(plain) after EncryptFile: %v", err)
+	}
+	if string(unchanged) != string(original) {
+		t.Fatal("EncryptFile modified its source file")
 	}
 
 	identities, err := IdentitiesFromPassphrase(testPassphrase)

--- a/internal/archive/crypto_test.go
+++ b/internal/archive/crypto_test.go
@@ -632,6 +632,41 @@ func TestEncryptFile_RejectsSymlinkOutput(t *testing.T) {
 	}
 }
 
+// TestEncryptFile_SurfacesUnexpectedLstatError guards createLike's Lstat
+// error handling: only "does not exist" should be treated as "no output to
+// check" and let the operation proceed. Any other Lstat failure (here, a
+// non-directory path component — a real, reproducible ENOTDIR, not ENOENT)
+// must be surfaced as a clear error, not silently swallowed and treated the
+// same as a fresh output path.
+func TestEncryptFile_SurfacesUnexpectedLstatError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("path-component-is-a-file produces different errors on Windows")
+	}
+	dir := t.TempDir()
+	plainPath := filepath.Join(dir, "plain.kshrk")
+	sampleArchive(t, plainPath)
+
+	notADir := filepath.Join(dir, "notadir")
+	if err := os.WriteFile(notADir, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile(notADir): %v", err)
+	}
+	// dstPath treats notADir (a regular file) as a directory component, so
+	// Lstat on it fails with ENOTDIR, not ENOENT.
+	dstPath := filepath.Join(notADir, "out.kshrk")
+
+	recipients, err := RecipientsFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("RecipientsFromPassphrase: %v", err)
+	}
+	err = EncryptFile(plainPath, dstPath, recipients)
+	if err == nil {
+		t.Fatal("EncryptFile with an unstatable output path succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "checking existing output") {
+		t.Errorf("error = %q, want it to mention checking the existing output, not a generic/silent failure", err)
+	}
+}
+
 func statMode(t *testing.T, path string) os.FileMode {
 	t.Helper()
 	fi, err := os.Stat(path)

--- a/internal/archive/crypto_test.go
+++ b/internal/archive/crypto_test.go
@@ -467,6 +467,52 @@ func TestEncryptFile_DecryptFile_ReadOnlySourceMode(t *testing.T) {
 	}
 }
 
+// TestCreateLike_NarrowsExistingLoosePermissionsBeforeWriting is a regression
+// guard for a gap in an earlier version of createLike: a pre-existing
+// dstPath that's MORE permissive than the source (e.g. a stale 0644 file
+// where the source is 0600) was only narrowed by the caller's final Chmod,
+// after all content had already been written — meaning plaintext/ciphertext
+// sat under the loose permissions for the entire write. createLike must
+// narrow dstPath to the source's mode *before* returning the open file, so
+// there is no window where content is written under looser-than-intended
+// permissions.
+func TestCreateLike_NarrowsExistingLoosePermissionsBeforeWriting(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits don't apply on Windows")
+	}
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "src.kshrk")
+	if err := os.WriteFile(srcPath, []byte("source"), 0o600); err != nil {
+		t.Fatalf("WriteFile(src, 0600): %v", err)
+	}
+	src, err := os.Open(srcPath)
+	if err != nil {
+		t.Fatalf("Open(src): %v", err)
+	}
+	defer src.Close()
+
+	dstPath := filepath.Join(dir, "dst.kshrk")
+	if err := os.WriteFile(dstPath, []byte("stale, loosely-permissioned prior output"), 0o644); err != nil {
+		t.Fatalf("WriteFile(stale dst, 0644): %v", err)
+	}
+
+	dst, mode, err := createLike(dstPath, src)
+	if err != nil {
+		t.Fatalf("createLike: %v", err)
+	}
+	defer dst.Close()
+
+	if mode != 0o600 {
+		t.Errorf("returned mode = %o, want 0600 (the source's mode)", mode)
+	}
+	// The critical assertion: by the time createLike returns — before any
+	// caller has written a single byte — dstPath must already be narrowed to
+	// the source's mode, not left at its old, looser 0644.
+	if got := statMode(t, dstPath); got != 0o600 {
+		t.Errorf("dstPath mode immediately after createLike = %o, want 0600 (narrowed before any write, not left at the stale 0644)", got)
+	}
+}
+
 // TestEncryptFile_ExistingReadOnlyOutput covers the case createLike's
 // pre-chmod exists for: dstPath already exists with a restrictive mode (e.g.
 // left behind, with a read-only mode, by an earlier run of this very

--- a/internal/archive/crypto_test.go
+++ b/internal/archive/crypto_test.go
@@ -419,6 +419,94 @@ func TestEncryptFile_DecryptFile_PreservesSourceMode(t *testing.T) {
 	}
 }
 
+// TestEncryptFile_DecryptFile_ReadOnlySourceMode is a regression guard for a
+// bug in an earlier version of createLike: creating the destination file
+// directly with the source's exact mode fails outright when that mode has no
+// owner-write bit (e.g. 0400/0444, a read-only source) — Unix applies the
+// create mode immediately, and the very open() call that's meant to write the
+// file is then denied write access to what it just created. createLike must
+// force the owner-write bit on while writing and chmod to the exact source
+// mode only once done, so a read-only source round-trips successfully with
+// its mode preserved rather than erroring.
+func TestEncryptFile_DecryptFile_ReadOnlySourceMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits don't apply on Windows")
+	}
+	dir := t.TempDir()
+	plainPath := filepath.Join(dir, "plain.kshrk")
+	sampleArchive(t, plainPath)
+	if err := os.Chmod(plainPath, 0o400); err != nil {
+		t.Fatalf("Chmod(plain, 0400): %v", err)
+	}
+
+	recipients, err := RecipientsFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("RecipientsFromPassphrase: %v", err)
+	}
+	encPath := filepath.Join(dir, "enc.kshrk")
+	if err := EncryptFile(plainPath, encPath, recipients); err != nil {
+		t.Fatalf("EncryptFile against a 0400 (read-only) source: %v", err)
+	}
+	if mode := statMode(t, encPath); mode != 0o400 {
+		t.Errorf("encrypted output mode = %o, want 0400 (matching the read-only source)", mode)
+	}
+	if err := os.Chmod(encPath, 0o444); err != nil {
+		t.Fatalf("Chmod(enc, 0444): %v", err)
+	}
+
+	identities, err := IdentitiesFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("IdentitiesFromPassphrase: %v", err)
+	}
+	decPath := filepath.Join(dir, "dec.kshrk")
+	if err := DecryptFile(encPath, decPath, identities); err != nil {
+		t.Fatalf("DecryptFile against a 0444 (read-only) source: %v", err)
+	}
+	if mode := statMode(t, decPath); mode != 0o444 {
+		t.Errorf("decrypted output mode = %o, want 0444 (matching the read-only source)", mode)
+	}
+}
+
+// TestEncryptFile_ExistingReadOnlyOutput covers the case createLike's
+// pre-chmod exists for: dstPath already exists with a restrictive mode (e.g.
+// left behind, with a read-only mode, by an earlier run of this very
+// mode-preservation logic). os.OpenFile's mode argument is ignored for a
+// file that already exists — only its current on-disk mode governs the
+// access check — so re-running EncryptFile against the same output path
+// must still succeed rather than failing with a permission error caused by
+// its own past output.
+func TestEncryptFile_ExistingReadOnlyOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits don't apply on Windows")
+	}
+	dir := t.TempDir()
+	plainPath := filepath.Join(dir, "plain.kshrk")
+	sampleArchive(t, plainPath)
+
+	encPath := filepath.Join(dir, "enc.kshrk")
+	if err := os.WriteFile(encPath, []byte("stale output from a prior run"), 0o400); err != nil {
+		t.Fatalf("WriteFile(stale output, 0400): %v", err)
+	}
+
+	recipients, err := RecipientsFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("RecipientsFromPassphrase: %v", err)
+	}
+	if err := EncryptFile(plainPath, encPath, recipients); err != nil {
+		t.Fatalf("EncryptFile overwriting a pre-existing 0400 output: %v", err)
+	}
+
+	identities, err := IdentitiesFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("IdentitiesFromPassphrase: %v", err)
+	}
+	ar, err := OpenWithIdentities(encPath, identities)
+	if err != nil {
+		t.Fatalf("OpenWithIdentities: %v", err)
+	}
+	_ = ar.Close()
+}
+
 func statMode(t *testing.T, path string) os.FileMode {
 	t.Helper()
 	fi, err := os.Stat(path)


### PR DESCRIPTION
## Summary

Sixth and final milestone of optional archive encryption-at-rest: standalone `kshrk encrypt`/`kshrk decrypt` commands for encrypting or decrypting an **existing** archive after the fact, rather than only at capture time (`capture --encrypt`) or via redaction (`redact --encrypt`).

Closes #117 — with this, the issue's acceptance criteria (passphrase round-trip on every read path, no plaintext spillage, documented threat model) are all met, plus the stretch goals (recipient keys, and now standalone encrypt/decrypt).

## What's in this PR

- **`internal/archive/crypto.go`**: `EncryptFile`/`DecryptFile` — whole-file transforms built directly on `age.Encrypt`/`age.Decrypt`, not the ZIP-aware `StreamWriter`/`Archive` machinery (these operate on an opaque existing file, not a fresh capture). Each refuses to run against a source already in the wrong state — `EncryptFile` on an already-encrypted file, `DecryptFile` on a plaintext one — with a clear error, and cleans up a partially-written output on any failure.
- **`cmd/encrypt.go`**: `kshrk encrypt <in> [-o out]`, reusing the existing `resolveEncryption()` (passphrase or recipient keys — the same flags as `capture`/`redact`). Requires an explicit encryption method; running it with no flags errors instead of silently no-op copying.
- **`cmd/decrypt.go`**: `kshrk decrypt <in> [-o out]`, reusing the existing `resolveDecryptIdentities()` (passphrase file / identity file / env / prompt — the same flags as every read command).
- Both default their output to `<in>-encrypted.kshrk` / `<in>-decrypted.kshrk` (mirroring `redact`'s default-output naming) and refuse to let `--output` overwrite the input.
- Together, these give a **real key-rotation path** — `decrypt` then `encrypt` to a new passphrase or recipient set — without `redact`'s `redacted: true` mislabeling workaround. The threat-model doc's "Rotating keys" section now documents this as the primary path (keeping the `redact`-based one as a plaintext-avoiding alternative).

## Verified end to end with the built binary

```
$ kshrk encrypt plain.kshrk --encrypt-passphrase-file pass.txt
Encrypted (age passphrase) -> plain-encrypted.kshrk (1.0 KiB)

$ kshrk inspect plain-encrypted.kshrk                              # no key
Error: archive "..." is encrypted: provide --decrypt-passphrase-file, ...

$ kshrk inspect plain-encrypted.kshrk --decrypt-passphrase-file pass.txt   # ✓ works

$ kshrk decrypt plain-encrypted.kshrk --decrypt-passphrase-file pass.txt --output roundtrip.kshrk
Decrypted -> roundtrip.kshrk (862 B)
$ cmp plain.kshrk roundtrip.kshrk && echo IDENTICAL                # ✓ byte-for-byte

$ kshrk encrypt plain-encrypted.kshrk --encrypt-passphrase-file pass.txt   # already encrypted
Error: "..." is already encrypted

$ kshrk decrypt plain.kshrk --decrypt-passphrase-file pass.txt             # not encrypted
Error: "..." is not encrypted

$ kshrk decrypt plain-encrypted.kshrk --decrypt-passphrase-file wrong.txt  # wrong key
Error: failed to decrypt "...": incorrect passphrase or key
```

Also verified the full re-key flow: `decrypt` (old passphrase) → `encrypt` (new recipient key) → the result opens with the new recipient's identity and the **old passphrase no longer works**.

## Tests

- `internal/archive/crypto_test.go`: `EncryptFile`/`DecryptFile` round-trip for both passphrase and X25519 modes (confirming byte-for-byte identical plaintext and that the source file is left untouched), already-encrypted/not-encrypted rejection, wrong-passphrase clean error.
- `cmd/encrypt_test.go` / `cmd/decrypt_test.go`: default output naming, explicit output, no-encryption-method error, same-output-as-input rejection, wrong passphrase.

`make fmt`, `make lint-ci`, full `make test`, and `go mod tidy` (idempotent) all clean.

## Docs

- `docs/usage.md`: new "Encrypting or decrypting after the fact" subsection with examples, including the two-step key-rotation flow.
- `docs/encryption-threat-model.md`: "Rotating keys" section rewritten around the real `decrypt`/`encrypt` path; intro updated to mention the new commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)