### PR TITLE
fix(archive,transitions): enforce format-version gate; harden golden compat tests

### DIFF
--- a/internal/archive/crypto_test.go
+++ b/internal/archive/crypto_test.go
@@ -247,6 +247,10 @@ func TestEncryptedArchiveConcurrentReads(t *testing.T) {
 	}
 }
 
+// goldenV1PassphraseSHA256 pins the checked-in golden-v1-passphrase.kshrk
+// fixture's content hash — see goldenV1SHA256 in format_test.go for why (#251).
+const goldenV1PassphraseSHA256 = "4085130da81f688222f71e3150105ed292854bf62839b3d34e2bbee8fa335497"
+
 // TestGoldenV1Passphrase opens a checked-in passphrase-encrypted fixture to
 // catch any future age-library upgrade or kshrk change that breaks reading
 // already-written encrypted archives. Regenerate with:
@@ -265,7 +269,11 @@ func TestGoldenV1Passphrase(t *testing.T) {
 		t.Logf("regenerated %s", golden)
 	}
 	if _, err := os.Stat(golden); err != nil {
-		t.Skipf("golden fixture missing (run with -update): %v", err)
+		// See TestGoldenV1's identical comment: fail loudly, don't skip (#251).
+		t.Fatalf("golden fixture missing (run with -update to regenerate): %v", err)
+	}
+	if !*update {
+		requireFixtureHash(t, golden, goldenV1PassphraseSHA256)
 	}
 
 	identities, err := IdentitiesFromPassphrase(testPassphrase)

