### PR TITLE
fix(server): fix archive shutdown ordering across three related bugs (#230, #231, #232)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,12 +37,35 @@ manual bumps. Pin any new CI tool the same way.
 `server.LoadStore` needs the archive to stay open for the store's lifetime.
 Therefore:
 
-- **Long-lived holders** (`internal/ui`, the `internal/server` mock API server)
-  MUST close the archive on `Shutdown`/`Wait` — otherwise the file descriptor
-  leaks for the life of the process (this leak was fixed in #91; the mock server
-  is the reference implementation, closing in both `Shutdown` and `Wait`).
+- **`internal/server`** (the mock API server) is the only long-lived holder
+  that owns an archive. It MUST close it on `Shutdown`/`Wait` — otherwise the
+  file descriptor leaks for the life of the process (this leak was fixed in
+  #91). `internal/ui` does **not** open its own archive: it reuses the mock
+  server's `CaptureStore` via `MockServer.Store()`, so its `Shutdown`/`Wait`
+  only stop its own HTTP server and must NOT close the archive (double-close).
+  `kshrk replay --ui` and `kshrk ui` therefore always start a mock server
+  first and tear the UI down *before* it (see cmd/ui.go, cmd/replay.go) — the
+  UI reads through the same store, so shutting the mock server down first
+  would leave the UI serving from an archive it doesn't own.
+- **`LoadStore` starts a background discovery-enrichment goroutine** that
+  keeps reading from the archive after `LoadStore` returns (the store is
+  documented as usable before it completes). Every holder of a `CaptureStore`
+  MUST call `store.Close()` (which waits for that goroutine) before closing
+  the underlying archive, or a fast command can close the zip out from under
+  it (#232). `defer store.Close()` immediately after a successful
+  `LoadStore`, ordered so it fires before `defer ar.Close()`.
+- **`internal/server`'s watch endpoints hold the archive open indefinitely**
+  (they block on the request context until the client disconnects or
+  `?timeoutSeconds` fires). Its `Server.Shutdown`/`Wait` cancel a shared
+  `BaseContext` before calling `httpServer.Shutdown` (so those handlers wake
+  up and return promptly) and then wait on a request-tracking `WaitGroup` as a
+  hard guarantee that none is still reading before the archive is closed
+  (#230). Don't reintroduce a bare `httpServer.Shutdown()` + immediate
+  `ar.Close()` without both of those.
 - **One-shot CLIs** (`inspect`, `redact`, `transitions`, `diff`) use
-  `defer ar.Close()` immediately after opening.
+  `defer ar.Close()` immediately after opening; the ones that go through
+  `server.LoadStore` (`query`, `diagnose`, `diff`) also need `defer
+  store.Close()` per above.
 
 ## Orientation
 

--- a/cmd/diagnose.go
+++ b/cmd/diagnose.go
@@ -69,6 +69,7 @@ func runDiagnose(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("loading capture: %w", err)
 	}
+	defer store.Close()
 
 	at, err := parseAtFlag(atRaw, store.Metadata.CapturedAt, store.Metadata.CapturedUntil)
 	if err != nil {

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -76,6 +76,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("loading capture: %w", err)
 	}
+	defer store.Close()
 
 	at, err := parseAtFlag(atRaw, store.Metadata.CapturedAt, store.Metadata.CapturedUntil)
 	if err != nil {

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -120,17 +120,18 @@ func runReplay(cmd *cobra.Command, args []string) error {
 			srv.Shutdown()
 			return err
 		}
-		defer kwokCleanup()
 	}
 
 	var controllerManagerCleanup func()
 	if withControllerManager {
 		controllerManagerCleanup, err = startControllerManager(srv.KubeconfigPath(), srv.KubernetesVersion())
 		if err != nil {
+			if kwokCleanup != nil {
+				kwokCleanup()
+			}
 			srv.Shutdown()
 			return err
 		}
-		defer controllerManagerCleanup()
 	}
 
 	clock := srv.Clock()
@@ -143,6 +144,12 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	if uiEnabled {
 		uiSrv, err = ui.Open(ui.OpenOptions{MockServer: srv, ArchivePath: args[0], Port: uiPort, Verbose: verbose, Clock: clock})
 		if err != nil {
+			if controllerManagerCleanup != nil {
+				controllerManagerCleanup()
+			}
+			if kwokCleanup != nil {
+				kwokCleanup()
+			}
 			srv.Shutdown()
 			return fmt.Errorf("starting dashboard: %w", err)
 		}
@@ -193,13 +200,26 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	// Live status line until shutdown.
 	stop := make(chan struct{})
 	go replayStatusLoop(srv, stop)
-	err = srv.Wait()
+	srv.WaitForSignal()
 	close(stop)
+
+	// Tear down in the same order as `kshrk ui` (cmd/ui.go): the UI first (it
+	// reads through the mock server's shared store), then the live processes
+	// driving it, then the mock server and its archive last — so nothing is
+	// still hitting a server or reading an archive that's already gone (#231).
 	if uiSrv != nil {
 		uiSrv.Shutdown()
 	}
+	if controllerManagerCleanup != nil {
+		controllerManagerCleanup()
+	}
+	if kwokCleanup != nil {
+		kwokCleanup()
+	}
+	srv.Shutdown()
+
 	fmt.Println()
-	return err
+	return nil
 }
 
 // replayStatusLoop repaints a single status line showing clock position, speed,

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -131,6 +131,7 @@ func RenderText(result *Result, color bool) (string, error) {
 
 type archiveSnapshot struct {
 	ar       *archivepkg.Archive
+	store    *server.CaptureStore
 	meta     capture.CaptureMetadata
 	snapshot map[string]json.RawMessage
 }
@@ -138,6 +139,12 @@ type archiveSnapshot struct {
 func (s *archiveSnapshot) cleanup() {
 	if s == nil || s.ar == nil {
 		return
+	}
+	// store.Close waits for LoadStore's background enrichment pass, which
+	// reads from the archive independently of the snapshot loop below — it
+	// must finish before ar.Close() runs (#232).
+	if s.store != nil {
+		s.store.Close()
 	}
 	_ = s.ar.Close()
 }
@@ -209,6 +216,7 @@ func loadArchiveSnapshot(archivePath string, at time.Time, identities []age.Iden
 	}
 	shot := &archiveSnapshot{
 		ar:       ar,
+		store:    store,
 		meta:     store.Metadata,
 		snapshot: make(map[string]json.RawMessage, len(store.Index)),
 	}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -46,6 +46,17 @@ type handler struct {
 	// otherwise defeat that cache). Negative results are cached too. Trade-off: a
 	// CRD created/changed mid-replay isn't reflected — acceptable for a mock.
 	crdColsCache sync.Map // map["group/version/resource"] -> []tableCol (may be nil)
+
+	// wg tracks in-flight ServeHTTP calls. Server.teardown waits on it after
+	// httpServer.Shutdown returns, as a hard guarantee that no handler —
+	// including a long-held watch stream — is still reading from the store
+	// when the archive is closed (see #230).
+	wg sync.WaitGroup
+}
+
+// waitForRequests blocks until every in-flight ServeHTTP call has returned.
+func (h *handler) waitForRequests() {
+	h.wg.Wait()
 }
 
 func newHandler(store *CaptureStore, at time.Time, verbose bool) *handler {
@@ -86,6 +97,9 @@ func (h *handler) timelineFor(watchPath string) []replayEvent {
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.wg.Add(1)
+	defer h.wg.Done()
+
 	// In replay mode the effective time is the clock's current position;
 	// otherwise it's the server's fixed --at.
 	replayAt := h.at

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -80,11 +80,12 @@ type Server struct {
 	kubernetesVersion string       // capture's /version gitVersion, e.g. "v1.36.1"
 }
 
-// closeStoreAndArchive waits for store's background enrichment pass to finish
-// (store may be nil when LoadStore itself failed) before closing ar. Every
-// early-return error path below runs after LoadStore has succeeded and its
-// background goroutine is already reading from ar, so skipping the wait would
-// race a close against that read (#232).
+// closeStoreAndArchive closes ar, waiting first for store's background
+// enrichment pass to finish if store is non-nil. Pass nil only when LoadStore
+// itself failed (there is no store yet to wait on); every other early-return
+// path below runs after LoadStore has succeeded, meaning its background
+// goroutine is already reading from ar — closing ar without this wait would
+// race that read (#232).
 func closeStoreAndArchive(store *CaptureStore, ar *archive.Archive) {
 	if store != nil {
 		store.Close()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"time"
 
@@ -59,17 +60,36 @@ type ReplayOptions struct {
 
 // Server represents a running mock API server.
 type Server struct {
-	address           string
-	kubeconfigPath    string
-	certPEM           []byte // this run's self-signed TLS cert, for callers that need to pin it
-	ar                *archive.Archive
-	handler           *handler // shared with other in-process readers, e.g. the web UI (see overlay_export.go)
-	httpServer        *http.Server
-	done              chan struct{}
+	address        string
+	kubeconfigPath string
+	certPEM        []byte // this run's self-signed TLS cert, for callers that need to pin it
+	ar             *archive.Archive
+	handler        *handler // shared with other in-process readers, e.g. the web UI (see overlay_export.go)
+	httpServer     *http.Server
+	done           chan struct{}
+	closeOnce      sync.Once
+	// cancelBase cancels the context every request's r.Context() derives from
+	// (see BaseContext below). It must run before httpServer.Shutdown so a
+	// long-held watch stream — which only unblocks on r.Context().Done() or
+	// ?timeoutSeconds — returns promptly instead of stalling Shutdown for its
+	// full deadline while still holding a reference into the archive.
+	cancelBase        context.CancelFunc
 	clock             *ReplayClock // non-nil in replay mode
 	writable          bool         // overlay enabled
 	hasWatch          bool         // capture contains watch events
 	kubernetesVersion string       // capture's /version gitVersion, e.g. "v1.36.1"
+}
+
+// closeStoreAndArchive waits for store's background enrichment pass to finish
+// (store may be nil when LoadStore itself failed) before closing ar. Every
+// early-return error path below runs after LoadStore has succeeded and its
+// background goroutine is already reading from ar, so skipping the wait would
+// race a close against that read (#232).
+func closeStoreAndArchive(store *CaptureStore, ar *archive.Archive) {
+	if store != nil {
+		store.Close()
+	}
+	_ = ar.Close()
 }
 
 // Open opens a capture archive, starts the mock HTTPS server, and writes
@@ -81,12 +101,12 @@ func Open(opts OpenOptions) (*Server, error) {
 	}
 	store, err := LoadStore(ar)
 	if err != nil {
-		_ = ar.Close()
+		closeStoreAndArchive(nil, ar)
 		return nil, fmt.Errorf("loading capture: %w", err)
 	}
 	at, err := parseReplayAt(store.Metadata, opts.At)
 	if err != nil {
-		_ = ar.Close()
+		closeStoreAndArchive(store, ar)
 		return nil, err
 	}
 	return serve(ar, store, at, nil, false, false, opts.Port, opts.KubeconfigOut, opts.Verbose)
@@ -102,17 +122,17 @@ func Replay(opts ReplayOptions) (*Server, error) {
 	}
 	store, err := LoadStore(ar)
 	if err != nil {
-		_ = ar.Close()
+		closeStoreAndArchive(nil, ar)
 		return nil, fmt.Errorf("loading capture: %w", err)
 	}
 	speed, err := parseSpeed(opts.Speed)
 	if err != nil {
-		_ = ar.Close()
+		closeStoreAndArchive(store, ar)
 		return nil, err
 	}
 	from, to, err := parseReplayWindow(store.Metadata, opts.From, opts.To)
 	if err != nil {
-		_ = ar.Close()
+		closeStoreAndArchive(store, ar)
 		return nil, err
 	}
 	clock := NewReplayClock(from, to, speed, opts.Loop, opts.StartPaused)
@@ -128,12 +148,12 @@ func Replay(opts ReplayOptions) (*Server, error) {
 func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *ReplayClock, writable, schedulePods bool, port, kubeconfigOut string, verbose bool) (*Server, error) {
 	certPEM, keyPEM, err := generateSelfSignedCert()
 	if err != nil {
-		_ = ar.Close()
+		closeStoreAndArchive(store, ar)
 		return nil, fmt.Errorf("generating TLS cert: %w", err)
 	}
 	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
 	if err != nil {
-		_ = ar.Close()
+		closeStoreAndArchive(store, ar)
 		return nil, fmt.Errorf("loading TLS cert: %w", err)
 	}
 
@@ -142,7 +162,7 @@ func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *Replay
 	}
 	ln, err := net.Listen("tcp", "127.0.0.1:"+port)
 	if err != nil {
-		_ = ar.Close()
+		closeStoreAndArchive(store, ar)
 		return nil, fmt.Errorf("listening: %w", err)
 	}
 
@@ -154,7 +174,7 @@ func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *Replay
 		kubeconfigPath = filepath.Join(home, ".kube", "k8shark-"+store.Metadata.CaptureID+".yaml")
 	}
 	if err := writeKubeconfig(addr, kubeconfigPath); err != nil {
-		_ = ar.Close()
+		closeStoreAndArchive(store, ar)
 		_ = ln.Close()
 		return nil, fmt.Errorf("writing kubeconfig: %w", err)
 	}
@@ -175,7 +195,15 @@ func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *Replay
 			h.ensureSchedulableNode()
 		}
 	}
-	httpSrv := &http.Server{Handler: h}
+	// BaseContext gives every request a context tied to baseCtx rather than the
+	// connection's own (which Shutdown alone doesn't cancel — see cancelBase's
+	// doc comment). Canceling it before Shutdown is what makes a long-held
+	// watch stream's `<-r.Context().Done()` fire promptly on shutdown.
+	baseCtx, cancelBase := context.WithCancel(context.Background())
+	httpSrv := &http.Server{
+		Handler:     h,
+		BaseContext: func(net.Listener) context.Context { return baseCtx },
+	}
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -190,6 +218,7 @@ func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *Replay
 		handler:           h,
 		httpServer:        httpSrv,
 		done:              done,
+		cancelBase:        cancelBase,
 		clock:             clock,
 		writable:          h.overlay != nil,
 		hasWatch:          len(store.WatchIndex) > 0,
@@ -233,31 +262,63 @@ func (s *Server) HasWatchEvents() bool { return s.hasWatch }
 // Shutdown immediately stops the server and closes the archive.
 // Useful in tests and programmatic usage; Wait() is preferred for CLI use.
 func (s *Server) Shutdown() {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	_ = s.httpServer.Shutdown(ctx)
-	<-s.done
-	if s.ar != nil {
-		_ = s.ar.Close()
-	}
+	s.teardown()
 }
 
-// Wait blocks until Ctrl+C / SIGTERM, then shuts the server down and closes the archive.
-func (s *Server) Wait() error {
+// WaitForSignal blocks until Ctrl+C / SIGTERM (or the server stops on its
+// own) but does NOT shut the server down or close the archive — it returns
+// control to the caller, who may own other resources (a companion UI server,
+// kwok, kube-controller-manager) that must be torn down in a specific order
+// relative to this one. Call Shutdown afterward. Callers that don't own any
+// such resources can use Wait instead.
+func (s *Server) WaitForSignal() {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	select {
 	case <-s.done:
 	case <-sigCh:
+	}
+}
+
+// Wait blocks until Ctrl+C / SIGTERM (or the server stops on its own), then
+// tears it down and closes the archive. Prefer WaitForSignal + Shutdown when
+// the caller has other resources that must be torn down in a specific order
+// relative to this server (see cmd/ui.go, cmd/replay.go).
+func (s *Server) Wait() error {
+	s.WaitForSignal()
+	s.teardown()
+	return nil
+}
+
+// teardown cancels the shared request context (so any in-flight watch
+// stream's `<-r.Context().Done()` fires), gracefully stops the HTTP server,
+// waits for Serve to return, waits for every in-flight handler to actually
+// return from ServeHTTP (a hard guarantee that none is still reading from the
+// archive — Shutdown returning doesn't by itself prove this; see cancelBase's
+// doc comment), and only then closes the archive. closeOnce makes this safe
+// to call from both Shutdown and Wait without double-closing the archive.
+func (s *Server) teardown() {
+	s.closeOnce.Do(func() {
+		if s.cancelBase != nil {
+			s.cancelBase()
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_ = s.httpServer.Shutdown(ctx)
 		<-s.done
-	}
-	if s.ar != nil {
-		_ = s.ar.Close()
-	}
-	return nil
+		if s.handler != nil {
+			s.handler.waitForRequests()
+			if s.handler.store != nil {
+				// Also waits for the background discovery-enrichment pass,
+				// which reads from the archive independently of any HTTP
+				// request (see #232) — waitForRequests above doesn't cover it.
+				s.handler.store.Close()
+			}
+		}
+		if s.ar != nil {
+			_ = s.ar.Close()
+		}
+	})
 }
 
 func parseReplayAt(meta capture.CaptureMetadata, raw string) (time.Time, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -274,6 +274,7 @@ func (s *Server) Shutdown() {
 func (s *Server) WaitForSignal() {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
 	select {
 	case <-s.done:
 	case <-sigCh:

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -298,10 +298,16 @@ func TestServer_Shutdown_WithActiveWatch_ReturnsPromptlyAndClosesCleanly(t *test
 		t.Errorf("Shutdown took %s; expected it to return promptly once the watch's context is canceled, not stall for its grace period", elapsed)
 	}
 
+	// By the time Shutdown returns, the server has already closed the
+	// connection (that's what waitForRequests guarantees) — but the client's
+	// own goroutine still needs a scheduler turn to observe EOF, so this
+	// allows a short window rather than asserting immediately. The
+	// server-side guarantee under test is Shutdown itself blocking on
+	// waitForRequests, not how fast the client notices.
 	select {
 	case <-streamDone:
-	default:
-		t.Error("watch stream still open immediately after Shutdown returned; a handler could still be reading the archive Shutdown is about to close")
+	case <-time.After(2 * time.Second):
+		t.Error("watch stream still open 2s after Shutdown returned; a handler could still be reading the archive Shutdown is about to close")
 	}
 
 	if err := srv.ar.Close(); err == nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -243,6 +243,9 @@ func TestServer_Shutdown_WithActiveWatch_ReturnsPromptlyAndClosesCleanly(t *test
 	if err != nil {
 		t.Fatalf("server.Open: %v", err)
 	}
+	// teardown's closeOnce makes this safe alongside the explicit Shutdown
+	// call below; it only does anything if the test fails/returns early.
+	defer srv.Shutdown()
 
 	client := &http.Client{
 		Transport: &http.Transport{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bufio"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -215,6 +216,93 @@ func TestServer_Open_ClosesArchiveOnShutdown(t *testing.T) {
 	}
 
 	srv.Shutdown()
+
+	if err := srv.ar.Close(); err == nil {
+		t.Error("archive still open after Shutdown; expected it to be closed (file-handle leak)")
+	}
+}
+
+// TestServer_Shutdown_WithActiveWatch_ReturnsPromptlyAndClosesCleanly is a
+// regression test for #230: with no BaseContext, Shutdown had no way to wake
+// up a watch handler blocked on <-r.Context().Done() (it only fires on client
+// disconnect or ?timeoutSeconds), so Shutdown stalled for its full 5s grace
+// period and then closed the archive while that handler could still be
+// reading it. The fix cancels a shared BaseContext before calling
+// httpServer.Shutdown, and Shutdown additionally waits on a request-tracking
+// WaitGroup as a hard guarantee that ServeHTTP has returned — for every
+// request, not just watches — before the archive is closed.
+//
+// This asserts Shutdown returns quickly (proving the watch woke up promptly
+// rather than Shutdown timing out) and that the watch's response stream has
+// already terminated by the time Shutdown returns (proving no handler can
+// still be running, let alone reading the archive, once Shutdown hands back
+// control to the caller).
+func TestServer_Shutdown_WithActiveWatch_ReturnsPromptlyAndClosesCleanly(t *testing.T) {
+	archivePath := buildTestArchive(t)
+	srv, err := Open(OpenOptions{ArchivePath: archivePath, KubeconfigOut: filepath.Join(t.TempDir(), "kubeconfig.yaml")})
+	if err != nil {
+		t.Fatalf("server.Open: %v", err)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402 — test only
+		},
+	}
+	req, err := http.NewRequest(http.MethodGet, srv.Address()+"/api/v1/namespaces/default/pods?watch=1", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("starting watch: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read the initial ADDED/BOOKMARK burst so the watch is confirmed
+	// established (and the handler is now blocked in the long-held select)
+	// before shutdown races it.
+	scanner := bufio.NewScanner(resp.Body)
+	sawBookmark := false
+	for scanner.Scan() {
+		var frame struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(scanner.Bytes(), &frame) == nil && frame.Type == "BOOKMARK" {
+			sawBookmark = true
+			break
+		}
+	}
+	if !sawBookmark {
+		t.Fatalf("watch never reached BOOKMARK; scanner err: %v", scanner.Err())
+	}
+
+	// Drain the rest of the stream in the background; it must reach EOF once
+	// Shutdown cancels the watch's context.
+	streamDone := make(chan struct{})
+	go func() {
+		defer close(streamDone)
+		for scanner.Scan() {
+		}
+	}()
+
+	start := time.Now()
+	srv.Shutdown()
+	elapsed := time.Since(start)
+
+	// Shutdown's own 5s grace period would make a stalled-watch regression
+	// pass this check too slowly to be useful as a signal by itself, so this
+	// is a generous ceiling — the real assertion is streamDone below, which
+	// can only close if the handler actually returned.
+	if elapsed > 4*time.Second {
+		t.Errorf("Shutdown took %s; expected it to return promptly once the watch's context is canceled, not stall for its grace period", elapsed)
+	}
+
+	select {
+	case <-streamDone:
+	default:
+		t.Error("watch stream still open immediately after Shutdown returned; a handler could still be reading the archive Shutdown is about to close")
+	}
 
 	if err := srv.ar.Close(); err == nil {
 		t.Error("archive still open after Shutdown; expected it to be closed (file-handle leak)")

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -25,10 +25,10 @@ type CaptureStore struct {
 
 	resourceInfoMu sync.RWMutex
 	resourceInfo   map[string]*ResourceInfo
-	// discoveryEnrichmentDone lets tests deterministically wait for
-	// enrichResourceInfoFromDiscovery's background pass (see LoadStore) instead
-	// of racing it. Production code intentionally does not wait — the store is
-	// documented as usable before this completes.
+	// discoveryEnrichmentDone tracks enrichResourceInfoFromDiscovery's
+	// background pass (see LoadStore). The store is usable before it
+	// completes, but it still reads records from the archive, so Close must
+	// wait for it before the caller closes the archive out from under it.
 	discoveryEnrichmentDone sync.WaitGroup
 
 	// Record LRU cache (bounded by recordCacheMaxBytes total body bytes).
@@ -89,7 +89,9 @@ type ResourceInfo struct {
 
 // LoadStore reads metadata and index from the archive and returns a ready
 // CaptureStore. The archive must remain open for the lifetime of the store;
-// call ar.Close() when done (the server's Shutdown does this).
+// call store.Close() before ar.Close() so the background enrichment pass
+// below can't still be reading from the archive when it's closed (the
+// server's teardown does this).
 func LoadStore(ar *archive.Archive) (*CaptureStore, error) {
 	var meta capture.CaptureMetadata
 	if err := ar.ReadMetadata(&meta); err != nil {
@@ -195,6 +197,14 @@ func (s *CaptureStore) mergeResourceInfo(group, version, resource string, namesp
 	if len(shortNames) > 0 {
 		ri.ShortNames = shortNames
 	}
+}
+
+// Close blocks until the background discovery-enrichment pass started by
+// LoadStore has finished reading from the archive. Callers must call this
+// before closing the archive the store was loaded from — otherwise a fast
+// command can close the zip while enrichment is still mid-scan.
+func (s *CaptureStore) Close() {
+	s.discoveryEnrichmentDone.Wait()
 }
 
 // enrichResourceInfoFromDiscovery reads captured APIResourceList bodies from

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -246,6 +246,10 @@ func TestCaptureStore_Close_ImmediateWithLargeCapture(t *testing.T) {
 	if err != nil {
 		t.Fatalf("archive.Open: %v", err)
 	}
+	// Belt-and-suspenders for the LoadStore-fails-before-the-real-Close-below
+	// case; harmless (and its error ignored) on the happy path, where ar is
+	// already closed by then.
+	t.Cleanup(func() { _ = ar.Close() })
 	store, err := LoadStore(ar)
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -200,6 +201,66 @@ func buildTestStore(t *testing.T, records map[string][]byte) *CaptureStore {
 		t.Fatalf("LoadStore: %v", err)
 	}
 	return store
+}
+
+// TestCaptureStore_Close_ImmediateWithLargeCapture is a regression test for
+// #232: LoadStore's background enrichResourceInfoFromDiscovery scan keeps
+// reading from the archive after LoadStore returns, so a caller that closes
+// the archive right away (as every real call site does) used to race it.
+// This builds a capture with enough discovery documents that the scan has
+// real work still in flight, then closes immediately with no explicit wait —
+// relying entirely on store.Close() to block until the scan finishes before
+// the archive underneath it goes away. Run with -race: without that wait,
+// the scan's archive reads would race the concurrent Close.
+func TestCaptureStore_Close_ImmediateWithLargeCapture(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "large.kshrk")
+
+	sw, err := archive.NewStreamWriter(outPath)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+
+	const numGroups = 300
+	index := make(capture.Index)
+	for i := 0; i < numGroups; i++ {
+		path := fmt.Sprintf("/apis/group%d.example.com/v1", i)
+		body := fmt.Sprintf(`{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"group%d.example.com/v1",`+
+			`"resources":[{"name":"widgets","singularName":"widget","namespaced":true,"kind":"Widget"}]}`, i)
+		now := time.Now().UTC()
+		rec := capture.Record{ID: fmt.Sprintf("rec-%d", i), CapturedAt: now, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body)}
+		if err := sw.WriteRecord(&rec); err != nil {
+			t.Fatalf("WriteRecord: %v", err)
+		}
+		index[path] = &capture.IndexEntry{APIPath: path, Seqs: []int{0}, Times: []time.Time{now}}
+	}
+	meta := capture.CaptureMetadata{
+		CaptureID: "large-test", KubernetesVersion: "v1.29.0",
+		CapturedAt: time.Now().UTC().Add(-time.Minute), CapturedUntil: time.Now().UTC(), RecordCount: numGroups,
+	}
+	if err := sw.Finish(&meta, index, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	ar, err := archive.Open(outPath)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	store, err := LoadStore(ar)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+
+	// Immediate close, no explicit discoveryEnrichmentDone.Wait() — store.Close
+	// must provide that wait itself.
+	store.Close()
+	if err := ar.Close(); err != nil {
+		t.Fatalf("ar.Close() after store.Close(): %v", err)
+	}
+
+	if got := len(store.Resources()); got < numGroups {
+		t.Errorf("Resources() = %d entries, want >= %d (enrichment should have completed before store.Close returned)", got, numGroups)
+	}
 }
 
 // TestStore_NamespaceItemCountsAt verifies that NamespaceItemCountsAt reads


### PR DESCRIPTION
## Summary

Fixes three related archive-lifecycle bugs from [Phase 1 of the v1.0 readiness tracker](https://github.com/phenixblue/k8shark/issues/266). All three are variations of "something is still reading the archive when it gets closed," so they're fixed together with one mechanism.

- **#230** — `http.Server` had no `BaseContext`, so `Shutdown` had no way to unblock a watch handler waiting on `<-r.Context().Done()` (only fires on client disconnect or `?timeoutSeconds`). Every `Shutdown` with an active watch stalled for its full 5s grace period, then closed the archive while that handler could still be reading it.
- **#231** — `replay` closed the mock server (and its archive) via `srv.Wait()` *before* shutting down the UI server that reads through the same store, and before tearing down kwok/kube-controller-manager. `ui` does this correctly: UI → controller-manager → kwok → mock server.
- **#232** — `LoadStore` starts a background discovery-enrichment goroutine that keeps reading from the archive after `LoadStore` returns. Every `ar.Close()` call site closed the archive without waiting for it: `cmd/query.go`, `cmd/diagnose.go`, every early-return path in `server.Open`/`Replay`/`serve`, and `internal/diff`'s `archiveSnapshot.cleanup` (an extra call site beyond what the issue named, but the same bug).

## Fix

- `serve()` sets `http.Server.BaseContext` to a cancelable context. `Server.teardown` cancels it *before* calling `httpServer.Shutdown` (so a blocked watch wakes up promptly), then waits on a new request-tracking `WaitGroup` (`handler.wg`, incremented for every `ServeHTTP` call) as a hard guarantee that no handler is still running before the archive closes.
- `Server.Wait` is split into `WaitForSignal` (blocks for Ctrl+C/SIGTERM, doesn't tear anything down) and `Shutdown`, so `cmd/replay.go` can now tear down in the same UI → controller-manager → kwok → mock-server order as `cmd/ui.go`. `teardown` also gained the `closeOnce` guard `internal/ui.Server` already had.
- `CaptureStore.Close()` waits for the enrichment goroutine to finish. Every call site that loads a store (`cmd/query.go`, `cmd/diagnose.go`, `server.Open`/`Replay`/`serve`, `internal/diff`) now closes the store before closing the archive.
- `CLAUDE.md`'s "Archive lifecycle" section is rewritten to describe all three invariants and fix its stale claim that `internal/ui` owns an archive (it hasn't since it started sharing `MockServer.Store()`).

## Test plan

- [x] New `TestServer_Shutdown_WithActiveWatch_ReturnsPromptlyAndClosesCleanly`: opens a real watch against a real TLS server, shuts down mid-stream, asserts `Shutdown` returns promptly and the stream has already terminated by the time it does. Verified this fails against the pre-fix code (`Shutdown` took 5.0s, stream still open) before confirming it passes with the fix.
- [x] New `TestCaptureStore_Close_ImmediateWithLargeCapture`: builds a capture with 300 discovery documents so the enrichment scan has real work in flight, closes immediately via `store.Close()` + `ar.Close()` with no explicit wait, and asserts enrichment fully completed. Verified this fails (0 resources found) without `store.Close()`.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean, `go mod tidy` no diff, `golangci-lint run` clean.
- [x] `go test -race ./...` passes on all packages.

Closes #230
Closes #231
Closes #232