### PR TITLE
test(e2e): cover encrypt/decrypt -> open -> kubectl round trip

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1135,15 +1135,21 @@ done
 if [[ ! -s "$ENC_DEC_KC" ]]; then
   fail "open (decrypted archive): mock server did not start within 15s"
 else
+  ENC_DEC_READY=false
   for i in $(seq 1 20); do
     if kubectl --kubeconfig "$ENC_DEC_KC" --request-timeout=2s \
         get namespaces </dev/null &>/dev/null 2>&1; then
+      ENC_DEC_READY=true
       break
     fi
     sleep 0.5
   done
-  out=$(kubectl --kubeconfig "$ENC_DEC_KC" --request-timeout=10s get pods -n k8shark-test -o name 2>&1) || true
-  assert_not_empty "open (decrypted archive): pods present" "$out"
+  if [[ "$ENC_DEC_READY" != "true" ]]; then
+    fail "open (decrypted archive): mock server did not become ready within 10s"
+  else
+    out=$(kubectl --kubeconfig "$ENC_DEC_KC" --request-timeout=10s get pods -n k8shark-test -o name 2>&1) || true
+    assert_contains "open (decrypted archive): pods present" "$out" "^pod/"
+  fi
 fi
 if [[ -n "$ENC_DEC_SERVER_PID" ]]; then
   kill "$ENC_DEC_SERVER_PID" 2>/dev/null || true
@@ -1165,15 +1171,21 @@ done
 if [[ ! -s "$ENC_OPEN_KC" ]]; then
   fail "open --decrypt-passphrase-file (still-encrypted archive): mock server did not start within 15s"
 else
+  ENC_OPEN_READY=false
   for i in $(seq 1 20); do
     if kubectl --kubeconfig "$ENC_OPEN_KC" --request-timeout=2s \
         get namespaces </dev/null &>/dev/null 2>&1; then
+      ENC_OPEN_READY=true
       break
     fi
     sleep 0.5
   done
-  out=$(kubectl --kubeconfig "$ENC_OPEN_KC" --request-timeout=10s get pods -n k8shark-test -o name 2>&1) || true
-  assert_not_empty "open --decrypt-passphrase-file: pods present (decrypted on the fly)" "$out"
+  if [[ "$ENC_OPEN_READY" != "true" ]]; then
+    fail "open --decrypt-passphrase-file (still-encrypted archive): mock server did not become ready within 10s"
+  else
+    out=$(kubectl --kubeconfig "$ENC_OPEN_KC" --request-timeout=10s get pods -n k8shark-test -o name 2>&1) || true
+    assert_contains "open --decrypt-passphrase-file: pods present (decrypted on the fly)" "$out" "^pod/"
+  fi
 fi
 if [[ -n "$ENC_OPEN_SERVER_PID" ]]; then
   kill "$ENC_OPEN_SERVER_PID" 2>/dev/null || true
@@ -1258,15 +1270,21 @@ GOEOF
     if [[ ! -s "$REC_KC" ]]; then
       fail "open (recipient-decrypted archive): mock server did not start within 15s"
     else
+      REC_READY=false
       for i in $(seq 1 20); do
         if kubectl --kubeconfig "$REC_KC" --request-timeout=2s \
             get namespaces </dev/null &>/dev/null 2>&1; then
+          REC_READY=true
           break
         fi
         sleep 0.5
       done
-      out=$(kubectl --kubeconfig "$REC_KC" --request-timeout=10s get pods -n k8shark-test -o name 2>&1) || true
-      assert_not_empty "open (recipient-decrypted archive): pods present" "$out"
+      if [[ "$REC_READY" != "true" ]]; then
+        fail "open (recipient-decrypted archive): mock server did not become ready within 10s"
+      else
+        out=$(kubectl --kubeconfig "$REC_KC" --request-timeout=10s get pods -n k8shark-test -o name 2>&1) || true
+        assert_contains "open (recipient-decrypted archive): pods present" "$out" "^pod/"
+      fi
     fi
     if [[ -n "$REC_SERVER_PID" ]]; then
       kill "$REC_SERVER_PID" 2>/dev/null || true

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1161,6 +1161,7 @@ fi
 if [[ -n "$ENC_DEC_SERVER_PID" ]]; then
   kill "$ENC_DEC_SERVER_PID" 2>/dev/null || true
   wait "$ENC_DEC_SERVER_PID" 2>/dev/null || true
+  ENC_DEC_SERVER_PID=""
 fi
 
 # Open the STILL-encrypted archive directly, decrypting on the fly — no