--- a/internal/archive/format_test.go
+++ b/internal/archive/format_test.go
@@ -13,13 +13,14 @@ import (
 
 var update = flag.Bool("update", false, "regenerate golden testdata fixtures")
 
-// goldenV1SHA256 pins the checked-in golden-v1.kshrk fixture's content hash.
-// TestGoldenV1 is the only guard that this build can still read archives
-// written by earlier releases; if the fixture goes missing, the test must
-// fail loudly (not skip), and if it's regenerated via -update, updating this
-// constant is a required second step — so running -update can't silently
-// swap in "whatever the current writer produces" as the thing being tested
-// against (#251).
+// goldenV1SHA256 pins the checked-in golden-v1.kshrk (plaintext) fixture's
+// content hash. TestGoldenV1 is the guard that this build can still read
+// plaintext archives written by earlier releases — see crypto_test.go's
+// goldenV1PassphraseSHA256 for the encrypted-fixture counterpart. If the
+// fixture goes missing, the test must fail loudly (not skip), and if it's
+// regenerated via -update, updating this constant is a required second
+// step — so running -update can't silently swap in "whatever the current
+// writer produces" as the thing being tested against (#251).
 const goldenV1SHA256 = "d7468f8f8b4b1d257f58fadbe4a8d839e1445869a8c6b11f3c4b0597e7ef4f83"
 
 // requireFixtureHash fails the test unless path's content hashes to want,

--- a/internal/archive/format_test.go
+++ b/internal/archive/format_test.go
@@ -2,6 +2,8 @@ package archive
 
 import (
 	"archive/zip"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"os"
@@ -10,6 +12,32 @@ import (
 )
 
 var update = flag.Bool("update", false, "regenerate golden testdata fixtures")
+
+// goldenV1SHA256 pins the checked-in golden-v1.kshrk fixture's content hash.
+// TestGoldenV1 is the only guard that this build can still read archives
+// written by earlier releases; if the fixture goes missing, the test must
+// fail loudly (not skip), and if it's regenerated via -update, updating this
+// constant is a required second step — so running -update can't silently
+// swap in "whatever the current writer produces" as the thing being tested
+// against (#251).
+const goldenV1SHA256 = "d7468f8f8b4b1d257f58fadbe4a8d839e1445869a8c6b11f3c4b0597e7ef4f83"
+
+// requireFixtureHash fails the test unless path's content hashes to want,
+// naming both hashes so a deliberate regeneration says exactly what to paste
+// into the pinned constant.
+func requireFixtureHash(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading fixture %s: %v", path, err)
+	}
+	sum := sha256.Sum256(data)
+	if got := hex.EncodeToString(sum[:]); got != want {
+		t.Fatalf("fixture %s has SHA-256 %s, want pinned %s — if this fixture was "+
+			"regenerated intentionally (go test -update), update the pinned constant to match",
+			path, got, want)
+	}
+}
 
 // sampleArchive writes a minimal but representative archive (one record + index
 // + metadata) to path using the production StreamWriter.
@@ -158,7 +186,14 @@ func TestGoldenV1(t *testing.T) {
 		t.Logf("regenerated %s", golden)
 	}
 	if _, err := os.Stat(golden); err != nil {
-		t.Skipf("golden fixture missing (run with -update): %v", err)
+		// A missing fixture is the highest-consequence failure this test
+		// guards against: it silently disables the only check that a v1.0
+		// build can still read archives written by earlier releases. Fail
+		// loudly, don't skip (#251).
+		t.Fatalf("golden fixture missing (run with -update to regenerate): %v", err)
+	}
+	if !*update {
+		requireFixtureHash(t, golden, goldenV1SHA256)
 	}
 
 	ar, err := Open(golden)

--- a/internal/server/format_version_gate_test.go
+++ b/internal/server/format_version_gate_test.go
@@ -24,6 +24,9 @@ func buildFutureFormatArchive(t *testing.T, path string) {
 	if err != nil {
 		t.Fatalf("NewStreamWriter: %v", err)
 	}
+	// Abort is a no-op once Finish has run, so this is a safe no-op on the
+	// happy path and a real cleanup if a t.Fatalf below skips Finish.
+	defer func() { _ = sw.Abort() }()
 	rec := capture.Record{
 		ID: "rec-1", CapturedAt: time.Now().UTC(), APIPath: "/api/v1/namespaces/default/pods",
 		HTTPMethod: "GET", ResponseCode: 200, ResponseBody: []byte(`{"kind":"PodList","items":[]}`),

--- a/internal/server/format_version_gate_test.go
+++ b/internal/server/format_version_gate_test.go
@@ -28,7 +28,8 @@ func buildFutureFormatArchive(t *testing.T, path string) {
 		ID: "rec-1", CapturedAt: time.Now().UTC(), APIPath: "/api/v1/namespaces/default/pods",
 		HTTPMethod: "GET", ResponseCode: 200, ResponseBody: []byte(`{"kind":"PodList","items":[]}`),
 	}
-	if _, err := sw.WriteRecord(&rec); err != nil {
+	seq, err := sw.WriteRecord(&rec)
+	if err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}
 	meta := capture.CaptureMetadata{
@@ -40,7 +41,7 @@ func buildFutureFormatArchive(t *testing.T, path string) {
 	index := capture.Index{
 		"/api/v1/namespaces/default/pods": {
 			APIPath: "/api/v1/namespaces/default/pods",
-			Seqs:    []int{0},
+			Seqs:    []int{seq},
 			Times:   []time.Time{rec.CapturedAt},
 		},
 	}

--- a/internal/server/format_version_gate_test.go
+++ b/internal/server/format_version_gate_test.go
@@ -1,0 +1,102 @@
+package server_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/diff"
+	"github.com/phenixblue/k8shark/internal/inspect"
+	"github.com/phenixblue/k8shark/internal/redact"
+	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/transitions"
+)
+
+// buildFutureFormatArchive writes a structurally valid archive whose
+// FormatVersion is one newer than this build understands, so every entry
+// point below should reject it rather than parse it under v1 assumptions.
+func buildFutureFormatArchive(t *testing.T, path string) {
+	t.Helper()
+	sw, err := archive.NewStreamWriter(path)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	rec := capture.Record{
+		ID: "rec-1", CapturedAt: time.Now().UTC(), APIPath: "/api/v1/namespaces/default/pods",
+		HTTPMethod: "GET", ResponseCode: 200, ResponseBody: []byte(`{"kind":"PodList","items":[]}`),
+	}
+	if _, err := sw.WriteRecord(&rec); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+	meta := capture.CaptureMetadata{
+		FormatVersion: capture.CurrentFormatVersion + 1,
+		CaptureID:     "future-format",
+		CapturedAt:    rec.CapturedAt.Add(-time.Minute),
+		CapturedUntil: rec.CapturedAt,
+	}
+	index := capture.Index{
+		"/api/v1/namespaces/default/pods": {
+			APIPath: "/api/v1/namespaces/default/pods",
+			Seqs:    []int{0},
+			Times:   []time.Time{rec.CapturedAt},
+		},
+	}
+	if err := sw.Finish(&meta, index, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+}
+
+// TestAllReaders_RejectFutureFormatVersion is a regression test for #250: a
+// future-format archive that every other subcommand correctly rejects with
+// an "upgrade kshrk" error was, at the time of filing, parsed by
+// transitions.LoadTransitions under v1 assumptions instead — producing
+// silently wrong output rather than a clear error. This asserts every public
+// entry point that opens an archive rejects it the same way.
+func TestAllReaders_RejectFutureFormatVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "future-format.kshrk")
+	buildFutureFormatArchive(t, path)
+
+	assertUpgradeError := func(t *testing.T, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatal("expected an error for a future-format archive, got nil")
+		}
+		if !strings.Contains(err.Error(), "upgrade") {
+			t.Errorf("error = %v, want it to mention \"upgrade\"", err)
+		}
+	}
+
+	t.Run("inspect.Run", func(t *testing.T) {
+		_, err := inspect.Run(path, nil)
+		assertUpgradeError(t, err)
+	})
+
+	t.Run("server.LoadStore", func(t *testing.T) {
+		ar, err := archive.Open(path)
+		if err != nil {
+			t.Fatalf("archive.Open: %v", err)
+		}
+		defer ar.Close()
+		_, err = server.LoadStore(ar)
+		assertUpgradeError(t, err)
+	})
+
+	t.Run("redact.Archive", func(t *testing.T) {
+		dst := filepath.Join(t.TempDir(), "out.kshrk")
+		_, err := redact.Archive(path, dst, redact.Options{})
+		assertUpgradeError(t, err)
+	})
+
+	t.Run("transitions.LoadTransitions", func(t *testing.T) {
+		_, err := transitions.LoadTransitions(path, transitions.FilterOpts{}, nil)
+		assertUpgradeError(t, err)
+	})
+
+	t.Run("diff.Run", func(t *testing.T) {
+		_, err := diff.Run(diff.Options{Archive: path, BeforeAt: "0s", AfterAt: "0s"})
+		assertUpgradeError(t, err)
+	})
+}

--- a/internal/transitions/transitions.go
+++ b/internal/transitions/transitions.go
@@ -54,6 +54,14 @@ func LoadTransitions(archivePath string, opts FilterOpts, identities []age.Ident
 	}
 	defer ar.Close()
 
+	var meta capture.CaptureMetadata
+	if err := ar.ReadMetadata(&meta); err != nil {
+		return nil, fmt.Errorf("reading metadata: %w", err)
+	}
+	if err := capture.CheckFormatVersion(meta); err != nil {
+		return nil, err
+	}
+
 	var idx capture.Index
 	if err := ar.ReadIndex(&idx); err != nil {
 		return nil, fmt.Errorf("reading index: %w", err)


### PR DESCRIPTION
## Summary

Fixes #250 and #251 from [Phase 1 of the v1.0 readiness tracker](https://github.com/phenixblue/k8shark/issues/266).

### #250 — format-version gate

Of the five entry points that open archives, `transitions.LoadTransitions` was the one that didn't call `capture.CheckFormatVersion` — it doesn't even read metadata. A future-format archive that every other subcommand correctly rejects with an "upgrade kshrk" error would instead be parsed under v1 assumptions, producing silently wrong output.

**Note:** the issue also named `diff.go` as missing the check. That turned out to already be fixed — it goes through `server.LoadStore`, which has called `CheckFormatVersion` since #232 (merged earlier in this readiness pass). Verified by reading the code and by the shared test below passing for `diff.Run` without any change to `diff.go`.

### #251 — golden compat tests degrade to no-ops

`format_test.go`'s `TestGoldenV1` and `crypto_test.go`'s `TestGoldenV1Passphrase` are the only guard that this build can still read archives from earlier releases, but `t.Skipf`'d if the fixture went missing — letting CI go green with the guard silently gone.

## Fix

- `transitions.LoadTransitions` now reads metadata and calls `CheckFormatVersion`, matching the other four entry points.
- Both golden tests: `t.Skipf` → `t.Fatalf` on a missing fixture.
- Each fixture's SHA-256 is pinned as a constant, checked before the fixture is used. Running `-update` (which regenerates the fixture from the current writer) now requires also updating the pinned hash — a deliberate two-place edit, not a silent swap of what's being tested against.

## Test plan

- [x] New `TestAllReaders_RejectFutureFormatVersion` (`internal/server`, as an external `_test` package to avoid an import cycle with `internal/diff`): writes a `FormatVersion: CurrentFormatVersion+1` archive and asserts `inspect.Run`, `server.LoadStore`, `redact.Archive`, `transitions.LoadTransitions`, and `diff.Run` all reject it with an "upgrade" error. Verified the `transitions.LoadTransitions` subtest fails against the pre-fix code.
- [x] Verified the pinned-hash check catches a tampered fixture (appended a byte, confirmed the test fails with both hashes shown; restored, confirmed it passes).
- [x] Verified a missing fixture now fails loudly instead of skipping (moved the fixture aside, confirmed `t.Fatalf`; restored).
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean, `go mod tidy` no diff, `golangci-lint run` clean.
- [x] `go test -race ./...` passes on all packages.

Closes #250
Closes #251