### PR TITLE
refactor(archive): extract internal/archive/format as a stdlib-only schema package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,15 @@ Therefore:
   with `/` redirecting there). The legacy v1 UI was removed in #91 — don't
   reference `/v1/` or `/api/ui/*`.
 - **Archive format version:** see `CheckFormatVersion` in
-  `internal/capture/record.go` and the "Format version & compatibility" section
-  of `docs/archive-format.md`. Semantics: `0` = pre-versioning (treated as v1),
+  `internal/archive/format/format.go` — the .kshrk schema types and version
+  check live in this stdlib-only leaf package so `internal/archive` can
+  reference them without an import cycle back to `internal/capture` (#233).
+  `internal/capture`'s `Record`/`CaptureMetadata`/`Index`/etc. are type
+  aliases to it, so existing `capture.X` call sites are unaffected.
+  `archive.Open`/`OpenWithIdentities` enforce the version check centrally,
+  so callers no longer need their own `CheckFormatVersion` call after
+  `ReadMetadata`. See also the "Format version & compatibility" section of
+  `docs/archive-format.md`. Semantics: `0` = pre-versioning (treated as v1),
   negative = corrupt (rejected), greater than `CurrentFormatVersion` = rejected
   with an "upgrade kshrk" error. Bump `CurrentFormatVersion` only on a breaking,
   structurally-incompatible change.
@@ -91,7 +98,9 @@ Therefore:
   ```
 
   claiming they need `&capture.IndexEntry{...}` because `Index` is
-  `map[string]*IndexEntry` (see `internal/capture/record.go`). This is valid Go:
+  `map[string]*IndexEntry` (see `internal/archive/format/format.go`, aliased
+  as `capture.Index`/`capture.IndexEntry` in `internal/capture/record.go`).
+  This is valid Go:
   the spec lets you elide the `&T` for map/array/slice values whose element type
   is a pointer to a composite literal ("elements or keys that are addresses of
   composite literals may elide the `&T` when the element or key type is `*T`").

--- a/cmd/decrypt_flags_test.go
+++ b/cmd/decrypt_flags_test.go
@@ -8,6 +8,7 @@ import (
 
 	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +35,7 @@ func writeEncryptedArchive(t *testing.T, path, passphrase string) {
 	if err != nil {
 		t.Fatalf("NewEncryptedStreamWriter: %v", err)
 	}
-	rec := map[string]any{"id": "r1", "api_path": "/api/v1/nodes"}
+	rec := &capture.Record{ID: "r1", APIPath: "/api/v1/nodes"}
 	if _, err := sw.WriteRecord(rec); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}
@@ -49,7 +50,7 @@ func writePlaintextArchive(t *testing.T, path string) {
 	if err != nil {
 		t.Fatalf("NewStreamWriter: %v", err)
 	}
-	rec := map[string]any{"id": "r1", "api_path": "/api/v1/nodes"}
+	rec := &capture.Record{ID: "r1", APIPath: "/api/v1/nodes"}
 	if _, err := sw.WriteRecord(rec); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}
@@ -104,12 +105,12 @@ func TestResolveDecryptIdentities_PassphraseFile(t *testing.T) {
 		t.Fatalf("OpenWithIdentities: %v", err)
 	}
 	defer ar.Close()
-	var meta map[string]any
-	if err := ar.ReadMetadata(&meta); err != nil {
+	meta, err := ar.ReadMetadata()
+	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	if meta["capture_id"] != "enc" {
-		t.Errorf("capture_id = %v, want enc", meta["capture_id"])
+	if meta.CaptureID != "enc" {
+		t.Errorf("capture_id = %v, want enc", meta.CaptureID)
 	}
 }
 
@@ -148,7 +149,7 @@ func TestResolveDecryptIdentities_IdentityFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEncryptedStreamWriter: %v", err)
 	}
-	if _, err := sw.WriteRecord(map[string]any{"id": "r1", "api_path": "/api/v1/nodes"}); err != nil {
+	if _, err := sw.WriteRecord(&capture.Record{ID: "r1", APIPath: "/api/v1/nodes"}); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}
 	if err := sw.Finish(map[string]any{"capture_id": "x25519"}, map[string]any{}, nil); err != nil {

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -179,7 +179,7 @@ func newStreamWriter(outputPath string, recipients []age.Recipient) (*StreamWrit
 // The record must have both ID and APIPath set. It returns the seq assigned
 // to the record, which is only valid when err is nil.
 func (w *StreamWriter) WriteRecord(rec *format.Record) (int, error) {
-	if rec.ID == "" || rec.APIPath == "" {
+	if rec == nil || rec.ID == "" || rec.APIPath == "" {
 		return 0, fmt.Errorf("record missing id or api_path field")
 	}
 	data, err := json.Marshal(rec)
@@ -342,6 +342,9 @@ func NewNDJSONWriter(w io.Writer) *NDJSONWriter {
 // to it within its api_path, matching StreamWriter's numbering even though
 // NDJSON output has no index to look it up by later.
 func (w *NDJSONWriter) WriteRecord(rec *format.Record) (int, error) {
+	if rec == nil {
+		return 0, fmt.Errorf("record missing id or api_path field")
+	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	b, err := json.Marshal(rec)

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -17,6 +17,8 @@ import (
 
 	"filippo.io/age"
 	"github.com/klauspost/compress/zstd"
+
+	"github.com/phenixblue/k8shark/internal/archive/format"
 )
 
 // epochModTime is a fixed, valid timestamp used for every ZIP entry so archives
@@ -31,7 +33,7 @@ type RecordSink interface {
 	// within its record's api_path — the same numbering readers use to
 	// address it later (see Archive.ReadRecord). The seq is only meaningful
 	// on success; callers must not use it when err is non-nil.
-	WriteRecord(rec any) (int, error)
+	WriteRecord(rec *format.Record) (int, error)
 	// Finish writes metadata.json, index.json, and (when watchIndex is non-nil)
 	// watch-index.json, then closes the archive.
 	Finish(meta, index, watchIndex any) error
@@ -174,38 +176,34 @@ func newStreamWriter(outputPath string, recipients []age.Recipient) (*StreamWrit
 
 // WriteRecord marshals rec to JSON, Zstd-compresses it, and appends it
 // to the ZIP archive under records/<pathDir(apiPath)>/<seq>.json.zst.
-// The record must have both "id" and "api_path" fields. It returns the seq
-// assigned to the record, which is only valid when err is nil.
-func (w *StreamWriter) WriteRecord(rec any) (int, error) {
+// The record must have both ID and APIPath set. It returns the seq assigned
+// to the record, which is only valid when err is nil.
+func (w *StreamWriter) WriteRecord(rec *format.Record) (int, error) {
+	if rec.ID == "" || rec.APIPath == "" {
+		return 0, fmt.Errorf("record missing id or api_path field")
+	}
 	data, err := json.Marshal(rec)
 	if err != nil {
 		return 0, fmt.Errorf("marshalling record: %w", err)
 	}
-	var hdr struct {
-		ID      string `json:"id"`
-		APIPath string `json:"api_path"`
-	}
-	if err := json.Unmarshal(data, &hdr); err != nil || hdr.ID == "" || hdr.APIPath == "" {
-		return 0, fmt.Errorf("record missing id or api_path field")
-	}
 
 	compressed, err := zstdCompress(data)
 	if err != nil {
-		return 0, fmt.Errorf("compressing record %s: %w", hdr.ID, err)
+		return 0, fmt.Errorf("compressing record %s: %w", rec.ID, err)
 	}
 
-	dir := pathDir(hdr.APIPath)
+	dir := pathDir(rec.APIPath)
 
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	seq := w.pathSeq[hdr.APIPath]
+	seq := w.pathSeq[rec.APIPath]
 	entryName := filepath.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq))
 
 	if err := writeBytes(w.zw, entryName, compressed); err != nil {
 		return 0, err
 	}
-	w.pathSeq[hdr.APIPath] = seq + 1
+	w.pathSeq[rec.APIPath] = seq + 1
 	w.n++
 	w.bytes += int64(len(data))
 	return seq, nil
@@ -343,7 +341,7 @@ func NewNDJSONWriter(w io.Writer) *NDJSONWriter {
 // WriteRecord encodes rec as a single JSON line and returns the seq assigned
 // to it within its api_path, matching StreamWriter's numbering even though
 // NDJSON output has no index to look it up by later.
-func (w *NDJSONWriter) WriteRecord(rec any) (int, error) {
+func (w *NDJSONWriter) WriteRecord(rec *format.Record) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	b, err := json.Marshal(rec)
@@ -351,12 +349,9 @@ func (w *NDJSONWriter) WriteRecord(rec any) (int, error) {
 		return 0, fmt.Errorf("marshalling record: %w", err)
 	}
 
-	var hdr struct {
-		APIPath string `json:"api_path"`
-	}
 	var seq int
-	if json.Unmarshal(b, &hdr) == nil && hdr.APIPath != "" {
-		seq = w.pathSeq[hdr.APIPath]
+	if rec.APIPath != "" {
+		seq = w.pathSeq[rec.APIPath]
 	}
 
 	if err := w.enc.Encode(rec); err != nil {
@@ -366,8 +361,8 @@ func (w *NDJSONWriter) WriteRecord(rec any) (int, error) {
 	// own only-meaningful-on-success rule, so a broken pipe mid-stream can't
 	// over-report bytes for a record that was never written.
 	w.bytes += int64(len(b))
-	if hdr.APIPath != "" {
-		w.pathSeq[hdr.APIPath] = seq + 1
+	if rec.APIPath != "" {
+		w.pathSeq[rec.APIPath] = seq + 1
 	}
 	w.n++
 	return seq, nil
@@ -403,12 +398,15 @@ type Archive struct {
 	size   int64
 	path   string
 	readN  atomic.Int64 // for diagnostics
+	meta   format.CaptureMetadata
 }
 
 // Open opens a k8shark archive for reading. The caller must call Close() when
 // done. If the archive is age-encrypted, Open returns a clear error instead
 // of a raw "not a valid zip file" failure; use OpenWithIdentities with key
-// material to open it.
+// material to open it. Open also reads and validates metadata.json against
+// format.CheckFormatVersion, so every caller gets the format-version gate for
+// free instead of needing to call it themselves after ReadMetadata.
 func Open(archivePath string) (*Archive, error) {
 	return openArchive(archivePath, nil)
 }
@@ -483,7 +481,23 @@ func openArchive(archivePath string, identities []age.Identity) (*Archive, error
 	for _, zf := range zr.File {
 		byName[zf.Name] = zf
 	}
-	return &Archive{zr: zr, closer: f, byName: byName, size: fi.Size(), path: archivePath}, nil
+	ar := &Archive{zr: zr, closer: f, byName: byName, size: fi.Size(), path: archivePath}
+
+	metaData, err := ar.readRaw("k8shark-capture/metadata.json")
+	if err != nil {
+		f.Close()
+		return nil, fmt.Errorf("reading metadata.json: %w", err)
+	}
+	if err := json.Unmarshal(metaData, &ar.meta); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("parsing metadata.json in archive %q: %w", archivePath, err)
+	}
+	if err := format.CheckFormatVersion(ar.meta); err != nil {
+		f.Close()
+		return nil, err
+	}
+
+	return ar, nil
 }
 
 // Close releases the underlying file handle.
@@ -495,45 +509,44 @@ func (a *Archive) Path() string { return a.path }
 // Size returns the on-disk size of the archive in bytes.
 func (a *Archive) Size() int64 { return a.size }
 
-// ReadMetadata reads and parses metadata.json from the archive.
-func (a *Archive) ReadMetadata(v any) error {
-	data, err := a.readRaw("k8shark-capture/metadata.json")
-	if err != nil {
-		return fmt.Errorf("reading metadata.json: %w", err)
-	}
-	if err := json.Unmarshal(data, v); err != nil {
-		return fmt.Errorf("parsing metadata.json in archive %q: %w", a.path, err)
-	}
-	return nil
+// ReadMetadata returns the archive's metadata.json, already parsed and
+// validated against format.CheckFormatVersion by Open — Open cannot have
+// succeeded otherwise, so this never actually fails, but it still returns an
+// error for symmetry with ReadIndex/ReadWatchIndex and to leave room for a
+// future on-demand read without a signature change.
+func (a *Archive) ReadMetadata() (format.CaptureMetadata, error) {
+	return a.meta, nil
 }
 
 // ReadIndex reads and parses the Zstd-compressed index.json.zst.
-func (a *Archive) ReadIndex(v any) error {
+func (a *Archive) ReadIndex() (format.Index, error) {
 	data, err := a.readZstd("k8shark-capture/index.json.zst")
 	if err != nil {
-		return fmt.Errorf("reading index.json.zst: %w", err)
+		return nil, fmt.Errorf("reading index.json.zst: %w", err)
 	}
-	if err := json.Unmarshal(data, v); err != nil {
-		return fmt.Errorf("parsing index.json.zst in archive %q: %w", a.path, err)
+	var idx format.Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return nil, fmt.Errorf("parsing index.json.zst in archive %q: %w", a.path, err)
 	}
-	return nil
+	return idx, nil
 }
 
 // ReadWatchIndex reads and parses watch-index.json.zst, if present.
-// Returns (false, nil) when the archive has no watch index.
-func (a *Archive) ReadWatchIndex(v any) (bool, error) {
+// Returns (nil, false, nil) when the archive has no watch index.
+func (a *Archive) ReadWatchIndex() (format.WatchIndex, bool, error) {
 	const name = "k8shark-capture/watch-index.json.zst"
 	if _, ok := a.byName[name]; !ok {
-		return false, nil
+		return nil, false, nil
 	}
 	data, err := a.readZstd(name)
 	if err != nil {
-		return false, fmt.Errorf("reading watch-index.json.zst: %w", err)
+		return nil, false, fmt.Errorf("reading watch-index.json.zst: %w", err)
 	}
-	if err := json.Unmarshal(data, v); err != nil {
-		return true, fmt.Errorf("parsing watch-index.json.zst in archive %q: %w", a.path, err)
+	var wi format.WatchIndex
+	if err := json.Unmarshal(data, &wi); err != nil {
+		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %q: %w", a.path, err)
 	}
-	return true, nil
+	return wi, true, nil
 }
 
 // ReadRecord reads the record at sequence seq under apiPath.

--- a/internal/archive/bench_test.go
+++ b/internal/archive/bench_test.go
@@ -4,22 +4,19 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+
+	"github.com/phenixblue/k8shark/internal/archive/format"
 )
 
-// sampleRecord is a minimal JSON object with an id field — the minimum
+// sampleRecord is a minimal record with an id field — the minimum
 // WriteRecord requires.
-func sampleRecord(i int) any {
-	return map[string]any{
-		"id":            fmt.Sprintf("record-%04d", i),
-		"captured_at":   "2026-04-10T10:00:00Z",
-		"api_path":      "/api/v1/namespaces/default/pods",
-		"http_method":   "GET",
-		"response_code": 200,
-		"response_body": map[string]any{
-			"kind":       "PodList",
-			"apiVersion": "v1",
-			"items":      []any{},
-		},
+func sampleRecord(i int) *format.Record {
+	return &format.Record{
+		ID:           fmt.Sprintf("record-%04d", i),
+		APIPath:      "/api/v1/namespaces/default/pods",
+		HTTPMethod:   "GET",
+		ResponseCode: 200,
+		ResponseBody: []byte(`{"kind":"PodList","apiVersion":"v1","items":[]}`),
 	}
 }
 

--- a/internal/archive/corrupt_test.go
+++ b/internal/archive/corrupt_test.go
@@ -135,8 +135,7 @@ func TestReadWatchIndex_MalformedEntry_StillReportsPresent(t *testing.T) {
 	}
 	defer ar.Close()
 
-	var wi map[string]any
-	found, err := ar.ReadWatchIndex(&wi)
+	_, found, err := ar.ReadWatchIndex()
 	if err == nil {
 		t.Fatal("ReadWatchIndex on a malformed entry succeeded, want error")
 	}
@@ -150,9 +149,12 @@ func TestReadWatchIndex_MalformedEntry_StillReportsPresent(t *testing.T) {
 // writes records in place via os.Create and only writes the index/metadata
 // in Finish, so an interrupted capture is a ZIP with records but no central
 // directory), plus a truncated transfer, garbage bytes, and a structurally
-// valid ZIP with a missing or malformed metadata.json. Every case must
-// produce a clear, non-nil error naming the archive path — never a panic,
-// a nil-map, or a wrong-but-plausible answer (#248).
+// valid ZIP with a missing or malformed metadata.json. Open reads and
+// validates metadata.json eagerly (#233), so every case here fails at Open
+// time — there's no longer a separate "Open succeeds, ReadMetadata fails"
+// path to exercise. Every case must produce a clear, non-nil error naming
+// the archive path — never a panic, a nil-map, or a wrong-but-plausible
+// answer (#248).
 func TestOpen_CorruptArchives(t *testing.T) {
 	valid := filepath.Join(t.TempDir(), "valid.kshrk")
 	sampleArchive(t, valid)
@@ -220,7 +222,7 @@ func TestOpen_CorruptArchives(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "corrupt.kshrk")
 			tc.build(t, path)
 
-			var openErr, metaErr error
+			var openErr error
 			func() {
 				defer func() {
 					if r := recover(); r != nil {
@@ -229,30 +231,19 @@ func TestOpen_CorruptArchives(t *testing.T) {
 				}()
 				ar, err := Open(path)
 				openErr = err
-				if err != nil {
-					return
+				if err == nil {
+					ar.Close()
 				}
-				defer ar.Close()
-				var meta map[string]any
-				metaErr = ar.ReadMetadata(&meta)
 			}()
 
-			if openErr == nil && metaErr == nil {
-				t.Fatal("expected an error from Open or ReadMetadata, got nil for both")
+			if openErr == nil {
+				t.Fatal("expected Open to fail, got nil")
 			}
-			if openErr != nil && !strings.Contains(openErr.Error(), path) {
+			if !strings.Contains(openErr.Error(), path) {
 				t.Errorf("Open error = %v, want it to name the archive path %q", openErr, path)
 			}
-			if metaErr != nil && !strings.Contains(metaErr.Error(), path) {
-				t.Errorf("ReadMetadata error = %v, want it to name the archive path %q", metaErr, path)
-			}
-			if tc.wantActionable {
-				if openErr == nil {
-					t.Fatalf("expected Open to fail with a corrupt/incomplete diagnosis, got nil")
-				}
-				if !strings.Contains(openErr.Error(), "corrupt or incomplete") {
-					t.Errorf("Open error = %v, want it to recognize the archive as corrupt or incomplete", openErr)
-				}
+			if tc.wantActionable && !strings.Contains(openErr.Error(), "corrupt or incomplete") {
+				t.Errorf("Open error = %v, want it to recognize the archive as corrupt or incomplete", openErr)
 			}
 		})
 	}

--- a/internal/archive/crypto_test.go
+++ b/internal/archive/crypto_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"filippo.io/age"
+
+	"github.com/phenixblue/k8shark/internal/archive/format"
 )
 
 // testPassphrase is a fixed, documented test-only passphrase. It must never
@@ -25,10 +27,10 @@ func sampleEncryptedArchive(t *testing.T, path string, recipients []age.Recipien
 	if err != nil {
 		t.Fatalf("NewEncryptedStreamWriter: %v", err)
 	}
-	rec := map[string]any{
-		"id": "rec-1", "api_path": "/api/v1/namespaces/default/pods",
-		"http_method": "GET", "response_code": 200,
-		"response_body": map[string]any{"apiVersion": "v1", "kind": "PodList", "items": []any{}},
+	rec := &format.Record{
+		ID: "rec-1", APIPath: "/api/v1/namespaces/default/pods",
+		HTTPMethod: "GET", ResponseCode: 200,
+		ResponseBody: []byte(`{"apiVersion":"v1","kind":"PodList","items":[]}`),
 	}
 	if _, err := sw.WriteRecord(rec); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
@@ -72,12 +74,12 @@ func TestEncryptedArchiveRoundTrip_Passphrase(t *testing.T) {
 	}
 	defer ar.Close()
 
-	var meta map[string]any
-	if err := ar.ReadMetadata(&meta); err != nil {
+	meta, err := ar.ReadMetadata()
+	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	if meta["capture_id"] != "encrypted-v1" {
-		t.Errorf("metadata.capture_id = %v", meta["capture_id"])
+	if meta.CaptureID != "encrypted-v1" {
+		t.Errorf("metadata.capture_id = %v", meta.CaptureID)
 	}
 	data, err := ar.ReadRecord("/api/v1/namespaces/default/pods", 0)
 	if err != nil {
@@ -102,12 +104,12 @@ func TestEncryptedArchiveRoundTrip_X25519(t *testing.T) {
 	}
 	defer ar.Close()
 
-	var meta map[string]any
-	if err := ar.ReadMetadata(&meta); err != nil {
+	meta, err := ar.ReadMetadata()
+	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	if meta["capture_id"] != "encrypted-v1" {
-		t.Errorf("metadata.capture_id = %v", meta["capture_id"])
+	if meta.CaptureID != "encrypted-v1" {
+		t.Errorf("metadata.capture_id = %v", meta.CaptureID)
 	}
 }
 
@@ -208,7 +210,7 @@ func TestEncryptedArchiveConcurrentReads(t *testing.T) {
 	idx := map[string]any{}
 	seqs := make([]int, 0, n)
 	for i := 0; i < n; i++ {
-		rec := map[string]any{"id": "rec", "api_path": "/api/v1/pods", "n": i}
+		rec := &format.Record{ID: "rec", APIPath: "/api/v1/pods", ResponseBody: []byte(`{}`)}
 		if _, err := sw.WriteRecord(rec); err != nil {
 			t.Fatalf("WriteRecord: %v", err)
 		}
@@ -285,10 +287,8 @@ func TestGoldenV1Passphrase(t *testing.T) {
 		t.Fatalf("OpenWithIdentities(golden): %v", err)
 	}
 	defer ar.Close()
-	var meta struct {
-		CaptureID string `json:"capture_id"`
-	}
-	if err := ar.ReadMetadata(&meta); err != nil {
+	meta, err := ar.ReadMetadata()
+	if err != nil {
 		t.Fatalf("ReadMetadata(golden): %v", err)
 	}
 	if meta.CaptureID != "encrypted-v1" {
@@ -310,12 +310,12 @@ func TestPlaintextArchiveStillOpens(t *testing.T) {
 		t.Fatalf("Open(plaintext): %v", err)
 	}
 	defer ar.Close()
-	var meta map[string]any
-	if err := ar.ReadMetadata(&meta); err != nil {
+	meta, err := ar.ReadMetadata()
+	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	if meta["capture_id"] != "golden-v1" {
-		t.Errorf("metadata.capture_id = %v", meta["capture_id"])
+	if meta.CaptureID != "golden-v1" {
+		t.Errorf("metadata.capture_id = %v", meta.CaptureID)
 	}
 
 	// OpenWithIdentities must also work transparently on a plaintext archive.

--- a/internal/archive/decompression_bomb_test.go
+++ b/internal/archive/decompression_bomb_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/klauspost/compress/zstd"
+
+	"github.com/phenixblue/k8shark/internal/archive/format"
 )
 
 // bombSize is how large a "bomb" fixture decompresses to: one byte past the
@@ -71,14 +73,14 @@ func TestArchive_ZstdBombRecord_ReturnsSizeLimitError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStreamWriter: %v", err)
 	}
-	bomb := map[string]any{
-		"id": "bomb-1", "api_path": "/api/v1/namespaces/default/pods",
-		"http_method": "GET", "response_code": 200,
+	bomb := &format.Record{
+		ID: "bomb-1", APIPath: "/api/v1/namespaces/default/pods",
+		HTTPMethod: "GET", ResponseCode: 200,
 		// Highly compressible: one byte past the cap once decompressed, but
-		// tiny once zstd-compressed. WriteRecord's any-typed API has no
-		// streaming form, so this string is necessarily materialized whole —
-		// bombSize (not an arbitrarily large size) keeps that to a minimum.
-		"response_body": strings.Repeat("A", bombSize),
+		// tiny once zstd-compressed. WriteRecord has no streaming form, so
+		// this string is necessarily materialized whole — bombSize (not an
+		// arbitrarily large size) keeps that to a minimum.
+		ResponseBody: []byte(`"` + strings.Repeat("A", bombSize) + `"`),
 	}
 	if _, err := sw.WriteRecord(bomb); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
@@ -136,16 +138,11 @@ func TestOpen_DeflateBombEntry_ReturnsSizeLimitError(t *testing.T) {
 		t.Fatalf("file Close: %v", err)
 	}
 
-	ar, err := Open(outPath)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer ar.Close()
-
-	var meta map[string]any
-	err = ar.ReadMetadata(&meta)
+	// Open reads and validates metadata.json eagerly (#233), so the bomb is
+	// caught here rather than via a later ReadMetadata call.
+	_, err = Open(outPath)
 	if err == nil {
-		t.Fatal("expected a size-limit error reading a deflate-bomb entry, got nil")
+		t.Fatal("expected a size-limit error opening a deflate-bomb metadata.json, got nil")
 	}
 	if !strings.Contains(err.Error(), outPath) {
 		t.Errorf("error = %v, want it to name the archive path %q", err, outPath)
@@ -168,10 +165,10 @@ func TestArchive_LargeLegitimateEntry_StillOpens(t *testing.T) {
 	if _, err := rand.Read(body); err != nil {
 		t.Fatalf("rand.Read: %v", err)
 	}
-	rec := map[string]any{
-		"id": "large-1", "api_path": "/api/v1/namespaces/default/pods",
-		"http_method": "GET", "response_code": 200,
-		"response_body": fmt.Sprintf("%x", body),
+	rec := &format.Record{
+		ID: "large-1", APIPath: "/api/v1/namespaces/default/pods",
+		HTTPMethod: "GET", ResponseCode: 200,
+		ResponseBody: []byte(`"` + fmt.Sprintf("%x", body) + `"`),
 	}
 	if _, err := sw.WriteRecord(rec); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
@@ -239,11 +236,11 @@ func TestOpen_ZipSlipEntryNameIsInert(t *testing.T) {
 	}
 	defer ar.Close()
 
-	var meta map[string]any
-	if err := ar.ReadMetadata(&meta); err != nil {
+	meta, err := ar.ReadMetadata()
+	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	if meta["capture_id"] != "zipslip-test" {
+	if meta.CaptureID != "zipslip-test" {
 		t.Fatalf("unexpected metadata: %+v", meta)
 	}
 

--- a/internal/archive/format/format.go
+++ b/internal/archive/format/format.go
@@ -1,0 +1,110 @@
+// Package format holds the .kshrk on-disk schema types and format-version
+// check. It is stdlib-only so internal/archive can depend on it directly
+// without an import cycle (internal/capture, which owns the fuller capture
+// pipeline, imports internal/archive — not the other way around).
+package format
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// CurrentFormatVersion is the .kshrk archive schema version written by this
+// build. It is bumped ONLY on a breaking, structurally-incompatible change.
+// Additive, backward-compatible changes (new omitempty metadata fields, new
+// optional archive entries) keep the same version. Archives written before this
+// field existed report 0 and are treated as version 1 — they are structurally
+// identical, the marker is simply the only addition.
+const CurrentFormatVersion = 1
+
+// CheckFormatVersion reports whether an archive can be read by this build.
+// A version newer than this build understands is rejected so we never silently
+// misread an incompatible layout. A zero version (pre-versioning archive) is
+// compatible. A negative version is invalid — it only arises from a corrupt or
+// tampered metadata.json, so it is rejected rather than rendered as "v-1".
+func CheckFormatVersion(m CaptureMetadata) error {
+	if m.FormatVersion < 0 {
+		return fmt.Errorf("archive format version %d is invalid (corrupt metadata?)", m.FormatVersion)
+	}
+	if m.FormatVersion > CurrentFormatVersion {
+		return fmt.Errorf("archive format version %d is newer than this kshrk supports (%d); upgrade kshrk to read it", m.FormatVersion, CurrentFormatVersion)
+	}
+	return nil
+}
+
+// Record holds one polled API response.
+type Record struct {
+	ID           string            `json:"id"`
+	CapturedAt   time.Time         `json:"captured_at"`
+	APIPath      string            `json:"api_path"`
+	EventType    string            `json:"event_type,omitempty"`
+	HTTPMethod   string            `json:"http_method"`
+	QueryParams  map[string]string `json:"query_params,omitempty"`
+	ResponseCode int               `json:"response_code"`
+	ResponseBody json.RawMessage   `json:"response_body"`
+}
+
+// CaptureMetadata is written as metadata.json inside the archive.
+type CaptureMetadata struct {
+	// FormatVersion is the archive schema version (see CurrentFormatVersion).
+	// Omitted/zero in pre-versioning archives, which are treated as version 1.
+	FormatVersion     int       `json:"format_version,omitempty"`
+	CaptureID         string    `json:"capture_id"`
+	CapturedAt        time.Time `json:"captured_at"`
+	CapturedUntil     time.Time `json:"captured_until"`
+	KubernetesVersion string    `json:"kubernetes_version"`
+	ServerAddress     string    `json:"server_address"`
+	RecordCount       int       `json:"record_count"`
+	DeduplicatedCount int       `json:"deduplicated_count"`
+	// Capture configuration facts, recorded so the UI can describe how the
+	// archive was produced. Omitted (zero) in archives captured before these
+	// fields existed.
+	AutoDiscovered    bool     `json:"auto_discovered,omitempty"`
+	WatchEnabled      bool     `json:"watch_enabled,omitempty"`
+	Intervals         []string `json:"intervals,omitempty"`
+	UncompressedBytes int64    `json:"uncompressed_bytes,omitempty"`
+	Redacted          bool     `json:"redacted,omitempty"`
+	SecretsRedacted   int      `json:"secrets_redacted,omitempty"`
+	FieldsRedacted    int      `json:"fields_redacted,omitempty"`
+	// Encrypted is true when the archive was written as an encrypted (age)
+	// envelope. It is informational only: encryption is detected structurally
+	// by sniffing the file, not from this field (which lives inside the
+	// ciphertext and so is only readable after decryption). Omitted for
+	// plaintext archives.
+	Encrypted bool `json:"encrypted,omitempty"`
+}
+
+// IndexEntry maps an API path to the ordered list of record sequence numbers.
+// Seqs[i] is the 0-based sequence index of the i-th record for this path,
+// matching the on-disk filename records/<pathDir>/<seq>.json.zst.
+type IndexEntry struct {
+	APIPath string      `json:"api_path"`
+	Seqs    []int       `json:"seqs"`
+	Times   []time.Time `json:"times"`
+	// Counts[i] is the number of top-level items in record i. Populated for
+	// list-shaped responses (anything with an items[] field or rows[] for
+	// Table responses); 0 for non-list records (single objects, discovery
+	// documents, OpenAPI specs). Optional — older archives omit this field
+	// and consumers must treat a nil/short Counts as "unknown" rather than 0.
+	Counts []int `json:"counts,omitempty"`
+}
+
+// Index is the top-level index.json written inside the archive.
+// Key is the canonical API path.
+type Index map[string]*IndexEntry
+
+// WatchIndexEntry maps an API path to the ordered watch events captured for it.
+// Each watch event is a separate record with event_type ADDED, MODIFIED, or DELETED.
+// EventTypes is kept in sync with Seqs and Times for fast filtering without
+// reading every record file.
+type WatchIndexEntry struct {
+	APIPath    string      `json:"api_path"`
+	Seqs       []int       `json:"seqs"`
+	Times      []time.Time `json:"times"`
+	EventTypes []string    `json:"event_types"`
+}
+
+// WatchIndex is the top-level watch-index.json written inside the archive.
+// Key is the canonical API path. Only present in archives captured with watch: true.
+type WatchIndex map[string]*WatchIndexEntry

--- a/internal/archive/format_test.go
+++ b/internal/archive/format_test.go
@@ -126,6 +126,22 @@ func TestArchiveFormatContract(t *testing.T) {
 	}
 }
 
+// TestStreamWriter_WriteRecord_NilRecord verifies a nil *format.Record
+// returns a clean error rather than panicking on a nil-pointer dereference —
+// a regression risk introduced when WriteRecord's parameter was retyped from
+// any to *format.Record (#233).
+func TestStreamWriter_WriteRecord_NilRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nil-record.kshrk")
+	sw, err := NewStreamWriter(path)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	defer func() { _ = sw.Abort() }()
+	if _, err := sw.WriteRecord(nil); err == nil {
+		t.Fatal("WriteRecord(nil) succeeded, want error")
+	}
+}
+
 // TestReaderAcceptsDeflateEntries proves the switch to Store stays
 // backward-compatible: an archive whose entries were written with Deflate (the
 // pre-change behavior) still opens, because the reader is ZIP-method-agnostic.

--- a/internal/archive/format_test.go
+++ b/internal/archive/format_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/phenixblue/k8shark/internal/archive/format"
 )
 
 var update = flag.Bool("update", false, "regenerate golden testdata fixtures")
@@ -48,10 +50,10 @@ func sampleArchive(t *testing.T, path string) {
 	if err != nil {
 		t.Fatalf("NewStreamWriter: %v", err)
 	}
-	rec := map[string]any{
-		"id": "rec-1", "api_path": "/api/v1/namespaces/default/pods",
-		"http_method": "GET", "response_code": 200,
-		"response_body": map[string]any{"apiVersion": "v1", "kind": "PodList", "items": []any{}},
+	rec := &format.Record{
+		ID: "rec-1", APIPath: "/api/v1/namespaces/default/pods",
+		HTTPMethod: "GET", ResponseCode: 200,
+		ResponseBody: []byte(`{"apiVersion":"v1","kind":"PodList","items":[]}`),
 	}
 	if _, err := sw.WriteRecord(rec); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
@@ -112,12 +114,12 @@ func TestArchiveFormatContract(t *testing.T) {
 		t.Fatalf("Open: %v", err)
 	}
 	defer ar.Close()
-	var meta map[string]any
-	if err := ar.ReadMetadata(&meta); err != nil {
+	meta, err := ar.ReadMetadata()
+	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	if meta["capture_id"] != "golden-v1" {
-		t.Errorf("metadata.capture_id = %v", meta["capture_id"])
+	if meta.CaptureID != "golden-v1" {
+		t.Errorf("metadata.capture_id = %v", meta.CaptureID)
 	}
 	if _, err := ar.ReadRecord("/api/v1/namespaces/default/pods", 0); err != nil {
 		t.Errorf("ReadRecord: %v", err)
@@ -166,12 +168,12 @@ func TestReaderAcceptsDeflateEntries(t *testing.T) {
 		t.Fatalf("Open(deflate archive): %v", err)
 	}
 	defer ar.Close()
-	var meta map[string]any
-	if err := ar.ReadMetadata(&meta); err != nil {
+	meta, err := ar.ReadMetadata()
+	if err != nil {
 		t.Fatalf("ReadMetadata(deflate): %v", err)
 	}
-	if meta["capture_id"] != "deflate" {
-		t.Errorf("capture_id = %v, want deflate", meta["capture_id"])
+	if meta.CaptureID != "deflate" {
+		t.Errorf("capture_id = %v, want deflate", meta.CaptureID)
 	}
 }
 
@@ -203,11 +205,8 @@ func TestGoldenV1(t *testing.T) {
 		t.Fatalf("Open(golden): %v", err)
 	}
 	defer ar.Close()
-	var meta struct {
-		FormatVersion int    `json:"format_version"`
-		CaptureID     string `json:"capture_id"`
-	}
-	if err := ar.ReadMetadata(&meta); err != nil {
+	meta, err := ar.ReadMetadata()
+	if err != nil {
 		t.Fatalf("ReadMetadata(golden): %v", err)
 	}
 	if meta.FormatVersion != 1 {

--- a/internal/archive/ndjson_test.go
+++ b/internal/archive/ndjson_test.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/phenixblue/k8shark/internal/archive/format"
@@ -40,5 +41,16 @@ func TestNDJSONWriter_WriteRecord_FailedEncodeDoesNotAdvanceState(t *testing.T) 
 	}
 	if got := w.pathSeq["/api/v1/namespaces/default/pods"]; got != 0 {
 		t.Errorf("pathSeq[...] = %d, want 0 — a failed write must not consume a seq number", got)
+	}
+}
+
+// TestNDJSONWriter_WriteRecord_NilRecord verifies a nil *format.Record
+// returns a clean error rather than panicking on a nil-pointer dereference —
+// a regression risk introduced when WriteRecord's parameter was retyped from
+// any to *format.Record (#233).
+func TestNDJSONWriter_WriteRecord_NilRecord(t *testing.T) {
+	w := NewNDJSONWriter(io.Discard)
+	if _, err := w.WriteRecord(nil); err == nil {
+		t.Fatal("WriteRecord(nil) succeeded, want error")
 	}
 }

--- a/internal/archive/ndjson_test.go
+++ b/internal/archive/ndjson_test.go
@@ -3,6 +3,8 @@ package archive
 import (
 	"errors"
 	"testing"
+
+	"github.com/phenixblue/k8shark/internal/archive/format"
 )
 
 // failingWriter returns an error from every Write, simulating a broken pipe
@@ -22,10 +24,10 @@ func TestNDJSONWriter_WriteRecord_FailedEncodeDoesNotAdvanceState(t *testing.T) 
 	wantErr := errors.New("broken pipe")
 	w := NewNDJSONWriter(&failingWriter{err: wantErr})
 
-	rec := map[string]any{
-		"id": "rec-1", "api_path": "/api/v1/namespaces/default/pods",
-		"http_method": "GET", "response_code": 200,
-		"response_body": map[string]any{"apiVersion": "v1", "kind": "PodList", "items": []any{}},
+	rec := &format.Record{
+		ID: "rec-1", APIPath: "/api/v1/namespaces/default/pods",
+		HTTPMethod: "GET", ResponseCode: 200,
+		ResponseBody: []byte(`{"apiVersion":"v1","kind":"PodList","items":[]}`),
 	}
 	if _, err := w.WriteRecord(rec); !errors.Is(err, wantErr) {
 		t.Fatalf("WriteRecord error = %v, want %v", err, wantErr)

--- a/internal/capture/encrypt_test.go
+++ b/internal/capture/encrypt_test.go
@@ -74,15 +74,15 @@ func TestEngine_CaptureEncrypted(t *testing.T) {
 	}
 	defer ar.Close()
 
-	var meta CaptureMetadata
-	if err := ar.ReadMetadata(&meta); err != nil {
+	meta, err := ar.ReadMetadata()
+	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
 	if !meta.Encrypted {
 		t.Error("decrypted metadata.Encrypted = false, want true")
 	}
-	var idx Index
-	if err := ar.ReadIndex(&idx); err != nil {
+	idx, err := ar.ReadIndex()
+	if err != nil {
 		t.Fatalf("ReadIndex: %v", err)
 	}
 	if _, ok := idx["/api/v1/namespaces/default/pods"]; !ok {

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -26,19 +26,15 @@ type sliceSink struct {
 	pathSeq map[string]int
 }
 
-func (s *sliceSink) WriteRecord(rec any) (int, error) {
-	r, ok := rec.(*Record)
-	if !ok {
-		return 0, nil
-	}
+func (s *sliceSink) WriteRecord(rec *Record) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.records = append(s.records, r)
+	s.records = append(s.records, rec)
 	if s.pathSeq == nil {
 		s.pathSeq = make(map[string]int)
 	}
-	seq := s.pathSeq[r.APIPath]
-	s.pathSeq[r.APIPath] = seq + 1
+	seq := s.pathSeq[rec.APIPath]
+	s.pathSeq[rec.APIPath] = seq + 1
 	return seq, nil
 }
 func (s *sliceSink) Finish(_, _, _ any) error { return nil }
@@ -54,10 +50,10 @@ func (s *sliceSink) UncompressedBytes() int64 { return 0 }
 // entry, and must not be silent.
 type failingSink struct{ err error }
 
-func (s *failingSink) WriteRecord(any) (int, error) { return 0, s.err }
-func (s *failingSink) Finish(_, _, _ any) error     { return nil }
-func (s *failingSink) RecordCount() int             { return 0 }
-func (s *failingSink) UncompressedBytes() int64     { return 0 }
+func (s *failingSink) WriteRecord(*Record) (int, error) { return 0, s.err }
+func (s *failingSink) Finish(_, _, _ any) error         { return nil }
+func (s *failingSink) RecordCount() int                 { return 0 }
+func (s *failingSink) UncompressedBytes() int64         { return 0 }
 
 // fakeK8sServer returns an httptest.TLSServer that responds to the paths used by
 // a minimal capture config (pods in default, nodes cluster-scoped).
@@ -122,13 +118,11 @@ func TestEngine_CaptureToArchive(t *testing.T) {
 	defer ar.Close()
 
 	// metadata must be readable.
-	var capMeta CaptureMetadata
-	if err := ar.ReadMetadata(&capMeta); err != nil {
+	if _, err := ar.ReadMetadata(); err != nil {
 		t.Error("metadata.json missing from archive")
 	}
 	// index must be readable.
-	var capIdx Index
-	if err := ar.ReadIndex(&capIdx); err != nil {
+	if _, err := ar.ReadIndex(); err != nil {
 		t.Error("index.json missing from archive")
 	}
 
@@ -190,12 +184,12 @@ func TestEngine_CapturedAt_ReflectsPollStart(t *testing.T) {
 	}
 	defer ar.Close()
 
-	var meta CaptureMetadata
-	if err := ar.ReadMetadata(&meta); err != nil {
+	meta, err := ar.ReadMetadata()
+	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	var idx Index
-	if err := ar.ReadIndex(&idx); err != nil {
+	idx, err := ar.ReadIndex()
+	if err != nil {
 		t.Fatalf("ReadIndex: %v", err)
 	}
 
@@ -1925,7 +1919,10 @@ func TestConcurrentPollAndWatch_NoIndexSeqCollision(t *testing.T) {
 
 	wg.Wait()
 
-	if err := sw.Finish(nil, eng.index, eng.watchIndex); err != nil {
+	// archive.Open reads and validates metadata.json unconditionally (#233),
+	// so this needs a real (if minimal) metadata value now — this test only
+	// cares about index/watch-index seq correctness, not metadata content.
+	if err := sw.Finish(&CaptureMetadata{}, eng.index, eng.watchIndex); err != nil {
 		t.Fatalf("Finish: %v", err)
 	}
 
@@ -2148,21 +2145,12 @@ func TestEngine_MetadataIncludesDeduplicatedCount(t *testing.T) {
 		t.Fatalf("failed to open archive: %v", err)
 	}
 	defer ar2.Close()
-	var meta map[string]any
-	if err := ar2.ReadMetadata(&meta); err != nil {
+	meta, err := ar2.ReadMetadata()
+	if err != nil {
 		t.Fatalf("failed to read metadata: %v", err)
 	}
-
-	v, ok := meta["deduplicated_count"]
-	if !ok {
-		t.Fatal("metadata missing deduplicated_count")
-	}
-	count, ok := v.(float64)
-	if !ok {
-		t.Fatalf("deduplicated_count has unexpected type %T", v)
-	}
-	if count < 1 {
-		t.Fatalf("deduplicated_count = %v, want >= 1", count)
+	if meta.DeduplicatedCount < 1 {
+		t.Fatalf("deduplicated_count = %v, want >= 1", meta.DeduplicatedCount)
 	}
 }
 

--- a/internal/capture/record.go
+++ b/internal/capture/record.go
@@ -1,106 +1,25 @@
 package capture
 
-import (
-	"encoding/json"
-	"fmt"
-	"time"
-)
+import "github.com/phenixblue/k8shark/internal/archive/format"
 
-// CurrentFormatVersion is the .kshrk archive schema version written by this
-// build. It is bumped ONLY on a breaking, structurally-incompatible change.
-// Additive, backward-compatible changes (new omitempty metadata fields, new
-// optional archive entries) keep the same version. Archives written before this
-// field existed report 0 and are treated as version 1 — they are structurally
-// identical, the marker is simply the only addition.
-const CurrentFormatVersion = 1
+// CurrentFormatVersion and the schema types below are defined in
+// internal/archive/format (a stdlib-only leaf package) so internal/archive
+// can reference them directly without an import cycle — internal/capture
+// imports internal/archive, not the other way around. These aliases keep
+// every existing capture.X call site working unchanged.
+const CurrentFormatVersion = format.CurrentFormatVersion
 
 // CheckFormatVersion reports whether an archive can be read by this build.
-// A version newer than this build understands is rejected so we never silently
-// misread an incompatible layout. A zero version (pre-versioning archive) is
-// compatible. A negative version is invalid — it only arises from a corrupt or
-// tampered metadata.json, so it is rejected rather than rendered as "v-1".
+// See format.CheckFormatVersion for the full doc.
 func CheckFormatVersion(m CaptureMetadata) error {
-	if m.FormatVersion < 0 {
-		return fmt.Errorf("archive format version %d is invalid (corrupt metadata?)", m.FormatVersion)
-	}
-	if m.FormatVersion > CurrentFormatVersion {
-		return fmt.Errorf("archive format version %d is newer than this kshrk supports (%d); upgrade kshrk to read it", m.FormatVersion, CurrentFormatVersion)
-	}
-	return nil
+	return format.CheckFormatVersion(m)
 }
 
-// Record holds one polled API response.
-type Record struct {
-	ID           string            `json:"id"`
-	CapturedAt   time.Time         `json:"captured_at"`
-	APIPath      string            `json:"api_path"`
-	EventType    string            `json:"event_type,omitempty"`
-	HTTPMethod   string            `json:"http_method"`
-	QueryParams  map[string]string `json:"query_params,omitempty"`
-	ResponseCode int               `json:"response_code"`
-	ResponseBody json.RawMessage   `json:"response_body"`
-}
-
-// CaptureMetadata is written as metadata.json inside the archive.
-type CaptureMetadata struct {
-	// FormatVersion is the archive schema version (see CurrentFormatVersion).
-	// Omitted/zero in pre-versioning archives, which are treated as version 1.
-	FormatVersion     int       `json:"format_version,omitempty"`
-	CaptureID         string    `json:"capture_id"`
-	CapturedAt        time.Time `json:"captured_at"`
-	CapturedUntil     time.Time `json:"captured_until"`
-	KubernetesVersion string    `json:"kubernetes_version"`
-	ServerAddress     string    `json:"server_address"`
-	RecordCount       int       `json:"record_count"`
-	DeduplicatedCount int       `json:"deduplicated_count"`
-	// Capture configuration facts, recorded so the UI can describe how the
-	// archive was produced. Omitted (zero) in archives captured before these
-	// fields existed.
-	AutoDiscovered    bool     `json:"auto_discovered,omitempty"`
-	WatchEnabled      bool     `json:"watch_enabled,omitempty"`
-	Intervals         []string `json:"intervals,omitempty"`
-	UncompressedBytes int64    `json:"uncompressed_bytes,omitempty"`
-	Redacted          bool     `json:"redacted,omitempty"`
-	SecretsRedacted   int      `json:"secrets_redacted,omitempty"`
-	FieldsRedacted    int      `json:"fields_redacted,omitempty"`
-	// Encrypted is true when the archive was written as an encrypted (age)
-	// envelope. It is informational only: encryption is detected structurally
-	// by sniffing the file, not from this field (which lives inside the
-	// ciphertext and so is only readable after decryption). Omitted for
-	// plaintext archives.
-	Encrypted bool `json:"encrypted,omitempty"`
-}
-
-// IndexEntry maps an API path to the ordered list of record sequence numbers.
-// Seqs[i] is the 0-based sequence index of the i-th record for this path,
-// matching the on-disk filename records/<pathDir>/<seq>.json.zst.
-type IndexEntry struct {
-	APIPath string      `json:"api_path"`
-	Seqs    []int       `json:"seqs"`
-	Times   []time.Time `json:"times"`
-	// Counts[i] is the number of top-level items in record i. Populated for
-	// list-shaped responses (anything with an items[] field or rows[] for
-	// Table responses); 0 for non-list records (single objects, discovery
-	// documents, OpenAPI specs). Optional — older archives omit this field
-	// and consumers must treat a nil/short Counts as "unknown" rather than 0.
-	Counts []int `json:"counts,omitempty"`
-}
-
-// Index is the top-level index.json written inside the archive.
-// Key is the canonical API path.
-type Index map[string]*IndexEntry
-
-// WatchIndexEntry maps an API path to the ordered watch events captured for it.
-// Each watch event is a separate record with event_type ADDED, MODIFIED, or DELETED.
-// EventTypes is kept in sync with Seqs and Times for fast filtering without
-// reading every record file.
-type WatchIndexEntry struct {
-	APIPath    string      `json:"api_path"`
-	Seqs       []int       `json:"seqs"`
-	Times      []time.Time `json:"times"`
-	EventTypes []string    `json:"event_types"`
-}
-
-// WatchIndex is the top-level watch-index.json written inside the archive.
-// Key is the canonical API path. Only present in archives captured with watch: true.
-type WatchIndex map[string]*WatchIndexEntry
+type (
+	Record          = format.Record
+	CaptureMetadata = format.CaptureMetadata
+	IndexEntry      = format.IndexEntry
+	Index           = format.Index
+	WatchIndexEntry = format.WatchIndexEntry
+	WatchIndex      = format.WatchIndex
+)

--- a/internal/inspect/encrypt_test.go
+++ b/internal/inspect/encrypt_test.go
@@ -6,6 +6,7 @@ import (
 
 	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/archive/format"
 )
 
 // TestRun_Encrypted verifies inspect.Run threads identities through to the
@@ -24,8 +25,8 @@ func TestRun_Encrypted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEncryptedStreamWriter: %v", err)
 	}
-	rec := map[string]any{"id": "r1", "api_path": "/api/v1/nodes", "response_code": 200,
-		"response_body": map[string]any{"apiVersion": "v1", "kind": "NodeList", "items": []any{}}}
+	rec := &format.Record{ID: "r1", APIPath: "/api/v1/nodes", ResponseCode: 200,
+		ResponseBody: []byte(`{"apiVersion":"v1","kind":"NodeList","items":[]}`)}
 	if _, err := sw.WriteRecord(rec); err != nil {
 		t.Fatalf("WriteRecord: %v", err)
 	}

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -48,16 +48,13 @@ func Run(archivePath string, identities []age.Identity) (*Report, error) {
 	}
 	defer ar.Close()
 
-	var meta capture.CaptureMetadata
-	if err := ar.ReadMetadata(&meta); err != nil {
+	meta, err := ar.ReadMetadata()
+	if err != nil {
 		return nil, fmt.Errorf("reading metadata: %w", err)
 	}
-	if err := capture.CheckFormatVersion(meta); err != nil {
-		return nil, err
-	}
 
-	var idx capture.Index
-	if err := ar.ReadIndex(&idx); err != nil {
+	idx, err := ar.ReadIndex()
+	if err != nil {
 		return nil, fmt.Errorf("reading index: %w", err)
 	}
 

--- a/internal/redact/encrypt_test.go
+++ b/internal/redact/encrypt_test.go
@@ -115,8 +115,8 @@ func TestRedact_EncryptedRoundTrip(t *testing.T) {
 	}
 	defer ar.Close()
 
-	var meta capture.CaptureMetadata
-	if err := ar.ReadMetadata(&meta); err != nil {
+	meta, err := ar.ReadMetadata()
+	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
 	if !meta.Encrypted {

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -51,24 +51,20 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	}
 	defer ar.Close()
 
-	var meta capture.CaptureMetadata
-	if err := ar.ReadMetadata(&meta); err != nil {
+	meta, err := ar.ReadMetadata()
+	if err != nil {
 		return Result{}, fmt.Errorf("reading metadata: %w", err)
-	}
-	if err := capture.CheckFormatVersion(meta); err != nil {
-		return Result{}, err
 	}
 	// The redacted archive is written by the current writer, so stamp it with
 	// the current format version.
 	meta.FormatVersion = capture.CurrentFormatVersion
 
-	var idx capture.Index
-	if err := ar.ReadIndex(&idx); err != nil {
+	idx, err := ar.ReadIndex()
+	if err != nil {
 		return Result{}, fmt.Errorf("reading index: %w", err)
 	}
 
-	var wi capture.WatchIndex
-	_, _ = ar.ReadWatchIndex(&wi)
+	wi, _, _ := ar.ReadWatchIndex()
 
 	result := Result{}
 

--- a/internal/server/format_version_gate_test.go
+++ b/internal/server/format_version_gate_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/phenixblue/k8shark/internal/diff"
 	"github.com/phenixblue/k8shark/internal/inspect"
 	"github.com/phenixblue/k8shark/internal/redact"
-	"github.com/phenixblue/k8shark/internal/server"
 	"github.com/phenixblue/k8shark/internal/transitions"
 )
 
@@ -73,18 +72,18 @@ func TestAllReaders_RejectFutureFormatVersion(t *testing.T) {
 		}
 	}
 
-	t.Run("inspect.Run", func(t *testing.T) {
-		_, err := inspect.Run(path, nil)
+	t.Run("archive.Open", func(t *testing.T) {
+		// archive.Open enforces the format-version gate directly (#233), so
+		// every caller below — including server.LoadStore's, which used to
+		// be exercised as its own subtest — actually rejects the archive
+		// here, before ever reaching its own logic. Pinned explicitly since
+		// it's the thing this test now fundamentally relies on.
+		_, err := archive.Open(path)
 		assertUpgradeError(t, err)
 	})
 
-	t.Run("server.LoadStore", func(t *testing.T) {
-		ar, err := archive.Open(path)
-		if err != nil {
-			t.Fatalf("archive.Open: %v", err)
-		}
-		defer ar.Close()
-		_, err = server.LoadStore(ar)
+	t.Run("inspect.Run", func(t *testing.T) {
+		_, err := inspect.Run(path, nil)
 		assertUpgradeError(t, err)
 	})
 

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -93,16 +93,13 @@ type ResourceInfo struct {
 // below can't still be reading from the archive when it's closed (the
 // server's teardown does this).
 func LoadStore(ar *archive.Archive) (*CaptureStore, error) {
-	var meta capture.CaptureMetadata
-	if err := ar.ReadMetadata(&meta); err != nil {
+	meta, err := ar.ReadMetadata()
+	if err != nil {
 		return nil, fmt.Errorf("reading metadata: %w", err)
 	}
-	if err := capture.CheckFormatVersion(meta); err != nil {
-		return nil, err
-	}
 
-	var idx capture.Index
-	if err := ar.ReadIndex(&idx); err != nil {
+	idx, err := ar.ReadIndex()
+	if err != nil {
 		return nil, fmt.Errorf("reading index: %w", err)
 	}
 
@@ -118,8 +115,7 @@ func LoadStore(ar *archive.Archive) (*CaptureStore, error) {
 	}
 
 	// Load watch index if present.
-	var wi capture.WatchIndex
-	if found, err := ar.ReadWatchIndex(&wi); err == nil && found && wi != nil {
+	if wi, found, err := ar.ReadWatchIndex(); err == nil && found && wi != nil {
 		s.WatchIndex = wi
 	}
 

--- a/internal/server/version_test.go
+++ b/internal/server/version_test.go
@@ -48,9 +48,13 @@ func loadStoreWithVersion(t *testing.T, version int) (*CaptureStore, error) {
 	if err := sw.Finish(meta, idx, nil); err != nil {
 		t.Fatalf("Finish: %v", err)
 	}
+	// archive.Open itself enforces the format-version gate (#233), so a
+	// too-new archive is rejected here rather than by LoadStore below —
+	// propagate the error instead of failing the test so the "newer is
+	// rejected" case can assert on it regardless of which layer catches it.
 	ar, err := archive.Open(out)
 	if err != nil {
-		t.Fatalf("archive.Open: %v", err)
+		return nil, err
 	}
 	t.Cleanup(func() { ar.Close() })
 	return LoadStore(ar)

--- a/internal/transitions/transitions.go
+++ b/internal/transitions/transitions.go
@@ -55,22 +55,13 @@ func LoadTransitions(archivePath string, opts FilterOpts, identities []age.Ident
 	}
 	defer ar.Close()
 
-	var meta capture.CaptureMetadata
-	if err := ar.ReadMetadata(&meta); err != nil {
-		return nil, fmt.Errorf("reading metadata: %w", err)
-	}
-	if err := capture.CheckFormatVersion(meta); err != nil {
-		return nil, err
-	}
-
-	var idx capture.Index
-	if err := ar.ReadIndex(&idx); err != nil {
+	idx, err := ar.ReadIndex()
+	if err != nil {
 		return nil, fmt.Errorf("reading index: %w", err)
 	}
 
 	// Watch-index may be absent for older archives.
-	var wi capture.WatchIndex
-	_, _ = ar.ReadWatchIndex(&wi)
+	wi, _, _ := ar.ReadWatchIndex()
 
 	var all []Transition
 


### PR DESCRIPTION
## Summary

First PR of [Phase 2](https://github.com/phenixblue/k8shark/issues/266) (freezing the contracts ahead of v1.0). Foundational — #219 (index files as bare JSON maps) builds directly on this.

The .kshrk on-disk schema types (`Record`, `CaptureMetadata`, `Index`, `IndexEntry`, `WatchIndexEntry`, `CheckFormatVersion`) lived in `internal/capture/record.go` — a package that pulls in client-go, age, and uuid, and one that `internal/archive` can't import back without a cycle (`internal/capture` already imports `internal/archive`). That forced `archive.go`'s `ReadMetadata`/`ReadIndex`/`WriteRecord` to be untyped `any`, and left the format-version gate opt-in per caller (two callers had already forgotten it — see #250, fixed in Phase 1).

## What changed

- New `internal/archive/format` package (stdlib-only: `encoding/json`, `fmt`, `time`) holds the schema types and `CheckFormatVersion`, moved verbatim from `internal/capture/record.go`.
- `internal/capture/record.go` now type-aliases to it (`type Record = format.Record`, etc.), so every existing `capture.X` call site across the repo is unaffected — this was the key to keeping the blast radius contained.
- `archive.go`'s `ReadMetadata`/`ReadIndex`/`ReadWatchIndex`/`WriteRecord` are properly typed against `format.CaptureMetadata`/`format.Index`/`format.WatchIndex`/`*format.Record` instead of `any`.
- `archive.Open`/`OpenWithIdentities` now read and validate `metadata.json` (via `format.CheckFormatVersion`) as part of opening, instead of leaving that to each caller after their own `ReadMetadata` call. Removed the now-redundant explicit `CheckFormatVersion` calls in `inspect.go`, `server/store.go`, `redact.go`, and `transitions.go`.

## Test changes

- Format-version-gate tests that expected `Open` to succeed and a downstream call (`server.LoadStore`) to reject now expect `Open` itself to reject — that's the whole point of centralizing the gate.
- Corrupt-archive tests that exercised a separate "Open succeeds, `ReadMetadata` fails" path now assert directly on `Open`'s error, since `ReadMetadata` can no longer fail on its own (it returns already-validated, cached data).
- `internal/archive`'s own tests — which couldn't previously import `internal/capture` for a typed `Record` (that would be the exact cycle this PR fixes) — now use `format.Record` literals instead of `map[string]any`.
- One test (`TestConcurrentPollAndWatch_NoIndexSeqCollision`) deliberately called `Finish(nil, ...)` to skip writing `metadata.json` while isolating index-seq behavior; since `Open` now requires `metadata.json` to exist, it passes a minimal non-nil `CaptureMetadata` instead.

## Acceptance criteria (from #233)

- [x] `internal/archive/format` imports only stdlib
- [x] No `any` in the archive read/write signatures (`ReadMetadata`, `ReadIndex`, `ReadWatchIndex`, `WriteRecord`) — `Finish` is intentionally left `any`, matching the issue's scope; retyping it would touch ~44 call sites for no acceptance-criterion benefit
- [x] `archive.Open` enforces the format-version check
- [x] No import cycles

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean, `go mod tidy` no diff, `golangci-lint run` clean.
- [x] `go test ./...` and `go test -race ./...` pass on all packages.

Closes #233