@@ -1197,6 +1198,7 @@ fi
 if [[ -n "$ENC_OPEN_SERVER_PID" ]]; then
   kill "$ENC_OPEN_SERVER_PID" 2>/dev/null || true
   wait "$ENC_OPEN_SERVER_PID" 2>/dev/null || true
+  ENC_OPEN_SERVER_PID=""
 fi
 
 rm -f "$ENC_FILE" "$DEC_FILE" "$ENC_PASS_FILE" "$ENC_WRONG_PASS_FILE" \
@@ -1296,6 +1298,7 @@ GOEOF
     if [[ -n "$REC_SERVER_PID" ]]; then
       kill "$REC_SERVER_PID" 2>/dev/null || true
       wait "$REC_SERVER_PID" 2>/dev/null || true
+      REC_SERVER_PID=""
     fi
 
     rm -f "$ENC_RECIPIENT_FILE" "$DEC_RECIPIENT_FILE" "$AGE_IDENTITY_FILE" "$REC_SERVER_LOG" "$REC_KC"

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1110,7 +1110,7 @@ fi
 
 # inspect with no key must reject the encrypted archive outright.
 out=$("$BINARY" inspect "$ENC_FILE" 2>&1) || true
-assert_contains "inspect (no passphrase): rejects encrypted archive" "$out" "supply a decryption key"
+assert_contains "inspect (no passphrase): rejects encrypted archive" "$out" "provide --decrypt-passphrase-file"
 
 # inspect with the wrong passphrase must fail with the documented message.
 out=$("$BINARY" inspect "$ENC_FILE" --decrypt-passphrase-file "$ENC_WRONG_PASS_FILE" 2>&1) || true
@@ -1215,7 +1215,12 @@ rm -f "$ENC_FILE" "$DEC_FILE" "$ENC_PASS_FILE" "$ENC_WRONG_PASS_FILE" \
 if ! command -v go >/dev/null 2>&1; then
   fail "encrypt-recipient: 'go' not found in PATH, cannot generate a test age keypair"
 else
-  KEYGEN_SRC="/tmp/k8shark-e2e-keygen-$$.go"
+  # go run requires a .go suffix, which mktemp's template can't preserve
+  # portably (see the passphrase-file fix above) — so create the file
+  # securely via mktemp, then atomically rename it to add the suffix.
+  KEYGEN_SRC=$(mktemp /tmp/k8shark-e2e-keygen-XXXXXX)
+  mv "$KEYGEN_SRC" "$KEYGEN_SRC.go"
+  KEYGEN_SRC="$KEYGEN_SRC.go"
   cat >"$KEYGEN_SRC" <<'GOEOF'
 package main
 

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1092,10 +1092,10 @@ rm -f "$ALL_TRUE_CAPTURE_FILE" "$ALL_TRUE_CONFIG" "$ALL_TRUE_SERVER_LOG" "$ALL_T
 # ── Phase 9c: encrypt -> decrypt -> open -> kubectl (passphrase + recipient) ──
 log "Testing capture -> encrypt -> decrypt -> open -> kubectl"
 
-ENC_PASS_FILE="/tmp/k8shark-e2e-encpass-$$.txt"
-ENC_WRONG_PASS_FILE="/tmp/k8shark-e2e-encpass-wrong-$$.txt"
-(umask 077 && echo "correct-horse-battery-staple-e2e" >"$ENC_PASS_FILE")
-(umask 077 && echo "definitely-the-wrong-passphrase" >"$ENC_WRONG_PASS_FILE")
+ENC_PASS_FILE=$(mktemp /tmp/k8shark-e2e-encpass-XXXXXX)
+ENC_WRONG_PASS_FILE=$(mktemp /tmp/k8shark-e2e-encpass-wrong-XXXXXX)
+echo "correct-horse-battery-staple-e2e" >"$ENC_PASS_FILE"
+echo "definitely-the-wrong-passphrase" >"$ENC_WRONG_PASS_FILE"
 
 # -- Passphrase mode --
 ENC_FILE="/tmp/k8shark-e2e-encrypted-$$.kshrk"
@@ -1110,7 +1110,7 @@ fi
 
 # inspect with no key must reject the encrypted archive outright.
 out=$("$BINARY" inspect "$ENC_FILE" 2>&1) || true
-assert_contains "inspect (no passphrase): rejects encrypted archive" "$out" "encrypted"
+assert_contains "inspect (no passphrase): rejects encrypted archive" "$out" "supply a decryption key"
 
 # inspect with the wrong passphrase must fail with the documented message.
 out=$("$BINARY" inspect "$ENC_FILE" --decrypt-passphrase-file "$ENC_WRONG_PASS_FILE" 2>&1) || true
@@ -1244,8 +1244,8 @@ GOEOF
   else
     pass "encrypt-recipient: generated a test age keypair"
 
