### PR TITLE
fix(capture): make index seq authoritative on the archive writer, not a second counter

### DIFF
--- a/cmd/decrypt_flags_test.go
+++ b/cmd/decrypt_flags_test.go
@@ -35,7 +35,7 @@ func writeEncryptedArchive(t *testing.T, path, passphrase string) {
 		t.Fatalf("NewEncryptedStreamWriter: %v", err)
 	}
 	rec := map[string]any{"id": "r1", "api_path": "/api/v1/nodes"}
-	if err := sw.WriteRecord(rec); err != nil {
+	if _, err := sw.WriteRecord(rec); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}
 	if err := sw.Finish(map[string]any{"capture_id": "enc"}, map[string]any{}, nil); err != nil {
@@ -50,7 +50,7 @@ func writePlaintextArchive(t *testing.T, path string) {
 		t.Fatalf("NewStreamWriter: %v", err)
 	}
 	rec := map[string]any{"id": "r1", "api_path": "/api/v1/nodes"}
-	if err := sw.WriteRecord(rec); err != nil {
+	if _, err := sw.WriteRecord(rec); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}
 	if err := sw.Finish(map[string]any{"capture_id": "plain"}, map[string]any{}, nil); err != nil {
@@ -148,7 +148,7 @@ func TestResolveDecryptIdentities_IdentityFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEncryptedStreamWriter: %v", err)
 	}
-	if err := sw.WriteRecord(map[string]any{"id": "r1", "api_path": "/api/v1/nodes"}); err != nil {
+	if _, err := sw.WriteRecord(map[string]any{"id": "r1", "api_path": "/api/v1/nodes"}); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}
 	if err := sw.Finish(map[string]any{"capture_id": "x25519"}, map[string]any{}, nil); err != nil {

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -111,7 +111,7 @@ func buildEncryptedDiffArchive(t *testing.T, body, passphrase string) string {
 	// TempDir cleanup can't be blocked by an open file. Abort is a no-op after
 	// a successful Finish.
 	defer func() { _ = sw.Abort() }()
-	if err := sw.WriteRecord(rec); err != nil {
+	if _, err := sw.WriteRecord(rec); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}
 	if err := sw.Finish(meta, index, nil); err != nil {
@@ -172,7 +172,7 @@ func buildDiffArchive(t *testing.T, body string) string {
 	if err != nil {
 		t.Fatalf("NewStreamWriter: %v", err)
 	}
-	if err := sw.WriteRecord(rec); err != nil {
+	if _, err := sw.WriteRecord(rec); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}
 	if err := sw.Finish(meta, index, nil); err != nil {

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -28,7 +28,7 @@ func buildMultiPathArchive(t *testing.T, bodies map[string]string) string {
 	i := 0
 	for path, body := range bodies {
 		rec := &capture.Record{ID: path, CapturedAt: now, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body)}
-		if err := sw.WriteRecord(rec); err != nil {
+		if _, err := sw.WriteRecord(rec); err != nil {
 			t.Fatalf("WriteRecord: %v", err)
 		}
 		index[path] = &capture.IndexEntry{APIPath: path, Seqs: []int{0}, Times: []time.Time{now}}

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -26,7 +26,11 @@ var epochModTime = time.Date(1980, 1, 1, 12, 0, 0, 0, time.UTC)
 
 // RecordSink accepts individual capture records as they arrive.
 type RecordSink interface {
-	WriteRecord(rec any) error
+	// WriteRecord writes rec and returns the sequence number assigned to it
+	// within its record's api_path — the same numbering readers use to
+	// address it later (see Archive.ReadRecord). The seq is only meaningful
+	// on success; callers must not use it when err is non-nil.
+	WriteRecord(rec any) (int, error)
 	// Finish writes metadata.json, index.json, and (when watchIndex is non-nil)
 	// watch-index.json, then closes the archive.
 	Finish(meta, index, watchIndex any) error
@@ -142,23 +146,24 @@ func newStreamWriter(outputPath string, recipients []age.Recipient) (*StreamWrit
 
 // WriteRecord marshals rec to JSON, Zstd-compresses it, and appends it
 // to the ZIP archive under records/<pathDir(apiPath)>/<seq>.json.zst.
-// The record must have both "id" and "api_path" fields.
-func (w *StreamWriter) WriteRecord(rec any) error {
+// The record must have both "id" and "api_path" fields. It returns the seq
+// assigned to the record, which is only valid when err is nil.
+func (w *StreamWriter) WriteRecord(rec any) (int, error) {
 	data, err := json.Marshal(rec)
 	if err != nil {
-		return fmt.Errorf("marshalling record: %w", err)
+		return 0, fmt.Errorf("marshalling record: %w", err)
 	}
 	var hdr struct {
 		ID      string `json:"id"`
 		APIPath string `json:"api_path"`
 	}
 	if err := json.Unmarshal(data, &hdr); err != nil || hdr.ID == "" || hdr.APIPath == "" {
-		return fmt.Errorf("record missing id or api_path field")
+		return 0, fmt.Errorf("record missing id or api_path field")
 	}
 
 	compressed, err := zstdCompress(data)
 	if err != nil {
-		return fmt.Errorf("compressing record %s: %w", hdr.ID, err)
+		return 0, fmt.Errorf("compressing record %s: %w", hdr.ID, err)
 	}
 
 	dir := pathDir(hdr.APIPath)
@@ -167,15 +172,15 @@ func (w *StreamWriter) WriteRecord(rec any) error {
 	defer w.mu.Unlock()
 
 	seq := w.pathSeq[hdr.APIPath]
-	w.pathSeq[hdr.APIPath] = seq + 1
 	entryName := filepath.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq))
 
 	if err := writeBytes(w.zw, entryName, compressed); err != nil {
-		return err
+		return 0, err
 	}
+	w.pathSeq[hdr.APIPath] = seq + 1
 	w.n++
 	w.bytes += int64(len(data))
-	return nil
+	return seq, nil
 }
 
 // WriteRecordRaw compresses data and writes it to the archive for the given
@@ -294,30 +299,47 @@ func (w *StreamWriter) UncompressedBytes() int64 {
 // NDJSONWriter writes each record as a newline-delimited JSON object to an
 // io.Writer (typically os.Stdout). Finish is a no-op. Thread-safe.
 type NDJSONWriter struct {
-	mu    sync.Mutex
-	w     io.Writer
-	enc   *json.Encoder
-	n     int
-	bytes int64
+	mu      sync.Mutex
+	w       io.Writer
+	enc     *json.Encoder
+	n       int
+	bytes   int64
+	pathSeq map[string]int // apiPath → next seq, mirrors StreamWriter's numbering
 }
 
 // NewNDJSONWriter creates an NDJSONWriter writing to w.
 func NewNDJSONWriter(w io.Writer) *NDJSONWriter {
-	return &NDJSONWriter{w: w, enc: json.NewEncoder(w)}
+	return &NDJSONWriter{w: w, enc: json.NewEncoder(w), pathSeq: make(map[string]int)}
 }
 
-// WriteRecord encodes rec as a single JSON line.
-func (w *NDJSONWriter) WriteRecord(rec any) error {
+// WriteRecord encodes rec as a single JSON line and returns the seq assigned
+// to it within its api_path, matching StreamWriter's numbering even though
+// NDJSON output has no index to look it up by later.
+func (w *NDJSONWriter) WriteRecord(rec any) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if b, err := json.Marshal(rec); err == nil {
-		w.bytes += int64(len(b))
+	b, err := json.Marshal(rec)
+	if err != nil {
+		return 0, fmt.Errorf("marshalling record: %w", err)
 	}
+	w.bytes += int64(len(b))
+
+	var hdr struct {
+		APIPath string `json:"api_path"`
+	}
+	var seq int
+	if json.Unmarshal(b, &hdr) == nil && hdr.APIPath != "" {
+		seq = w.pathSeq[hdr.APIPath]
+	}
+
 	if err := w.enc.Encode(rec); err != nil {
-		return err
+		return 0, err
+	}
+	if hdr.APIPath != "" {
+		w.pathSeq[hdr.APIPath] = seq + 1
 	}
 	w.n++
-	return nil
+	return seq, nil
 }
 
 // Finish is a no-op for NDJSONWriter.

--- a/internal/archive/bench_test.go
+++ b/internal/archive/bench_test.go
@@ -33,7 +33,7 @@ func BenchmarkStreamWriter_WriteRecord(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := w.WriteRecord(sampleRecord(i)); err != nil {
+		if _, err := w.WriteRecord(sampleRecord(i)); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -55,7 +55,7 @@ func BenchmarkStreamWriter_RoundTrip(b *testing.B) {
 					b.Fatal(err)
 				}
 				for j := 0; j < n; j++ {
-					if err := w.WriteRecord(sampleRecord(j)); err != nil {
+					if _, err := w.WriteRecord(sampleRecord(j)); err != nil {
 						b.Fatal(err)
 					}
 				}
@@ -77,7 +77,7 @@ func BenchmarkNDJSONWriter_WriteRecord(b *testing.B) {
 	w := NewNDJSONWriter(&bytes.Buffer{})
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := w.WriteRecord(sampleRecord(i)); err != nil {
+		if _, err := w.WriteRecord(sampleRecord(i)); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/internal/archive/crypto_test.go
+++ b/internal/archive/crypto_test.go
@@ -30,7 +30,7 @@ func sampleEncryptedArchive(t *testing.T, path string, recipients []age.Recipien
 		"http_method": "GET", "response_code": 200,
 		"response_body": map[string]any{"apiVersion": "v1", "kind": "PodList", "items": []any{}},
 	}
-	if err := sw.WriteRecord(rec); err != nil {
+	if _, err := sw.WriteRecord(rec); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}
 	meta := map[string]any{"format_version": 1, "capture_id": "encrypted-v1", "record_count": 1}
@@ -209,7 +209,7 @@ func TestEncryptedArchiveConcurrentReads(t *testing.T) {
 	seqs := make([]int, 0, n)
 	for i := 0; i < n; i++ {
 		rec := map[string]any{"id": "rec", "api_path": "/api/v1/pods", "n": i}
-		if err := sw.WriteRecord(rec); err != nil {
+		if _, err := sw.WriteRecord(rec); err != nil {
 			t.Fatalf("WriteRecord: %v", err)
 		}
 		seqs = append(seqs, i)

--- a/internal/archive/format_test.go
+++ b/internal/archive/format_test.go
@@ -24,7 +24,7 @@ func sampleArchive(t *testing.T, path string) {
 		"http_method": "GET", "response_code": 200,
 		"response_body": map[string]any{"apiVersion": "v1", "kind": "PodList", "items": []any{}},
 	}
-	if err := sw.WriteRecord(rec); err != nil {
+	if _, err := sw.WriteRecord(rec); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}
 	meta := map[string]any{"format_version": 1, "capture_id": "golden-v1", "record_count": 1}

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -113,9 +113,12 @@ type Engine struct {
 	lastHash       map[string][32]byte
 	dedupSkipped   int
 	warnedFallback map[string]bool // dedup set for allNotFound cluster-scoped fallback warnings
-	pathSeq        map[string]int  // per-path record sequence counter (matches archive on-disk seq)
 	fetchSem       chan struct{}   // semaphore bounding concurrent body reads
 	fetchTimeout   time.Duration   // per-fetch cap (request + body read); 0 means perFetchTimeout
+	// captureErr is set by storeRecord on the first record-write failure and
+	// surfaced by Run() so the process exits non-zero instead of silently
+	// producing an archive with a dangling index reference. Guarded by mu.
+	captureErr error
 	// clusterListNamespacesSeen tracks, per wildcard-namespaced resource path,
 	// the set of namespaces that have produced items in any prior cluster-wide
 	// LIST response. Used by the demux so a namespace that empties out between
@@ -169,7 +172,6 @@ func NewEngine(cfg *config.Config, verbose bool) (*Engine, error) {
 		discoveryCache:            make(map[string][]byte),
 		lastHash:                  make(map[string][32]byte),
 		warnedFallback:            make(map[string]bool),
-		pathSeq:                   make(map[string]int),
 		fetchSem:                  make(chan struct{}, maxConcurrentFetches),
 		fetchTimeout:              perFetchTimeout,
 		clusterListNamespacesSeen: make(map[string]map[string]bool),
@@ -203,7 +205,6 @@ func newEngineWith(cfg *config.Config, client *http.Client, baseURL string, verb
 		discoveryCache:            make(map[string][]byte),
 		lastHash:                  make(map[string][32]byte),
 		warnedFallback:            make(map[string]bool),
-		pathSeq:                   make(map[string]int),
 		fetchSem:                  make(chan struct{}, maxConcurrentFetches),
 		fetchTimeout:              perFetchTimeout,
 		clusterListNamespacesSeen: make(map[string]map[string]bool),
@@ -380,6 +381,17 @@ func (e *Engine) Run() (*CaptureSummary, error) {
 
 	if err := e.sink.Finish(meta, e.index, e.watchIndex); err != nil {
 		return nil, err
+	}
+
+	// A record-write failure doesn't abort the capture — everything else that
+	// succeeded is still worth keeping in the archive — but it must not exit
+	// 0: the archive is missing data the user asked for and, absent this,
+	// would have no way of knowing.
+	e.mu.Lock()
+	captureErr := e.captureErr
+	e.mu.Unlock()
+	if captureErr != nil {
+		return nil, captureErr
 	}
 
 	var outputSize int64
@@ -636,21 +648,21 @@ func (e *Engine) streamWatch(ctx context.Context, res config.Resource, apiPath, 
 				ResponseBody: body,
 			}
 
-			if e.sink != nil {
-				if err := e.sink.WriteRecord(rec); err != nil {
-					if e.verbose {
-						fmt.Fprintf(os.Stderr, "  [warn] writing watch record %s: %v\n", recordPath, err)
-					}
-					continue
+			if e.sink == nil {
+				continue
+			}
+			seq, err := e.sink.WriteRecord(rec)
+			if err != nil {
+				if e.verbose {
+					fmt.Fprintf(os.Stderr, "  [warn] writing watch record %s: %v\n", recordPath, err)
 				}
+				continue
 			}
 
 			e.mu.Lock()
 			if _, ok := e.watchIndex[recordPath]; !ok {
 				e.watchIndex[recordPath] = &WatchIndexEntry{APIPath: recordPath}
 			}
-			seq := e.pathSeq[recordPath]
-			e.pathSeq[recordPath] = seq + 1
 			e.watchIndex[recordPath].Seqs = append(e.watchIndex[recordPath].Seqs, seq)
 			e.watchIndex[recordPath].Times = append(e.watchIndex[recordPath].Times, rec.CapturedAt)
 			e.watchIndex[recordPath].EventTypes = append(e.watchIndex[recordPath].EventTypes, rec.EventType)
@@ -1762,6 +1774,16 @@ func (e *Engine) rawFetch(ctx context.Context, apiPath, tableKeySuffix string) (
 		return nil, resp.StatusCode
 	}
 
+	// Skip non-JSON bodies — a proxying error page (HTML 502, a plaintext
+	// error from an aggregated APIService) is a non-empty body that would
+	// otherwise reach storeRecord and fail to marshal as a record.
+	if !json.Valid(body) {
+		if e.verbose {
+			fmt.Fprintf(os.Stderr, "  [warn] non-JSON body %s (status %d)\n", apiPath, resp.StatusCode)
+		}
+		return nil, resp.StatusCode
+	}
+
 	if e.verbose {
 		label := apiPath
 		if tableKeySuffix != "" {
@@ -1804,18 +1826,24 @@ func (e *Engine) storeRecord(indexKey string, body []byte, statusCode int, dedup
 		ResponseCode: statusCode,
 		ResponseBody: json.RawMessage(body),
 	}
-	if e.sink != nil {
-		if err := e.sink.WriteRecord(rec); err != nil && e.verbose {
-			fmt.Fprintf(os.Stderr, "  [warn] writing record %s: %v\n", indexKey, err)
+	if e.sink == nil {
+		return
+	}
+	seq, err := e.sink.WriteRecord(rec)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  [warn] writing record %s: %v\n", indexKey, err)
+		e.mu.Lock()
+		if e.captureErr == nil {
+			e.captureErr = fmt.Errorf("writing record %s: %w", indexKey, err)
 		}
+		e.mu.Unlock()
+		return
 	}
 	itemCount := countListItems(body)
 	e.mu.Lock()
 	if _, ok := e.index[indexKey]; !ok {
 		e.index[indexKey] = &IndexEntry{APIPath: indexKey}
 	}
-	seq := e.pathSeq[indexKey]
-	e.pathSeq[indexKey] = seq + 1
 	e.index[indexKey].Seqs = append(e.index[indexKey].Seqs, seq)
 	e.index[indexKey].Times = append(e.index[indexKey].Times, rec.CapturedAt)
 	e.index[indexKey].Counts = append(e.index[indexKey].Counts, itemCount)
@@ -2084,8 +2112,11 @@ func (e *Engine) fetchOnePodLog(ctx context.Context, namespace, podName, contain
 		ResponseCode: http.StatusOK,
 		ResponseBody: json.RawMessage(jsonBody),
 	}
+	var seq int
 	if e.sink != nil {
-		if err := e.sink.WriteRecord(rec); err != nil {
+		var err error
+		seq, err = e.sink.WriteRecord(rec)
+		if err != nil {
 			return failure(fmt.Sprintf("writing record: %v", err))
 		}
 	}
@@ -2094,8 +2125,6 @@ func (e *Engine) fetchOnePodLog(ctx context.Context, namespace, podName, contain
 	if _, ok := e.index[indexKey]; !ok {
 		e.index[indexKey] = &IndexEntry{APIPath: indexKey}
 	}
-	seq := e.pathSeq[indexKey]
-	e.pathSeq[indexKey] = seq + 1
 	e.index[indexKey].Seqs = append(e.index[indexKey].Seqs, seq)
 	e.index[indexKey].Times = append(e.index[indexKey].Times, rec.CapturedAt)
 	e.mu.Unlock()

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -1836,6 +1836,13 @@ func (e *Engine) storeRecord(indexKey string, body []byte, statusCode int, dedup
 		if e.captureErr == nil {
 			e.captureErr = fmt.Errorf("writing record %s: %w", indexKey, err)
 		}
+		if dedupEnabled {
+			// The write never landed, so nothing was actually deduplicated
+			// against — clear the hash so a later poll of the same
+			// (unwritten) body isn't wrongly skipped as "unchanged" and a
+			// transient write error can be retried on the next interval.
+			delete(e.lastHash, indexKey)
+		}
 		e.mu.Unlock()
 		return
 	}
@@ -2112,13 +2119,12 @@ func (e *Engine) fetchOnePodLog(ctx context.Context, namespace, podName, contain
 		ResponseCode: http.StatusOK,
 		ResponseBody: json.RawMessage(jsonBody),
 	}
-	var seq int
-	if e.sink != nil {
-		var err error
-		seq, err = e.sink.WriteRecord(rec)
-		if err != nil {
-			return failure(fmt.Sprintf("writing record: %v", err))
-		}
+	if e.sink == nil {
+		return failure("no output sink configured")
+	}
+	seq, err := e.sink.WriteRecord(rec)
+	if err != nil {
+		return failure(fmt.Sprintf("writing record: %v", err))
 	}
 
 	e.mu.Lock()

--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -653,9 +653,12 @@ func (e *Engine) streamWatch(ctx context.Context, res config.Resource, apiPath, 
 			}
 			seq, err := e.sink.WriteRecord(rec)
 			if err != nil {
-				if e.verbose {
-					fmt.Fprintf(os.Stderr, "  [warn] writing watch record %s: %v\n", recordPath, err)
+				fmt.Fprintf(os.Stderr, "  [warn] writing watch record %s: %v\n", recordPath, err)
+				e.mu.Lock()
+				if e.captureErr == nil {
+					e.captureErr = fmt.Errorf("writing watch record %s: %w", recordPath, err)
 				}
+				e.mu.Unlock()
 				continue
 			}
 

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -2213,6 +2213,61 @@ func TestEngine_DedupPerResourceOptOut(t *testing.T) {
 	}
 }
 
+// TestStreamWatch_WriteFailure_SetsStickyCaptureErr verifies a write failure
+// on the watch path (not just the poll path storeRecord covers) sets the
+// sticky Engine.captureErr, so a capture that only ever fails on its watch
+// writes still exits non-zero via Run() rather than reporting a clean
+// capture that silently dropped events.
+func TestStreamWatch_WriteFailure_SetsStickyCaptureErr(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/namespaces/default/pods" && r.URL.Query().Get("watch") != "" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"type":"ADDED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"name":"p1"}}}`+"\n")
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			return
+		}
+		fmt.Fprint(w, `{"kind":"PodList","metadata":{"resourceVersion":"10"},"items":[]}`)
+	}))
+	defer srv.Close()
+
+	eng := newEngineWith(&config.Config{}, srv.Client(), srv.URL, false)
+	wantErr := fmt.Errorf("boom")
+	eng.sink = &failingSink{err: wantErr}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	res := config.Resource{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, Watch: true}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		eng.watchResource(ctx, res)
+	}()
+
+	deadline := time.Now().Add(1500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		eng.mu.Lock()
+		set := eng.captureErr != nil
+		eng.mu.Unlock()
+		if set {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	if eng.captureErr == nil {
+		t.Fatal("captureErr not set after a failed watch record write")
+	}
+	if !strings.Contains(eng.captureErr.Error(), wantErr.Error()) {
+		t.Errorf("captureErr = %v, want it to wrap %v", eng.captureErr, wantErr)
+	}
+}
+
 func TestWatchResource_RecordsEvents(t *testing.T) {
 	var watchHits int32
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -1824,6 +1824,35 @@ func TestStoreRecord_WriteFailure_NoIndexEntryAndSticky(t *testing.T) {
 	}
 }
 
+// TestStoreRecord_WriteFailure_ClearsDedupHash verifies that a failed write
+// under --dedup doesn't poison the dedup hash for that path: storeRecord sets
+// lastHash before attempting the write, and if the write then fails, a
+// following poll of the exact same (never-written) body must not be silently
+// dedup-skipped — it needs to actually retry the write, not stay stuck behind
+// a hash for a record that was never persisted.
+func TestStoreRecord_WriteFailure_ClearsDedupHash(t *testing.T) {
+	eng := newEngineWith(&config.Config{}, nil, "", false)
+	failing := &failingSink{err: fmt.Errorf("boom")}
+	eng.sink = failing
+
+	const apiPath = "/api/v1/namespaces/default/pods"
+	body := []byte(`{"kind":"PodList","items":[]}`)
+
+	eng.storeRecord(apiPath, body, 200, true)
+	if _, ok := eng.lastHash[apiPath]; ok {
+		t.Fatal("lastHash still set for a path whose write failed; a retry of the same body would be wrongly dedup-skipped")
+	}
+
+	// Swap in a working sink and retry the identical body: it must be written
+	// (not skipped as "unchanged"), because nothing was ever actually stored.
+	ss := &sliceSink{}
+	eng.sink = ss
+	eng.storeRecord(apiPath, body, 200, true)
+	if got := ss.RecordCount(); got != 1 {
+		t.Fatalf("RecordCount() = %d, want 1 (retry of a never-written body must not be dedup-skipped)", got)
+	}
+}
+
 // TestConcurrentPollAndWatch_NoIndexSeqCollision reproduces the #210 race: a
 // polled resource and a watched one demux to the same api_path, so
 // storeRecord (the poll path) and the watch event loop's inline write both

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -23,17 +23,23 @@ import (
 type sliceSink struct {
 	mu      sync.Mutex
 	records []*Record
+	pathSeq map[string]int
 }
 
-func (s *sliceSink) WriteRecord(rec any) error {
+func (s *sliceSink) WriteRecord(rec any) (int, error) {
 	r, ok := rec.(*Record)
 	if !ok {
-		return nil
+		return 0, nil
 	}
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.records = append(s.records, r)
-	s.mu.Unlock()
-	return nil
+	if s.pathSeq == nil {
+		s.pathSeq = make(map[string]int)
+	}
+	seq := s.pathSeq[r.APIPath]
+	s.pathSeq[r.APIPath] = seq + 1
+	return seq, nil
 }
 func (s *sliceSink) Finish(_, _, _ any) error { return nil }
 func (s *sliceSink) RecordCount() int {
@@ -42,6 +48,16 @@ func (s *sliceSink) RecordCount() int {
 	return len(s.records)
 }
 func (s *sliceSink) UncompressedBytes() int64 { return 0 }
+
+// failingSink is a RecordSink whose WriteRecord always fails, for exercising
+// the #211 write-failure path: a failed write must not produce an index
+// entry, and must not be silent.
+type failingSink struct{ err error }
+
+func (s *failingSink) WriteRecord(any) (int, error) { return 0, s.err }
+func (s *failingSink) Finish(_, _, _ any) error     { return nil }
+func (s *failingSink) RecordCount() int             { return 0 }
+func (s *failingSink) UncompressedBytes() int64     { return 0 }
 
 // fakeK8sServer returns an httptest.TLSServer that responds to the paths used by
 // a minimal capture config (pods in default, nodes cluster-scoped).
@@ -1743,6 +1759,202 @@ func TestStoreRecord_PopulatesItemCounts(t *testing.T) {
 	single := eng.index["/api/v1/namespaces/default/pods/foo"]
 	if got := single.Counts; len(got) != 1 || got[0] != 0 {
 		t.Errorf("single-object Counts = %v, want [0]", got)
+	}
+}
+
+// TestRun_RecordWriteFailure_ExitsNonZero verifies the other half of #211's
+// acceptance criteria: when every record write fails, Run() itself — not
+// just storeRecord in isolation — returns a non-nil error naming the failing
+// path, so the CLI exits non-zero instead of reporting a clean capture.
+func TestRun_RecordWriteFailure_ExitsNonZero(t *testing.T) {
+	fake := fakeK8sServer(t)
+	defer fake.Close()
+
+	cfg := &config.Config{
+		DurationRaw: "2s",
+		Duration:    2 * time.Second,
+		Output:      filepath.Join(t.TempDir(), "capture.kshrk"),
+		Resources: []config.Resource{
+			{Version: "v1", Resource: "pods", Namespaces: []string{"default"}, IntervalRaw: "500ms", Interval: 500 * time.Millisecond},
+		},
+	}
+
+	eng := newEngineWith(cfg, fake.Client(), fake.URL, false)
+	eng.pollPasses = 1
+	eng.sink = &failingSink{err: fmt.Errorf("disk full")}
+
+	_, err := eng.Run()
+	if err == nil {
+		t.Fatal("Run() returned nil error despite every record write failing")
+	}
+	if !strings.Contains(err.Error(), "disk full") {
+		t.Errorf("Run() error = %v, want it to name the underlying write failure", err)
+	}
+	if !strings.Contains(err.Error(), "writing record /") {
+		t.Errorf("Run() error = %v, want it to name the failing path", err)
+	}
+}
+
+// TestStoreRecord_WriteFailure_NoIndexEntryAndSticky verifies the #211 fix:
+// a record whose sink write fails must not be added to the index (previously
+// storeRecord fell through and appended regardless, producing a dangling
+// index reference and a permanent off-by-one for every later record on that
+// path), and the engine must remember the failure so Run() can exit non-zero
+// instead of silently succeeding.
+func TestStoreRecord_WriteFailure_NoIndexEntryAndSticky(t *testing.T) {
+	wantErr := fmt.Errorf("boom")
+	eng := newEngineWith(&config.Config{}, nil, "", false)
+	eng.sink = &failingSink{err: wantErr}
+
+	const apiPath = "/api/v1/namespaces/default/pods"
+	eng.storeRecord(apiPath, []byte(`{"kind":"PodList","items":[]}`), 200, false)
+
+	if entry, ok := eng.index[apiPath]; ok {
+		t.Fatalf("index entry created for a failed write: %+v", entry)
+	}
+	if eng.captureErr == nil {
+		t.Fatal("captureErr not set after a failed record write")
+	}
+
+	// A second failure must not overwrite the first — Run() reports the
+	// original cause, not whichever failure happened to land last.
+	eng.storeRecord(apiPath, []byte(`{"kind":"PodList","items":[]}`), 200, false)
+	if !strings.Contains(eng.captureErr.Error(), wantErr.Error()) {
+		t.Fatalf("captureErr = %v, want it to wrap %v", eng.captureErr, wantErr)
+	}
+}
+
+// TestConcurrentPollAndWatch_NoIndexSeqCollision reproduces the #210 race: a
+// polled resource and a watched one demux to the same api_path, so
+// storeRecord (the poll path) and the watch event loop's inline write both
+// assign seq numbers for that path concurrently, from different goroutines.
+// Before the fix, each side kept its own independent pathSeq counter under a
+// different mutex, so nothing kept the archive's on-disk seq (assigned by
+// StreamWriter under sw.mu) in agreement with the index's seq (assigned by
+// Engine under e.mu) — some index entries pointed at the wrong record body.
+// The fix deletes Engine.pathSeq entirely; both call sites now use the seq
+// StreamWriter.WriteRecord returns, so there is exactly one counter and it is
+// assigned atomically with the write. This test writes real, distinguishable
+// bodies through both code paths against a real archive.StreamWriter and
+// verifies every index/watch-index seq resolves to the exact body that call
+// wrote — not a body written by the other goroutine.
+func TestConcurrentPollAndWatch_NoIndexSeqCollision(t *testing.T) {
+	outPath := filepath.Join(t.TempDir(), "capture.kshrk")
+	sw, err := archive.NewStreamWriter(outPath)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+
+	eng := newEngineWith(&config.Config{}, nil, "", false)
+	eng.sink = sw
+
+	const apiPath = "/api/v1/namespaces/default/pods"
+	const n = 3000
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Poll side: the exact storeRecord code path fixed by #211/#210.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < n; i++ {
+			body := fmt.Sprintf(`{"kind":"PodList","poll":%d}`, i)
+			eng.storeRecord(apiPath, []byte(body), 200, false)
+		}
+	}()
+
+	// Watch side: mirrors the inline write-then-index-update block in
+	// streamWatch's event loop (engine.go, the watchIndex update following
+	// e.sink.WriteRecord), writing to the SAME api path concurrently.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < n; i++ {
+			rec := &Record{
+				ID:           fmt.Sprintf("watch-%d", i),
+				CapturedAt:   time.Now().UTC(),
+				APIPath:      apiPath,
+				EventType:    "MODIFIED",
+				HTTPMethod:   http.MethodGet,
+				ResponseCode: http.StatusOK,
+				ResponseBody: json.RawMessage(fmt.Sprintf(`{"kind":"Pod","watch":%d}`, i)),
+			}
+			seq, err := eng.sink.WriteRecord(rec)
+			if err != nil {
+				t.Errorf("watch WriteRecord(%d): %v", i, err)
+				return
+			}
+			eng.mu.Lock()
+			if _, ok := eng.watchIndex[apiPath]; !ok {
+				eng.watchIndex[apiPath] = &WatchIndexEntry{APIPath: apiPath}
+			}
+			eng.watchIndex[apiPath].Seqs = append(eng.watchIndex[apiPath].Seqs, seq)
+			eng.watchIndex[apiPath].Times = append(eng.watchIndex[apiPath].Times, rec.CapturedAt)
+			eng.watchIndex[apiPath].EventTypes = append(eng.watchIndex[apiPath].EventTypes, rec.EventType)
+			eng.mu.Unlock()
+		}
+	}()
+
+	wg.Wait()
+
+	if err := sw.Finish(nil, eng.index, eng.watchIndex); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	ar, err := archive.Open(outPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer ar.Close()
+
+	pollEntry := eng.index[apiPath]
+	watchEntry := eng.watchIndex[apiPath]
+	if len(pollEntry.Seqs) != n || len(watchEntry.Seqs) != n {
+		t.Fatalf("expected %d poll seqs and %d watch seqs, got %d and %d", n, n, len(pollEntry.Seqs), len(watchEntry.Seqs))
+	}
+
+	seen := make(map[int]string) // seq -> which side claimed it
+	checkUnique := func(side string, seq int) {
+		t.Helper()
+		if prior, ok := seen[seq]; ok {
+			t.Fatalf("seq %d claimed by both %s and %s — the two counters collided", seq, prior, side)
+		}
+		seen[seq] = side
+	}
+
+	type probeBody struct {
+		Poll  *int `json:"poll"`
+		Watch *int `json:"watch"`
+	}
+	var probe struct {
+		ResponseBody probeBody `json:"response_body"`
+	}
+	for _, seq := range pollEntry.Seqs {
+		checkUnique("poll", seq)
+		data, err := ar.ReadRecord(apiPath, seq)
+		if err != nil {
+			t.Fatalf("ReadRecord(poll seq=%d): %v", seq, err)
+		}
+		probe.ResponseBody = probeBody{}
+		if err := json.Unmarshal(data, &probe); err != nil {
+			t.Fatalf("unmarshal record body at seq=%d: %v", seq, err)
+		}
+		if probe.ResponseBody.Poll == nil {
+			t.Fatalf("index says seq=%d is a poll record, but the archive body at that seq is: %s", seq, data)
+		}
+	}
+	for _, seq := range watchEntry.Seqs {
+		checkUnique("watch", seq)
+		data, err := ar.ReadRecord(apiPath, seq)
+		if err != nil {
+			t.Fatalf("ReadRecord(watch seq=%d): %v", seq, err)
+		}
+		probe.ResponseBody = probeBody{}
+		if err := json.Unmarshal(data, &probe); err != nil {
+			t.Fatalf("unmarshal record body at seq=%d: %v", seq, err)
+		}
+		if probe.ResponseBody.Watch == nil {
+			t.Fatalf("watch-index says seq=%d is a watch record, but the archive body at that seq is: %s", seq, data)
+		}
 	}
 }
 

--- a/internal/diagnose/engine_test.go
+++ b/internal/diagnose/engine_test.go
@@ -23,7 +23,7 @@ func buildDiagStore(t *testing.T, bodies map[string]string) *server.CaptureStore
 	i := 0
 	for path, body := range bodies {
 		rec := &capture.Record{ID: path, CapturedAt: now, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body)}
-		if err := sw.WriteRecord(rec); err != nil {
+		if _, err := sw.WriteRecord(rec); err != nil {
 			t.Fatalf("WriteRecord: %v", err)
 		}
 		idx[path] = &capture.IndexEntry{APIPath: path, Seqs: []int{0}, Times: []time.Time{now}}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -143,7 +143,7 @@ func buildArchive(t *testing.T, entries map[string][]capture.Record) string {
 				capturedUntil = rec.CapturedAt
 			}
 			rcopy := rec
-			if err := sw.WriteRecord(&rcopy); err != nil {
+			if _, err := sw.WriteRecord(&rcopy); err != nil {
 				t.Fatalf("WriteRecord: %v", err)
 			}
 			entry.Seqs = append(entry.Seqs, i)

--- a/internal/inspect/encrypt_test.go
+++ b/internal/inspect/encrypt_test.go
@@ -26,7 +26,7 @@ func TestRun_Encrypted(t *testing.T) {
 	}
 	rec := map[string]any{"id": "r1", "api_path": "/api/v1/nodes", "response_code": 200,
 		"response_body": map[string]any{"apiVersion": "v1", "kind": "NodeList", "items": []any{}}}
-	if err := sw.WriteRecord(rec); err != nil {
+	if _, err := sw.WriteRecord(rec); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}
 	meta := map[string]any{"format_version": 1, "capture_id": "enc", "record_count": 1}

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -46,7 +46,7 @@ func buildArchive(t *testing.T, records []*capture.Record) string {
 		t.Fatalf("buildArchive NewStreamWriter: %v", err)
 	}
 	for _, r := range records {
-		if err := sw.WriteRecord(r); err != nil {
+		if _, err := sw.WriteRecord(r); err != nil {
 			t.Fatalf("buildArchive WriteRecord: %v", err)
 		}
 	}

--- a/internal/inspect/version_test.go
+++ b/internal/inspect/version_test.go
@@ -50,7 +50,7 @@ func buildArchiveWithVersion(t *testing.T, version int) string {
 	if err != nil {
 		t.Fatalf("NewStreamWriter: %v", err)
 	}
-	if err := sw.WriteRecord(r); err != nil {
+	if _, err := sw.WriteRecord(r); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}
 	if err := sw.Finish(meta, idx, nil); err != nil {

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -23,7 +23,7 @@ func buildQueryStore(t *testing.T, bodies map[string]string) *server.CaptureStor
 	i := 0
 	for path, body := range bodies {
 		rec := &capture.Record{ID: path, CapturedAt: now, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body)}
-		if err := sw.WriteRecord(rec); err != nil {
+		if _, err := sw.WriteRecord(rec); err != nil {
 			t.Fatalf("WriteRecord: %v", err)
 		}
 		idx[path] = &capture.IndexEntry{APIPath: path, Seqs: []int{0}, Times: []time.Time{now}}

--- a/internal/redact/encrypt_test.go
+++ b/internal/redact/encrypt_test.go
@@ -54,7 +54,7 @@ func buildEncryptedArchive(t *testing.T, records []*capture.Record, recipients [
 	// after a successful Finish.
 	defer func() { _ = sw.Abort() }()
 	for _, r := range records {
-		if err := sw.WriteRecord(r); err != nil {
+		if _, err := sw.WriteRecord(r); err != nil {
 			t.Fatalf("buildEncryptedArchive WriteRecord: %v", err)
 		}
 	}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -48,7 +48,7 @@ func buildTestArchive(t *testing.T, records []*capture.Record) string {
 		t.Fatalf("buildTestArchive NewStreamWriter: %v", err)
 	}
 	for _, r := range records {
-		if err := sw.WriteRecord(r); err != nil {
+		if _, err := sw.WriteRecord(r); err != nil {
 			t.Fatalf("buildTestArchive WriteRecord: %v", err)
 		}
 	}

--- a/internal/server/bench_test.go
+++ b/internal/server/bench_test.go
@@ -40,7 +40,7 @@ func buildBenchStore(b *testing.B, n int) *CaptureStore {
 			ResponseCode: 200,
 			ResponseBody: body,
 		}
-		if err := sw.WriteRecord(&rec); err != nil {
+		if _, err := sw.WriteRecord(&rec); err != nil {
 			b.Fatal(err)
 		}
 		index[apiPath] = &capture.IndexEntry{

--- a/internal/server/encrypt_test.go
+++ b/internal/server/encrypt_test.go
@@ -57,7 +57,7 @@ func buildEncryptedTestArchive(t *testing.T) string {
 	// TempDir cleanup can't be blocked by an open file. Abort is a no-op after
 	// a successful Finish.
 	defer func() { _ = sw.Abort() }()
-	if err := sw.WriteRecord(rec); err != nil {
+	if _, err := sw.WriteRecord(rec); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}
 	if err := sw.Finish(meta, idx, nil); err != nil {

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -633,7 +633,7 @@ func TestHandler_ReplayAtTimestamp(t *testing.T) {
 	}
 	for _, rec := range records {
 		rcopy := rec
-		if err := sw.WriteRecord(&rcopy); err != nil {
+		if _, err := sw.WriteRecord(&rcopy); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/server/memory_bench_test.go
+++ b/internal/server/memory_bench_test.go
@@ -90,7 +90,7 @@ func writeLargeArchive(tb testing.TB, path string, namespaces, snapshots, pods i
 					ID: fmt.Sprintf("%s-%s-%d", ns, res, s), CapturedAt: ts,
 					APIPath: apiPath, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: body,
 				}
-				if err := sw.WriteRecord(&rec); err != nil {
+				if _, err := sw.WriteRecord(&rec); err != nil {
 					tb.Fatal(err)
 				}
 				entry.Seqs = append(entry.Seqs, s)

--- a/internal/server/replay_rv_test.go
+++ b/internal/server/replay_rv_test.go
@@ -29,7 +29,7 @@ func buildPollStore(t *testing.T, apiPath string, snaps []struct {
 	entry := &capture.IndexEntry{APIPath: apiPath}
 	for i, s := range snaps {
 		rec := &capture.Record{ID: apiPath, CapturedAt: s.at, APIPath: apiPath, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(s.body)}
-		if err := sw.WriteRecord(rec); err != nil {
+		if _, err := sw.WriteRecord(rec); err != nil {
 			t.Fatalf("WriteRecord: %v", err)
 		}
 		entry.Seqs = append(entry.Seqs, i)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -52,7 +52,7 @@ func buildTestArchive(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("NewStreamWriter: %v", err)
 	}
-	if err := sw.WriteRecord(rec[0]); err != nil {
+	if _, err := sw.WriteRecord(rec[0]); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}
 	if err := sw.Finish(meta, idx, nil); err != nil {

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -168,7 +168,7 @@ func buildTestStore(t *testing.T, records map[string][]byte) *CaptureStore {
 			ResponseCode: 200,
 			ResponseBody: json.RawMessage(body),
 		}
-		if err := sw.WriteRecord(&rec); err != nil {
+		if _, err := sw.WriteRecord(&rec); err != nil {
 			t.Fatalf("WriteRecord: %v", err)
 		}
 		index[apiPath] = &capture.IndexEntry{
@@ -338,7 +338,7 @@ func TestStore_Latest_AtTimestamp(t *testing.T) {
 	}
 	for _, rec := range records {
 		rcopy := rec
-		if err := sw.WriteRecord(&rcopy); err != nil {
+		if _, err := sw.WriteRecord(&rcopy); err != nil {
 			t.Fatalf("WriteRecord: %v", err)
 		}
 	}
@@ -427,7 +427,7 @@ func buildTestStoreWithWatch(t *testing.T, snapshots map[string]watchTestRecord,
 			ResponseCode: 200,
 			ResponseBody: json.RawMessage(s.body),
 		}
-		if err := sw.WriteRecord(&rec); err != nil {
+		if _, err := sw.WriteRecord(&rec); err != nil {
 			t.Fatalf("WriteRecord(snap): %v", err)
 		}
 		index[apiPath] = &capture.IndexEntry{
@@ -452,7 +452,7 @@ func buildTestStoreWithWatch(t *testing.T, snapshots map[string]watchTestRecord,
 			ResponseCode: 200,
 			ResponseBody: json.RawMessage(ev.objectBody),
 		}
-		if err := sw.WriteRecord(&rec); err != nil {
+		if _, err := sw.WriteRecord(&rec); err != nil {
 			t.Fatalf("WriteRecord(watch %s): %v", ev.id, err)
 		}
 		wi := watchIndex[ev.apiPath]

--- a/internal/server/version_test.go
+++ b/internal/server/version_test.go
@@ -42,7 +42,7 @@ func loadStoreWithVersion(t *testing.T, version int) (*CaptureStore, error) {
 	if err != nil {
 		t.Fatalf("NewStreamWriter: %v", err)
 	}
-	if err := sw.WriteRecord(r); err != nil {
+	if _, err := sw.WriteRecord(r); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}
 	if err := sw.Finish(meta, idx, nil); err != nil {

--- a/internal/transitions/transitions_test.go
+++ b/internal/transitions/transitions_test.go
@@ -40,7 +40,7 @@ func buildPollArchive(t *testing.T, apiPath string, bodies []string) string {
 			ResponseCode: 200,
 			ResponseBody: json.RawMessage(body),
 		}
-		if err := w.WriteRecord(rec); err != nil {
+		if _, err := w.WriteRecord(rec); err != nil {
 			t.Fatalf("WriteRecord: %v", err)
 		}
 
@@ -99,7 +99,7 @@ func buildWatchArchive(t *testing.T, apiPath, snapBody string, events []watchEve
 	if err != nil {
 		t.Fatalf("NewStreamWriter: %v", err)
 	}
-	if err := w.WriteRecord(snapRec); err != nil {
+	if _, err := w.WriteRecord(snapRec); err != nil {
 		t.Fatalf("WriteRecord(snap): %v", err)
 	}
 
@@ -115,7 +115,7 @@ func buildWatchArchive(t *testing.T, apiPath, snapBody string, events []watchEve
 			ResponseCode: 200,
 			ResponseBody: json.RawMessage(ev.body),
 		}
-		if err := w.WriteRecord(rec); err != nil {
+		if _, err := w.WriteRecord(rec); err != nil {
 			t.Fatalf("WriteRecord(watch %d): %v", i, err)
 		}
 		wiEntry.Seqs = append(wiEntry.Seqs, i+1) // seq continues after snap (seq 0)

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -174,7 +174,7 @@ func writeMinimalArchive(t *testing.T) string {
 		t.Fatalf("NewStreamWriter: %v", err)
 	}
 	for _, r := range recs {
-		if err := sw.WriteRecord(r); err != nil {
+		if _, err := sw.WriteRecord(r); err != nil {
 			t.Fatalf("WriteRecord: %v", err)
 		}
 	}

--- a/internal/ui/v2/history_test.go
+++ b/internal/ui/v2/history_test.go
@@ -36,7 +36,7 @@ func buildV2WatchStore(t *testing.T, events []v2WatchEvent, captureStart time.Ti
 			ID: ev.id, CapturedAt: ev.at, APIPath: ev.apiPath, EventType: ev.eventType,
 			HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(ev.body),
 		}
-		if err := sw.WriteRecord(&rec); err != nil {
+		if _, err := sw.WriteRecord(&rec); err != nil {
 			t.Fatalf("WriteRecord(%s): %v", ev.id, err)
 		}
 		wi := watchIndex[ev.apiPath]

--- a/internal/ui/v2/objects_test.go
+++ b/internal/ui/v2/objects_test.go
@@ -265,7 +265,7 @@ func buildV2TestStore(t *testing.T, recs []*capture.Record, idx capture.Index, m
 		t.Fatalf("NewStreamWriter: %v", err)
 	}
 	for _, r := range recs {
-		if err := sw.WriteRecord(r); err != nil {
+		if _, err := sw.WriteRecord(r); err != nil {
 			t.Fatalf("WriteRecord: %v", err)
 		}
 	}

--- a/internal/ui/v2/overlay_test.go
+++ b/internal/ui/v2/overlay_test.go
@@ -44,7 +44,7 @@ func newOverlayTestHandler(t *testing.T) (*Handler, *server.Server) {
 		t.Fatalf("NewStreamWriter: %v", err)
 	}
 	for _, r := range recs {
-		if err := sw.WriteRecord(r); err != nil {
+		if _, err := sw.WriteRecord(r); err != nil {
 			t.Fatalf("WriteRecord: %v", err)
 		}
 	}
@@ -390,7 +390,7 @@ func TestServeObject_WholeListView_IgnoresNonListCapturedBody(t *testing.T) {
 		t.Fatalf("NewStreamWriter: %v", err)
 	}
 	for _, r := range recs {
-		if err := sw.WriteRecord(r); err != nil {
+		if _, err := sw.WriteRecord(r); err != nil {
 			t.Fatalf("WriteRecord: %v", err)
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes the two ship-stopping capture-correctness bugs at the top of the [v1.0 readiness tracker](https://github.com/phenixblue/k8shark/issues/266) (Phase 1).

- **#210** — `StreamWriter.pathSeq` (assigns the on-disk seq, guarded by `sw.mu`) and `Engine.pathSeq` (assigns the index seq, guarded by `e.mu`) were two independent counters with nothing keeping them in agreement. For any watched resource, `pollResource` and `watchResource` derive the same path key and raced across the two lock domains — reproduced at ~0.3–0.5% of index entries misattributed to the wrong record body, invisible to `go test -race` by construction (both counters are individually well-locked).
- **#211** — `storeRecord` logged a write failure only under `--verbose` and appended to the index regardless, leaving a dangling index reference (hard-fails `redact`) and a permanent off-by-one for every later record on that path, with capture exiting 0.

## Fix

- `RecordSink.WriteRecord` now returns `(int, error)` — the seq assigned to the record, atomically with the write. `Engine.pathSeq` is deleted entirely; both the poll (`storeRecord`) and watch code paths use the seq the sink hands back, so there is exactly one counter per path, in one lock domain.
- `storeRecord` logs unconditionally, skips the index append on a failed write, and sets a sticky `Engine.captureErr` that `Run()` surfaces so the process exits non-zero and names the failing path — the archive still gets a `Finish()` with whatever succeeded.
- `rawFetch` also rejects non-JSON bodies (e.g. a proxying HTML 502) with a `json.Valid` guard, so they can't reach `storeRecord` and manifest as a marshal failure in the first place.
- `NDJSONWriter.WriteRecord` gained the same per-path seq bookkeeping so it satisfies the widened interface honestly, even though NDJSON output has no index to look the seq up by later.

## Test plan

- [x] New `TestConcurrentPollAndWatch_NoIndexSeqCollision`: drives `storeRecord` and a watch-shaped write concurrently (3000 iterations each) against a real `archive.StreamWriter` on the same api path, then opens the archive and asserts every index/watch-index seq resolves to the exact body that call wrote.
- [x] New `TestStoreRecord_WriteFailure_NoIndexEntryAndSticky`: injects a failing sink and asserts no index entry is created and the failure is sticky.
- [x] New `TestRun_RecordWriteFailure_ExitsNonZero`: asserts `Run()` itself returns a non-nil error naming the failing path when writes fail.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean, `go mod tidy` no diff, `golangci-lint run` clean.
- [x] `go test -race ./...` passes on all packages.

Closes #210
Closes #211