### PR TITLE
fix(archive): surface malformed watch-index errors instead of silently degrading

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -543,7 +543,7 @@ func (a *Archive) ReadWatchIndex() (format.WatchIndex, bool, error) {
 	}
 	data, err := a.readZstd(name)
 	if err != nil {
-		return nil, false, fmt.Errorf("reading watch-index.json.zst: %w", err)
+		return nil, true, fmt.Errorf("reading watch-index.json.zst: %w", err)
 	}
 	var wi format.WatchIndex
 	if err := json.Unmarshal(data, &wi); err != nil {

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -549,6 +549,12 @@ func (a *Archive) ReadWatchIndex() (format.WatchIndex, bool, error) {
 	if err := json.Unmarshal(data, &wi); err != nil {
 		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %q: %w", a.path, err)
 	}
+	// The writer always emits at least "{}" (never a bare "null") for
+	// watch-index.json.zst, so a top-level JSON null here — which unmarshals
+	// to a nil map without error — is corrupt, not simply an empty index.
+	if wi == nil {
+		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %q: top-level null", a.path)
+	}
 	// A well-formed watch-index.json never has a null entry for a path — the
 	// writer only ever inserts a populated *WatchIndexEntry. A null entry here
 	// means the JSON is structurally valid but semantically corrupt, and every

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -549,6 +549,15 @@ func (a *Archive) ReadWatchIndex() (format.WatchIndex, bool, error) {
 	if err := json.Unmarshal(data, &wi); err != nil {
 		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %q: %w", a.path, err)
 	}
+	// A well-formed watch-index.json never has a null entry for a path — the
+	// writer only ever inserts a populated *WatchIndexEntry. A null entry here
+	// means the JSON is structurally valid but semantically corrupt, and every
+	// reader dereferences the entry (e.g. entry.Seqs) without a nil check.
+	for apiPath, entry := range wi {
+		if entry == nil {
+			return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %q: null entry for path %q", a.path, apiPath)
+		}
+	}
 	return wi, true, nil
 }
 

--- a/internal/archive/corrupt_test.go
+++ b/internal/archive/corrupt_test.go
@@ -190,11 +190,11 @@ func buildZipNullWatchIndexEntry(t *testing.T, path string) {
 	}
 }
 
-// buildZipUndecompressableWatchIndex writes a structurally valid ZIP archive
+// buildZipUndecompressibleWatchIndex writes a structurally valid ZIP archive
 // whose watch-index.json.zst entry is not valid Zstd data at all (as opposed
 // to buildZipMalformedWatchIndex, whose entry decompresses fine but fails to
 // parse as JSON) — e.g. bit-rot in the compressed bytes themselves.
-func buildZipUndecompressableWatchIndex(t *testing.T, path string) {
+func buildZipUndecompressibleWatchIndex(t *testing.T, path string) {
 	t.Helper()
 	f, err := os.Create(path)
 	if err != nil {
@@ -215,7 +215,7 @@ func buildZipUndecompressableWatchIndex(t *testing.T, path string) {
 		}
 	}
 
-	writeEntry("k8shark-capture/metadata.json", []byte(`{"format_version":1,"capture_id":"undecompressable-watch-index"}`))
+	writeEntry("k8shark-capture/metadata.json", []byte(`{"format_version":1,"capture_id":"undecompressible-watch-index"}`))
 	idxZ, err := zstdCompress([]byte(`{}`))
 	if err != nil {
 		t.Fatalf("zstdCompress(index): %v", err)
@@ -231,7 +231,7 @@ func buildZipUndecompressableWatchIndex(t *testing.T, path string) {
 	}
 }
 
-// TestReadWatchIndex_UndecompressableEntry_StillReportsPresent is a
+// TestReadWatchIndex_UndecompressibleEntry_StillReportsPresent is a
 // regression test: ReadWatchIndex's found return value means "the entry is
 // present in the archive", independent of whether it could even be
 // decompressed. A watch-index.json.zst entry that isn't valid Zstd data must
@@ -239,9 +239,9 @@ func buildZipUndecompressableWatchIndex(t *testing.T, path string) {
 // decompresses but fails to parse as JSON — otherwise a caller that checks
 // err first would still be fine, but found would inconsistently read
 // "absent" for one corruption mode and "present" for another.
-func TestReadWatchIndex_UndecompressableEntry_StillReportsPresent(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "undecompressable-watch-index.kshrk")
-	buildZipUndecompressableWatchIndex(t, path)
+func TestReadWatchIndex_UndecompressibleEntry_StillReportsPresent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "undecompressible-watch-index.kshrk")
+	buildZipUndecompressibleWatchIndex(t, path)
 
 	ar, err := Open(path)
 	if err != nil {
@@ -251,10 +251,80 @@ func TestReadWatchIndex_UndecompressableEntry_StillReportsPresent(t *testing.T) 
 
 	_, found, err := ar.ReadWatchIndex()
 	if err == nil {
-		t.Fatal("ReadWatchIndex on an undecompressable entry succeeded, want error")
+		t.Fatal("ReadWatchIndex on an undecompressible entry succeeded, want error")
 	}
 	if !found {
 		t.Error("ReadWatchIndex found = false, want true — the entry is present even though it couldn't be decompressed")
+	}
+}
+
+// buildZipNullWatchIndex writes a structurally valid ZIP archive whose
+// watch-index.json.zst entry is the literal JSON `null` — the writer always
+// emits at least "{}", so this can only come from a hand-crafted or
+// corrupted file.
+func buildZipNullWatchIndex(t *testing.T, path string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("os.Create: %v", err)
+	}
+	defer f.Close() // safety net; see buildZipMissingMetadata
+	zw := zip.NewWriter(f)
+	defer zw.Close()
+
+	writeEntry := func(name string, data []byte) {
+		t.Helper()
+		w, err := zw.CreateHeader(&zip.FileHeader{Name: name, Method: zip.Store})
+		if err != nil {
+			t.Fatalf("CreateHeader(%s): %v", name, err)
+		}
+		if _, err := w.Write(data); err != nil {
+			t.Fatalf("write(%s): %v", name, err)
+		}
+	}
+
+	writeEntry("k8shark-capture/metadata.json", []byte(`{"format_version":1,"capture_id":"null-watch-index"}`))
+	idxZ, err := zstdCompress([]byte(`{}`))
+	if err != nil {
+		t.Fatalf("zstdCompress(index): %v", err)
+	}
+	writeEntry("k8shark-capture/index.json.zst", idxZ)
+	watchZ, err := zstdCompress([]byte(`null`))
+	if err != nil {
+		t.Fatalf("zstdCompress(watch-index): %v", err)
+	}
+	writeEntry("k8shark-capture/watch-index.json.zst", watchZ)
+
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip Close: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("file Close: %v", err)
+	}
+}
+
+// TestReadWatchIndex_TopLevelNull_Rejected is a regression test: a
+// watch-index.json.zst containing the literal JSON `null` unmarshals
+// without error into a nil WatchIndex map, which is indistinguishable from
+// "no watch index" at any call site that doesn't check found — but the
+// writer never emits a bare null, so this shape means the archive is
+// corrupt. ReadWatchIndex must reject it instead of returning (nil, true, nil).
+func TestReadWatchIndex_TopLevelNull_Rejected(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "null-watch-index.kshrk")
+	buildZipNullWatchIndex(t, path)
+
+	ar, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer ar.Close()
+
+	_, found, err := ar.ReadWatchIndex()
+	if err == nil {
+		t.Fatal("ReadWatchIndex on a top-level null watch index succeeded, want error")
+	}
+	if !found {
+		t.Error("ReadWatchIndex found = false, want true — the entry is present even though it failed validation")
 	}
 }
 

