### PR TITLE
fix(archive): don't count NDJSONWriter bytes for a record that failed to write

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -322,7 +322,6 @@ func (w *NDJSONWriter) WriteRecord(rec any) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("marshalling record: %w", err)
 	}
-	w.bytes += int64(len(b))
 
 	var hdr struct {
 		APIPath string `json:"api_path"`
@@ -335,6 +334,10 @@ func (w *NDJSONWriter) WriteRecord(rec any) (int, error) {
 	if err := w.enc.Encode(rec); err != nil {
 		return 0, err
 	}
+	// Only advance state once Encode has actually succeeded — mirrors seq's
+	// own only-meaningful-on-success rule, so a broken pipe mid-stream can't
+	// over-report bytes for a record that was never written.
+	w.bytes += int64(len(b))
 	if hdr.APIPath != "" {
 		w.pathSeq[hdr.APIPath] = seq + 1
 	}

--- a/internal/archive/ndjson_test.go
+++ b/internal/archive/ndjson_test.go
@@ -1,0 +1,42 @@
+package archive
+
+import (
+	"errors"
+	"testing"
+)
+
+// failingWriter returns an error from every Write, simulating a broken pipe
+// (e.g. `kshrk capture --output -` piped into a process that exits early).
+type failingWriter struct{ err error }
+
+func (w *failingWriter) Write(p []byte) (int, error) { return 0, w.err }
+
+// TestNDJSONWriter_WriteRecord_FailedEncodeDoesNotAdvanceState verifies that
+// when the underlying io.Writer fails mid-Encode, WriteRecord doesn't credit
+// the record as written: UncompressedBytes and RecordCount must not advance,
+// and the per-path seq counter must not be consumed — a record that was never
+// actually written must not occupy a seq number or be counted in size
+// reporting, mirroring the rule that WriteRecord's returned seq is only
+// meaningful on success.
+func TestNDJSONWriter_WriteRecord_FailedEncodeDoesNotAdvanceState(t *testing.T) {
+	wantErr := errors.New("broken pipe")
+	w := NewNDJSONWriter(&failingWriter{err: wantErr})
+
+	rec := map[string]any{
+		"id": "rec-1", "api_path": "/api/v1/namespaces/default/pods",
+		"http_method": "GET", "response_code": 200,
+		"response_body": map[string]any{"apiVersion": "v1", "kind": "PodList", "items": []any{}},
+	}
+	if _, err := w.WriteRecord(rec); !errors.Is(err, wantErr) {
+		t.Fatalf("WriteRecord error = %v, want %v", err, wantErr)
+	}
+	if got := w.RecordCount(); got != 0 {
+		t.Errorf("RecordCount() = %d, want 0 after a failed write", got)
+	}
+	if got := w.UncompressedBytes(); got != 0 {
+		t.Errorf("UncompressedBytes() = %d, want 0 — a record that failed to write must not be counted", got)
+	}
+	if got := w.pathSeq["/api/v1/namespaces/default/pods"]; got != 0 {
+		t.Errorf("pathSeq[...] = %d, want 0 — a failed write must not consume a seq number", got)
+	}
+}

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -229,10 +229,11 @@ func TestCaptureStore_Close_ImmediateWithLargeCapture(t *testing.T) {
 			`"resources":[{"name":"widgets","singularName":"widget","namespaced":true,"kind":"Widget"}]}`, i)
 		now := time.Now().UTC()
 		rec := capture.Record{ID: fmt.Sprintf("rec-%d", i), CapturedAt: now, APIPath: path, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body)}
-		if _, err := sw.WriteRecord(&rec); err != nil {
+		seq, err := sw.WriteRecord(&rec)
+		if err != nil {
 			t.Fatalf("WriteRecord: %v", err)
 		}
-		index[path] = &capture.IndexEntry{APIPath: path, Seqs: []int{0}, Times: []time.Time{now}}
+		index[path] = &capture.IndexEntry{APIPath: path, Seqs: []int{seq}, Times: []time.Time{now}}
 	}
 	meta := capture.CaptureMetadata{
 		CaptureID: "large-test", KubernetesVersion: "v1.29.0",


### PR DESCRIPTION
## Summary

Follow-up from a Copilot review comment on #267 that arrived after that PR had already been merged, so this fix landed on an orphaned commit — reopening it here.

`NDJSONWriter.WriteRecord` incremented `w.bytes` from the marshaled record size *before* calling `Encode`, so a broken pipe (e.g. `kshrk capture --output -` piped into a process that exits early) would over-report `UncompressedBytes` for a record that was never actually written. This breaks the same only-meaningful-on-success rule the returned `seq` already follows (per #210/#211, merged in #267).

**Depends on #269** (this branch is currently based on that hotfix so its own CI is green; it'll show as a normal diff against `main` once #269 merges).

## Fix

Move the `w.bytes += int64(len(b))` increment to after a successful `Encode`.

## Test plan

- [x] New `TestNDJSONWriter_WriteRecord_FailedEncodeDoesNotAdvanceState`: a failing `io.Writer` simulates a broken pipe; asserts `RecordCount()`, `UncompressedBytes()`, and the per-path seq counter all stay at zero. Verified this fails (reports 163 bytes for a record that was never written) without the fix.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean, `go mod tidy` no diff, `golangci-lint run` clean.
- [x] `go test -race ./...` passes on all packages.