### PR TITLE
fix(server): fix build break on main (WriteRecord signature mismatch)

### DIFF
--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -229,7 +229,7 @@ func TestCaptureStore_Close_ImmediateWithLargeCapture(t *testing.T) {
 			`"resources":[{"name":"widgets","singularName":"widget","namespaced":true,"kind":"Widget"}]}`, i)
 		now := time.Now().UTC()
 		rec := capture.Record{ID: fmt.Sprintf("rec-%d", i), CapturedAt: now, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body)}
-		if err := sw.WriteRecord(&rec); err != nil {
+		if _, err := sw.WriteRecord(&rec); err != nil {
 			t.Fatalf("WriteRecord: %v", err)
 		}
 		index[path] = &capture.IndexEntry{APIPath: path, Seqs: []int{0}, Times: []time.Time{now}}


### PR DESCRIPTION
## Summary

**main is currently red.** PR #267 changed `archive.RecordSink.WriteRecord`'s signature from `(error)` to `(int, error)`. PR #268 (`fix/server-shutdown-ordering`) was branched before that merged and added `TestCaptureStore_Close_ImmediateWithLargeCapture`, which used the old single-return form. The two PRs touched different lines in different files, so GitHub's merge detected no textual conflict and squashed both into main without surfacing the now-broken call. `go build` / `go vet` have failed on `main` since 7c84ede.

## Fix

One-line fix: `if err := sw.WriteRecord(&rec); err != nil` → `if _, err := sw.WriteRecord(&rec); err != nil` in `internal/server/store_test.go`.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean (previously failing on main)
- [x] `go test -race ./...` passes on all packages
- [x] `gofmt -l .` clean, `go mod tidy` no diff, `golangci-lint run` clean