### PR TITLE
test(archive): add corrupt-archive and zero-record coverage

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -531,7 +531,7 @@ func (a *Archive) ReadWatchIndex(v any) (bool, error) {
 		return false, fmt.Errorf("reading watch-index.json.zst: %w", err)
 	}
 	if err := json.Unmarshal(data, v); err != nil {
-		return false, fmt.Errorf("parsing watch-index.json.zst in archive %q: %w", a.path, err)
+		return true, fmt.Errorf("parsing watch-index.json.zst in archive %q: %w", a.path, err)
 	}
 	return true, nil
 }

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -485,7 +485,10 @@ func (a *Archive) ReadMetadata(v any) error {
 	if err != nil {
 		return fmt.Errorf("reading metadata.json: %w", err)
 	}
-	return json.Unmarshal(data, v)
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("parsing metadata.json in archive %q: %w", a.path, err)
+	}
+	return nil
 }
 
 // ReadIndex reads and parses the Zstd-compressed index.json.zst.
@@ -576,7 +579,7 @@ func PathDir(apiPath string) string { return pathDir(apiPath) }
 func (a *Archive) readRaw(name string) ([]byte, error) {
 	zf, ok := a.byName[name]
 	if !ok {
-		return nil, fmt.Errorf("entry %q not found in archive", name)
+		return nil, fmt.Errorf("entry %q not found in archive %q", name, a.path)
 	}
 	rc, err := zf.Open()
 	if err != nil {

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -441,6 +442,9 @@ func openArchive(archivePath string, identities []age.Identity) (*Archive, error
 		zr, err = zip.NewReader(f, fi.Size())
 		if err != nil {
 			f.Close()
+			if errors.Is(err, zip.ErrFormat) {
+				return nil, fmt.Errorf("archive %q is corrupt or incomplete: not a valid zip file — this can happen if a capture was interrupted (e.g. Ctrl+C) or the file was truncated in transfer: %w", archivePath, err)
+			}
 			return nil, fmt.Errorf("opening zip archive %q: %w", archivePath, err)
 		}
 	} else {

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -501,7 +501,10 @@ func (a *Archive) ReadIndex(v any) error {
 	if err != nil {
 		return fmt.Errorf("reading index.json.zst: %w", err)
 	}
-	return json.Unmarshal(data, v)
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("parsing index.json.zst in archive %q: %w", a.path, err)
+	}
+	return nil
 }
 
 // ReadWatchIndex reads and parses watch-index.json.zst, if present.
@@ -515,7 +518,10 @@ func (a *Archive) ReadWatchIndex(v any) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("reading watch-index.json.zst: %w", err)
 	}
-	return true, json.Unmarshal(data, v)
+	if err := json.Unmarshal(data, v); err != nil {
+		return false, fmt.Errorf("parsing watch-index.json.zst in archive %q: %w", a.path, err)
+	}
+	return true, nil
 }
 
 // ReadRecord reads the record at sequence seq under apiPath.

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -421,6 +421,21 @@ func OpenWithIdentities(archivePath string, identities []age.Identity) (*Archive
 	return openArchive(archivePath, identities)
 }
 