-    AGE_IDENTITY_FILE="/tmp/k8shark-e2e-age-identity-$$.txt"
-    (umask 077 && echo "$AGE_IDENTITY" >"$AGE_IDENTITY_FILE")
+    AGE_IDENTITY_FILE=$(mktemp /tmp/k8shark-e2e-age-identity-XXXXXX)
+    echo "$AGE_IDENTITY" >"$AGE_IDENTITY_FILE"
 
     ENC_RECIPIENT_FILE="/tmp/k8shark-e2e-encrypted-recipient-$$.kshrk"
     "$BINARY" --config "$CAPTURE_CONFIG" capture \

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -70,14 +70,47 @@ sorted_names() {
 
 # ── Cleanup ────────────────────────────────────────────────────────────────────
 SERVER_PID=""
+# Phase 9c (encrypt/decrypt) temp paths and background-server PIDs. Declared
+# here (before Phase 9c assigns them) so cleanup() can always reference them
+# under `set -u`, and so a `set -e` exit partway through Phase 9c — leaving
+# the private age identity file or a background mock server behind — is
+# still cleaned up rather than relying on the rm/kill calls at the end of
+# each Phase 9c block, which an early exit skips.
+ENC_PASS_FILE=""
+ENC_WRONG_PASS_FILE=""
+ENC_FILE=""
+DEC_FILE=""
+ENC_DEC_SERVER_LOG=""
+ENC_DEC_KC=""
+ENC_DEC_SERVER_PID=""
+ENC_OPEN_SERVER_LOG=""
+ENC_OPEN_KC=""
+ENC_OPEN_SERVER_PID=""
+KEYGEN_SRC=""
+AGE_IDENTITY_FILE=""
+ENC_RECIPIENT_FILE=""
+DEC_RECIPIENT_FILE=""
+REC_SERVER_LOG=""
+REC_KC=""
+REC_SERVER_PID=""
 cleanup() {
   if [[ -n "$SERVER_PID" ]]; then
     kill "$SERVER_PID" 2>/dev/null || true
     wait "$SERVER_PID" 2>/dev/null || true
   fi
+  for pid in "$ENC_DEC_SERVER_PID" "$ENC_OPEN_SERVER_PID" "$REC_SERVER_PID"; do
+    if [[ -n "$pid" ]]; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
   info "Deleting KinD cluster '$CLUSTER_NAME'..."
   kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
-  rm -f "$CAPTURE_FILE" "$CAPTURE_CONFIG" "$KIND_KUBECONFIG" "$SERVER_LOG"
+  rm -f "$CAPTURE_FILE" "$CAPTURE_CONFIG" "$KIND_KUBECONFIG" "$SERVER_LOG" \
+    "$ENC_PASS_FILE" "$ENC_WRONG_PASS_FILE" "$ENC_FILE" "$DEC_FILE" \
+    "$ENC_DEC_SERVER_LOG" "$ENC_DEC_KC" "$ENC_OPEN_SERVER_LOG" "$ENC_OPEN_KC" \
+    "$KEYGEN_SRC" "$AGE_IDENTITY_FILE" "$ENC_RECIPIENT_FILE" "$DEC_RECIPIENT_FILE" \
+    "$REC_SERVER_LOG" "$REC_KC"
 }
 trap cleanup EXIT
 
@@ -1054,8 +1087,8 @@ log "Testing capture -> encrypt -> decrypt -> open -> kubectl"
 
 ENC_PASS_FILE="/tmp/k8shark-e2e-encpass-$$.txt"
 ENC_WRONG_PASS_FILE="/tmp/k8shark-e2e-encpass-wrong-$$.txt"
-echo "correct-horse-battery-staple-e2e" >"$ENC_PASS_FILE"
-echo "definitely-the-wrong-passphrase" >"$ENC_WRONG_PASS_FILE"
+(umask 077 && echo "correct-horse-battery-staple-e2e" >"$ENC_PASS_FILE")
+(umask 077 && echo "definitely-the-wrong-passphrase" >"$ENC_WRONG_PASS_FILE")
 
 # -- Passphrase mode --
 ENC_FILE="/tmp/k8shark-e2e-encrypted-$$.kshrk"
@@ -1151,11 +1184,18 @@ rm -f "$ENC_FILE" "$DEC_FILE" "$ENC_PASS_FILE" "$ENC_WRONG_PASS_FILE" \
   "$ENC_DEC_SERVER_LOG" "$ENC_DEC_KC" "$ENC_OPEN_SERVER_LOG" "$ENC_OPEN_KC"
 
 # -- Recipient-key mode --
-# Generate a throwaway age X25519 keypair via the age library already vendored
-# in go.sum, rather than depending on the separate age-keygen binary being
-# present in every environment this script runs in.
-KEYGEN_SRC="/tmp/k8shark-e2e-keygen-$$.go"
-cat >"$KEYGEN_SRC" <<'GOEOF'
+# Generate a throwaway age X25519 keypair via filippo.io/age, which is
+# already a module dependency of this codebase (see go.mod/go.sum) and
+# downloadable through the Go toolchain, rather than depending on the
+# separate age-keygen binary being present in every environment this script
+# runs in. Requires the go toolchain, unlike the rest of this script — check
+# explicitly so a missing 'go' fails clearly here instead of aborting the
+# whole script under set -e with a bare "command not found".
+if ! command -v go >/dev/null 2>&1; then
+  fail "encrypt-recipient: 'go' not found in PATH, cannot generate a test age keypair"
+else
+  KEYGEN_SRC="/tmp/k8shark-e2e-keygen-$$.go"
+  cat >"$KEYGEN_SRC" <<'GOEOF'
 package main
 
 import (
@@ -1173,67 +1213,68 @@ func main() {
 	fmt.Println(id.Recipient().String())
 }
 GOEOF
-KEYPAIR=$(cd "$PROJ_ROOT" && go run "$KEYGEN_SRC") || true
-rm -f "$KEYGEN_SRC"
-AGE_IDENTITY=$(echo "$KEYPAIR" | sed -n '1p')
-AGE_RECIPIENT=$(echo "$KEYPAIR" | sed -n '2p')
+  KEYPAIR=$(cd "$PROJ_ROOT" && go run "$KEYGEN_SRC") || true
+  rm -f "$KEYGEN_SRC"
+  AGE_IDENTITY=$(echo "$KEYPAIR" | sed -n '1p')
+  AGE_RECIPIENT=$(echo "$KEYPAIR" | sed -n '2p')
 
-if [[ -z "$AGE_IDENTITY" || -z "$AGE_RECIPIENT" ]]; then
-  fail "encrypt-recipient: failed to generate an age keypair"
-else
-  pass "encrypt-recipient: generated a test age keypair"
-
-  AGE_IDENTITY_FILE="/tmp/k8shark-e2e-age-identity-$$.txt"
-  echo "$AGE_IDENTITY" >"$AGE_IDENTITY_FILE"
-
-  ENC_RECIPIENT_FILE="/tmp/k8shark-e2e-encrypted-recipient-$$.kshrk"
-  "$BINARY" --config "$CAPTURE_CONFIG" capture \
-    --encrypt-recipient "$AGE_RECIPIENT" \
-    --output "$ENC_RECIPIENT_FILE"
-  if [[ -s "$ENC_RECIPIENT_FILE" ]]; then
-    pass "capture --encrypt-recipient: encrypted archive created"
+  if [[ -z "$AGE_IDENTITY" || -z "$AGE_RECIPIENT" ]]; then
+    fail "encrypt-recipient: failed to generate an age keypair"
   else
-    fail "capture --encrypt-recipient: archive missing or empty"
-  fi
+    pass "encrypt-recipient: generated a test age keypair"
 
-  DEC_RECIPIENT_FILE="/tmp/k8shark-e2e-decrypted-recipient-$$.kshrk"
-  "$BINARY" decrypt "$ENC_RECIPIENT_FILE" \
-    --decrypt-identity-file "$AGE_IDENTITY_FILE" \
-    --output "$DEC_RECIPIENT_FILE"
-  if [[ -s "$DEC_RECIPIENT_FILE" ]]; then
-    pass "kshrk decrypt --decrypt-identity-file: plaintext archive created"
-  else
-    fail "kshrk decrypt --decrypt-identity-file: output archive missing or empty"
-  fi
+    AGE_IDENTITY_FILE="/tmp/k8shark-e2e-age-identity-$$.txt"
+    (umask 077 && echo "$AGE_IDENTITY" >"$AGE_IDENTITY_FILE")
 
-  REC_SERVER_LOG="/tmp/k8shark-recipient-server-$$.log"
-  REC_KC="/tmp/k8shark-recipient-kc-$$.yaml"
-  REC_SERVER_PID=""
-  "$BINARY" open "$DEC_RECIPIENT_FILE" --kubeconfig-out "$REC_KC" >"$REC_SERVER_LOG" 2>&1 &
-  REC_SERVER_PID=$!
-  for i in $(seq 1 30); do
-    if [[ -s "$REC_KC" ]]; then break; fi
-    sleep 0.5
-  done
-  if [[ ! -s "$REC_KC" ]]; then
-    fail "open (recipient-decrypted archive): mock server did not start within 15s"
-  else
-    for i in $(seq 1 20); do
-      if kubectl --kubeconfig "$REC_KC" --request-timeout=2s \
-          get namespaces </dev/null &>/dev/null 2>&1; then
-        break
-      fi
+    ENC_RECIPIENT_FILE="/tmp/k8shark-e2e-encrypted-recipient-$$.kshrk"
+    "$BINARY" --config "$CAPTURE_CONFIG" capture \
+      --encrypt-recipient "$AGE_RECIPIENT" \
+      --output "$ENC_RECIPIENT_FILE"
+    if [[ -s "$ENC_RECIPIENT_FILE" ]]; then
+      pass "capture --encrypt-recipient: encrypted archive created"
+    else
+      fail "capture --encrypt-recipient: archive missing or empty"
+    fi
+
+    DEC_RECIPIENT_FILE="/tmp/k8shark-e2e-decrypted-recipient-$$.kshrk"
+    "$BINARY" decrypt "$ENC_RECIPIENT_FILE" \
+      --decrypt-identity-file "$AGE_IDENTITY_FILE" \
+      --output "$DEC_RECIPIENT_FILE"
+    if [[ -s "$DEC_RECIPIENT_FILE" ]]; then
+      pass "kshrk decrypt --decrypt-identity-file: plaintext archive created"
+    else
+      fail "kshrk decrypt --decrypt-identity-file: output archive missing or empty"
+    fi
+
+    REC_SERVER_LOG="/tmp/k8shark-recipient-server-$$.log"
+    REC_KC="/tmp/k8shark-recipient-kc-$$.yaml"
+    REC_SERVER_PID=""
+    "$BINARY" open "$DEC_RECIPIENT_FILE" --kubeconfig-out "$REC_KC" >"$REC_SERVER_LOG" 2>&1 &
+    REC_SERVER_PID=$!
+    for i in $(seq 1 30); do
+      if [[ -s "$REC_KC" ]]; then break; fi
       sleep 0.5
     done
-    out=$(kubectl --kubeconfig "$REC_KC" --request-timeout=10s get pods -n k8shark-test -o name 2>&1) || true
-    assert_not_empty "open (recipient-decrypted archive): pods present" "$out"
-  fi
-  if [[ -n "$REC_SERVER_PID" ]]; then
-    kill "$REC_SERVER_PID" 2>/dev/null || true
-    wait "$REC_SERVER_PID" 2>/dev/null || true
-  fi
+    if [[ ! -s "$REC_KC" ]]; then
+      fail "open (recipient-decrypted archive): mock server did not start within 15s"
+    else
+      for i in $(seq 1 20); do
+        if kubectl --kubeconfig "$REC_KC" --request-timeout=2s \
+            get namespaces </dev/null &>/dev/null 2>&1; then
+          break
+        fi
+        sleep 0.5
+      done
+      out=$(kubectl --kubeconfig "$REC_KC" --request-timeout=10s get pods -n k8shark-test -o name 2>&1) || true
+      assert_not_empty "open (recipient-decrypted archive): pods present" "$out"
+    fi
+    if [[ -n "$REC_SERVER_PID" ]]; then
+      kill "$REC_SERVER_PID" 2>/dev/null || true
+      wait "$REC_SERVER_PID" 2>/dev/null || true
+    fi
 
-  rm -f "$ENC_RECIPIENT_FILE" "$DEC_RECIPIENT_FILE" "$AGE_IDENTITY_FILE" "$REC_SERVER_LOG" "$REC_KC"
+    rm -f "$ENC_RECIPIENT_FILE" "$DEC_RECIPIENT_FILE" "$AGE_IDENTITY_FILE" "$REC_SERVER_LOG" "$REC_KC"
+  fi
 fi
 
 # ── Phase 10: Summary ───────────────────────────────────────────────────────────

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1049,6 +1049,193 @@ if [[ -n "$ALL_TRUE_SERVER_PID" ]]; then
 fi
 rm -f "$ALL_TRUE_CAPTURE_FILE" "$ALL_TRUE_CONFIG" "$ALL_TRUE_SERVER_LOG" "$ALL_TRUE_KC"
 
+# ── Phase 9c: encrypt -> decrypt -> open -> kubectl (passphrase + recipient) ──
+log "Testing capture -> encrypt -> decrypt -> open -> kubectl"
+
+ENC_PASS_FILE="/tmp/k8shark-e2e-encpass-$$.txt"
+ENC_WRONG_PASS_FILE="/tmp/k8shark-e2e-encpass-wrong-$$.txt"
+echo "correct-horse-battery-staple-e2e" >"$ENC_PASS_FILE"
+echo "definitely-the-wrong-passphrase" >"$ENC_WRONG_PASS_FILE"
+
+# -- Passphrase mode --
+ENC_FILE="/tmp/k8shark-e2e-encrypted-$$.kshrk"
+"$BINARY" --config "$CAPTURE_CONFIG" capture \
+  --encrypt-passphrase-file "$ENC_PASS_FILE" \
+  --output "$ENC_FILE"
+if [[ -s "$ENC_FILE" ]]; then
+  pass "capture --encrypt-passphrase-file: encrypted archive created"
+else
+  fail "capture --encrypt-passphrase-file: archive missing or empty"
+fi
+
+# inspect with no key must reject the encrypted archive outright.
+out=$("$BINARY" inspect "$ENC_FILE" 2>&1) || true
+assert_contains "inspect (no passphrase): rejects encrypted archive" "$out" "encrypted"
+
+# inspect with the wrong passphrase must fail with the documented message.
+out=$("$BINARY" inspect "$ENC_FILE" --decrypt-passphrase-file "$ENC_WRONG_PASS_FILE" 2>&1) || true
+assert_contains "inspect (wrong passphrase): fails with documented message" "$out" "incorrect passphrase or key"
+
+# inspect with the correct passphrase succeeds.
+out=$("$BINARY" inspect "$ENC_FILE" --decrypt-passphrase-file "$ENC_PASS_FILE" 2>&1) || true
+assert_contains "inspect (correct passphrase): succeeds" "$out" "Capture ID:"
+
+# kshrk decrypt to a standalone plaintext archive.
+DEC_FILE="/tmp/k8shark-e2e-decrypted-$$.kshrk"
+"$BINARY" decrypt "$ENC_FILE" --decrypt-passphrase-file "$ENC_PASS_FILE" --output "$DEC_FILE"
+if [[ -s "$DEC_FILE" ]]; then
+  pass "kshrk decrypt: plaintext archive created"
+else
+  fail "kshrk decrypt: output archive missing or empty"
+fi
+
+# Open the decrypted archive (no key needed) and confirm kubectl works.
+ENC_DEC_SERVER_LOG="/tmp/k8shark-enc-dec-server-$$.log"
+ENC_DEC_KC="/tmp/k8shark-enc-dec-kc-$$.yaml"
+ENC_DEC_SERVER_PID=""
+"$BINARY" open "$DEC_FILE" --kubeconfig-out "$ENC_DEC_KC" >"$ENC_DEC_SERVER_LOG" 2>&1 &
+ENC_DEC_SERVER_PID=$!
+for i in $(seq 1 30); do
+  if [[ -s "$ENC_DEC_KC" ]]; then break; fi
+  sleep 0.5
+done
+if [[ ! -s "$ENC_DEC_KC" ]]; then
+  fail "open (decrypted archive): mock server did not start within 15s"
+else
+  for i in $(seq 1 20); do
+    if kubectl --kubeconfig "$ENC_DEC_KC" --request-timeout=2s \
+        get namespaces </dev/null &>/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+  done
+  out=$(kubectl --kubeconfig "$ENC_DEC_KC" --request-timeout=10s get pods -n k8shark-test -o name 2>&1) || true
+  assert_not_empty "open (decrypted archive): pods present" "$out"
+fi
+if [[ -n "$ENC_DEC_SERVER_PID" ]]; then
+  kill "$ENC_DEC_SERVER_PID" 2>/dev/null || true
+  wait "$ENC_DEC_SERVER_PID" 2>/dev/null || true
+fi
+
+# Open the STILL-encrypted archive directly, decrypting on the fly — no
+# separate decrypt step.
+ENC_OPEN_SERVER_LOG="/tmp/k8shark-enc-open-server-$$.log"
+ENC_OPEN_KC="/tmp/k8shark-enc-open-kc-$$.yaml"
+ENC_OPEN_SERVER_PID=""
+"$BINARY" open "$ENC_FILE" --decrypt-passphrase-file "$ENC_PASS_FILE" \
+  --kubeconfig-out "$ENC_OPEN_KC" >"$ENC_OPEN_SERVER_LOG" 2>&1 &
+ENC_OPEN_SERVER_PID=$!
+for i in $(seq 1 30); do
+  if [[ -s "$ENC_OPEN_KC" ]]; then break; fi
+  sleep 0.5
+done
+if [[ ! -s "$ENC_OPEN_KC" ]]; then
+  fail "open --decrypt-passphrase-file (still-encrypted archive): mock server did not start within 15s"
+else
+  for i in $(seq 1 20); do
+    if kubectl --kubeconfig "$ENC_OPEN_KC" --request-timeout=2s \
+        get namespaces </dev/null &>/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+  done
+  out=$(kubectl --kubeconfig "$ENC_OPEN_KC" --request-timeout=10s get pods -n k8shark-test -o name 2>&1) || true
+  assert_not_empty "open --decrypt-passphrase-file: pods present (decrypted on the fly)" "$out"
+fi
+if [[ -n "$ENC_OPEN_SERVER_PID" ]]; then
+  kill "$ENC_OPEN_SERVER_PID" 2>/dev/null || true
+  wait "$ENC_OPEN_SERVER_PID" 2>/dev/null || true
+fi
+
+rm -f "$ENC_FILE" "$DEC_FILE" "$ENC_PASS_FILE" "$ENC_WRONG_PASS_FILE" \
+  "$ENC_DEC_SERVER_LOG" "$ENC_DEC_KC" "$ENC_OPEN_SERVER_LOG" "$ENC_OPEN_KC"
+
+# -- Recipient-key mode --
+# Generate a throwaway age X25519 keypair via the age library already vendored
+# in go.sum, rather than depending on the separate age-keygen binary being
+# present in every environment this script runs in.
+KEYGEN_SRC="/tmp/k8shark-e2e-keygen-$$.go"
+cat >"$KEYGEN_SRC" <<'GOEOF'
+package main
+
+import (
+	"fmt"
+
+	"filippo.io/age"
+)
+
+func main() {
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(id.String())
+	fmt.Println(id.Recipient().String())
+}
+GOEOF
+KEYPAIR=$(cd "$PROJ_ROOT" && go run "$KEYGEN_SRC") || true
+rm -f "$KEYGEN_SRC"
+AGE_IDENTITY=$(echo "$KEYPAIR" | sed -n '1p')
+AGE_RECIPIENT=$(echo "$KEYPAIR" | sed -n '2p')
+
+if [[ -z "$AGE_IDENTITY" || -z "$AGE_RECIPIENT" ]]; then
+  fail "encrypt-recipient: failed to generate an age keypair"
+else
+  pass "encrypt-recipient: generated a test age keypair"
+
+  AGE_IDENTITY_FILE="/tmp/k8shark-e2e-age-identity-$$.txt"
+  echo "$AGE_IDENTITY" >"$AGE_IDENTITY_FILE"
+
+  ENC_RECIPIENT_FILE="/tmp/k8shark-e2e-encrypted-recipient-$$.kshrk"
+  "$BINARY" --config "$CAPTURE_CONFIG" capture \
+    --encrypt-recipient "$AGE_RECIPIENT" \
+    --output "$ENC_RECIPIENT_FILE"
+  if [[ -s "$ENC_RECIPIENT_FILE" ]]; then
+    pass "capture --encrypt-recipient: encrypted archive created"
+  else
+    fail "capture --encrypt-recipient: archive missing or empty"
+  fi
+
+  DEC_RECIPIENT_FILE="/tmp/k8shark-e2e-decrypted-recipient-$$.kshrk"
+  "$BINARY" decrypt "$ENC_RECIPIENT_FILE" \
+    --decrypt-identity-file "$AGE_IDENTITY_FILE" \
+    --output "$DEC_RECIPIENT_FILE"
+  if [[ -s "$DEC_RECIPIENT_FILE" ]]; then
+    pass "kshrk decrypt --decrypt-identity-file: plaintext archive created"
+  else
+    fail "kshrk decrypt --decrypt-identity-file: output archive missing or empty"
+  fi
+
+  REC_SERVER_LOG="/tmp/k8shark-recipient-server-$$.log"
+  REC_KC="/tmp/k8shark-recipient-kc-$$.yaml"
+  REC_SERVER_PID=""
+  "$BINARY" open "$DEC_RECIPIENT_FILE" --kubeconfig-out "$REC_KC" >"$REC_SERVER_LOG" 2>&1 &
+  REC_SERVER_PID=$!
+  for i in $(seq 1 30); do
+    if [[ -s "$REC_KC" ]]; then break; fi
+    sleep 0.5
+  done
+  if [[ ! -s "$REC_KC" ]]; then
+    fail "open (recipient-decrypted archive): mock server did not start within 15s"
+  else
+    for i in $(seq 1 20); do
+      if kubectl --kubeconfig "$REC_KC" --request-timeout=2s \
+          get namespaces </dev/null &>/dev/null 2>&1; then
+        break
+      fi
+      sleep 0.5
+    done
+    out=$(kubectl --kubeconfig "$REC_KC" --request-timeout=10s get pods -n k8shark-test -o name 2>&1) || true
+    assert_not_empty "open (recipient-decrypted archive): pods present" "$out"
+  fi
+  if [[ -n "$REC_SERVER_PID" ]]; then
+    kill "$REC_SERVER_PID" 2>/dev/null || true
+    wait "$REC_SERVER_PID" 2>/dev/null || true
+  fi
+
+  rm -f "$ENC_RECIPIENT_FILE" "$DEC_RECIPIENT_FILE" "$AGE_IDENTITY_FILE" "$REC_SERVER_LOG" "$REC_KC"
+fi
+
 # ── Phase 10: Summary ───────────────────────────────────────────────────────────
 log "Test summary"
 printf '  Passed: \033[1;32m%d\033[0m\n' "$PASS"

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -106,11 +106,18 @@ cleanup() {
   done
   info "Deleting KinD cluster '$CLUSTER_NAME'..."
   kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
-  rm -f "$CAPTURE_FILE" "$CAPTURE_CONFIG" "$KIND_KUBECONFIG" "$SERVER_LOG" \
-    "$ENC_PASS_FILE" "$ENC_WRONG_PASS_FILE" "$ENC_FILE" "$DEC_FILE" \
-    "$ENC_DEC_SERVER_LOG" "$ENC_DEC_KC" "$ENC_OPEN_SERVER_LOG" "$ENC_OPEN_KC" \
-    "$KEYGEN_SRC" "$AGE_IDENTITY_FILE" "$ENC_RECIPIENT_FILE" "$DEC_RECIPIENT_FILE" \
+  # Phase 9c's paths may still be "" if the script exited before reaching
+  # that phase; filter those out rather than passing empty strings to rm.
+  local cleanup_paths=(
+    "$CAPTURE_FILE" "$CAPTURE_CONFIG" "$KIND_KUBECONFIG" "$SERVER_LOG"
+    "$ENC_PASS_FILE" "$ENC_WRONG_PASS_FILE" "$ENC_FILE" "$DEC_FILE"
+    "$ENC_DEC_SERVER_LOG" "$ENC_DEC_KC" "$ENC_OPEN_SERVER_LOG" "$ENC_OPEN_KC"
+    "$KEYGEN_SRC" "$AGE_IDENTITY_FILE" "$ENC_RECIPIENT_FILE" "$DEC_RECIPIENT_FILE"
     "$REC_SERVER_LOG" "$REC_KC"
+  )
+  for p in "${cleanup_paths[@]}"; do
+    [[ -n "$p" ]] && rm -f "$p"
+  done
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
## Summary

Fixes #249 from [Phase 1 of the v1.0 readiness tracker](https://github.com/phenixblue/k8shark/issues/266).

Zero occurrences of `encrypt`/`decrypt` existed in either e2e script. `capture --encrypt`, `kshrk encrypt`, `kshrk decrypt`, and `open` on an encrypted archive had never run against a real capture in CI — the biggest E2E hole for the newest, flagship feature shipping in v1.0. Unit coverage (`internal/archive/crypto.go`, 22 test functions) was already thorough; nothing proved the CLI flags, passphrase prompting, and default output paths compose into a working workflow end to end.

## What this adds

Added to `scripts/e2e.sh`, against a real capture from the KinD cluster the rest of the script already sets up:

1. `capture --encrypt-passphrase-file`, then `inspect` with no key (rejected), the wrong passphrase (fails with the documented `incorrect passphrase or key` message), and the correct one (succeeds)
2. `kshrk decrypt` to a standalone plaintext archive, then `open` + `kubectl` against it
3. `open` directly against the still-encrypted archive with `--decrypt-passphrase-file` (no separate decrypt step)
4. `capture --encrypt-recipient` against a throwaway age keypair, `decrypt --decrypt-identity-file`, `open` + `kubectl`

The recipient keypair is generated via a tiny inline Go program using the `filippo.io/age` library already vendored in `go.sum` (`go run` on a heredoc-written file), rather than depending on a separate `age-keygen` binary being present in the CI/dev environment.

## Test plan / verification

**I could not run the full script end to end in this environment — no Docker available, so no KinD cluster.** What I did verify:

- [x] `bash -n scripts/e2e.sh` — syntax check passes.
- [x] Manually built the binary and exercised every command in the new phase against a real archive (the checked-in `golden-v1.kshrk` fixture): `encrypt --encrypt-passphrase-file`, `inspect` with no key / wrong passphrase / correct passphrase (all three messages match exactly), `decrypt --decrypt-passphrase-file`, `open` + kubeconfig + `kubectl`, `encrypt --encrypt-recipient` + `decrypt --decrypt-identity-file` with a generated keypair, and the `go run` keygen snippet itself.
- [x] `go build ./...`, `go vet ./...` clean (no Go source changed, this is a shell script only).

Given the lack of local KinD/Docker, I'd appreciate a CI run (or your own local run of `make e2e`) to confirm the full round trip against a live cluster before merging.

Closes #249