### PR TITLE
fix(archive): bound decompression against zip/zstd bombs

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -83,7 +83,34 @@ func zstdDecompress(data []byte) ([]byte, error) {
 	if err := dec.Reset(bytes.NewReader(data)); err != nil {
 		return nil, err
 	}
-	return io.ReadAll(dec)
+	return readAllLimited(dec, maxEntryBytes)
+}
+
+// maxEntryBytes bounds how much data a single archive entry may expand to
+// when decompressed or read. A .kshrk archive is designed to be handed
+// between organizations, so every read path must defend against a crafted
+// entry whose declared/compressed size is tiny but whose true decompressed
+// size is enormous (a "zip/zstd bomb") — mirroring internal/k8sbin's
+// maxExtractedBytes guard against the same class of untrusted input. Applied
+// per entry (a record, the index, metadata.json, ...) rather than as a
+// cumulative budget across the archive's lifetime, since a long-running
+// replay server legitimately reads many records over its lifetime and a
+// cumulative cap would eventually reject that regardless of any bomb. High
+// enough that legitimate captures (hundreds of MB total, far smaller per
+// entry) still open.
+const maxEntryBytes = 512 << 20 // 512 MiB
+
+// readAllLimited reads all of r, returning an error instead of allocating
+// unbounded memory if more than limit bytes would be read.
+func readAllLimited(r io.Reader, limit int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("exceeds %d bytes", limit)
+	}
+	return data, nil
 }
 
 // StreamWriter streams each record directly into a .kshrk (ZIP+Zstd) archive.
@@ -541,7 +568,11 @@ func (a *Archive) PathDirs() []string {
 // PathDir exposes the pathDir function for use by other packages (e.g. capture engine).
 func PathDir(apiPath string) string { return pathDir(apiPath) }
 
-// readRaw reads an uncompressed ZIP entry.
+// readRaw reads an uncompressed ZIP entry. A ZIP entry may itself use Deflate
+// (see writeBytes's doc comment — the method is not part of the format
+// contract, so older archives may still use it), which zf.Open() decompresses
+// on the fly; readAllLimited bounds that against a deflate bomb the same way
+// zstdDecompress bounds a zstd one.
 func (a *Archive) readRaw(name string) ([]byte, error) {
 	zf, ok := a.byName[name]
 	if !ok {
@@ -552,7 +583,11 @@ func (a *Archive) readRaw(name string) ([]byte, error) {
 		return nil, err
 	}
 	defer rc.Close()
-	return io.ReadAll(rc)
+	data, err := readAllLimited(rc, maxEntryBytes)
+	if err != nil {
+		return nil, fmt.Errorf("reading entry %q in archive %q: %w", name, a.path, err)
+	}
+	return data, nil
 }
 
 // readZstd reads a Zstd-compressed ZIP entry and returns decompressed bytes.
@@ -561,7 +596,11 @@ func (a *Archive) readZstd(name string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return zstdDecompress(compressed)
+	data, err := zstdDecompress(compressed)
+	if err != nil {
+		return nil, fmt.Errorf("decompressing entry %q in archive %q: %w", name, a.path, err)
+	}
+	return data, nil
 }
 
 // ---- helpers used by StreamWriter ----

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -580,7 +580,7 @@ func (a *Archive) readRaw(name string) ([]byte, error) {
 	}
 	rc, err := zf.Open()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("opening entry %q in archive %q: %w", name, a.path, err)
 	}
 	defer rc.Close()
 	data, err := readAllLimited(rc, maxEntryBytes)

--- a/internal/archive/decompression_bomb_test.go
+++ b/internal/archive/decompression_bomb_test.go
@@ -9,18 +9,49 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/klauspost/compress/zstd"
 )
 