+// wrapZipFormatErr gives zip.NewReader's ErrFormat an actionable diagnosis:
+// Go's archive/zip returns that identical error for a truncated capture
+// (missing central directory), an empty file, and garbage bytes — it can't
+// distinguish the causes — so name both plausible ones instead of surfacing
+// the raw "not a valid zip file". Applies equally to a plaintext archive and
+// the plaintext zip data recovered from decrypting an age-encrypted one,
+// since an interrupted encrypted capture truncates the same underlying zip
+// stream before it's ever encrypted.
+func wrapZipFormatErr(archivePath string, err error) error {
+	if errors.Is(err, zip.ErrFormat) {
+		return fmt.Errorf("archive %q is corrupt or incomplete: not a valid zip file — this can happen if a capture was interrupted (e.g. Ctrl+C) or the file was truncated in transfer: %w", archivePath, err)
+	}
+	return fmt.Errorf("opening zip archive %q: %w", archivePath, err)
+}
+
 func openArchive(archivePath string, identities []age.Identity) (*Archive, error) {
 	fi, err := os.Stat(archivePath)
 	if err != nil {
@@ -442,10 +457,7 @@ func openArchive(archivePath string, identities []age.Identity) (*Archive, error
 		zr, err = zip.NewReader(f, fi.Size())
 		if err != nil {
 			f.Close()
-			if errors.Is(err, zip.ErrFormat) {
-				return nil, fmt.Errorf("archive %q is corrupt or incomplete: not a valid zip file — this can happen if a capture was interrupted (e.g. Ctrl+C) or the file was truncated in transfer: %w", archivePath, err)
-			}
-			return nil, fmt.Errorf("opening zip archive %q: %w", archivePath, err)
+			return nil, wrapZipFormatErr(archivePath, err)
 		}
 	} else {
 		if len(identities) == 0 {
@@ -463,7 +475,7 @@ func openArchive(archivePath string, identities []age.Identity) (*Archive, error
 		zr, err = zip.NewReader(ra, plainSize)
 		if err != nil {
 			f.Close()
-			return nil, fmt.Errorf("opening decrypted archive %q: %w", archivePath, err)
+			return nil, wrapZipFormatErr(archivePath, err)
 		}
 	}
 

--- a/internal/archive/corrupt_test.go
+++ b/internal/archive/corrupt_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"filippo.io/age"
 )
 
 // buildZipMissingMetadata writes a structurally valid ZIP archive with an
@@ -183,5 +185,53 @@ func TestOpen_CorruptArchives(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestOpenWithIdentities_EncryptedCorruptZip covers the encrypted counterpart
+// of TestOpen_CorruptArchives's corrupt-zip cases. A truncated encrypted
+// capture is normally caught earlier, by age's own AEAD authentication (the
+// ciphertext fails to decrypt at all), so to exercise the case where
+// decryption succeeds but the recovered plaintext still isn't a valid zip —
+// e.g. a bug elsewhere produced a broken archive before it was ever
+// encrypted — this encrypts garbage bytes directly rather than going through
+// StreamWriter, bypassing that earlier check on purpose (#248).
+func TestOpenWithIdentities_EncryptedCorruptZip(t *testing.T) {
+	recipients, err := RecipientsFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("RecipientsFromPassphrase: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "encrypted-corrupt.kshrk")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("os.Create: %v", err)
+	}
+	w, err := age.Encrypt(f, recipients...)
+	if err != nil {
+		t.Fatalf("age.Encrypt: %v", err)
+	}
+	if _, err := w.Write(bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, 64)); err != nil {
+		t.Fatalf("write garbage: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("age writer Close: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("file Close: %v", err)
+	}
+
+	identities, err := IdentitiesFromPassphrase(testPassphrase)
+	if err != nil {
+		t.Fatalf("IdentitiesFromPassphrase: %v", err)
+	}
+	_, err = OpenWithIdentities(path, identities)
+	if err == nil {
+		t.Fatal("OpenWithIdentities on an encrypted-but-corrupt-plaintext archive succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("error = %v, want it to name the archive path %q", err, path)
+	}
+	if !strings.Contains(err.Error(), "corrupt or incomplete") {
+		t.Errorf("error = %v, want it to recognize the archive as corrupt or incomplete", err)
 	}
 }

--- a/internal/archive/corrupt_test.go
+++ b/internal/archive/corrupt_test.go
@@ -88,9 +88,16 @@ func TestOpen_CorruptArchives(t *testing.T) {
 		t.Fatalf("reading valid fixture: %v", err)
 	}
 
+	// wantActionable cases hit zip.NewReader's ErrFormat — Go's archive/zip
+	// package doesn't distinguish a missing central directory (truncation)
+	// from garbage bytes, so the most honest "recognized as such" diagnosis
+	// available is a single message naming both plausible causes (#248's
+	// acceptance criteria: "an interrupted capture is recognized as such and
+	// says so").
 	cases := []struct {
-		name  string
-		build func(t *testing.T, path string)
+		name           string
+		build          func(t *testing.T, path string)
+		wantActionable bool
 	}{
 		{
 			name: "truncated at 50% (no central directory, like a Ctrl+C'd capture)",
@@ -100,6 +107,7 @@ func TestOpen_CorruptArchives(t *testing.T) {
 					t.Fatalf("WriteFile: %v", err)
 				}
 			},
+			wantActionable: true,
 		},
 		{
 			name: "truncated to 10 bytes",
@@ -109,6 +117,7 @@ func TestOpen_CorruptArchives(t *testing.T) {
 					t.Fatalf("WriteFile: %v", err)
 				}
 			},
+			wantActionable: true,
 		},
 		{
 			name: "empty file",
@@ -117,6 +126,7 @@ func TestOpen_CorruptArchives(t *testing.T) {
 					t.Fatalf("WriteFile: %v", err)
 				}
 			},
+			wantActionable: true,
 		},
 		{
 			name: "random bytes",
@@ -126,6 +136,7 @@ func TestOpen_CorruptArchives(t *testing.T) {
 					t.Fatalf("WriteFile: %v", err)
 				}
 			},
+			wantActionable: true,
 		},
 		{name: "valid ZIP missing metadata.json", build: buildZipMissingMetadata},
 		{name: "valid ZIP with malformed metadata.json", build: buildZipMalformedMetadata},
@@ -161,6 +172,14 @@ func TestOpen_CorruptArchives(t *testing.T) {
 			}
 			if metaErr != nil && !strings.Contains(metaErr.Error(), path) {
 				t.Errorf("ReadMetadata error = %v, want it to name the archive path %q", metaErr, path)
+			}
+			if tc.wantActionable {
+				if openErr == nil {
+					t.Fatalf("expected Open to fail with a corrupt/incomplete diagnosis, got nil")
+				}
+				if !strings.Contains(openErr.Error(), "corrupt or incomplete") {
+					t.Errorf("Open error = %v, want it to recognize the archive as corrupt or incomplete", openErr)
+				}
 			}
 		})
 	}