--- a/internal/archive/corrupt_test.go
+++ b/internal/archive/corrupt_test.go
@@ -144,6 +144,76 @@ func TestReadWatchIndex_MalformedEntry_StillReportsPresent(t *testing.T) {
 	}
 }
 
+// buildZipNullWatchIndexEntry writes a structurally valid ZIP archive whose
+// watch-index.json.zst is valid JSON but maps a path to a null entry — the
+// writer never produces this shape (it only ever inserts a populated
+// *WatchIndexEntry), so it can only come from a hand-crafted or corrupted
+// file.
+func buildZipNullWatchIndexEntry(t *testing.T, path string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("os.Create: %v", err)
+	}
+	defer f.Close() // safety net; see buildZipMissingMetadata
+	zw := zip.NewWriter(f)
+	defer zw.Close()
+
+	writeEntry := func(name string, data []byte) {
+		t.Helper()
+		w, err := zw.CreateHeader(&zip.FileHeader{Name: name, Method: zip.Store})
+		if err != nil {
+			t.Fatalf("CreateHeader(%s): %v", name, err)
+		}
+		if _, err := w.Write(data); err != nil {
+			t.Fatalf("write(%s): %v", name, err)
+		}
+	}
+
+	writeEntry("k8shark-capture/metadata.json", []byte(`{"format_version":1,"capture_id":"null-watch-index-entry"}`))
+	idxZ, err := zstdCompress([]byte(`{}`))
+	if err != nil {
+		t.Fatalf("zstdCompress(index): %v", err)
+	}
+	writeEntry("k8shark-capture/index.json.zst", idxZ)
+	watchZ, err := zstdCompress([]byte(`{"/api/v1/namespaces/default/pods":null}`))
+	if err != nil {
+		t.Fatalf("zstdCompress(watch-index): %v", err)
+	}
+	writeEntry("k8shark-capture/watch-index.json.zst", watchZ)
+
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip Close: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("file Close: %v", err)
+	}
+}
+
+// TestReadWatchIndex_NullEntry_Rejected is a regression test: a
+// watch-index.json.zst that is valid JSON but maps a path to a null entry is
+// still corrupt, since every reader dereferences the entry (e.g. entry.Seqs)
+// without a nil check and would panic. ReadWatchIndex must reject this shape
+// rather than returning a WatchIndex containing a nil *WatchIndexEntry.
+func TestReadWatchIndex_NullEntry_Rejected(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "null-watch-index-entry.kshrk")
+	buildZipNullWatchIndexEntry(t, path)
+
+	ar, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer ar.Close()
+
+	_, found, err := ar.ReadWatchIndex()
+	if err == nil {
+		t.Fatal("ReadWatchIndex on a null entry succeeded, want error")
+	}
+	if !found {
+		t.Error("ReadWatchIndex found = false, want true — the entry is present even though it failed validation")
+	}
+}
+
 // TestOpen_CorruptArchives covers every malformed-archive shape a user might
 // plausibly hand kshrk — most likely a Ctrl+C'd capture (`kshrk capture`
 // writes records in place via os.Create and only writes the index/metadata

