### PR TITLE
fix(server): sort index paths before cross-namespace aggregation

### DIFF
--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -691,10 +691,10 @@ func itemDedupeKey(raw json.RawMessage) string {
 // aggregateItemCap is a safety cap: resources like packagemanifests return the
 // full cluster list for every namespace (OLM behavior). Aggregating across all
 // namespaces would multiply the item count by the number of namespaces and
-// materialise hundreds of millions of items. Cap the aggregate at this many
+// materialize hundreds of millions of items. Cap the aggregate at this many
 // unique items (keyed by uid or name) to prevent unbounded memory use. A var
 // (not const) so tests can lower it to exercise the cap without building a
-// 10 000-item fixture.
+// 10,000-item fixture.
 var aggregateItemCap = 10_000
 
 // AggregateAcrossNamespaces aggregates list items from all namespaced paths.

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -688,6 +688,15 @@ func itemDedupeKey(raw json.RawMessage) string {
 	return obj.Metadata.UID
 }
 
+// aggregateItemCap is a safety cap: resources like packagemanifests return the
+// full cluster list for every namespace (OLM behavior). Aggregating across all
+// namespaces would multiply the item count by the number of namespaces and
+// materialise hundreds of millions of items. Cap the aggregate at this many
+// unique items (keyed by uid or name) to prevent unbounded memory use. A var
+// (not const) so tests can lower it to exercise the cap without building a
+// 10 000-item fixture.
+var aggregateItemCap = 10_000
+
 // AggregateAcrossNamespaces aggregates list items from all namespaced paths.
 func (s *CaptureStore) AggregateAcrossNamespaces(clusterPath string, at time.Time) ([]byte, int, error) {
 	g, v, resource, _ := parseAPIPath(clusterPath)
@@ -699,13 +708,6 @@ func (s *CaptureStore) AggregateAcrossNamespaces(clusterPath string, at time.Tim
 	}
 	suffix := "/" + resource
 
-	// Safety cap: resources like packagemanifests return the full cluster list
-	// for every namespace (OLM behavior). Aggregating across all namespaces
-	// would multiply the item count by the number of namespaces and materialise
-	// hundreds of millions of items. Cap the aggregate at 10 000 unique items
-	// (keyed by uid or name) to prevent unbounded memory use.
-	const aggregateItemCap = 10_000
-
 	var (
 		allItems   []json.RawMessage
 		listKind   string
@@ -715,10 +717,19 @@ func (s *CaptureStore) AggregateAcrossNamespaces(clusterPath string, at time.Tim
 		capped     bool
 	)
 
+	var matchingPaths []string
 	for indexPath := range s.Index {
-		if !strings.HasPrefix(indexPath, pathPrefix) || !strings.HasSuffix(indexPath, suffix) {
-			continue
+		if strings.HasPrefix(indexPath, pathPrefix) && strings.HasSuffix(indexPath, suffix) {
+			matchingPaths = append(matchingPaths, indexPath)
 		}
+	}
+	// s.Index is a map; iterating it directly makes every downstream
+	// decision (item order, which namespace's list Kind/apiVersion win, which
+	// items survive the cap below) depend on Go's randomized map iteration
+	// order — a different, arbitrary answer on every request (#212).
+	sort.Strings(matchingPaths)
+
+	for _, indexPath := range matchingPaths {
 		body, code, err := s.ReconstructAt(indexPath, at)
 		if err != nil || code != 200 {
 			continue
@@ -824,10 +835,18 @@ func (s *CaptureStore) AggregateTableAcrossNamespaces(clusterPath string, at tim
 		seen    = make(map[string]struct{})
 	)
 
+	var matchingPaths []string
 	for indexPath := range s.Index {
-		if !strings.HasPrefix(indexPath, pathPrefix) || !strings.HasSuffix(indexPath, tableKeySuffix) {
-			continue
+		if strings.HasPrefix(indexPath, pathPrefix) && strings.HasSuffix(indexPath, tableKeySuffix) {
+			matchingPaths = append(matchingPaths, indexPath)
 		}
+	}
+	// See the identical comment in AggregateAcrossNamespaces: without this,
+	// colDefs (and therefore the output's column set) comes from whichever
+	// namespace wins the map's randomized iteration order (#212).
+	sort.Strings(matchingPaths)
+
+	for _, indexPath := range matchingPaths {
 		body, code, err := s.Latest(indexPath, at)
 		if err != nil || code != 200 {
 			continue

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -201,6 +202,147 @@ func buildTestStore(t *testing.T, records map[string][]byte) *CaptureStore {
 		t.Fatalf("LoadStore: %v", err)
 	}
 	return store
+}
+
+// TestAggregateAcrossNamespaces_Deterministic verifies AggregateAcrossNamespaces
+// iterates a sorted path list rather than ranging s.Index directly, so the
+// merged output is byte-identical across repeated calls instead of shuffling
+// item order on every request depending on Go's randomized map iteration
+// (#212).
+func TestAggregateAcrossNamespaces_Deterministic(t *testing.T) {
+	records := map[string][]byte{}
+	for _, ns := range []string{"ns-a", "ns-b", "ns-c", "ns-d", "ns-e"} {
+		records["/api/v1/namespaces/"+ns+"/pods"] = []byte(fmt.Sprintf(
+			`{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"pod-%s","namespace":"%s","uid":"%s"}}]}`, ns, ns, ns))
+	}
+	store := buildTestStore(t, records)
+
+	var first []byte
+	for i := 0; i < 20; i++ {
+		out, code, err := store.AggregateAcrossNamespaces("/api/v1/pods", time.Time{})
+		if err != nil {
+			t.Fatalf("run %d: AggregateAcrossNamespaces: %v", i, err)
+		}
+		if code != 200 {
+			t.Fatalf("run %d: code = %d, want 200", i, code)
+		}
+		if first == nil {
+			first = out
+			continue
+		}
+		if !bytes.Equal(first, out) {
+			t.Fatalf("run %d: output differs from run 0\nrun0: %s\nrun%d: %s", i, first, i, out)
+		}
+	}
+}
+
+// TestAggregateTableAcrossNamespaces_Deterministic verifies the Table variant
+// of the same fix: iterating a sorted path list keeps row order, and which
+// namespace's columnDefinitions win, stable across repeated calls — rather
+// than depending on whichever namespace the map iteration visits first.
+func TestAggregateTableAcrossNamespaces_Deterministic(t *testing.T) {
+	records := map[string][]byte{}
+	for _, ns := range []string{"ns-a", "ns-b", "ns-c", "ns-d", "ns-e"} {
+		records[fmt.Sprintf("/api/v1/namespaces/%s/pods?as=Table", ns)] = []byte(fmt.Sprintf(
+			`{"kind":"Table","columnDefinitions":[{"name":"from-%s"}],"rows":[{"object":{"metadata":{"name":"pod-%s","namespace":"%s","uid":"%s"}}}]}`,
+			ns, ns, ns, ns))
+	}
+	store := buildTestStore(t, records)
+
+	var first []byte
+	for i := 0; i < 20; i++ {
+		out, code, err := store.AggregateTableAcrossNamespaces("/api/v1/pods", time.Time{})
+		if err != nil {
+			t.Fatalf("run %d: AggregateTableAcrossNamespaces: %v", i, err)
+		}
+		if code != 200 {
+			t.Fatalf("run %d: code = %d, want 200", i, code)
+		}
+		if first == nil {
+			first = out
+			continue
+		}
+		if !bytes.Equal(first, out) {
+			t.Fatalf("run %d: output differs from run 0\nrun0: %s\nrun%d: %s", i, first, i, out)
+		}
+	}
+
+	// The winning columnDefinitions must come from the alphabetically-first
+	// namespace (ns-a), not an arbitrary one.
+	var table struct {
+		ColumnDefinitions []struct {
+			Name string `json:"name"`
+		} `json:"columnDefinitions"`
+	}
+	if err := json.Unmarshal(first, &table); err != nil {
+		t.Fatalf("decode: %v\n%s", err, first)
+	}
+	if len(table.ColumnDefinitions) != 1 || table.ColumnDefinitions[0].Name != "from-ns-a" {
+		t.Fatalf("columnDefinitions = %v, want [from-ns-a] (first namespace in sorted order)", table.ColumnDefinitions)
+	}
+}
+
+// TestAggregateAcrossNamespaces_Capped_StableAndNamespaceOrdered verifies the
+// aggregate item cap (lowered here via aggregateItemCap, a test hook) keeps
+// the same retained set across repeated calls, and that the items admitted
+// before the cap trips are the ones from the alphabetically-earliest
+// namespaces — the direct consequence of iterating a sorted path list.
+// Previously, which arbitrary subset of the cluster survived the cap changed
+// on every request (#212).
+func TestAggregateAcrossNamespaces_Capped_StableAndNamespaceOrdered(t *testing.T) {
+	origCap := aggregateItemCap
+	aggregateItemCap = 3
+	t.Cleanup(func() { aggregateItemCap = origCap })
+
+	records := map[string][]byte{}
+	for _, ns := range []string{"ns-a", "ns-b", "ns-c"} {
+		records["/api/v1/namespaces/"+ns+"/pods"] = []byte(fmt.Sprintf(
+			`{"kind":"PodList","apiVersion":"v1","items":[`+
+				`{"metadata":{"name":"%s-1","namespace":"%s","uid":"%s-1"}},`+
+				`{"metadata":{"name":"%s-2","namespace":"%s","uid":"%s-2"}}]}`,
+			ns, ns, ns, ns, ns, ns))
+	}
+	store := buildTestStore(t, records)
+
+	var want []string
+	for i := 0; i < 5; i++ {
+		out, code, err := store.AggregateAcrossNamespaces("/api/v1/pods", time.Time{})
+		if err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+		if code != 200 {
+			t.Fatalf("run %d: code = %d, want 200", i, code)
+		}
+		var list struct {
+			Items []struct {
+				Metadata struct {
+					Name string `json:"name"`
+				} `json:"metadata"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal(out, &list); err != nil {
+			t.Fatalf("run %d: decode: %v\n%s", i, err, out)
+		}
+		if len(list.Items) != 3 {
+			t.Fatalf("run %d: got %d items, want 3 (the lowered cap)", i, len(list.Items))
+		}
+		names := make([]string, len(list.Items))
+		for j, it := range list.Items {
+			names[j] = it.Metadata.Name
+		}
+		if want == nil {
+			want = names
+			// The cap should trip inside ns-b (2 items from ns-a, then 1 from
+			// ns-b), so ns-c must never be represented.
+			if want[0] != "ns-a-1" || want[1] != "ns-a-2" || want[2] != "ns-b-1" {
+				t.Fatalf("retained items = %v, want [ns-a-1 ns-a-2 ns-b-1] (namespace-ordered)", want)
+			}
+			continue
+		}
+		if !reflect.DeepEqual(names, want) {
+			t.Fatalf("run %d: retained items = %v, want stable set %v", i, names, want)
+		}
+	}
 }
 
 // TestCaptureStore_Close_ImmediateWithLargeCapture is a regression test for


### PR DESCRIPTION
## Summary

Fixes #212 from [Phase 1 of the v1.0 readiness tracker](https://github.com/phenixblue/k8shark/issues/266).

`AggregateAcrossNamespaces` and `AggregateTableAcrossNamespaces` (`internal/server/store.go`) both iterated `s.Index` — a map — directly:

```go
for indexPath := range s.Index {   // map iteration order is nondeterministic
```

Three escalating consequences:
1. `kubectl get pods -A` prints rows in a different order on every request.
2. `AggregateTableAcrossNamespaces` takes its `columnDefinitions` from whichever namespace wins the map race — if namespaces have differing column definitions, the output's column set itself is nondeterministic.
3. `AggregateAcrossNamespaces` has a 10,000-item safety cap. Which 10,000 items survive depends entirely on map order, so on a large capture the user gets a different arbitrary subset of their cluster on every request, with no warning.

The codebase already knew this hazard elsewhere (`handler.go:635` sorts group names with the same comment), it just never reached `store.go`.

## Fix

- Collect matching index paths into a slice and sort it before iterating, in both functions.
- Hoisted `aggregateItemCap` from a local `const` to a package-level `var` so tests can lower it to exercise the cap without building a 10,000-item fixture.

## Test plan

- [x] `TestAggregateAcrossNamespaces_Deterministic` / `TestAggregateTableAcrossNamespaces_Deterministic`: 20 iterations, byte-identical output, over a store with 5 namespaces.
- [x] `TestAggregateAcrossNamespaces_Capped_StableAndNamespaceOrdered`: lowers the cap via the new test hook and asserts the retained item set is stable across repeated calls and namespace-ordered (items from the alphabetically-earliest namespaces survive).
- [x] Verified all three tests fail reliably (10/10 runs) against the pre-fix code.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean, `go mod tidy` no diff, `golangci-lint run` clean.
- [x] `go test -race ./...` passes on all packages.

Closes #212