--- a/internal/archive/corrupt_test.go
+++ b/internal/archive/corrupt_test.go
@@ -11,21 +11,28 @@ import (
 
 // buildZipMissingMetadata writes a structurally valid ZIP archive with an
 // index.json.zst entry but no metadata.json — e.g. a capture interrupted
-// between Finish's writes.
+// between Finish's writes. Uses zip.Store (via CreateHeader), matching how
+// writeBytes in archive.go actually writes entries.
 func buildZipMissingMetadata(t *testing.T, path string) {
 	t.Helper()
 	f, err := os.Create(path)
 	if err != nil {
 		t.Fatalf("os.Create: %v", err)
 	}
+	// Safety net for any t.Fatalf below: on the happy path these are already
+	// closed by the explicit, error-checked calls at the end of the
+	// function, so this is a harmless no-op second close.
+	defer f.Close()
 	zw := zip.NewWriter(f)
+	defer zw.Close()
+
 	idxZ, err := zstdCompress([]byte(`{}`))
 	if err != nil {
 		t.Fatalf("zstdCompress: %v", err)
 	}
-	w, err := zw.Create("k8shark-capture/index.json.zst")
+	w, err := zw.CreateHeader(&zip.FileHeader{Name: "k8shark-capture/index.json.zst", Method: zip.Store})
 	if err != nil {
-		t.Fatalf("Create: %v", err)
+		t.Fatalf("CreateHeader: %v", err)
 	}
 	if _, err := w.Write(idxZ); err != nil {
 		t.Fatalf("write: %v", err)
@@ -46,7 +53,10 @@ func buildZipMalformedMetadata(t *testing.T, path string) {
 	if err != nil {
 		t.Fatalf("os.Create: %v", err)
 	}
+	defer f.Close() // safety net; see buildZipMissingMetadata
 	zw := zip.NewWriter(f)
+	defer zw.Close()
+
 	w, err := zw.CreateHeader(&zip.FileHeader{Name: "k8shark-capture/metadata.json", Method: zip.Store})
 	if err != nil {
 		t.Fatalf("CreateHeader: %v", err)
@@ -148,6 +158,9 @@ func TestOpen_CorruptArchives(t *testing.T) {
 			}
 			if openErr != nil && !strings.Contains(openErr.Error(), path) {
 				t.Errorf("Open error = %v, want it to name the archive path %q", openErr, path)
+			}
+			if metaErr != nil && !strings.Contains(metaErr.Error(), path) {
+				t.Errorf("ReadMetadata error = %v, want it to name the archive path %q", metaErr, path)
 			}
 		})
 	}

--- a/internal/archive/corrupt_test.go
+++ b/internal/archive/corrupt_test.go
@@ -21,7 +21,8 @@ func buildZipMissingMetadata(t *testing.T, path string) {
 	}
 	// Safety net for any t.Fatalf below: on the happy path these are already
 	// closed by the explicit, error-checked calls at the end of the
-	// function, so this is a harmless no-op second close.
+	// function, so this second Close just returns (and discards) an
+	// "already closed" error rather than doing anything harmful.
 	defer f.Close()
 	zw := zip.NewWriter(f)
 	defer zw.Close()

--- a/internal/archive/corrupt_test.go
+++ b/internal/archive/corrupt_test.go
@@ -206,10 +206,12 @@ func TestOpenWithIdentities_EncryptedCorruptZip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("os.Create: %v", err)
 	}
+	defer f.Close() // safety net; see buildZipMissingMetadata
 	w, err := age.Encrypt(f, recipients...)
 	if err != nil {
 		t.Fatalf("age.Encrypt: %v", err)
 	}
+	defer w.Close() // safety net; see buildZipMissingMetadata
 	if _, err := w.Write(bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, 64)); err != nil {
 		t.Fatalf("write garbage: %v", err)
 	}