--- a/internal/archive/corrupt_test.go
+++ b/internal/archive/corrupt_test.go
@@ -190,6 +190,74 @@ func buildZipNullWatchIndexEntry(t *testing.T, path string) {
 	}
 }
 
+// buildZipUndecompressableWatchIndex writes a structurally valid ZIP archive
+// whose watch-index.json.zst entry is not valid Zstd data at all (as opposed
+// to buildZipMalformedWatchIndex, whose entry decompresses fine but fails to
+// parse as JSON) — e.g. bit-rot in the compressed bytes themselves.
+func buildZipUndecompressableWatchIndex(t *testing.T, path string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("os.Create: %v", err)
+	}
+	defer f.Close() // safety net; see buildZipMissingMetadata
+	zw := zip.NewWriter(f)
+	defer zw.Close()
+
+	writeEntry := func(name string, data []byte) {
+		t.Helper()
+		w, err := zw.CreateHeader(&zip.FileHeader{Name: name, Method: zip.Store})
+		if err != nil {
+			t.Fatalf("CreateHeader(%s): %v", name, err)
+		}
+		if _, err := w.Write(data); err != nil {
+			t.Fatalf("write(%s): %v", name, err)
+		}
+	}
+
+	writeEntry("k8shark-capture/metadata.json", []byte(`{"format_version":1,"capture_id":"undecompressable-watch-index"}`))
+	idxZ, err := zstdCompress([]byte(`{}`))
+	if err != nil {
+		t.Fatalf("zstdCompress(index): %v", err)
+	}
+	writeEntry("k8shark-capture/index.json.zst", idxZ)
+	writeEntry("k8shark-capture/watch-index.json.zst", []byte("not zstd data at all"))
+
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip Close: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("file Close: %v", err)
+	}
+}
+
+// TestReadWatchIndex_UndecompressableEntry_StillReportsPresent is a
+// regression test: ReadWatchIndex's found return value means "the entry is
+// present in the archive", independent of whether it could even be
+// decompressed. A watch-index.json.zst entry that isn't valid Zstd data must
+// still report found=true (with a non-nil error), the same as an entry that
+// decompresses but fails to parse as JSON — otherwise a caller that checks
+// err first would still be fine, but found would inconsistently read
+// "absent" for one corruption mode and "present" for another.
+func TestReadWatchIndex_UndecompressableEntry_StillReportsPresent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "undecompressable-watch-index.kshrk")
+	buildZipUndecompressableWatchIndex(t, path)
+
+	ar, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer ar.Close()
+
+	_, found, err := ar.ReadWatchIndex()
+	if err == nil {
+		t.Fatal("ReadWatchIndex on an undecompressable entry succeeded, want error")
+	}
+	if !found {
+		t.Error("ReadWatchIndex found = false, want true — the entry is present even though it couldn't be decompressed")
+	}
+}
+
 // TestReadWatchIndex_NullEntry_Rejected is a regression test: a
 // watch-index.json.zst that is valid JSON but maps a path to a null entry is
 // still corrupt, since every reader dereferences the entry (e.g. entry.Seqs)

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -67,8 +67,13 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 		return Result{}, fmt.Errorf("reading index: %w", err)
 	}
 