-// TestZstdDecompress_BombRejected verifies zstdDecompress itself rejects a
-// zstd "bomb": a payload that compresses 1 GiB of zeros down to a few KB but
-// would otherwise decompress back to the full 1 GiB, unbounded (#214).
-func TestZstdDecompress_BombRejected(t *testing.T) {
-	zeros := make([]byte, 1<<30) // 1 GiB of zeros
-	compressed, err := zstdCompress(zeros)
+// bombSize is how large a "bomb" fixture decompresses to: one byte past the
+// cap is all the guard needs to see to reject it, so tests target this
+// instead of an arbitrarily large size like 1 GiB.
+const bombSize = maxEntryBytes + 1
+
+// buildZstdBomb streams n zero bytes through a zstd encoder in fixed-size
+// chunks, without ever materializing them as one contiguous n-byte slice,
+// and returns the (tiny) compressed result.
+func buildZstdBomb(t *testing.T, n int) []byte {
+	t.Helper()
+	enc, err := zstd.NewWriter(nil)
 	if err != nil {
-		t.Fatalf("zstdCompress: %v", err)
+		t.Fatalf("zstd.NewWriter: %v", err)
 	}
-	t.Logf("1 GiB of zeros compressed to %d bytes", len(compressed))
+	var buf bytes.Buffer
+	enc.Reset(&buf)
+	chunk := make([]byte, 1<<20) // 1 MiB of zeros, reused across writes
+	for remaining := n; remaining > 0; {
+		w := len(chunk)
+		if remaining < w {
+			w = remaining
+		}
+		if _, err := enc.Write(chunk[:w]); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		remaining -= w
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestZstdDecompress_BombRejected verifies zstdDecompress itself rejects a
+// zstd "bomb": a payload that compresses many zero bytes down to a few KB but
+// would otherwise decompress back to the full size, unbounded (#214).
+func TestZstdDecompress_BombRejected(t *testing.T) {
+	compressed := buildZstdBomb(t, bombSize)
+	t.Logf("%d zero bytes compressed to %d bytes", bombSize, len(compressed))
 
 	if _, err := zstdDecompress(compressed); err == nil {
 		t.Fatal("expected a size-limit error, got nil")
@@ -43,9 +74,11 @@ func TestArchive_ZstdBombRecord_ReturnsSizeLimitError(t *testing.T) {
 	bomb := map[string]any{
 		"id": "bomb-1", "api_path": "/api/v1/namespaces/default/pods",
 		"http_method": "GET", "response_code": 200,
-		// Highly compressible: 600 MiB of the same byte, comfortably above the
-		// 512 MiB cap once decompressed, but tiny once zstd-compressed.
-		"response_body": strings.Repeat("A", 600<<20),
+		// Highly compressible: one byte past the cap once decompressed, but
+		// tiny once zstd-compressed. WriteRecord's any-typed API has no
+		// streaming form, so this string is necessarily materialized whole —
+		// bombSize (not an arbitrarily large size) keeps that to a minimum.
+		"response_body": strings.Repeat("A", bombSize),
 	}
 	if _, err := sw.WriteRecord(bomb); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
@@ -90,7 +123,7 @@ func TestOpen_DeflateBombEntry_ReturnsSizeLimitError(t *testing.T) {
 		t.Fatalf("CreateHeader: %v", err)
 	}
 	chunk := bytes.Repeat([]byte("A"), 1<<20) // 1 MiB, highly compressible
-	const chunks = 600                        // 600 MiB decompressed, above the 512 MiB cap
+	chunks := bombSize/(1<<20) + 1            // one MiB past the cap, not an arbitrarily large size
 	for i := 0; i < chunks; i++ {
 		if _, err := w.Write(chunk); err != nil {
 			t.Fatalf("write chunk %d: %v", i, err)
@@ -214,9 +247,11 @@ func TestOpen_ZipSlipEntryNameIsInert(t *testing.T) {
 		t.Fatalf("unexpected metadata: %+v", meta)
 	}
 
+	// Only check for existence — never remove it. The name is unique per test
+	// run (it embeds t.Name()), but this path is outside the test's own temp
+	// directory, so a test must never delete anything there even on failure.
 	markerPath := filepath.Join(os.TempDir(), markerName)
 	if _, err := os.Stat(markerPath); err == nil {
-		os.Remove(markerPath)
-		t.Fatal("archive entry with a path-traversal name escaped to disk")
+		t.Fatalf("archive entry with a path-traversal name escaped to disk: %s", markerPath)
 	}
 }

--- a/internal/archive/decompression_bomb_test.go
+++ b/internal/archive/decompression_bomb_test.go
@@ -1,0 +1,222 @@
+package archive
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestZstdDecompress_BombRejected verifies zstdDecompress itself rejects a
+// zstd "bomb": a payload that compresses 1 GiB of zeros down to a few KB but
+// would otherwise decompress back to the full 1 GiB, unbounded (#214).
+func TestZstdDecompress_BombRejected(t *testing.T) {
+	zeros := make([]byte, 1<<30) // 1 GiB of zeros
+	compressed, err := zstdCompress(zeros)
+	if err != nil {
+		t.Fatalf("zstdCompress: %v", err)
+	}
+	t.Logf("1 GiB of zeros compressed to %d bytes", len(compressed))
+
+	if _, err := zstdDecompress(compressed); err == nil {
+		t.Fatal("expected a size-limit error, got nil")
+	} else if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("error = %v, want it to mention the size limit", err)
+	}
+}
+
+// TestArchive_ZstdBombRecord_ReturnsSizeLimitError verifies the full read
+// path (Archive.ReadRecord -> readZstd -> zstdDecompress) rejects a record
+// whose compressed size is tiny but whose decompressed size is enormous,
+// with an error naming both the archive path and the limit (#214).
+func TestArchive_ZstdBombRecord_ReturnsSizeLimitError(t *testing.T) {
+	outPath := filepath.Join(t.TempDir(), "zstd-bomb.kshrk")
+
+	sw, err := NewStreamWriter(outPath)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	bomb := map[string]any{
+		"id": "bomb-1", "api_path": "/api/v1/namespaces/default/pods",
+		"http_method": "GET", "response_code": 200,
+		// Highly compressible: 600 MiB of the same byte, comfortably above the
+		// 512 MiB cap once decompressed, but tiny once zstd-compressed.
+		"response_body": strings.Repeat("A", 600<<20),
+	}
+	if _, err := sw.WriteRecord(bomb); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+	if err := sw.Finish(map[string]any{"format_version": 1, "capture_id": "zstd-bomb"}, map[string]any{}, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	ar, err := Open(outPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer ar.Close()
+
+	_, err = ar.ReadRecord("/api/v1/namespaces/default/pods", 0)
+	if err == nil {
+		t.Fatal("expected a size-limit error reading a zstd-bomb record, got nil")
+	}
+	if !strings.Contains(err.Error(), outPath) {
+		t.Errorf("error = %v, want it to name the archive path %q", err, outPath)
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("%d", int64(maxEntryBytes))) {
+		t.Errorf("error = %v, want it to name the limit %d", err, int64(maxEntryBytes))
+	}
+}
+
+// TestOpen_DeflateBombEntry_ReturnsSizeLimitError verifies readRaw rejects a
+// ZIP entry using ordinary Deflate (which zip.File.Open decompresses
+// transparently) whose compressed size is tiny but whose decompressed size
+// is enormous — the same bomb class as the zstd case, through the other read
+// path (#214).
+func TestOpen_DeflateBombEntry_ReturnsSizeLimitError(t *testing.T) {
+	outPath := filepath.Join(t.TempDir(), "deflate-bomb.kshrk")
+
+	f, err := os.Create(outPath)
+	if err != nil {
+		t.Fatalf("os.Create: %v", err)
+	}
+	zw := zip.NewWriter(f)
+	w, err := zw.CreateHeader(&zip.FileHeader{Name: "k8shark-capture/metadata.json", Method: zip.Deflate})
+	if err != nil {
+		t.Fatalf("CreateHeader: %v", err)
+	}
+	chunk := bytes.Repeat([]byte("A"), 1<<20) // 1 MiB, highly compressible
+	const chunks = 600                        // 600 MiB decompressed, above the 512 MiB cap
+	for i := 0; i < chunks; i++ {
+		if _, err := w.Write(chunk); err != nil {
+			t.Fatalf("write chunk %d: %v", i, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip Close: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("file Close: %v", err)
+	}
+
+	ar, err := Open(outPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer ar.Close()
+
+	var meta map[string]any
+	err = ar.ReadMetadata(&meta)
+	if err == nil {
+		t.Fatal("expected a size-limit error reading a deflate-bomb entry, got nil")
+	}
+	if !strings.Contains(err.Error(), outPath) {
+		t.Errorf("error = %v, want it to name the archive path %q", err, outPath)
+	}
+}
+
+// TestArchive_LargeLegitimateEntry_StillOpens verifies a large-but-legitimate
+// single entry (well under maxEntryBytes) still reads normally — the cap
+// must not regress ordinary large captures.
+func TestArchive_LargeLegitimateEntry_StillOpens(t *testing.T) {
+	outPath := filepath.Join(t.TempDir(), "large-legit.kshrk")
+
+	sw, err := NewStreamWriter(outPath)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	// Random (not compressible), so the entry stays sizable after zstd —
+	// still comfortably under the cap.
+	body := make([]byte, 10<<20) // 10 MiB
+	if _, err := rand.Read(body); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	rec := map[string]any{
+		"id": "large-1", "api_path": "/api/v1/namespaces/default/pods",
+		"http_method": "GET", "response_code": 200,
+		"response_body": fmt.Sprintf("%x", body),
+	}
+	if _, err := sw.WriteRecord(rec); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+	if err := sw.Finish(map[string]any{"format_version": 1, "capture_id": "large-legit"}, map[string]any{}, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	ar, err := Open(outPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer ar.Close()
+
+	data, err := ar.ReadRecord("/api/v1/namespaces/default/pods", 0)
+	if err != nil {
+		t.Fatalf("ReadRecord: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected a non-empty record body")
+	}
+}
+
+// TestOpen_ZipSlipEntryNameIsInert pins the invariant noted in #214: openArchive
+// builds an exact-name lookup (byName) and nothing in this package ever joins
+// an entry's name onto a filesystem path to extract it, so a maliciously
+// named entry (path traversal via "..") can't escape anywhere — unlike a
+// tar/zip extractor that does. This builds an archive containing such an
+// entry and asserts opening/reading it succeeds without creating any file
+// outside the test's own temp directory.
+func TestOpen_ZipSlipEntryNameIsInert(t *testing.T) {
+	outPath := filepath.Join(t.TempDir(), "zipslip.kshrk")
+
+	f, err := os.Create(outPath)
+	if err != nil {
+		t.Fatalf("os.Create: %v", err)
+	}
+	zw := zip.NewWriter(f)
+	mw, err := zw.CreateHeader(&zip.FileHeader{Name: "k8shark-capture/metadata.json", Method: zip.Store})
+	if err != nil {
+		t.Fatalf("CreateHeader(metadata): %v", err)
+	}
+	if _, err := mw.Write([]byte(`{"format_version":1,"capture_id":"zipslip-test"}`)); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+	markerName := "k8shark-zipslip-marker-" + t.Name()
+	traversalName := "../../../../../../../../../../tmp/" + markerName
+	ew, err := zw.CreateHeader(&zip.FileHeader{Name: traversalName, Method: zip.Store})
+	if err != nil {
+		t.Fatalf("CreateHeader(traversal): %v", err)
+	}
+	if _, err := ew.Write([]byte("payload")); err != nil {
+		t.Fatalf("write traversal entry: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip Close: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("file Close: %v", err)
+	}
+
+	ar, err := Open(outPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer ar.Close()
+
+	var meta map[string]any
+	if err := ar.ReadMetadata(&meta); err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if meta["capture_id"] != "zipslip-test" {
+		t.Fatalf("unexpected metadata: %+v", meta)
+	}
+
+	markerPath := filepath.Join(os.TempDir(), markerName)
+	if _, err := os.Stat(markerPath); err == nil {
+		os.Remove(markerPath)
+		t.Fatal("archive entry with a path-traversal name escaped to disk")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #214 from [Phase 1 of the v1.0 readiness tracker](https://github.com/phenixblue/k8shark/issues/266).

Both archive read paths were bare `io.ReadAll` with no size limit:
- `zstdDecompress` (`internal/archive/archive.go`) — the zstd decompression step in `readZstd`
- `readRaw` — reads a raw ZIP entry via `zip.File.Open()`, which transparently decompresses a Deflate-method entry

A crafted 50 KB `.kshrk` file with a tiny compressed entry that decompresses to gigabytes would OOM the process reading it. This is reachable from every read entry point — `open`, `inspect`, `diagnose`, `query`, `ui`, `redact`, `transitions`, `diff` — since `.kshrk` files are designed to be handed between organizations (the product's core workflow).

`internal/k8sbin` already defends the identical class of input (a hostile tarball) with a running extraction total and `io.LimitReader`. This mirrors that approach.

## Fix

- New `maxEntryBytes` (512 MiB) and `readAllLimited` helper in `internal/archive/archive.go`.
- Applied **per entry**, not as a cumulative budget across the archive's lifetime — a long-running replay server legitimately reads many records over time, and a cumulative cap would eventually reject that regardless of any bomb.
- `readRaw`/`readZstd` errors now name the archive path and the entry, chaining down to the `exceeds N bytes` cause.

## Test plan

- [x] `TestZstdDecompress_BombRejected`: 1 GiB of zeros compresses to ~115 KB; decompressing it is rejected.
- [x] `TestArchive_ZstdBombRecord_ReturnsSizeLimitError`: same bomb through a real archive's `ReadRecord`, asserting the error names the archive path and the limit.
- [x] `TestOpen_DeflateBombEntry_ReturnsSizeLimitError`: same class of bomb through `readRaw`'s Deflate path (metadata.json entry).
- [x] `TestArchive_LargeLegitimateEntry_StillOpens`: a large-but-legitimate 10 MiB random (incompressible) entry still opens and reads fine — the cap doesn't regress normal captures.
- [x] `TestOpen_ZipSlipEntryNameIsInert`: pins the "Related" note in #214 — a path-traversal entry name is inert since nothing in this package joins an entry name onto a filesystem path.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean, `go mod tidy` no diff, `golangci-lint run` clean.
- [x] `go test -race ./...` passes on all packages.

Closes #214