### PR TITLE
docs(archive): scope TestGoldenV1's comment to the plaintext fixture

### DIFF
--- a/internal/archive/format_test.go
+++ b/internal/archive/format_test.go
@@ -188,9 +188,10 @@ func TestGoldenV1(t *testing.T) {
 	}
 	if _, err := os.Stat(golden); err != nil {
 		// A missing fixture is the highest-consequence failure this test
-		// guards against: it silently disables the only check that a v1.0
-		// build can still read archives written by earlier releases. Fail
-		// loudly, don't skip (#251).
+		// guards against: it silently disables this test's check that a v1.0
+		// build can still read plaintext archives written by earlier
+		// releases (see TestGoldenV1Passphrase in crypto_test.go for the
+		// encrypted counterpart). Fail loudly, don't skip (#251).
 		t.Fatalf("golden fixture missing (run with -update to regenerate): %v", err)
 	}
 	if !*update {


### PR DESCRIPTION
## Summary

Follow-up from [#274](https://github.com/phenixblue/k8shark/pull/274)'s review: Copilot flagged (as a suppressed low-confidence comment) that `TestGoldenV1`'s missing-fixture comment claimed it's "the only check that a v1.0 build can still read archives written by earlier releases" — but `TestGoldenV1Passphrase` in `crypto_test.go` covers the encrypted counterpart. #274 was merged (and its branch deleted) before this comment could be addressed there, so it's a small standalone follow-up here.

## What changed

Scoped the comment to say "plaintext archives" and cross-referenced `TestGoldenV1Passphrase` for the encrypted case, instead of implying `TestGoldenV1` is the sole backward-compat guard. Comment-only change, no logic changes.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean, `go mod tidy` no diff, `golangci-lint run` clean.
- [x] `go test ./...` passes on all packages.