--- a/internal/archive/corrupt_test.go
+++ b/internal/archive/corrupt_test.go
@@ -1,0 +1,154 @@
+package archive
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildZipMissingMetadata writes a structurally valid ZIP archive with an
+// index.json.zst entry but no metadata.json — e.g. a capture interrupted
+// between Finish's writes.
+func buildZipMissingMetadata(t *testing.T, path string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("os.Create: %v", err)
+	}
+	zw := zip.NewWriter(f)
+	idxZ, err := zstdCompress([]byte(`{}`))
+	if err != nil {
+		t.Fatalf("zstdCompress: %v", err)
+	}
+	w, err := zw.Create("k8shark-capture/index.json.zst")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := w.Write(idxZ); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip Close: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("file Close: %v", err)
+	}
+}
+
+// buildZipMalformedMetadata writes a structurally valid ZIP archive whose
+// metadata.json entry is present but not valid JSON.
+func buildZipMalformedMetadata(t *testing.T, path string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("os.Create: %v", err)
+	}
+	zw := zip.NewWriter(f)
+	w, err := zw.CreateHeader(&zip.FileHeader{Name: "k8shark-capture/metadata.json", Method: zip.Store})
+	if err != nil {
+		t.Fatalf("CreateHeader: %v", err)
+	}
+	if _, err := w.Write([]byte("{")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip Close: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("file Close: %v", err)
+	}
+}
+
+// TestOpen_CorruptArchives covers every malformed-archive shape a user might
+// plausibly hand kshrk — most likely a Ctrl+C'd capture (`kshrk capture`
+// writes records in place via os.Create and only writes the index/metadata
+// in Finish, so an interrupted capture is a ZIP with records but no central
+// directory), plus a truncated transfer, garbage bytes, and a structurally
+// valid ZIP with a missing or malformed metadata.json. Every case must
+// produce a clear, non-nil error naming the archive path — never a panic,
+// a nil-map, or a wrong-but-plausible answer (#248).
+func TestOpen_CorruptArchives(t *testing.T) {
+	valid := filepath.Join(t.TempDir(), "valid.kshrk")
+	sampleArchive(t, valid)
+	validData, err := os.ReadFile(valid)
+	if err != nil {
+		t.Fatalf("reading valid fixture: %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		build func(t *testing.T, path string)
+	}{
+		{
+			name: "truncated at 50% (no central directory, like a Ctrl+C'd capture)",
+			build: func(t *testing.T, path string) {
+				half := validData[:len(validData)/2]
+				if err := os.WriteFile(path, half, 0o600); err != nil {
+					t.Fatalf("WriteFile: %v", err)
+				}
+			},
+		},
+		{
+			name: "truncated to 10 bytes",
+			build: func(t *testing.T, path string) {
+				n := min(10, len(validData))
+				if err := os.WriteFile(path, validData[:n], 0o600); err != nil {
+					t.Fatalf("WriteFile: %v", err)
+				}
+			},
+		},
+		{
+			name: "empty file",
+			build: func(t *testing.T, path string) {
+				if err := os.WriteFile(path, nil, 0o600); err != nil {
+					t.Fatalf("WriteFile: %v", err)
+				}
+			},
+		},
+		{
+			name: "random bytes",
+			build: func(t *testing.T, path string) {
+				garbage := bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, len(validData)/4+1)[:len(validData)]
+				if err := os.WriteFile(path, garbage, 0o600); err != nil {
+					t.Fatalf("WriteFile: %v", err)
+				}
+			},
+		},
+		{name: "valid ZIP missing metadata.json", build: buildZipMissingMetadata},
+		{name: "valid ZIP with malformed metadata.json", build: buildZipMalformedMetadata},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "corrupt.kshrk")
+			tc.build(t, path)
+
+			var openErr, metaErr error
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("panicked: %v", r)
+					}
+				}()
+				ar, err := Open(path)
+				openErr = err
+				if err != nil {
+					return
+				}
+				defer ar.Close()
+				var meta map[string]any
+				metaErr = ar.ReadMetadata(&meta)
+			}()
+
+			if openErr == nil && metaErr == nil {
+				t.Fatal("expected an error from Open or ReadMetadata, got nil for both")
+			}
+			if openErr != nil && !strings.Contains(openErr.Error(), path) {
+				t.Errorf("Open error = %v, want it to name the archive path %q", openErr, path)
+			}
+		})
+	}
+}