+	// Watch-index may be absent for older archives, but a present-and-malformed
+	// one is a corrupt archive, not an absent one — surface that error rather
+	// than silently redacting as if it were never captured.
 	var wi capture.WatchIndex
-	_, _ = ar.ReadWatchIndex(&wi)
+	if _, err := ar.ReadWatchIndex(&wi); err != nil {
+		return Result{}, fmt.Errorf("reading watch index: %w", err)
+	}
 
 	result := Result{}
 

--- a/internal/server/malformed_watch_index_test.go
+++ b/internal/server/malformed_watch_index_test.go
@@ -1,0 +1,115 @@
+package server_test
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/redact"
+	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/transitions"
+)
+
+// buildMalformedWatchIndexArchive writes a structurally valid ZIP archive
+// with valid metadata.json and index.json.zst entries, but whose
+// watch-index.json.zst entry decompresses to invalid JSON. Mirrors
+// internal/archive's buildZipMalformedWatchIndex fixture, which established
+// that ReadWatchIndex reports found=true with a non-nil error in this case
+// specifically so callers can tell a corrupt watch index apart from an
+// archive that simply predates the feature.
+func buildMalformedWatchIndexArchive(t *testing.T, path string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("os.Create: %v", err)
+	}
+	defer f.Close()
+	zw := zip.NewWriter(f)
+	defer zw.Close()
+
+	zstdCompress := func(data []byte) []byte {
+		t.Helper()
+		var buf strings.Builder
+		enc, err := zstd.NewWriter(&buf)
+		if err != nil {
+			t.Fatalf("zstd.NewWriter: %v", err)
+		}
+		if _, err := enc.Write(data); err != nil {
+			t.Fatalf("zstd Write: %v", err)
+		}
+		if err := enc.Close(); err != nil {
+			t.Fatalf("zstd Close: %v", err)
+		}
+		return []byte(buf.String())
+	}
+
+	writeEntry := func(name string, data []byte) {
+		t.Helper()
+		w, err := zw.CreateHeader(&zip.FileHeader{Name: name, Method: zip.Store})
+		if err != nil {
+			t.Fatalf("CreateHeader(%s): %v", name, err)
+		}
+		if _, err := w.Write(data); err != nil {
+			t.Fatalf("write(%s): %v", name, err)
+		}
+	}
+
+	writeEntry("k8shark-capture/metadata.json", []byte(`{"format_version":1,"capture_id":"malformed-watch-index"}`))
+	writeEntry("k8shark-capture/index.json.zst", zstdCompress([]byte(`{}`)))
+	writeEntry("k8shark-capture/watch-index.json.zst", zstdCompress([]byte("{")))
+
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip Close: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("file Close: %v", err)
+	}
+}
+
+// TestAllReaders_RejectMalformedWatchIndex is a regression test: a
+// watch-index.json.zst entry that is present but fails to parse means the
+// archive is corrupt, not that it predates the watch-index feature. Every
+// reader that consults ReadWatchIndex must surface that error instead of
+// silently degrading to poll-based inference (transitions), dropping watch
+// records from redacted output (redact), or running without watch
+// transitions (server) — the same class of bug #250 fixed for a
+// too-new format version.
+func TestAllReaders_RejectMalformedWatchIndex(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "malformed-watch-index.kshrk")
+	buildMalformedWatchIndexArchive(t, path)
+
+	assertWatchIndexError := func(t *testing.T, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatal("expected an error for a malformed watch index, got nil")
+		}
+		if !strings.Contains(err.Error(), "watch index") {
+			t.Errorf("error = %v, want it to mention the watch index", err)
+		}
+	}
+
+	t.Run("server.LoadStore", func(t *testing.T) {
+		ar, err := archive.Open(path)
+		if err != nil {
+			t.Fatalf("archive.Open: %v", err)
+		}
+		defer ar.Close()
+		_, err = server.LoadStore(ar)
+		assertWatchIndexError(t, err)
+	})
+
+	t.Run("redact.Archive", func(t *testing.T) {
+		dst := filepath.Join(t.TempDir(), "out.kshrk")
+		_, err := redact.Archive(path, dst, redact.Options{})
+		assertWatchIndexError(t, err)
+	})
+
+	t.Run("transitions.LoadTransitions", func(t *testing.T) {
+		_, err := transitions.LoadTransitions(path, transitions.FilterOpts{}, nil)
+		assertWatchIndexError(t, err)
+	})
+}

