### PR TITLE
refactor: extract internal/k8spath.Parse, fix diff --resource dropping pod logs

### DIFF
--- a/internal/diagnose/engine.go
+++ b/internal/diagnose/engine.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/phenixblue/k8shark/internal/k8spath"
 	"github.com/phenixblue/k8shark/internal/server"
 )
 
@@ -104,32 +105,7 @@ func forEachResource(store *server.CaptureStore, at time.Time, resource string, 
 // parseAPIPath extracts group, version, resource, and namespace from a canonical
 // API list path. Cluster-scoped paths return an empty namespace.
 func parseAPIPath(path string) (group, version, resource, namespace string) {
-	p := path
-	if i := strings.IndexByte(p, '?'); i >= 0 {
-		p = p[:i]
-	}
-	parts := strings.Split(strings.TrimPrefix(p, "/"), "/")
-	switch {
-	case len(parts) >= 3 && parts[0] == "api": // /api/v1/...
-		version = parts[1]
-		rest := parts[2:]
-		if len(rest) >= 3 && rest[0] == "namespaces" {
-			namespace = rest[1]
-			resource = rest[2]
-		} else {
-			resource = rest[0]
-		}
-	case len(parts) >= 4 && parts[0] == "apis": // /apis/<group>/<version>/...
-		group, version = parts[1], parts[2]
-		rest := parts[3:]
-		if len(rest) >= 3 && rest[0] == "namespaces" {
-			namespace = rest[1]
-			resource = rest[2]
-		} else if len(rest) >= 1 {
-			resource = rest[0]
-		}
-	}
-	return
+	return k8spath.Parse(path)
 }
 
 type objMeta struct {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -11,6 +11,7 @@ import (
 	"filippo.io/age"
 	archivepkg "github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/k8spath"
 	"github.com/phenixblue/k8shark/internal/server"
 	"github.com/pmezard/go-difflib/difflib"
 )
@@ -270,27 +271,7 @@ func matchesFilters(path, resource, namespace string) bool {
 }
 
 func parseAPIPath(path string) (group, version, resource, namespace string) {
-	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
-	switch {
-	case len(parts) >= 3 && parts[0] == "api":
-		version = parts[1]
-		if len(parts) == 3 {
-			resource = parts[2]
-		} else if len(parts) == 5 && parts[2] == "namespaces" {
-			namespace = parts[3]
-			resource = parts[4]
-		}
-	case len(parts) >= 4 && parts[0] == "apis":
-		group = parts[1]
-		version = parts[2]
-		if len(parts) == 4 {
-			resource = parts[3]
-		} else if len(parts) == 6 && parts[3] == "namespaces" {
-			namespace = parts[4]
-			resource = parts[5]
-		}
-	}
-	return
+	return k8spath.Parse(path)
 }
 
 func prettyJSON(body []byte) string {

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -101,6 +101,45 @@ func TestRun_Filters(t *testing.T) {
 	}
 }
 
+// TestRun_ResourceFilter_SurfacesPodLogChanges is a regression test for
+// #235: pod-log index keys carry a "?container=" query suffix
+// (".../pods/<name>/log?container=<c>"), which the pre-fix parseAPIPath (no
+// query stripping, rigid segment-count match) mis-parsed to
+// resource="", namespace="". matchesFilters then rejected every such entry
+// whenever --resource/--namespace was set, so `diff --resource pods`
+// silently dropped pod-log changes and exited 0 as if nothing had changed.
+func TestRun_ResourceFilter_SurfacesPodLogChanges(t *testing.T) {
+	const logPath = "/api/v1/namespaces/default/pods/nginx/log?container=app"
+	before := buildArchive(t, map[string][]capture.Record{
+		logPath: {
+			newRecord("log-1", logPath, time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC), `"starting up"`),
+		},
+	})
+	after := buildArchive(t, map[string][]capture.Record{
+		logPath: {
+			newRecord("log-2", logPath, time.Date(2026, 4, 9, 10, 5, 0, 0, time.UTC), `"starting up\ncrash: OOMKilled"`),
+		},
+	})
+
+	result, err := Run(Options{BeforeArchive: before, AfterArchive: after, Resource: "pods"})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if len(result.Changes) != 1 {
+		t.Fatalf("expected 1 change (the pod log), got %d: %+v", len(result.Changes), result.Changes)
+	}
+	ch := result.Changes[0]
+	if ch.Path != logPath {
+		t.Fatalf("unexpected path %q, want %q", ch.Path, logPath)
+	}
+	if ch.Resource != "pods" || ch.Namespace != "default" {
+		t.Errorf("Change.Resource/Namespace = %q/%q, want pods/default", ch.Resource, ch.Namespace)
+	}
+	if !strings.Contains(string(ch.After), "OOMKilled") {
+		t.Errorf("expected the after body to contain the new log line, got %s", ch.After)
+	}
+}
+
 func TestRun_NoDiff(t *testing.T) {
 	before := buildArchive(t, map[string][]capture.Record{
 		"/api/v1/namespaces/default/pods": {

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -10,6 +10,7 @@ import (
 	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/k8spath"
 )
 
 // Report summarizes the contents of a capture archive.
@@ -158,29 +159,7 @@ func summarizeResources(ar *archive.Archive, idx capture.Index) []ResourceSummar
 	return summaries
 }
 
-// parseAPIPath is a local copy of the equivalent function in internal/server/store.go.
-// Duplicated here to avoid an import cycle — the inspect package must not depend on
-// the server package.
+// parseAPIPath extracts (group, version, resource, namespace) from a REST path.
 func parseAPIPath(path string) (group, version, resource, namespace string) {
-	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
-	switch {
-	case len(parts) >= 3 && parts[0] == "api":
-		version = parts[1]
-		if len(parts) == 3 {
-			resource = parts[2]
-		} else if len(parts) == 5 && parts[2] == "namespaces" {
-			namespace = parts[3]
-			resource = parts[4]
-		}
-	case len(parts) >= 4 && parts[0] == "apis":
-		group = parts[1]
-		version = parts[2]
-		if len(parts) == 4 {
-			resource = parts[3]
-		} else if len(parts) == 6 && parts[3] == "namespaces" {
-			namespace = parts[4]
-			resource = parts[5]
-		}
-	}
-	return
+	return k8spath.Parse(path)
 }

--- a/internal/k8spath/k8spath.go
+++ b/internal/k8spath/k8spath.go
@@ -1,0 +1,46 @@
+// Package k8spath extracts (group, version, resource, namespace) from a
+// captured API path such as "/api/v1/namespaces/default/pods" or
+// "/apis/apps/v1/deployments". Every package that reads a capture.Index key
+// (a Kubernetes REST path, possibly with a query suffix) as structured
+// group/version/resource/namespace needs this; it was previously copy-pasted
+// into seven packages with three subtly different behaviors (#235).
+package k8spath
+
+import "strings"
+
+// Parse extracts group, version, resource, and namespace from a captured API
+// path. Any query string — ?as=Table, ?as=TableSchema, ?container=,
+// ?previous=, or any other suffix the capture engine emits — is stripped
+// first, and any path segments past the resource (e.g. a pod's /log
+// subresource) are ignored. This matters for index keys like
+// ".../namespaces/ns/pods/name/log?container=app": a rigid segment-count
+// check mis-parses that to resource="", namespace="" (the #235 bug in
+// internal/diff's diff --resource pods, which silently dropped every pod-log
+// change as a result). Cluster-scoped paths return an empty namespace.
+func Parse(path string) (group, version, resource, namespace string) {
+	if i := strings.IndexByte(path, '?'); i >= 0 {
+		path = path[:i]
+	}
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	switch {
+	case len(parts) >= 3 && parts[0] == "api": // /api/v1/...
+		version = parts[1]
+		rest := parts[2:]
+		if len(rest) >= 3 && rest[0] == "namespaces" {
+			namespace = rest[1]
+			resource = rest[2]
+		} else {
+			resource = rest[0]
+		}
+	case len(parts) >= 4 && parts[0] == "apis": // /apis/<group>/<version>/...
+		group, version = parts[1], parts[2]
+		rest := parts[3:]
+		if len(rest) >= 3 && rest[0] == "namespaces" {
+			namespace = rest[1]
+			resource = rest[2]
+		} else {
+			resource = rest[0]
+		}
+	}
+	return
+}

--- a/internal/k8spath/k8spath_test.go
+++ b/internal/k8spath/k8spath_test.go
@@ -1,0 +1,53 @@
+package k8spath
+
+import "testing"
+
+// TestParse covers every path shape the capture engine emits as an index key
+// (see internal/capture/engine.go: buildAPIPath, and the pod-log index key
+// format in fetchOnePodLog), plus the query-string suffixes it appends.
+func TestParse(t *testing.T) {
+	cases := []struct {
+		name                string
+		path                string
+		group, version      string
+		resource, namespace string
+	}{
+		{"core cluster-scoped", "/api/v1/nodes", "", "v1", "nodes", ""},
+		{"core namespaced", "/api/v1/namespaces/default/pods", "", "v1", "pods", "default"},
+		{"core namespaced, other namespace", "/api/v1/namespaces/kube-system/configmaps", "", "v1", "configmaps", "kube-system"},
+		{"group cluster-scoped", "/apis/apps/v1/deployments", "apps", "v1", "deployments", ""},
+		{"group namespaced", "/apis/apps/v1/namespaces/default/deployments", "apps", "v1", "deployments", "default"},
+		{"group namespaced, other group/namespace", "/apis/batch/v1/namespaces/ci/jobs", "batch", "v1", "jobs", "ci"},
+
+		// Table / TableSchema views (?as=...) — same resource, query stripped.
+		{"core namespaced, as=Table", "/api/v1/namespaces/default/pods?as=Table", "", "v1", "pods", "default"},
+		{"group cluster-scoped, as=TableSchema", "/apis/apps/v1/deployments?as=TableSchema", "apps", "v1", "deployments", ""},
+
+		// Pod-log subresource keys (fetchOnePodLog's indexKey format): a
+		// subresource segment past the resource, plus a query suffix. This is
+		// the #235 regression — a rigid segment-count parser mis-parses these
+		// to resource="", namespace="".
+		{"core pod log, container", "/api/v1/namespaces/default/pods/nginx/log?container=app", "", "v1", "pods", "default"},
+		{"core pod log, container+previous", "/api/v1/namespaces/default/pods/nginx/log?container=app&previous=true", "", "v1", "pods", "default"},
+		{"core pod log, no query", "/api/v1/namespaces/default/pods/nginx/log", "", "v1", "pods", "default"},
+
+		// Single-object GET (no namespaces/ segment ambiguity for cluster-scoped).
+		{"core cluster-scoped single object", "/api/v1/nodes/node-1", "", "v1", "nodes", ""},
+		{"group namespaced single object", "/apis/apps/v1/namespaces/default/deployments/my-app", "apps", "v1", "deployments", "default"},
+
+		// Degenerate inputs.
+		{"empty", "", "", "", "", ""},
+		{"root", "/", "", "", "", ""},
+		{"unrecognized prefix", "/healthz", "", "", "", ""},
+		{"api with no version", "/api", "", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g, v, r, ns := Parse(tc.path)
+			if g != tc.group || v != tc.version || r != tc.resource || ns != tc.namespace {
+				t.Errorf("Parse(%q) = (%q,%q,%q,%q), want (%q,%q,%q,%q)",
+					tc.path, g, v, r, ns, tc.group, tc.version, tc.resource, tc.namespace)
+			}
+		})
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/phenixblue/k8shark/internal/k8spath"
 	"github.com/phenixblue/k8shark/internal/server"
 	"k8s.io/client-go/util/jsonpath"
 )
@@ -180,30 +181,5 @@ func isDuplicateView(path string) bool {
 // parseAPIPath extracts group, version, resource, and namespace from a canonical
 // API list path. Cluster-scoped paths return an empty namespace.
 func parseAPIPath(path string) (group, version, resource, namespace string) {
-	p := path
-	if i := strings.IndexByte(p, '?'); i >= 0 {
-		p = p[:i]
-	}
-	parts := strings.Split(strings.TrimPrefix(p, "/"), "/")
-	switch {
-	case len(parts) >= 3 && parts[0] == "api": // /api/v1/...
-		version = parts[1]
-		rest := parts[2:]
-		if len(rest) >= 3 && rest[0] == "namespaces" {
-			namespace = rest[1]
-			resource = rest[2]
-		} else if len(rest) >= 1 {
-			resource = rest[0]
-		}
-	case len(parts) >= 4 && parts[0] == "apis": // /apis/<group>/<version>/...
-		group, version = parts[1], parts[2]
-		rest := parts[3:]
-		if len(rest) >= 3 && rest[0] == "namespaces" {
-			namespace = rest[1]
-			resource = rest[2]
-		} else if len(rest) >= 1 {
-			resource = rest[0]
-		}
-	}
-	return
+	return k8spath.Parse(path)
 }

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -874,7 +874,16 @@ func (s *CaptureStore) AggregateTableAcrossNamespaces(clusterPath string, at tim
 	return out, 200, nil
 }
 
-// parseAPIPath extracts (group, version, resource, namespace) from a REST path.
+// parseAPIPath extracts (group, version, resource, namespace) from a REST
+// path. Deliberately NOT internal/k8spath.Parse (see #235): this rigid,
+// exact-segment-count form doubles as handler.go's "is this a list-level
+// path, or something with more segments (an item GET)?" sentinel — an
+// item-level path returns resource="" here on purpose, which several call
+// sites (handler.go's 404 handling, the cluster-scoped fallback) branch on to
+// fall through to parseWritePath instead, which is built to parse item-level
+// paths (including the object name). Unifying this with k8spath.Parse's
+// looser, subresource-tolerant matching changes that sentinel and breaks
+// item-level GET 404 handling — see the regression this caused when tried.
 func parseAPIPath(path string) (group, version, resource, namespace string) {
 	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
 	switch {

--- a/internal/transitions/transitions.go
+++ b/internal/transitions/transitions.go
@@ -10,6 +10,7 @@ import (
 	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/k8spath"
 )
 
 // Transition is a single state-change event for a Kubernetes object detected
@@ -374,27 +375,7 @@ func inWindow(t, since, until time.Time) bool {
 // parseAPIPath extracts group, version, resource, and namespace from a
 // canonical Kubernetes API path (/api/... or /apis/...).
 func parseAPIPath(path string) (group, version, resource, namespace string) {
-	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
-	switch {
-	case len(parts) >= 3 && parts[0] == "api":
-		version = parts[1]
-		if len(parts) == 3 {
-			resource = parts[2]
-		} else if len(parts) == 5 && parts[2] == "namespaces" {
-			namespace = parts[3]
-			resource = parts[4]
-		}
-	case len(parts) >= 4 && parts[0] == "apis":
-		group = parts[1]
-		version = parts[2]
-		if len(parts) == 4 {
-			resource = parts[3]
-		} else if len(parts) == 6 && parts[3] == "namespaces" {
-			namespace = parts[4]
-			resource = parts[5]
-		}
-	}
-	return
+	return k8spath.Parse(path)
 }
 
 // jsonEqual reports whether two JSON blobs are semantically equivalent.

--- a/internal/ui/v2/overview.go
+++ b/internal/ui/v2/overview.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/k8spath"
 	"github.com/phenixblue/k8shark/internal/server"
 )
 
@@ -266,34 +267,9 @@ func getName(raw json.RawMessage) string {
 	return m.Metadata.Name
 }
 
-// parseAPIPath is a local mirror of server.parseAPIPath (unexported there).
-// Returns (group, version, resource, namespace).
+// parseAPIPath extracts (group, version, resource, namespace) from a REST path.
 func parseAPIPath(path string) (group, version, resource, namespace string) {
-	// Strip any query suffix.
-	if i := strings.Index(path, "?"); i >= 0 {
-		path = path[:i]
-	}
-	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
-	switch {
-	case len(parts) >= 3 && parts[0] == "api":
-		version = parts[1]
-		if len(parts) == 3 {
-			resource = parts[2]
-		} else if len(parts) == 5 && parts[2] == "namespaces" {
-			namespace = parts[3]
-			resource = parts[4]
-		}
-	case len(parts) >= 4 && parts[0] == "apis":
-		group = parts[1]
-		version = parts[2]
-		if len(parts) == 4 {
-			resource = parts[3]
-		} else if len(parts) == 6 && parts[3] == "namespaces" {
-			namespace = parts[4]
-			resource = parts[5]
-		}
-	}
-	return
+	return k8spath.Parse(path)
 }
 
 // clusterScopedResourceCounts walks paths with no namespace segment.


### PR DESCRIPTION
## Summary

Fixes #235 from [Phase 1 of the v1.0 readiness tracker](https://github.com/phenixblue/k8shark/issues/266).

`parseAPIPath` was copy-pasted seven times across three behavioral variants: some stripped query strings before parsing, some didn't; some used a rigid exact-segment-count match, some tolerated extra segments (subresources).

**This is already a live bug.** `internal/diff`'s copy did neither: no query stripping, rigid matching. Its snapshot loop only skips `?as=Table`, so pod-log index keys (which carry `?container=`) reach `matchesFilters` and mis-parse to `resource=""` — silently dropping every pod-log change whenever `--resource`/`--namespace` is set. `kshrk diff --resource pods` exits 0 showing a clean diff that isn't.

## Fix

- Extract `internal/k8spath.Parse` — one implementation that strips any query suffix and tolerates trailing subresource segments, so a key like `.../pods/name/log?container=app` still resolves `resource="pods"`, `namespace=ns`.
- Replace **six** of the seven duplicated definitions (`inspect`, `ui/v2/overview`, `diff`, `transitions`, `query`, `diagnose/engine`) with a one-line delegation to it. Their callers already either guard against query-suffixed paths before calling `parseAPIPath`, or (`query.go`, `diagnose/engine.go`) already used equivalent loose parsing — so this changes nothing for them except `diff.go`, where it's the fix.
- **`internal/server/store.go`'s `parseAPIPath` is deliberately left alone.** Its rigid matching doubles as `handler.go`'s "list-level path vs. item-level path" sentinel — an item-level GET returns `resource=""` on purpose, and several call sites branch on that to fall through to `parseWritePath` (a separate, purpose-built parser) instead. Unifying it broke item-level GET 404 handling in testing (`TestHandler_NotFound_ItemPath` and five others). Left as its own implementation with a comment explaining why, so it doesn't get "fixed" again by mistake later.

## Test plan

- [x] `internal/k8spath`: table-driven tests over every path shape the capture engine emits — core/group, cluster-scoped/namespaced, `?as=Table`/`?as=TableSchema`, pod-log `?container=`/`?previous=`, degenerate inputs.
- [x] New `TestRun_ResourceFilter_SurfacesPodLogChanges` in `internal/diff`: asserts `diff --resource pods` now surfaces a changed pod log. Verified it fails against the pre-fix parser (0 changes instead of 1).
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean, `go mod tidy` no diff, `golangci-lint run` clean.
- [x] `go test -race ./...` passes on all packages — including catching the `internal/server` regression before it was reverted.

Closes #235