--- a/internal/archive/corrupt_test.go
+++ b/internal/archive/corrupt_test.go
@@ -75,6 +75,76 @@ func buildZipMalformedMetadata(t *testing.T, path string) {
 	}
 }
 
+// buildZipMalformedWatchIndex writes a structurally valid ZIP archive with
+// valid metadata.json and index.json.zst entries, but whose
+// watch-index.json.zst entry decompresses to invalid JSON.
+func buildZipMalformedWatchIndex(t *testing.T, path string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("os.Create: %v", err)
+	}
+	defer f.Close() // safety net; see buildZipMissingMetadata
+	zw := zip.NewWriter(f)
+	defer zw.Close()
+
+	writeEntry := func(name string, data []byte) {
+		t.Helper()
+		w, err := zw.CreateHeader(&zip.FileHeader{Name: name, Method: zip.Store})
+		if err != nil {
+			t.Fatalf("CreateHeader(%s): %v", name, err)
+		}
+		if _, err := w.Write(data); err != nil {
+			t.Fatalf("write(%s): %v", name, err)
+		}
+	}
+
+	writeEntry("k8shark-capture/metadata.json", []byte(`{"format_version":1,"capture_id":"malformed-watch-index"}`))
+	idxZ, err := zstdCompress([]byte(`{}`))
+	if err != nil {
+		t.Fatalf("zstdCompress(index): %v", err)
+	}
+	writeEntry("k8shark-capture/index.json.zst", idxZ)
+	watchZ, err := zstdCompress([]byte("{"))
+	if err != nil {
+		t.Fatalf("zstdCompress(watch-index): %v", err)
+	}
+	writeEntry("k8shark-capture/watch-index.json.zst", watchZ)
+
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip Close: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("file Close: %v", err)
+	}
+}
+
+// TestReadWatchIndex_MalformedEntry_StillReportsPresent is a regression test:
+// ReadWatchIndex's returned bool means "the entry is present in the
+// archive", independent of whether it parsed. A malformed watch-index.json.zst
+// must still report present=true (with a non-nil error) so a caller that
+// checks err first never mistakes a corrupt watch index for an archive that
+// simply predates the watch-index feature.
+func TestReadWatchIndex_MalformedEntry_StillReportsPresent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "malformed-watch-index.kshrk")
+	buildZipMalformedWatchIndex(t, path)
+
+	ar, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer ar.Close()
+
+	var wi map[string]any
+	found, err := ar.ReadWatchIndex(&wi)
+	if err == nil {
+		t.Fatal("ReadWatchIndex on a malformed entry succeeded, want error")
+	}
+	if !found {
+		t.Error("ReadWatchIndex found = false, want true — the entry is present even though it failed to parse")
+	}
+}
+
 // TestOpen_CorruptArchives covers every malformed-archive shape a user might
 // plausibly hand kshrk — most likely a Ctrl+C'd capture (`kshrk capture`
 // writes records in place via os.Create and only writes the index/metadata