--- a/internal/server/malformed_watch_index_test.go
+++ b/internal/server/malformed_watch_index_test.go
@@ -27,6 +27,11 @@ func buildMalformedWatchIndexArchive(t *testing.T, path string) {
 	if err != nil {
 		t.Fatalf("os.Create: %v", err)
 	}
+	// Safety net for any t.Fatalf below: on the happy path these are already
+	// closed by the explicit, error-checked calls at the end of this
+	// function, so this second Close just returns (and discards) an
+	// "already closed" error rather than doing anything harmful — see
+	// internal/archive/corrupt_test.go's buildZipMissingMetadata.
 	defer f.Close()
 	zw := zip.NewWriter(f)
 	defer zw.Close()

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -117,9 +117,13 @@ func LoadStore(ar *archive.Archive) (*CaptureStore, error) {
 		responseCacheMap: make(map[responseCacheKey]*responseCacheEntry),
 	}
 
-	// Load watch index if present.
+	// Load watch index if present. A present-and-malformed entry is a
+	// corrupt archive, not an absent one — surface that error rather than
+	// silently running without watch transitions.
 	var wi capture.WatchIndex
-	if found, err := ar.ReadWatchIndex(&wi); err == nil && found && wi != nil {
+	if found, err := ar.ReadWatchIndex(&wi); err != nil {
+		return nil, fmt.Errorf("reading watch index: %w", err)
+	} else if found && wi != nil {
 		s.WatchIndex = wi
 	}
 

--- a/internal/transitions/transitions.go
+++ b/internal/transitions/transitions.go
@@ -68,9 +68,13 @@ func LoadTransitions(archivePath string, opts FilterOpts, identities []age.Ident
 		return nil, fmt.Errorf("reading index: %w", err)
 	}
 
-	// Watch-index may be absent for older archives.
+	// Watch-index may be absent for older archives, but a present-and-malformed
+	// one is a corrupt archive, not an absent one — surface that error rather
+	// than silently falling back to poll-based inference.
 	var wi capture.WatchIndex
-	_, _ = ar.ReadWatchIndex(&wi)
+	if _, err := ar.ReadWatchIndex(&wi); err != nil {
+		return nil, fmt.Errorf("reading watch index: %w", err)
+	}
 
 	var all []Transition
 


### PR DESCRIPTION
## Summary

`archive.Archive.ReadWatchIndex` reports `found=true` with a non-nil error when `watch-index.json.zst` is present but fails to parse — a corrupt archive, not one that predates the watch-index feature. Its own regression test (`internal/archive/corrupt_test.go:TestReadWatchIndex_MalformedEntry_StillReportsPresent`) documents this is deliberate, "so a caller that checks err first never mistakes a corrupt watch index for an archive that simply predates the watch-index feature."

None of the three call sites actually honored that contract:

- `internal/transitions/transitions.go` discarded the error entirely (`_, _ = ar.ReadWatchIndex(&wi)`), silently falling back to poll-based inference.
- `internal/redact/redact.go` did the same, silently dropping watch records from the redacted output.
- `internal/server/store.go` only assigned `s.WatchIndex` when `err == nil`, so on error it silently ran without watch transitions instead of failing.

This was flagged by a Copilot review as a suppressed low-confidence comment on #279; confirmed the discarding behavior predates that PR (pre-existing gap, not a regression).

Fixed all three to check the error and return a wrapped `"reading watch index: %w"` failure instead of silently degrading.

## Test plan

- [x] Added `TestAllReaders_RejectMalformedWatchIndex` (`internal/server/malformed_watch_index_test.go`), mirroring the existing `TestAllReaders_RejectFutureFormatVersion` cross-cutting regression test, exercising `server.LoadStore`, `redact.Archive`, and `transitions.LoadTransitions` against a structurally valid archive whose `watch-index.json.zst` decompresses to invalid JSON — asserting all three now fail loudly instead of silently falling back.
- [x] `make fmt` (no diff)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (all packages pass)
- [x] `go mod tidy` (no diff)
- [x] `golangci-lint run` (pinned v1.64.8, clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)