--- a/internal/archive/zero_records_test.go
+++ b/internal/archive/zero_records_test.go
@@ -21,6 +21,9 @@ func buildZeroRecordArchive(t *testing.T, path string) {
 	if err != nil {
 		t.Fatalf("NewStreamWriter: %v", err)
 	}
+	// Abort is a no-op once Finish has run, so this is a safe no-op on the
+	// happy path and a real cleanup if a t.Fatalf below skips Finish.
+	defer func() { _ = sw.Abort() }()
 	meta := capture.CaptureMetadata{
 		FormatVersion: capture.CurrentFormatVersion,
 		CaptureID:     "zero-records",

--- a/internal/archive/zero_records_test.go
+++ b/internal/archive/zero_records_test.go
@@ -65,7 +65,10 @@ func TestArchive_ZeroRecords(t *testing.T) {
 		if err != nil {
 			t.Fatalf("server.LoadStore: %v", err)
 		}
-		store.Close()
+		// Deferred immediately (not just called at the end) so a t.Fatalf added
+		// later in this subtest can't skip it and leave the enrichment
+		// goroutine running when the deferred ar.Close() above runs.
+		defer store.Close()
 		if len(store.Index) != 0 {
 			t.Errorf("Index = %v, want empty", store.Index)
 		}

--- a/internal/archive/zero_records_test.go
+++ b/internal/archive/zero_records_test.go
@@ -1,0 +1,73 @@
+package archive_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/inspect"
+	"github.com/phenixblue/k8shark/internal/server"
+)
+
+// buildZeroRecordArchive writes a structurally valid, completely empty
+// capture: Finish runs with a real (non-nil) but zero-entry index, and no
+// records were ever written. A capture with all-empty resources (e.g. a
+// namespace with nothing in it, or a duration too short for any poll to
+// fire) produces exactly this.
+func buildZeroRecordArchive(t *testing.T, path string) {
+	t.Helper()
+	sw, err := archive.NewStreamWriter(path)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	meta := capture.CaptureMetadata{
+		FormatVersion: capture.CurrentFormatVersion,
+		CaptureID:     "zero-records",
+		RecordCount:   0,
+	}
+	if err := sw.Finish(&meta, capture.Index{}, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+}
+
+// TestArchive_ZeroRecords verifies that a capture with zero records — not
+// corrupt, just empty — is read cleanly by every consumer: inspect.Run and
+// server.LoadStore must succeed and report zero resources rather than
+// panicking on a nil/empty index or record set (#248).
+func TestArchive_ZeroRecords(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty.kshrk")
+	buildZeroRecordArchive(t, path)
+
+	t.Run("inspect.Run", func(t *testing.T) {
+		report, err := inspect.Run(path, nil)
+		if err != nil {
+			t.Fatalf("inspect.Run: %v", err)
+		}
+		if report.RecordCount != 0 {
+			t.Errorf("RecordCount = %d, want 0", report.RecordCount)
+		}
+		if len(report.Resources) != 0 {
+			t.Errorf("Resources = %v, want empty", report.Resources)
+		}
+	})
+
+	t.Run("server.LoadStore", func(t *testing.T) {
+		ar, err := archive.Open(path)
+		if err != nil {
+			t.Fatalf("archive.Open: %v", err)
+		}
+		defer ar.Close()
+		store, err := server.LoadStore(ar)
+		if err != nil {
+			t.Fatalf("server.LoadStore: %v", err)
+		}
+		store.Close()
+		if len(store.Index) != 0 {
+			t.Errorf("Index = %v, want empty", store.Index)
+		}
+		if got := len(store.Resources()); got != 0 {
+			t.Errorf("Resources() = %d entries, want 0", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #248 from [Phase 1 of the v1.0 readiness tracker](https://github.com/phenixblue/k8shark/issues/266).

No test previously covered any of: a ZIP cut short, garbage bytes, a missing `metadata.json`, a malformed `metadata.json`, or a zero-record capture. The most likely real-world case is a **Ctrl+C'd capture** — `StreamWriter` writes records in place via `os.Create` and only writes the index/metadata in `Finish`, so an interrupted capture is a ZIP with records but no central directory.

## What this adds

- `TestOpen_CorruptArchives` (6 cases): truncated at 50% (no central directory, like a Ctrl+C'd capture), truncated to 10 bytes, empty file, random bytes, valid ZIP missing `metadata.json`, valid ZIP with malformed `metadata.json`. Each asserts a clear error naming the archive path, with a panic guard around the whole `Open`/`ReadMetadata` sequence.
- `TestArchive_ZeroRecords`: a structurally valid, zero-record capture (a real, empty `capture.Index{}`, `Finish`'d normally — the state a namespace-with-nothing-in-it or an interval too short to poll would produce) opened via both `inspect.Run` and `server.LoadStore`, asserting both succeed and report 0 rather than panicking.

**Mostly coverage, with a few small observable changes.** Every case already fails as expected against the current implementation, but three error paths needed better wording to satisfy #248's acceptance criteria and let the tests assert on it:
- `ReadMetadata`'s JSON-parse error now includes the archive path (`archive.go`'s `ReadMetadata`).
- `readRaw`'s "entry not found" error now includes both the entry name and the archive path.
- `ReadIndex`/`ReadWatchIndex`'s JSON-parse errors now include the archive path too, for consistency with `ReadMetadata`.
- `openArchive`'s zip-parse failure: Go's `archive/zip` returns the identical `zip.ErrFormat` for a truncated capture (missing central directory), an empty file, and garbage bytes — it can't distinguish the causes. `Open` now wraps that specific error with a message naming both plausible causes ("corrupt or incomplete... this can happen if a capture was interrupted (e.g. Ctrl+C) or the file was truncated in transfer") instead of surfacing the raw `zip: not a valid zip file`, satisfying the criterion that an interrupted capture is recognized as such and says so.

These are error-message wording improvements, not behavior/logic changes — no return types, control flow, or success/failure outcomes changed.

## Test plan

- [x] All 6 corruption-mode subtests + the zero-record test pass.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean, `go mod tidy` no diff, `golangci-lint run` clean.
- [x] `go test -race ./...` passes on all packages.

Closes #248
