### PR TITLE
refactor(store): extract internal/store from internal/server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ manual bumps. Pin any new CI tool the same way.
 ## Archive lifecycle (gotcha)
 
 `archive.Open` returns a `*zip.ReadCloser` that holds a real OS file handle, and
-`server.LoadStore` needs the archive to stay open for the store's lifetime.
+`store.LoadStore` needs the archive to stay open for the store's lifetime.
 Therefore:
 
 - **`internal/server`** (the mock API server) is the only long-lived holder
@@ -85,6 +85,18 @@ Therefore:
   negative = corrupt (rejected), greater than `CurrentFormatVersion` = rejected
   with an "upgrade kshrk" error. Bump `CurrentFormatVersion` only on a breaking,
   structurally-incompatible change.
+- **`internal/store`** holds `CaptureStore`/`LoadStore` (archive-backed
+  reads, selectors, response content negotiation) — extracted from
+  `internal/server` (#234) so `diagnose`/`query`/`diff` read an archive
+  without importing the HTTP mock apiserver package. `internal/server`
+  imports it back (aliased `kstore`, since many of its functions/methods take
+  or hold a local/field variable literally named `store`) for the mock
+  apiserver's own reads. `internal/ui/v2`'s `Handler.Overlay` is typed as an
+  `OverlayReader` interface (defined in `v2`, satisfied by `*server.Server`)
+  rather than the concrete server type — but unlike `*server.Server`'s
+  nil-safe methods, a nil `OverlayReader` interface value panics on any method
+  call, so every `h.Overlay.OverlayScopes()`/`MergeOverlayList` call site
+  still nil-checks `h.Overlay` first.
 
 ## Code review notes
 

--- a/cmd/diagnose.go
+++ b/cmd/diagnose.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/diagnose"
-	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -65,7 +65,7 @@ func runDiagnose(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("opening archive: %w", err)
 	}
 	defer ar.Close()
-	store, err := server.LoadStore(ar)
+	store, err := store.LoadStore(ar)
 	if err != nil {
 		return fmt.Errorf("loading capture: %w", err)
 	}

--- a/cmd/diagnose.go
+++ b/cmd/diagnose.go
@@ -65,18 +65,18 @@ func runDiagnose(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("opening archive: %w", err)
 	}
 	defer ar.Close()
-	store, err := store.LoadStore(ar)
+	cs, err := store.LoadStore(ar)
 	if err != nil {
 		return fmt.Errorf("loading capture: %w", err)
 	}
-	defer store.Close()
+	defer cs.Close()
 
-	at, err := parseAtFlag(atRaw, store.Metadata.CapturedAt, store.Metadata.CapturedUntil)
+	at, err := parseAtFlag(atRaw, cs.Metadata.CapturedAt, cs.Metadata.CapturedUntil)
 	if err != nil {
 		return err
 	}
 
-	report := diagnose.Run(store, diagnose.Options{At: at, MinSeverity: severity, Category: category})
+	report := diagnose.Run(cs, diagnose.Options{At: at, MinSeverity: severity, Category: category})
 
 	switch strings.ToLower(output) {
 	case "json":

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/query"
-	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -72,7 +72,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("opening archive: %w", err)
 	}
 	defer ar.Close()
-	store, err := server.LoadStore(ar)
+	store, err := store.LoadStore(ar)
 	if err != nil {
 		return fmt.Errorf("loading capture: %w", err)
 	}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -72,19 +72,19 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("opening archive: %w", err)
 	}
 	defer ar.Close()
-	store, err := store.LoadStore(ar)
+	cs, err := store.LoadStore(ar)
 	if err != nil {
 		return fmt.Errorf("loading capture: %w", err)
 	}
-	defer store.Close()
+	defer cs.Close()
 
-	at, err := parseAtFlag(atRaw, store.Metadata.CapturedAt, store.Metadata.CapturedUntil)
+	at, err := parseAtFlag(atRaw, cs.Metadata.CapturedAt, cs.Metadata.CapturedUntil)
 	if err != nil {
 		return err
 	}
 
 	if text || useRegex {
-		result, err := query.SearchText(store, query.TextOptions{
+		result, err := query.SearchText(cs, query.TextOptions{
 			Pattern:   args[1],
 			Regex:     useRegex,
 			At:        at,
@@ -105,7 +105,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	result, err := query.Run(store, query.Options{
+	result, err := query.Run(cs, query.Options{
 		Expression: args[1],
 		At:         at,
 		Resource:   resource,

--- a/internal/archive/zero_records_test.go
+++ b/internal/archive/zero_records_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
 	"github.com/phenixblue/k8shark/internal/inspect"
-	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 )
 
 // buildZeroRecordArchive writes a structurally valid, completely empty
@@ -36,7 +36,7 @@ func buildZeroRecordArchive(t *testing.T, path string) {
 
 // TestArchive_ZeroRecords verifies that a capture with zero records — not
 // corrupt, just empty — is read cleanly by every consumer: inspect.Run and
-// server.LoadStore must succeed and report zero resources rather than
+// store.LoadStore must succeed and report zero resources rather than
 // panicking on a nil/empty index or record set (#248).
 func TestArchive_ZeroRecords(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "empty.kshrk")
@@ -55,15 +55,15 @@ func TestArchive_ZeroRecords(t *testing.T) {
 		}
 	})
 
-	t.Run("server.LoadStore", func(t *testing.T) {
+	t.Run("store.LoadStore", func(t *testing.T) {
 		ar, err := archive.Open(path)
 		if err != nil {
 			t.Fatalf("archive.Open: %v", err)
 		}
 		defer ar.Close()
-		store, err := server.LoadStore(ar)
+		store, err := store.LoadStore(ar)
 		if err != nil {
-			t.Fatalf("server.LoadStore: %v", err)
+			t.Fatalf("store.LoadStore: %v", err)
 		}
 		// Deferred immediately (not just called at the end) so a t.Fatalf added
 		// later in this subtest can't skip it and leave the enrichment

--- a/internal/archive/zero_records_test.go
+++ b/internal/archive/zero_records_test.go
@@ -61,18 +61,18 @@ func TestArchive_ZeroRecords(t *testing.T) {
 			t.Fatalf("archive.Open: %v", err)
 		}
 		defer ar.Close()
-		store, err := store.LoadStore(ar)
+		cs, err := store.LoadStore(ar)
 		if err != nil {
 			t.Fatalf("store.LoadStore: %v", err)
 		}
 		// Deferred immediately (not just called at the end) so a t.Fatalf added
 		// later in this subtest can't skip it and leave the enrichment
 		// goroutine running when the deferred ar.Close() above runs.
-		defer store.Close()
-		if len(store.Index) != 0 {
-			t.Errorf("Index = %v, want empty", store.Index)
+		defer cs.Close()
+		if len(cs.Index) != 0 {
+			t.Errorf("Index = %v, want empty", cs.Index)
 		}
-		if got := len(store.Resources()); got != 0 {
+		if got := len(cs.Resources()); got != 0 {
 			t.Errorf("Resources() = %d entries, want 0", got)
 		}
 	})

--- a/internal/diagnose/engine.go
+++ b/internal/diagnose/engine.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/phenixblue/k8shark/internal/k8spath"
-	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 )
 
 // Options configures a diagnose run.
@@ -17,7 +17,7 @@ type Options struct {
 }
 
 // Run analyzes the capture in store and returns a ranked Report.
-func Run(store *server.CaptureStore, opts Options) Report {
+func Run(store *store.CaptureStore, opts Options) Report {
 	at := opts.At
 	if at.IsZero() {
 		at = store.Metadata.CapturedUntil
@@ -79,7 +79,7 @@ func Run(store *server.CaptureStore, opts Options) Report {
 
 // forEachResource calls fn for every captured list of the given resource
 // (skipping Table/query variants), passing the namespace, list path, and items.
-func forEachResource(store *server.CaptureStore, at time.Time, resource string, fn func(ns, path string, items []json.RawMessage)) {
+func forEachResource(store *store.CaptureStore, at time.Time, resource string, fn func(ns, path string, items []json.RawMessage)) {
 	for path := range store.Index {
 		if strings.Contains(path, "?") {
 			continue

--- a/internal/diagnose/engine_test.go
+++ b/internal/diagnose/engine_test.go
@@ -45,6 +45,7 @@ func buildDiagStore(t *testing.T, bodies map[string]string) *store.CaptureStore 
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}
+	t.Cleanup(cs.Close)
 	return cs
 }
 

--- a/internal/diagnose/engine_test.go
+++ b/internal/diagnose/engine_test.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
-	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 )
 
-func buildDiagStore(t *testing.T, bodies map[string]string) *server.CaptureStore {
+func buildDiagStore(t *testing.T, bodies map[string]string) *store.CaptureStore {
 	t.Helper()
 	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
 	out := filepath.Join(t.TempDir(), "diag.kshrk")
@@ -41,7 +41,7 @@ func buildDiagStore(t *testing.T, bodies map[string]string) *server.CaptureStore
 		t.Fatalf("archive.Open: %v", err)
 	}
 	t.Cleanup(func() { ar.Close() })
-	store, err := server.LoadStore(ar)
+	store, err := store.LoadStore(ar)
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}

--- a/internal/diagnose/engine_test.go
+++ b/internal/diagnose/engine_test.go
@@ -41,11 +41,11 @@ func buildDiagStore(t *testing.T, bodies map[string]string) *store.CaptureStore 
 		t.Fatalf("archive.Open: %v", err)
 	}
 	t.Cleanup(func() { ar.Close() })
-	store, err := store.LoadStore(ar)
+	cs, err := store.LoadStore(ar)
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}
-	return store
+	return cs
 }
 
 // fullFixture exercises every PR-1 rule plus a healthy pod (which must yield

--- a/internal/diagnose/rules.go
+++ b/internal/diagnose/rules.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 )
 
 // ── workload: pod health ─────────────────────────────────────────────────────
@@ -37,7 +37,7 @@ func reasonRule(reason string) (ruleID, severity, title, suggestion string, ok b
 	}
 }
 
-func podHealthFindings(store *server.CaptureStore, at time.Time) []Finding {
+func podHealthFindings(store *store.CaptureStore, at time.Time) []Finding {
 	g := newGrouper()
 	forEachResource(store, at, "pods", func(ns, path string, items []json.RawMessage) {
 		for _, raw := range items {
@@ -76,7 +76,7 @@ func sanitizeReason(s string) string {
 
 // ── scheduling: unschedulable pods ───────────────────────────────────────────
 
-func schedulingFindings(store *server.CaptureStore, at time.Time) []Finding {
+func schedulingFindings(store *store.CaptureStore, at time.Time) []Finding {
 	g := newGrouper()
 	forEachResource(store, at, "pods", func(ns, path string, items []json.RawMessage) {
 		for _, raw := range items {
@@ -117,7 +117,7 @@ func schedulingFindings(store *server.CaptureStore, at time.Time) []Finding {
 
 // ── storage: unbound PVCs ────────────────────────────────────────────────────
 
-func pvcFindings(store *server.CaptureStore, at time.Time) []Finding {
+func pvcFindings(store *store.CaptureStore, at time.Time) []Finding {
 	g := newGrouper()
 	forEachResource(store, at, "persistentvolumeclaims", func(ns, path string, items []json.RawMessage) {
 		for _, raw := range items {
@@ -156,7 +156,7 @@ func pvcFindings(store *server.CaptureStore, at time.Time) []Finding {
 
 // ── cluster: control-plane / node version skew ───────────────────────────────
 
-func versionSkewFindings(store *server.CaptureStore, at time.Time) []Finding {
+func versionSkewFindings(store *store.CaptureStore, at time.Time) []Finding {
 	cpMinor, okCP := parseMinor(store.Metadata.KubernetesVersion)
 	if !okCP {
 		return nil

--- a/internal/diagnose/rules2.go
+++ b/internal/diagnose/rules2.go
@@ -6,12 +6,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 )
 
 // ── workload: missing resource requests/limits ───────────────────────────────
 
-func missingResourceFindings(store *server.CaptureStore, at time.Time) []Finding {
+func missingResourceFindings(store *store.CaptureStore, at time.Time) []Finding {
 	g := newGrouper()
 	forEachResource(store, at, "pods", func(ns, path string, items []json.RawMessage) {
 		for _, raw := range items {
@@ -64,7 +64,7 @@ func missingResourceFindings(store *server.CaptureStore, at time.Time) []Finding
 
 // ── workload: replica/availability shortfall ─────────────────────────────────
 
-func replicaFindings(store *server.CaptureStore, at time.Time) []Finding {
+func replicaFindings(store *store.CaptureStore, at time.Time) []Finding {
 	var out []Finding
 	for _, rk := range []struct{ resource, kind string }{
 		{"deployments", "Deployment"}, {"statefulsets", "StatefulSet"}, {"replicasets", "ReplicaSet"},
@@ -135,7 +135,7 @@ func replicaFindings(store *server.CaptureStore, at time.Time) []Finding {
 
 // ── node: conditions ─────────────────────────────────────────────────────────
 
-func nodeConditionFindings(store *server.CaptureStore, at time.Time) []Finding {
+func nodeConditionFindings(store *store.CaptureStore, at time.Time) []Finding {
 	var out []Finding
 	forEachResource(store, at, "nodes", func(_, path string, items []json.RawMessage) {
 		for _, raw := range items {
@@ -192,7 +192,7 @@ var deprecatedGroupVersions = map[string]string{
 	"storage.k8s.io/v1beta1":            "deprecated; use storage.k8s.io/v1",
 }
 
-func deprecatedAPIFindings(store *server.CaptureStore) []Finding {
+func deprecatedAPIFindings(store *store.CaptureStore) []Finding {
 	seen := map[string]bool{}
 	var out []Finding
 	for path := range store.Index {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -210,22 +210,22 @@ func loadArchiveSnapshot(archivePath string, at time.Time, identities []age.Iden
 	if err != nil {
 		return nil, fmt.Errorf("opening archive %q: %w", archivePath, err)
 	}
-	store, err := store.LoadStore(ar)
+	cs, err := store.LoadStore(ar)
 	if err != nil {
 		_ = ar.Close()
 		return nil, fmt.Errorf("loading archive %q: %w", archivePath, err)
 	}
 	shot := &archiveSnapshot{
 		ar:       ar,
-		store:    store,
-		meta:     store.Metadata,
-		snapshot: make(map[string]json.RawMessage, len(store.Index)),
+		store:    cs,
+		meta:     cs.Metadata,
+		snapshot: make(map[string]json.RawMessage, len(cs.Index)),
 	}
-	for path := range store.Index {
+	for path := range cs.Index {
 		if strings.Contains(path, "?as=Table") {
 			continue
 		}
-		body, code, err := store.Latest(path, at)
+		body, code, err := cs.Latest(path, at)
 		if err != nil {
 			shot.cleanup()
 			return nil, fmt.Errorf("reading %s from %q: %w", path, archivePath, err)

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -12,7 +12,7 @@ import (
 	archivepkg "github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
 	"github.com/phenixblue/k8shark/internal/k8spath"
-	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 	"github.com/pmezard/go-difflib/difflib"
 )
 
@@ -132,7 +132,7 @@ func RenderText(result *Result, color bool) (string, error) {
 
 type archiveSnapshot struct {
 	ar       *archivepkg.Archive
-	store    *server.CaptureStore
+	store    *store.CaptureStore
 	meta     capture.CaptureMetadata
 	snapshot map[string]json.RawMessage
 }
@@ -210,7 +210,7 @@ func loadArchiveSnapshot(archivePath string, at time.Time, identities []age.Iden
 	if err != nil {
 		return nil, fmt.Errorf("opening archive %q: %w", archivePath, err)
 	}
-	store, err := server.LoadStore(ar)
+	store, err := store.LoadStore(ar)
 	if err != nil {
 		_ = ar.Close()
 		return nil, fmt.Errorf("loading archive %q: %w", archivePath, err)

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/phenixblue/k8shark/internal/k8spath"
-	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 	"k8s.io/client-go/util/jsonpath"
 )
 
@@ -49,7 +49,7 @@ type Result struct {
 // object — including zero-value results like "" or null, since those mean
 // the field exists. Objects that don't have the queried field at all produce
 // no results (via AllowMissingKeys) and are skipped, not treated as errors.
-func Run(store *server.CaptureStore, opts Options) (*Result, error) {
+func Run(store *store.CaptureStore, opts Options) (*Result, error) {
 	jp := jsonpath.New("query").AllowMissingKeys(true)
 	if err := jp.Parse(opts.Expression); err != nil {
 		return nil, fmt.Errorf("parsing jsonpath expression %q: %w", opts.Expression, err)

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -41,11 +41,11 @@ func buildQueryStore(t *testing.T, bodies map[string]string) *store.CaptureStore
 		t.Fatalf("archive.Open: %v", err)
 	}
 	t.Cleanup(func() { _ = ar.Close() })
-	store, err := store.LoadStore(ar)
+	cs, err := store.LoadStore(ar)
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}
-	return store
+	return cs
 }
 
 func TestRun_MatchesAcrossResourceTypes(t *testing.T) {

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
-	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 )
 
-func buildQueryStore(t *testing.T, bodies map[string]string) *server.CaptureStore {
+func buildQueryStore(t *testing.T, bodies map[string]string) *store.CaptureStore {
 	t.Helper()
 	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
 	out := filepath.Join(t.TempDir(), "query.kshrk")
@@ -41,7 +41,7 @@ func buildQueryStore(t *testing.T, bodies map[string]string) *server.CaptureStor
 		t.Fatalf("archive.Open: %v", err)
 	}
 	t.Cleanup(func() { _ = ar.Close() })
-	store, err := server.LoadStore(ar)
+	store, err := store.LoadStore(ar)
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -45,6 +45,7 @@ func buildQueryStore(t *testing.T, bodies map[string]string) *store.CaptureStore
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}
+	t.Cleanup(cs.Close)
 	return cs
 }
 

--- a/internal/query/text.go
+++ b/internal/query/text.go
@@ -10,7 +10,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 )
 
 // TextOptions configures a SearchText.
@@ -64,7 +64,7 @@ type TextResult struct {
 
 // SearchText finds opts.Pattern across every captured object body and pod
 // log in store at the resolved snapshot.
-func SearchText(store *server.CaptureStore, opts TextOptions) (*TextResult, error) {
+func SearchText(store *store.CaptureStore, opts TextOptions) (*TextResult, error) {
 	find, err := newFinder(opts.Pattern, opts.Regex)
 	if err != nil {
 		return nil, err
@@ -129,7 +129,7 @@ func SearchText(store *server.CaptureStore, opts TextOptions) (*TextResult, erro
 	return &TextResult{Matches: matches}, nil
 }
 
-func searchLogPath(store *server.CaptureStore, path string, at time.Time, find finder, opts TextOptions) ([]TextMatch, bool) {
+func searchLogPath(store *store.CaptureStore, path string, at time.Time, find finder, opts TextOptions) ([]TextMatch, bool) {
 	ns, name, container, previous, ok := parseLogPath(path)
 	if !ok {
 		return nil, false

--- a/internal/server/bench_test.go
+++ b/internal/server/bench_test.go
@@ -11,12 +11,14 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/archive"
 	capture "github.com/phenixblue/k8shark/internal/capture"
+
+	kstore "github.com/phenixblue/k8shark/internal/store"
 )
 
-// buildBenchStore builds a CaptureStore with n pod list records for
+// buildBenchStore builds a kstore.CaptureStore with n pod list records for
 // benchmarking. It bypasses buildTestStore because that helper only accepts
 // *testing.T.
-func buildBenchStore(b *testing.B, n int) *CaptureStore {
+func buildBenchStore(b *testing.B, n int) *kstore.CaptureStore {
 	b.Helper()
 	dir := b.TempDir()
 	outPath := filepath.Join(dir, "bench.kshrk")
@@ -67,9 +69,9 @@ func buildBenchStore(b *testing.B, n int) *CaptureStore {
 	}
 	b.Cleanup(func() { ar.Close() })
 
-	store, err := LoadStore(ar)
+	store, err := kstore.LoadStore(ar)
 	if err != nil {
-		b.Fatalf("LoadStore: %v", err)
+		b.Fatalf("kstore.LoadStore: %v", err)
 	}
 	return store
 }

--- a/internal/server/bench_test.go
+++ b/internal/server/bench_test.go
@@ -73,6 +73,7 @@ func buildBenchStore(b *testing.B, n int) *kstore.CaptureStore {
 	if err != nil {
 		b.Fatalf("kstore.LoadStore: %v", err)
 	}
+	b.Cleanup(store.Close)
 	return store
 }
 

--- a/internal/server/format_version_gate_test.go
+++ b/internal/server/format_version_gate_test.go
@@ -74,7 +74,7 @@ func TestAllReaders_RejectFutureFormatVersion(t *testing.T) {
 
 	t.Run("archive.Open", func(t *testing.T) {
 		// archive.Open enforces the format-version gate directly (#233), so
-		// every caller below — including server.LoadStore's, which used to
+		// every caller below — including store.LoadStore's, which used to
 		// be exercised as its own subtest — actually rejects the archive
 		// here, before ever reaching its own logic. Pinned explicitly since
 		// it's the thing this test now fundamentally relies on.

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -11,11 +11,13 @@ import (
 	"time"
 
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
+
+	kstore "github.com/phenixblue/k8shark/internal/store"
 )
 
 // handler is the http.Handler for the mock Kubernetes API server.
 type handler struct {
-	store   *CaptureStore
+	store   *kstore.CaptureStore
 	at      time.Time
 	verbose bool
 	// clock, when non-nil, puts the handler in replay mode: LIST/GET reconstruct
@@ -59,7 +61,7 @@ func (h *handler) waitForRequests() {
 	h.wg.Wait()
 }
 
-func newHandler(store *CaptureStore, at time.Time, verbose bool) *handler {
+func newHandler(store *kstore.CaptureStore, at time.Time, verbose bool) *handler {
 	return &handler{store: store, at: at, verbose: verbose}
 }
 
@@ -85,7 +87,7 @@ func (h *handler) timelineFor(watchPath string) []replayEvent {
 	}
 	h.timelineMu.Unlock()
 
-	tl := h.store.buildReplayTimeline(watchPath)
+	tl := buildReplayTimeline(h.store, watchPath)
 
 	h.timelineMu.Lock()
 	defer h.timelineMu.Unlock()
@@ -125,9 +127,9 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// and for endpoints that never return a protobuf object and may be large or
 	// streamed (OpenAPI docs, pod logs), to avoid buffering them pointlessly.
 	watchParam := r.URL.Query().Get("watch")
-	if wantsProtobuf(r) && watchParam != "1" && watchParam != "true" && !isNonProtobufPath(path) {
-		pw := newProtobufResponseWriter(w)
-		defer pw.flush()
+	if kstore.WantsProtobuf(r) && watchParam != "1" && watchParam != "true" && !kstore.IsNonProtobufPath(path) {
+		pw := kstore.NewProtobufResponseWriter(w)
+		defer pw.Flush()
 		w = pw
 	}
 
@@ -618,7 +620,7 @@ func (h *handler) serveAPIVersions(w http.ResponseWriter) {
 // serveAPIGroupList (building a full APIGroupList from scratch) and
 // tryServeAPIGroupListFromStore (checking for/merging only the groups a
 // captured discovery document doesn't already list).
-func groupVersionsByGroup(resources []ResourceInfo, exclude map[string]bool) map[string][]groupVersion {
+func groupVersionsByGroup(resources []kstore.ResourceInfo, exclude map[string]bool) map[string][]groupVersion {
 	seen := map[string][]groupVersion{}
 	for _, ri := range resources {
 		if ri.Group == "" || exclude[ri.Group] {
@@ -670,7 +672,7 @@ func (h *handler) serveAPIGroupList(w http.ResponseWriter) {
 }
 
 // groupVersion is one version entry within a group, as returned by
-// CaptureStore.Resources() (an unordered map iteration — see
+// kstore.CaptureStore.Resources() (an unordered map iteration — see
 // sortedGroupVersions).
 type groupVersion struct{ version, groupVersion string }
 
@@ -702,7 +704,7 @@ func sortedGroupVersions(gvs []groupVersion) []map[string]string {
 // exclude (nil is fine). Shared by serveAPIGroup (building a full APIGroup
 // from scratch) and tryServeAPIGroupFromStore (checking for/merging only the
 // versions a captured discovery document doesn't already list).
-func groupVersionsFor(resources []ResourceInfo, group string, exclude map[string]bool) []groupVersion {
+func groupVersionsFor(resources []kstore.ResourceInfo, group string, exclude map[string]bool) []groupVersion {
 	var gvs []groupVersion
 	seen := map[string]bool{}
 	for _, ri := range resources {
@@ -778,12 +780,12 @@ func shortNamesFor(resource string) []string {
 // apiResourceEntry renders a single APIResourceList entry for ri. verbs is
 // always the read-only set — the store has no record of which verbs a
 // resource's real APIResource advertised, only what got captured/registered
-// (see ResourceInfo). Shared by serveAPIResourceList (building a full
+// (see kstore.ResourceInfo). Shared by serveAPIResourceList (building a full
 // APIResourceList from scratch, where this is the entire entry) and
 // tryServeAPIResourceListFromStore (only for a resource newly registered
 // after capture — e.g. a CRD created via the overlay — since an
 // already-captured resource keeps its original, richer entry untouched).
-func apiResourceEntry(ri ResourceInfo) map[string]any {
+func apiResourceEntry(ri kstore.ResourceInfo) map[string]any {
 	entry := map[string]any{
 		"name":       ri.Resource,
 		"namespaced": ri.Namespaced,
@@ -896,7 +898,7 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		// like /api/v1/pods or /apis/apps/v1/deployments. Only fire for paths
 		// with no namespace segment; namespace-scoped 404s fall through to the
 		// cluster-scoped fallback below, which correctly filters by namespace.
-		if _, _, _, reqNS := parseAPIPath(path); reqNS == "" {
+		if _, _, _, reqNS := kstore.ParseAPIPath(path); reqNS == "" {
 			body, code, err = h.store.AggregateAcrossNamespaces(path, at)
 			if err != nil {
 				writeJSON(w, http.StatusInternalServerError, statusObj(500, err.Error()))
@@ -911,7 +913,7 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		// but the request targets a specific namespace, try the cluster path and
 		// filter items by metadata.namespace. This makes kubectl get pods -n <ns>
 		// work even when only /api/v1/pods (not per-namespace paths) was captured.
-		g, v, resource, ns := parseAPIPath(path)
+		g, v, resource, ns := kstore.ParseAPIPath(path)
 		if ns != "" && resource != "" {
 			var clusterPath string
 			if g == "" {
@@ -925,7 +927,7 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 				return
 			}
 			if clusterCode == 200 {
-				filtered, ferr := applySelectors(clusterBody, "", "metadata.namespace="+ns)
+				filtered, ferr := kstore.ApplySelectors(clusterBody, "", "metadata.namespace="+ns)
 				if ferr == nil {
 					body, code = filtered, 200
 				}
@@ -940,19 +942,19 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		// empty live collection: no warning, since a client may well create
 		// objects of it next (especially in writable mode). Reserve the warning
 		// for a genuinely unknown/misconfigured kind (#177).
-		g, v, resource, _ := parseAPIPath(path)
+		g, v, resource, _ := kstore.ParseAPIPath(path)
 		if resource != "" {
 			av := v
 			if g != "" {
 				av = g + "/" + v
 			}
 			// Prefer the authoritative Kind from discovery/index metadata over the
-			// resourceToKind heuristic, which guesses wrong for resources whose
+			// kstore.ResourceToKind heuristic, which guesses wrong for resources whose
 			// Kind doesn't follow simple depluralization (e.g. endpointslices)
 			// and for most CRDs — a client deserializing by GVK would break.
-			kind := h.store.resourceKind(g, v, resource)
+			kind := h.store.ResourceKind(g, v, resource)
 			if kind == "" {
-				kind = resourceToKind(resource)
+				kind = kstore.ResourceToKind(resource)
 			}
 			emptyList, _ := json.Marshal(map[string]any{
 				"apiVersion": av,
@@ -960,13 +962,13 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 				"metadata":   map[string]string{"resourceVersion": "0"},
 				"items":      []any{},
 			})
-			if !h.store.isKnownResource(g, v, resource) {
+			if !h.store.IsKnownResource(g, v, resource) {
 				w.Header().Set("Warning", fmt.Sprintf(`299 k8shark %q`,
 					resource+" not found in capture; was it included in the capture config?"))
 			}
 			body, code = emptyList, 200
 		} else {
-			// Item-level GET (path has more segments than parseAPIPath handles):
+			// Item-level GET (path has more segments than kstore.ParseAPIPath handles):
 			// for a known resource, a standard NotFound Status matching a live
 			// cluster, so apierrors.IsNotFound() recognizes it (#177). An unknown
 			// resource keeps the k8shark-specific message instead — it signals a
@@ -974,7 +976,7 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 			// "<resource> \"<name>\" not found" would misleadingly present as "the
 			// object is just missing".
 			ig, iv, iresource, _, iname, _ := parseWritePath(strings.TrimSuffix(path, "/"))
-			if iresource != "" && iname != "" && h.store.isKnownResource(ig, iv, iresource) {
+			if iresource != "" && iname != "" && h.store.IsKnownResource(ig, iv, iresource) {
 				writeJSON(w, http.StatusNotFound, notFoundStatus(ig, iresource, iname))
 				return
 			}
@@ -986,7 +988,7 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 	// Apply label/field selectors if present.
 	labelSel := r.URL.Query().Get("labelSelector")
 	fieldSel := r.URL.Query().Get("fieldSelector")
-	body, err = applySelectors(body, labelSel, fieldSel)
+	body, err = kstore.ApplySelectors(body, labelSel, fieldSel)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, statusObj(500, err.Error()))
 		return
@@ -997,7 +999,7 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 	// consistently with replayed items.
 	if h.overlay != nil {
 		body, _ = h.mergeOverlayList(path, body)
-		if filtered, ferr := applySelectors(body, labelSel, fieldSel); ferr == nil {
+		if filtered, ferr := kstore.ApplySelectors(body, labelSel, fieldSel); ferr == nil {
 			body = filtered
 		}
 	}
@@ -1009,7 +1011,7 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		if labelSel == "" && fieldSel == "" {
 			return tb
 		}
-		if out, ferr := filterTableRows(tb, labelSel, fieldSel); ferr == nil {
+		if out, ferr := kstore.FilterTableRows(tb, labelSel, fieldSel); ferr == nil {
 			return out
 		}
 		return tb
@@ -1044,7 +1046,7 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		}
 		// Aggregated Table across namespaces (for -A / cluster-scoped paths only).
 		// Also bypassed in writable mode (see above).
-		if _, _, _, reqNS := parseAPIPath(path); reqNS == "" && h.overlay == nil {
+		if _, _, _, reqNS := kstore.ParseAPIPath(path); reqNS == "" && h.overlay == nil {
 			if tb, tbCode, _ := h.store.AggregateTableAcrossNamespaces(path, at); tbCode == 200 {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(200)
@@ -1069,7 +1071,7 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		body = rewriteListResourceVersion(body, func() int64 {
 			rv := rvAsOf(h.timelineFor(path), at)
 			if h.overlay != nil {
-				g, v, resource, namespace := parseAPIPath(strings.TrimSuffix(path, "/"))
+				g, v, resource, namespace := kstore.ParseAPIPath(strings.TrimSuffix(path, "/"))
 				if orv := h.overlay.scopeRV(g, v, resource, namespace); orv > rv {
 					rv = orv
 				}
@@ -1114,7 +1116,7 @@ func (h *handler) serveScale(w http.ResponseWriter, group, version, resource, na
 // burst uses it as its overlay-event skip floor. LIST callers ignore the RV.
 func (h *handler) mergeOverlayList(path string, body []byte) ([]byte, int64) {
 	h.syncEpoch() // reset-on-loop before merging into a LIST
-	group, version, resource, namespace := parseAPIPath(strings.TrimSuffix(path, "/"))
+	group, version, resource, namespace := kstore.ParseAPIPath(strings.TrimSuffix(path, "/"))
 	if resource == "" {
 		return body, 0
 	}
@@ -1192,7 +1194,7 @@ func (h *handler) trySingleItemGet(path string, at time.Time) ([]byte, int) {
 	if err != nil || code != 200 {
 		// Namespace-scoped single-item GET whose per-namespace list was not
 		// captured: fall back to the cluster-scoped list and filter by namespace.
-		g, v, resource, ns := parseAPIPath(parentPath)
+		g, v, resource, ns := kstore.ParseAPIPath(parentPath)
 		if ns != "" && resource != "" {
 			var clusterParent string
 			if g == "" {
@@ -1203,7 +1205,7 @@ func (h *handler) trySingleItemGet(path string, at time.Time) ([]byte, int) {
 			clusterBody, clusterCode, cerr := h.store.ReconstructAt(clusterParent, at)
 			if cerr == nil && clusterCode == 200 {
 				// Filter to the requested namespace before doing the name lookup.
-				filtered, ferr := applySelectors(clusterBody, "", "metadata.namespace="+ns)
+				filtered, ferr := kstore.ApplySelectors(clusterBody, "", "metadata.namespace="+ns)
 				if ferr == nil {
 					body, code = filtered, 200
 				}

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -657,6 +657,7 @@ func TestHandler_ReplayAtTimestamp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("kstore.LoadStore: %v", err)
 	}
+	t.Cleanup(store.Close)
 	h := newHandler(store, t1.Add(time.Minute), false)
 
 	req := httptest.NewRequest(http.MethodGet, path, nil)

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
+
+	kstore "github.com/phenixblue/k8shark/internal/store"
 )
 
 func TestHandler_Version(t *testing.T) {
@@ -91,7 +93,7 @@ func TestHandler_APIGroupList(t *testing.T) {
 // TestHandler_APIGroupList_PreferredVersionDeterministic verifies a group
 // with multiple captured versions always reports the highest-priority one
 // (GA over beta/alpha, highest major/minor within a type) as preferredVersion
-// — CaptureStore.Resources() iterates a map internally, so without sorting,
+// — kstore.CaptureStore.Resources() iterates a map internally, so without sorting,
 // preferredVersion could flip between any of the group's versions from one
 // call to the next. Found via Copilot review of the /apis/<group> fix.
 func TestHandler_APIGroupList_PreferredVersionDeterministic(t *testing.T) {
@@ -277,7 +279,7 @@ func TestHandler_NotFound_ItemPath(t *testing.T) {
 	store := buildTestStore(t, map[string][]byte{})
 	h := newHandler(store, time.Time{}, false)
 
-	// 6-segment path (item-level): parseAPIPath returns empty resource → 404.
+	// 6-segment path (item-level): kstore.ParseAPIPath returns empty resource → 404.
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/services/my-svc", nil)
 	rw := httptest.NewRecorder()
 	h.ServeHTTP(rw, req)
@@ -297,7 +299,7 @@ func TestHandler_NotFound_ItemPath_StandardStatus(t *testing.T) {
 	store := buildTestStore(t, map[string][]byte{
 		"/apis/networking.k8s.io/v1": []byte(discoveryBody),
 	})
-	store.discoveryEnrichmentDone.Wait()
+	store.Close()
 	h := newHandler(store, time.Time{}, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/apis/networking.k8s.io/v1/namespaces/default/ingresses/nope", nil)
@@ -413,7 +415,7 @@ func TestHandler_NotFound_ListPath_KnownResourceNoWarning(t *testing.T) {
 	store := buildTestStore(t, map[string][]byte{
 		"/apis/networking.k8s.io/v1": []byte(discoveryBody),
 	})
-	store.discoveryEnrichmentDone.Wait()
+	store.Close()
 	h := newHandler(store, time.Time{}, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/apis/networking.k8s.io/v1/namespaces/default/ingresses", nil)
@@ -441,7 +443,7 @@ func TestHandler_NotFound_ListPath_KnownResourceNoWarning(t *testing.T) {
 
 // TestHandler_NotFound_ListPath_KnownResourceUsesDiscoveryKind verifies the
 // empty-list fallback uses the authoritative Kind from discovery metadata,
-// not the resourceToKind heuristic — which guesses "Endpointslice" (wrong)
+// not the kstore.ResourceToKind heuristic — which guesses "Endpointslice" (wrong)
 // rather than the real "EndpointSlice" for "endpointslices", since it doesn't
 // follow simple depluralization. A client deserializing by GVK would break on
 // the heuristic's guess.
@@ -451,7 +453,7 @@ func TestHandler_NotFound_ListPath_KnownResourceUsesDiscoveryKind(t *testing.T) 
 	store := buildTestStore(t, map[string][]byte{
 		"/apis/discovery.k8s.io/v1": []byte(discoveryBody),
 	})
-	store.discoveryEnrichmentDone.Wait()
+	store.Close()
 	h := newHandler(store, time.Time{}, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/apis/discovery.k8s.io/v1/namespaces/default/endpointslices", nil)
@@ -651,9 +653,9 @@ func TestHandler_ReplayAtTimestamp(t *testing.T) {
 	}
 	t.Cleanup(func() { ar.Close() })
 
-	store, err := LoadStore(ar)
+	store, err := kstore.LoadStore(ar)
 	if err != nil {
-		t.Fatalf("LoadStore: %v", err)
+		t.Fatalf("kstore.LoadStore: %v", err)
 	}
 	h := newHandler(store, t1.Add(time.Minute), false)
 

--- a/internal/server/memory_bench_test.go
+++ b/internal/server/memory_bench_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
+
+	kstore "github.com/phenixblue/k8shark/internal/store"
 )
 
 // varyPodList builds a realistic, *varied* PodList body — not the near-identical
@@ -115,7 +117,7 @@ func writeLargeArchive(tb testing.TB, path string, namespaces, snapshots, pods i
 // populates the record + response caches. Returns the number of paths that
 // failed to reconstruct, so callers can surface silent reconstruction errors
 // instead of measuring against a broken store.
-func sweep(store *CaptureStore, at time.Time) int {
+func sweep(store *kstore.CaptureStore, at time.Time) int {
 	fails := 0
 	for path := range store.Index {
 		body, code, err := store.ReconstructAt(path, at)
@@ -145,7 +147,7 @@ func BenchmarkServeLargeCapture(b *testing.B) {
 		b.Fatal(err)
 	}
 	b.Cleanup(func() { ar.Close() })
-	store, err := LoadStore(ar)
+	store, err := kstore.LoadStore(ar)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -186,7 +188,7 @@ func TestLargeCaptureMemory(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ar.Close()
-	store, err := LoadStore(ar)
+	store, err := kstore.LoadStore(ar)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +214,7 @@ func TestLargeCaptureMemory(t *testing.T) {
 	t.Logf("  records=%d  raw record bytes=%.1f MiB  archive on disk=%.1f MiB",
 		recs, float64(raw)/(1<<20), float64(fi.Size())/(1<<20))
 	t.Logf("  record cache cap=%.0f MiB  response cache cap=%.0f MiB",
-		float64(recordCacheMaxBytes)/(1<<20), float64(responseCacheMaxBytes)/(1<<20))
+		float64(kstore.RecordCacheMaxBytes)/(1<<20), float64(kstore.ResponseCacheMaxBytes)/(1<<20))
 	t.Logf("  HeapInuse=%.1f MiB  HeapAlloc=%.1f MiB  Sys=%.1f MiB",
 		mib(m.HeapInuse), mib(m.HeapAlloc), mib(m.Sys))
 }

--- a/internal/server/memory_bench_test.go
+++ b/internal/server/memory_bench_test.go
@@ -151,6 +151,7 @@ func BenchmarkServeLargeCapture(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+	b.Cleanup(store.Close)
 	end := store.Metadata.CapturedUntil
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -192,6 +193,7 @@ func TestLargeCaptureMemory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer store.Close()
 
 	// Warm caches the way open/ui would: sweep every path at a few timestamps.
 	for _, frac := range []float64{0.25, 0.5, 0.75, 1.0} {

--- a/internal/server/overlay_export.go
+++ b/internal/server/overlay_export.go
@@ -1,6 +1,10 @@
 package server
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	kstore "github.com/phenixblue/k8shark/internal/store"
+)
 
 // This file exposes a read-only view of the store and (when writable replay
 // is on) the overlay to other in-process readers — namely the web UI
@@ -11,10 +15,10 @@ import "encoding/json"
 // they behave as if the overlay were empty, so callers don't need to check
 // for nil or Writable() first.
 
-// Store returns the CaptureStore backing this server, so a second in-process
+// Store returns the kstore.CaptureStore backing this server, so a second in-process
 // reader (the web UI) can share it instead of loading the archive again.
 // Returns nil on a nil *Server, matching every other accessor in this file.
-func (s *Server) Store() *CaptureStore {
+func (s *Server) Store() *kstore.CaptureStore {
 	if s == nil {
 		return nil
 	}

--- a/internal/server/protobuf_negotiation_test.go
+++ b/internal/server/protobuf_negotiation_test.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	kstore "github.com/phenixblue/k8shark/internal/store"
+)
+
+// getWithAccept issues a GET with an Accept header and returns status, the
+// response Content-Type, and the raw body.
+func getWithAccept(t *testing.T, url, accept string) (int, string, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Accept", accept)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	return resp.StatusCode, resp.Header.Get("Content-Type"), b
+}
+
+// A protobuf-preferring client gets a protobuf response for a built-in list; a
+// JSON client still gets JSON. (issue #150) End-to-end coverage for the
+// handler.go ResponseWriter wrapper that internal/store's WantsProtobuf/
+// jsonToProtobuf unit tests don't exercise on their own.
+func TestProtobufResponseNegotiation(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	store := buildTestStoreWithWatch(t,
+		map[string]watchTestRecord{podsPath: {id: "s", at: from, body: podList("pod-base")}}, nil)
+	h := newHandler(store, from, false)
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	// Protobuf-preferring client: protobuf response that decodes back to a List.
+	code, ct, body := getWithAccept(t, srv.URL+podsPath, "application/vnd.kubernetes.protobuf,application/json")
+	if code != http.StatusOK {
+		t.Fatalf("protobuf GET: status %d, want 200", code)
+	}
+	if ct != kstore.ProtobufMediaType {
+		t.Errorf("Content-Type = %q, want %q", ct, kstore.ProtobufMediaType)
+	}
+	if len(body) < 4 || string(body[:4]) != "k8s\x00" {
+		t.Errorf("protobuf framing missing, got %q", body[:min(4, len(body))])
+	}
+	if obj, _, err := protobufSerializer.Decode(body, nil, nil); err != nil || obj == nil {
+		t.Errorf("protobuf body did not decode: %v", err)
+	}
+
+	// JSON client: unchanged JSON response.
+	code, ct, _ = getWithAccept(t, srv.URL+podsPath, "application/json")
+	if code != http.StatusOK {
+		t.Fatalf("json GET: status %d, want 200", code)
+	}
+	if ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+}

--- a/internal/server/replay_rv.go
+++ b/internal/server/replay_rv.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/phenixblue/k8shark/internal/transitions"
+
+	kstore "github.com/phenixblue/k8shark/internal/store"
 )
 
 // Replay resourceVersion (RV) scheme
@@ -38,7 +40,7 @@ const replayRVBase = 1
 // watchIndexPaths returns the capture watch-index paths feeding a watch on
 // watchPath: the exact path if captured, else (for a cluster-wide path) the
 // per-namespace demultiplexed paths. The result is sorted for determinism.
-func (s *CaptureStore) watchIndexPaths(watchPath string) []string {
+func watchIndexPaths(s *kstore.CaptureStore, watchPath string) []string {
 	if _, ok := s.WatchIndex[watchPath]; ok {
 		return []string{watchPath}
 	}
@@ -59,7 +61,7 @@ func (s *CaptureStore) watchIndexPaths(watchPath string) []string {
 // snapshotPaths returns the capture snapshot (index) paths feeding a watch on
 // watchPath for poll-only inference. Same resolution as watchIndexPaths but over
 // the snapshot index, skipping Table-format keys.
-func (s *CaptureStore) snapshotPaths(watchPath string) []string {
+func snapshotPaths(s *kstore.CaptureStore, watchPath string) []string {
 	if _, ok := s.Index[watchPath]; ok {
 		return []string{watchPath}
 	}
@@ -96,7 +98,7 @@ const tableSchemaIndexKeySuffix = "?as=TableSchema"
 // suffix used to find the per-namespace children of a cluster-wide watch path.
 // ok is false when watchPath is namespaced or not a resource path.
 func clusterWideChildPrefix(watchPath string) (prefix, suffix string, ok bool) {
-	g, v, resource, ns := parseAPIPath(watchPath)
+	g, v, resource, ns := kstore.ParseAPIPath(watchPath)
 	if ns != "" || resource == "" {
 		return "", "", false
 	}
@@ -112,10 +114,10 @@ func clusterWideChildPrefix(watchPath string) (prefix, suffix string, ok bool) {
 // path and assigns each event a monotonic rv. Watch-enabled paths use the watch
 // index (bodies read lazily); poll-only paths synthesize events by diffing
 // consecutive snapshots (bodies inlined).
-func (s *CaptureStore) buildReplayTimeline(watchPath string) []replayEvent {
+func buildReplayTimeline(s *kstore.CaptureStore, watchPath string) []replayEvent {
 	var evs []replayEvent
 
-	if wps := s.watchIndexPaths(watchPath); len(wps) > 0 {
+	if wps := watchIndexPaths(s, watchPath); len(wps) > 0 {
 		for _, p := range wps {
 			wi := s.WatchIndex[p]
 			for i := range wi.Seqs {
@@ -127,12 +129,12 @@ func (s *CaptureStore) buildReplayTimeline(watchPath string) []replayEvent {
 		}
 	} else {
 		// Poll-only: infer events from snapshot diffs.
-		for _, p := range s.snapshotPaths(watchPath) {
+		for _, p := range snapshotPaths(s, watchPath) {
 			entry := s.Index[p]
 			if entry == nil {
 				continue
 			}
-			trs, err := transitions.InferPollTransitions(s.ar, p, entry)
+			trs, err := transitions.InferPollTransitions(s.Archive(), p, entry)
 			if err != nil {
 				continue
 			}

--- a/internal/server/replay_rv_test.go
+++ b/internal/server/replay_rv_test.go
@@ -54,6 +54,7 @@ func buildPollStore(t *testing.T, apiPath string, snaps []struct {
 	if err != nil {
 		t.Fatalf("kstore.LoadStore: %v", err)
 	}
+	t.Cleanup(store.Close)
 	return store
 }
 

--- a/internal/server/replay_rv_test.go
+++ b/internal/server/replay_rv_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
+
+	kstore "github.com/phenixblue/k8shark/internal/store"
 )
 
 // buildPollStore writes a capture with multiple snapshots for one path and NO
@@ -18,7 +20,7 @@ import (
 func buildPollStore(t *testing.T, apiPath string, snaps []struct {
 	at   time.Time
 	body string
-}) *CaptureStore {
+}) *kstore.CaptureStore {
 	t.Helper()
 	out := filepath.Join(t.TempDir(), "poll.kshrk")
 	sw, err := archive.NewStreamWriter(out)
@@ -48,9 +50,9 @@ func buildPollStore(t *testing.T, apiPath string, snaps []struct {
 		t.Fatalf("archive.Open: %v", err)
 	}
 	t.Cleanup(func() { ar.Close() })
-	store, err := LoadStore(ar)
+	store, err := kstore.LoadStore(ar)
 	if err != nil {
-		t.Fatalf("LoadStore: %v", err)
+		t.Fatalf("kstore.LoadStore: %v", err)
 	}
 	return store
 }
@@ -250,7 +252,7 @@ func TestReplayWatch_PollOnly(t *testing.T) {
 	if len(store.WatchIndex) != 0 {
 		t.Fatalf("expected poll-only store (no watch index), got %d entries", len(store.WatchIndex))
 	}
-	tl := store.buildReplayTimeline(path)
+	tl := buildReplayTimeline(store, path)
 	if len(tl) != 2 {
 		t.Fatalf("inferred timeline length = %d, want 2 (pod-a, pod-b ADDED)", len(tl))
 	}

--- a/internal/server/schedule_test.go
+++ b/internal/server/schedule_test.go
@@ -10,12 +10,14 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	kstore "github.com/phenixblue/k8shark/internal/store"
 )
 
 // newWritableServerSched is newWritableServer with the pod-scheduling shim
 // enabled (as production --writable enables it). The default newWritableServer
 // leaves it off so the many existing pod-create tests aren't perturbed.
-func newWritableServerSched(t *testing.T, store *CaptureStore, clock *ReplayClock) *httptest.Server {
+func newWritableServerSched(t *testing.T, store *kstore.CaptureStore, clock *ReplayClock) *httptest.Server {
 	t.Helper()
 	h := newHandler(store, time.Time{}, false)
 	h.clock = clock
@@ -38,7 +40,7 @@ func nodeList(names ...string) string {
 	return `{"apiVersion":"v1","kind":"NodeList","metadata":{"resourceVersion":"1"},"items":[` + items + `]}`
 }
 
-func schedStore(t *testing.T, from time.Time, nodes ...string) *CaptureStore {
+func schedStore(t *testing.T, from time.Time, nodes ...string) *kstore.CaptureStore {
 	t.Helper()
 	snaps := map[string]watchTestRecord{podsPath: {id: "p", at: from, body: emptyPodList}}
 	if nodes != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,8 @@ import (
 	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
+
+	kstore "github.com/phenixblue/k8shark/internal/store"
 )
 
 // OpenOptions holds parameters for opening a capture archive.
@@ -81,12 +83,12 @@ type Server struct {
 }
 
 // closeStoreAndArchive closes ar, waiting first for store's background
-// enrichment pass to finish if store is non-nil. Pass nil only when LoadStore
+// enrichment pass to finish if store is non-nil. Pass nil only when kstore.LoadStore
 // itself failed (there is no store yet to wait on); every other early-return
-// path below runs after LoadStore has succeeded, meaning its background
+// path below runs after kstore.LoadStore has succeeded, meaning its background
 // goroutine is already reading from ar — closing ar without this wait would
 // race that read (#232).
-func closeStoreAndArchive(store *CaptureStore, ar *archive.Archive) {
+func closeStoreAndArchive(store *kstore.CaptureStore, ar *archive.Archive) {
 	if store != nil {
 		store.Close()
 	}
@@ -100,7 +102,7 @@ func Open(opts OpenOptions) (*Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("opening archive: %w", err)
 	}
-	store, err := LoadStore(ar)
+	store, err := kstore.LoadStore(ar)
 	if err != nil {
 		closeStoreAndArchive(nil, ar)
 		return nil, fmt.Errorf("loading capture: %w", err)
@@ -121,7 +123,7 @@ func Replay(opts ReplayOptions) (*Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("opening archive: %w", err)
 	}
-	store, err := LoadStore(ar)
+	store, err := kstore.LoadStore(ar)
 	if err != nil {
 		closeStoreAndArchive(nil, ar)
 		return nil, fmt.Errorf("loading capture: %w", err)
@@ -146,7 +148,7 @@ func Replay(opts ReplayOptions) (*Server, error) {
 // serve brings up the shared TLS listener, kubeconfig, and HTTP server. When
 // clock is non-nil the handler runs in replay mode; when writable is set (replay
 // only) client writes land in an in-memory overlay.
-func serve(ar *archive.Archive, store *CaptureStore, at time.Time, clock *ReplayClock, writable, schedulePods bool, port, kubeconfigOut string, verbose bool) (*Server, error) {
+func serve(ar *archive.Archive, store *kstore.CaptureStore, at time.Time, clock *ReplayClock, writable, schedulePods bool, port, kubeconfigOut string, verbose bool) (*Server, error) {
 	certPEM, keyPEM, err := generateSelfSignedCert()
 	if err != nil {
 		closeStoreAndArchive(store, ar)

--- a/internal/server/table.go
+++ b/internal/server/table.go
@@ -10,6 +10,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/client-go/util/jsonpath"
+
+	kstore "github.com/phenixblue/k8shark/internal/store"
 )
 
 // Table rendering
@@ -729,13 +731,13 @@ func genericColumns(objs []map[string]any) []tableCol {
 func (h *handler) renderResourceTable(path string, body []byte, at time.Time) ([]byte, bool) {
 	trimmed := strings.TrimSuffix(path, "/")
 	listPath := trimmed
-	group, version, resource, _ := parseAPIPath(trimmed)
+	group, version, resource, _ := kstore.ParseAPIPath(trimmed)
 	if resource == "" {
-		// parseAPIPath only resolves list paths; a single-object GET
+		// kstore.ParseAPIPath only resolves list paths; a single-object GET
 		// (.../<resource>/<name>) resolves after dropping the trailing name.
 		if i := strings.LastIndex(trimmed, "/"); i > 0 {
 			listPath = trimmed[:i]
-			group, version, resource, _ = parseAPIPath(listPath)
+			group, version, resource, _ = kstore.ParseAPIPath(listPath)
 		}
 	}
 	if resource == "" {

--- a/internal/server/teststore_test.go
+++ b/internal/server/teststore_test.go
@@ -1,0 +1,235 @@
+package server
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+
+	kstore "github.com/phenixblue/k8shark/internal/store"
+)
+
+// buildTestStore creates a kstore.CaptureStore with the given per-path
+// response bodies. A near-duplicate of internal/store's own buildTestStore:
+// that one can't be reused here directly since unexported test helpers aren't
+// visible across package boundaries, and this package's HTTP-layer tests
+// (handler_test.go, writes_test.go, ...) need a real *kstore.CaptureStore to
+// drive the mock apiserver against.
+func buildTestStore(t *testing.T, records map[string][]byte) *kstore.CaptureStore {
+	t.Helper()
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "test.kshrk")
+
+	sw, err := archive.NewStreamWriter(outPath)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+
+	index := make(capture.Index)
+	for apiPath, body := range records {
+		now := time.Now().UTC()
+		rec := capture.Record{
+			ID:           "rec-" + apiPath,
+			CapturedAt:   now,
+			APIPath:      apiPath,
+			HTTPMethod:   "GET",
+			ResponseCode: 200,
+			ResponseBody: json.RawMessage(body),
+		}
+		if _, err := sw.WriteRecord(&rec); err != nil {
+			t.Fatalf("WriteRecord: %v", err)
+		}
+		index[apiPath] = &capture.IndexEntry{
+			APIPath: apiPath,
+			Seqs:    []int{0},
+			Times:   []time.Time{now},
+		}
+	}
+
+	meta := capture.CaptureMetadata{
+		CaptureID:         "test-capture-id",
+		KubernetesVersion: "v1.29.0",
+		CapturedAt:        time.Now().UTC().Add(-time.Minute),
+		CapturedUntil:     time.Now().UTC(),
+		RecordCount:       len(records),
+	}
+	if err := sw.Finish(&meta, index, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	ar, err := archive.Open(outPath)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	t.Cleanup(func() { ar.Close() })
+
+	store, err := kstore.LoadStore(ar)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	return store
+}
+
+// podSpec describes one Pod for listWithPods.
+type podSpec struct {
+	name      string
+	namespace string
+	labels    map[string]string
+}
+
+// listWithPods builds a PodList body from pods, defaulting an empty namespace
+// to "default". A near-duplicate of internal/store's own listWithPods — see
+// buildTestStore's doc comment for why.
+func listWithPods(pods []podSpec) []byte {
+	items := make([]map[string]any, 0, len(pods))
+	for _, p := range pods {
+		ns := p.namespace
+		if ns == "" {
+			ns = "default"
+		}
+		items = append(items, map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name":      p.name,
+				"namespace": ns,
+				"labels":    p.labels,
+			},
+		})
+	}
+	body, _ := json.Marshal(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "PodList",
+		"metadata":   map[string]any{},
+		"items":      items,
+	})
+	return body
+}
+
+// itemNames returns the metadata.name of every item in a list body.
+func itemNames(t *testing.T, body []byte) []string {
+	t.Helper()
+	var list struct {
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(body, &list); err != nil {
+		t.Fatalf("itemNames unmarshal: %v\nbody: %s", err, body)
+	}
+	names := make([]string, 0, len(list.Items))
+	for _, it := range list.Items {
+		names = append(names, it.Metadata.Name)
+	}
+	return names
+}
+
+// watchTestRecord describes a single snapshot record for buildTestStoreWithWatch.
+type watchTestRecord struct {
+	id   string
+	at   time.Time
+	body string
+}
+
+// watchTestEvent describes a single watch event record for buildTestStoreWithWatch.
+type watchTestEvent struct {
+	id         string
+	apiPath    string
+	at         time.Time
+	eventType  string
+	objectBody string
+}
+
+// buildTestStoreWithWatch creates a kstore.CaptureStore with snapshot records
+// in index.json and watch event records in watch-index.json.
+func buildTestStoreWithWatch(t *testing.T, snapshots map[string]watchTestRecord, events []watchTestEvent) *kstore.CaptureStore {
+	t.Helper()
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "test.kshrk")
+
+	sw, err := archive.NewStreamWriter(outPath)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+
+	index := make(capture.Index)
+	watchIndex := make(capture.WatchIndex)
+
+	for apiPath, s := range snapshots {
+		rec := capture.Record{
+			ID:           s.id,
+			CapturedAt:   s.at,
+			APIPath:      apiPath,
+			HTTPMethod:   "GET",
+			ResponseCode: 200,
+			ResponseBody: json.RawMessage(s.body),
+		}
+		if _, err := sw.WriteRecord(&rec); err != nil {
+			t.Fatalf("WriteRecord(snap): %v", err)
+		}
+		index[apiPath] = &capture.IndexEntry{
+			APIPath: apiPath,
+			Seqs:    []int{0},
+			Times:   []time.Time{s.at},
+		}
+	}
+
+	// Track per-path seq counter for ALL records (snap + watch share path namespace).
+	allSeq := map[string]int{}
+	for apiPath := range snapshots {
+		allSeq[apiPath] = 1 // snapshot already wrote seq=0
+	}
+	for _, ev := range events {
+		rec := capture.Record{
+			ID:           ev.id,
+			CapturedAt:   ev.at,
+			APIPath:      ev.apiPath,
+			EventType:    ev.eventType,
+			HTTPMethod:   "GET",
+			ResponseCode: 200,
+			ResponseBody: json.RawMessage(ev.objectBody),
+		}
+		if _, err := sw.WriteRecord(&rec); err != nil {
+			t.Fatalf("WriteRecord(watch %s): %v", ev.id, err)
+		}
+		wi := watchIndex[ev.apiPath]
+		if wi == nil {
+			wi = &capture.WatchIndexEntry{APIPath: ev.apiPath}
+			watchIndex[ev.apiPath] = wi
+		}
+		seq := allSeq[ev.apiPath]
+		allSeq[ev.apiPath] = seq + 1
+		wi.Seqs = append(wi.Seqs, seq)
+		wi.Times = append(wi.Times, ev.at)
+		wi.EventTypes = append(wi.EventTypes, ev.eventType)
+	}
+
+	meta := capture.CaptureMetadata{
+		CaptureID: "test-watch-id", KubernetesVersion: "v1.29.0",
+		CapturedAt: time.Now().UTC().Add(-time.Minute), CapturedUntil: time.Now().UTC(),
+	}
+	var wi any
+	if len(watchIndex) > 0 {
+		wi = watchIndex
+	}
+	if err := sw.Finish(&meta, index, wi); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	ar, err := archive.Open(outPath)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	t.Cleanup(func() { ar.Close() })
+
+	store, err := kstore.LoadStore(ar)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	return store
+}

--- a/internal/server/teststore_test.go
+++ b/internal/server/teststore_test.go
@@ -70,6 +70,7 @@ func buildTestStore(t *testing.T, records map[string][]byte) *kstore.CaptureStor
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}
+	t.Cleanup(store.Close)
 	return store
 }
 
@@ -231,5 +232,6 @@ func buildTestStoreWithWatch(t *testing.T, snapshots map[string]watchTestRecord,
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}
+	t.Cleanup(store.Close)
 	return store
 }

--- a/internal/server/version_test.go
+++ b/internal/server/version_test.go
@@ -59,5 +59,10 @@ func loadStoreWithVersion(t *testing.T, version int) (*kstore.CaptureStore, erro
 		return nil, err
 	}
 	t.Cleanup(func() { ar.Close() })
-	return kstore.LoadStore(ar)
+	store, err := kstore.LoadStore(ar)
+	if err != nil {
+		return nil, err
+	}
+	t.Cleanup(store.Close)
+	return store, nil
 }

--- a/internal/server/version_test.go
+++ b/internal/server/version_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
+
+	kstore "github.com/phenixblue/k8shark/internal/store"
 )
 
 func TestLoadStore_FormatVersionGuard(t *testing.T) {
@@ -22,12 +24,12 @@ func TestLoadStore_FormatVersionGuard(t *testing.T) {
 	})
 	t.Run("newer is rejected", func(t *testing.T) {
 		if _, err := loadStoreWithVersion(t, capture.CurrentFormatVersion+1); err == nil {
-			t.Error("expected LoadStore to reject a newer format version")
+			t.Error("expected kstore.LoadStore to reject a newer format version")
 		}
 	})
 }
 
-func loadStoreWithVersion(t *testing.T, version int) (*CaptureStore, error) {
+func loadStoreWithVersion(t *testing.T, version int) (*kstore.CaptureStore, error) {
 	t.Helper()
 	now := time.Date(2026, 4, 9, 8, 0, 0, 0, time.UTC)
 	body := []byte(`{"apiVersion":"v1","kind":"PodList","items":[{"metadata":{"name":"p","namespace":"default"}}]}`)
@@ -49,7 +51,7 @@ func loadStoreWithVersion(t *testing.T, version int) (*CaptureStore, error) {
 		t.Fatalf("Finish: %v", err)
 	}
 	// archive.Open itself enforces the format-version gate (#233), so a
-	// too-new archive is rejected here rather than by LoadStore below —
+	// too-new archive is rejected here rather than by kstore.LoadStore below —
 	// propagate the error instead of failing the test so the "newer is
 	// rejected" case can assert on it regardless of which layer catches it.
 	ar, err := archive.Open(out)
@@ -57,5 +59,5 @@ func loadStoreWithVersion(t *testing.T, version int) (*CaptureStore, error) {
 		return nil, err
 	}
 	t.Cleanup(func() { ar.Close() })
-	return LoadStore(ar)
+	return kstore.LoadStore(ar)
 }

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	kstore "github.com/phenixblue/k8shark/internal/store"
 )
 
 // watchList is a parsed list body ready to be streamed as watch events.
@@ -40,7 +42,7 @@ func (h *handler) resolveWatchList(watchPath string, at time.Time, labelSelector
 
 	if code == 404 {
 		// Only aggregate across namespaces for cluster-wide watch paths.
-		if _, _, _, reqNS := parseAPIPath(watchPath); reqNS == "" {
+		if _, _, _, reqNS := kstore.ParseAPIPath(watchPath); reqNS == "" {
 			rawBody, code, err = h.store.AggregateAcrossNamespaces(watchPath, at)
 			if err != nil {
 				return watchList{}, false, err
@@ -52,7 +54,7 @@ func (h *handler) resolveWatchList(watchPath string, at time.Time, labelSelector
 		// Cluster-scoped fallback: resource was captured at the cluster path
 		// (e.g. /api/v1/pods) but the watch targets a specific namespace. Filter
 		// by metadata.namespace so namespaced watchers see the right items.
-		g, v, resource, ns := parseAPIPath(watchPath)
+		g, v, resource, ns := kstore.ParseAPIPath(watchPath)
 		if ns != "" && resource != "" {
 			var clusterPath string
 			if g == "" {
@@ -62,7 +64,7 @@ func (h *handler) resolveWatchList(watchPath string, at time.Time, labelSelector
 			}
 			clusterBody, clusterCode, cerr := h.store.ReconstructAt(clusterPath, at)
 			if cerr == nil && clusterCode == 200 {
-				filtered, ferr := applySelectors(clusterBody, "", "metadata.namespace="+ns)
+				filtered, ferr := kstore.ApplySelectors(clusterBody, "", "metadata.namespace="+ns)
 				if ferr == nil {
 					rawBody, code = filtered, 200
 				}
@@ -71,7 +73,7 @@ func (h *handler) resolveWatchList(watchPath string, at time.Time, labelSelector
 	}
 
 	if code == 404 {
-		g, v, resource, _ := parseAPIPath(watchPath)
+		g, v, resource, _ := kstore.ParseAPIPath(watchPath)
 		if resource != "" {
 			av := v
 			if g != "" {
@@ -79,7 +81,7 @@ func (h *handler) resolveWatchList(watchPath string, at time.Time, labelSelector
 			}
 			emptyList, _ := json.Marshal(map[string]any{
 				"apiVersion": av,
-				"kind":       resourceToKind(resource) + "List",
+				"kind":       kstore.ResourceToKind(resource) + "List",
 				"metadata":   map[string]string{"resourceVersion": "0"},
 				"items":      []any{},
 			})
@@ -101,7 +103,7 @@ func (h *handler) resolveWatchList(watchPath string, at time.Time, labelSelector
 		rawBody, overlaySkipRV = h.mergeOverlayList(watchPath, rawBody)
 	}
 
-	body, serr := applySelectors(rawBody, labelSelector, fieldSelector)
+	body, serr := kstore.ApplySelectors(rawBody, labelSelector, fieldSelector)
 	if serr != nil {
 		// Best-effort: fall back to the unfiltered list rather than failing the
 		// whole watch on a selector/marshal error.
@@ -147,16 +149,16 @@ func matchesSelectors(raw json.RawMessage, labelSelector, fieldSelector string) 
 	if labelSelector == "" && fieldSelector == "" {
 		return true
 	}
-	labelReqs, err := parseRequirements(labelSelector)
+	labelReqs, err := kstore.ParseRequirements(labelSelector)
 	if err != nil {
 		return true
 	}
-	fieldReqs := parseFieldSelector(fieldSelector)
-	var obj k8sObject
+	fieldReqs := kstore.ParseFieldSelector(fieldSelector)
+	var obj kstore.K8sObject
 	if err := json.Unmarshal(raw, &obj); err != nil {
 		return true
 	}
-	return matchesLabels(&obj, labelReqs) && matchesFields(&obj, fieldReqs)
+	return kstore.MatchesLabels(&obj, labelReqs) && kstore.MatchesFields(&obj, fieldReqs)
 }
 
 // withKind stamps apiVersion/kind onto a watch event object when they're absent,
@@ -254,7 +256,7 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 		// (otherwise a LIST→WATCH informer would loop on 410).
 		maxRV := replayRVBase + int64(len(timeline))
 		if h.overlay != nil {
-			g, v, resource, namespace := parseAPIPath(watchPath)
+			g, v, resource, namespace := kstore.ParseAPIPath(watchPath)
 			if orv := h.overlay.scopeRV(g, v, resource, namespace); orv > maxRV {
 				maxRV = orv
 			}
@@ -271,8 +273,8 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 
 	// Path-derived defaults for the BOOKMARK object kind/apiVersion, and the scope
 	// for overlay watch feedback.
-	g, v, resource, watchNS := parseAPIPath(watchPath)
-	defKind := resourceToKind(resource)
+	g, v, resource, watchNS := kstore.ParseAPIPath(watchPath)
+	defKind := kstore.ResourceToKind(resource)
 	defAPIVersion := v
 	if g != "" {
 		defAPIVersion = g + "/" + v
@@ -666,7 +668,7 @@ func (h *handler) replayPass(ctx context.Context, timer <-chan time.Time, clock 
 		// Poll-only events carry their body inline; watch events read it lazily.
 		body := ev.body
 		if body == nil {
-			rec, err := h.store.readRecord(ev.apiPath, ev.seq)
+			rec, err := h.store.ReadRecord(ev.apiPath, ev.seq)
 			if err != nil {
 				continue
 			}

--- a/internal/server/watch_replay_test.go
+++ b/internal/server/watch_replay_test.go
@@ -247,7 +247,7 @@ func TestWatchTimeline_AggregatesAcrossNamespaces(t *testing.T) {
 		},
 	)
 
-	timeline := store.buildReplayTimeline("/api/v1/pods")
+	timeline := buildReplayTimeline(store, "/api/v1/pods")
 	if len(timeline) != 3 {
 		t.Fatalf("timeline length = %d, want 3", len(timeline))
 	}

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
+
+	kstore "github.com/phenixblue/k8shark/internal/store"
 )
 
 // handleWrite services a create/update/patch/delete against the in-memory overlay
@@ -182,7 +184,7 @@ func (h *handler) storeNewObject(group, version, resource, namespace, name strin
 		// A real apiextensions-apiserver also registers the CRD's defined type
 		// with the aggregated discovery document the moment it's created. The
 		// store's resourceInfo is otherwise a snapshot built once from the
-		// capture archive (see CaptureStore.buildResourceInfo/LoadStore), so
+		// capture archive (see kstore.CaptureStore.buildResourceInfo/kstore.LoadStore), so
 		// without this a CRD applied at runtime (e.g. `istioctl install`) is
 		// visible via `kubectl get crd` (a plain object read) but absent from
 		// `kubectl api-resources` / `istioctl analyze` (which walk discovery),
@@ -447,7 +449,7 @@ func ensureCRDEstablished(body json.RawMessage, now string) json.RawMessage {
 
 // registerCRDResourceInfo parses a freshly created CustomResourceDefinition's
 // spec and registers its defined group/version/resource/kind with the store's
-// discovery metadata (CaptureStore.mergeResourceInfo), so /apis and
+// discovery metadata (kstore.CaptureStore.MergeResourceInfo), so /apis and
 // /apis/<group>/<version> — and therefore `kubectl api-resources` and any
 // client that walks discovery (e.g. `istioctl analyze`) — reflect it
 // immediately, rather than only once the archive is reloaded. Best-effort: a
@@ -477,13 +479,13 @@ func (h *handler) registerCRDResourceInfo(body json.RawMessage) {
 		return
 	}
 	if crd.Spec.Group == "" || crd.Spec.Names.Plural == "" || crd.Spec.Names.Kind == "" {
-		// A missing Kind would otherwise fall through to mergeResourceInfo's
-		// resourceToKind heuristic fallback, which is a plural-depluralizing
+		// A missing Kind would otherwise fall through to MergeResourceInfo's
+		// kstore.ResourceToKind heuristic fallback, which is a plural-depluralizing
 		// guess known to be wrong for most CRDs — skipping keeps a malformed
 		// CRD body from polluting discovery with a made-up Kind.
 		return
 	}
-	// mergeResourceInfo treats namespaced as authoritative and overwrites any
+	// MergeResourceInfo treats namespaced as authoritative and overwrites any
 	// existing value, so an empty/unrecognized spec.scope (a malformed body)
 	// must be skipped entirely rather than defaulting to namespaced=true.
 	var namespaced bool
@@ -507,7 +509,7 @@ func (h *handler) registerCRDResourceInfo(body json.RawMessage) {
 		if !v.Served || v.Name == "" {
 			continue
 		}
-		h.store.mergeResourceInfo(crd.Spec.Group, v.Name, crd.Spec.Names.Plural, namespaced,
+		h.store.MergeResourceInfo(crd.Spec.Group, v.Name, crd.Spec.Names.Plural, namespaced,
 			crd.Spec.Names.Kind, crd.Spec.Names.Singular, crd.Spec.Names.ShortNames)
 	}
 }
@@ -710,7 +712,7 @@ func (h *handler) overlayDelete(w http.ResponseWriter, group, version, resource,
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"apiVersion": "v1", "kind": "Status", "status": "Success",
-		"details": map[string]any{"name": name, "kind": resourceToKind(resource)},
+		"details": map[string]any{"name": name, "kind": kstore.ResourceToKind(resource)},
 	})
 }
 
@@ -727,13 +729,13 @@ func (h *handler) overlayDeleteCollection(w http.ResponseWriter, r *http.Request
 		writeJSON(w, http.StatusInternalServerError, statusObj(http.StatusInternalServerError, err.Error()))
 		return
 	}
-	// Unlike a read (applySelectors/filterItems, deliberately best-effort — a
+	// Unlike a read (kstore.ApplySelectors/kstore.FilterItems, deliberately best-effort — a
 	// malformed selector there just means "show more than intended"), a
 	// malformed or unsupported selector here would mean "delete more than
-	// intended" — filterItemsStrict parses with apimachinery's real selector
+	// intended" — kstore.FilterItemsStrict parses with apimachinery's real selector
 	// grammar and 400s on anything malformed, rather than silently matching
 	// everything.
-	msg, filtered := filterItemsStrict(items, r.URL.Query().Get("labelSelector"), r.URL.Query().Get("fieldSelector"))
+	msg, filtered := kstore.FilterItemsStrict(items, r.URL.Query().Get("labelSelector"), r.URL.Query().Get("fieldSelector"))
 	if msg != "" {
 		h.writeStatus(w, http.StatusBadRequest, msg)
 		return
@@ -767,7 +769,7 @@ func (h *handler) overlayDeleteCollection(w http.ResponseWriter, r *http.Request
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"apiVersion": "v1", "kind": "Status", "status": "Success",
-		"details": map[string]any{"kind": resourceToKind(resource)},
+		"details": map[string]any{"kind": kstore.ResourceToKind(resource)},
 	})
 }
 
@@ -830,7 +832,7 @@ func (h *handler) currentListItems(group, version, resource, namespace string) (
 // reconstructListItems reconstructs a captured list at `at` and returns its
 // items. Returns nil (not an error) when nothing was captured at that exact
 // path (a non-200 reconstruction), or when the 200 body isn't list-shaped
-// (e.g. a Table-format or other non-list snapshot — CaptureStore.ReconstructAt
+// (e.g. a Table-format or other non-list snapshot — kstore.CaptureStore.ReconstructAt
 // is deliberately tolerant of those and returns them unchanged, so failing to
 // decode "items" here is best-effort, not a hard error) — either way,
 // currentListItems' overlay merge still applies on top. A genuine store error

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -11,12 +11,14 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	kstore "github.com/phenixblue/k8shark/internal/store"
 )
 
 const podsPath = "/api/v1/namespaces/default/pods"
 
 // newWritableServer builds a writable replay handler over the given store/clock.
-func newWritableServer(t *testing.T, store *CaptureStore, clock *ReplayClock) *httptest.Server {
+func newWritableServer(t *testing.T, store *kstore.CaptureStore, clock *ReplayClock) *httptest.Server {
 	t.Helper()
 	h := newHandler(store, time.Time{}, false)
 	h.clock = clock
@@ -77,7 +79,7 @@ func contains(ss []string, want string) bool {
 	return false
 }
 
-func writableTestStore(t *testing.T, from time.Time) *CaptureStore {
+func writableTestStore(t *testing.T, from time.Time) *kstore.CaptureStore {
 	return buildTestStoreWithWatch(t,
 		map[string]watchTestRecord{podsPath: {id: "s", at: from, body: podList("pod-base")}},
 		nil)
@@ -1774,7 +1776,7 @@ func TestOverlay_DeleteCollection_LabelSelectorFilters(t *testing.T) {
 
 // TestOverlay_DeleteCollection_SetBasedSelectorFilters verifies well-formed
 // set-based ("in"/"notin") labelSelectors still work for deletecollection —
-// filterItemsStrict's strict parsing must reject malformed set syntax without
+// kstore.FilterItemsStrict's strict parsing must reject malformed set syntax without
 // breaking legitimate use.
 func TestOverlay_DeleteCollection_SetBasedSelectorFilters(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
@@ -1963,9 +1965,9 @@ func TestOverlay_DeleteCollection_AggregateAcrossNamespacesFallback(t *testing.T
 
 // TestOverlay_DeleteCollection_InvalidSelectorRejected verifies deletecollection
 // rejects a malformed or unsupported labelSelector/fieldSelector with 400
-// (filterItemsStrict, backed by k8s.io/apimachinery's labels.Parse and
+// (kstore.FilterItemsStrict, backed by k8s.io/apimachinery's labels.Parse and
 // fields.ParseSelector) rather than the read path's best-effort leniency
-// (filterItems/applySelectors) — which for a mutating deletecollection would
+// (kstore.FilterItems/kstore.ApplySelectors) — which for a mutating deletecollection would
 // mean "delete more than the caller asked for," not just "display more than
 // intended."
 func TestOverlay_DeleteCollection_InvalidSelectorRejected(t *testing.T) {
@@ -1985,7 +1987,7 @@ func TestOverlay_DeleteCollection_InvalidSelectorRejected(t *testing.T) {
 		// An unclosed "notin (" is a syntax error in the real grammar.
 		{"unclosed notin paren", "?labelSelector=app+notin+%28"},
 		// fields.ParseSelector is lenient about a stray comma (parses to an
-		// Empty selector rather than erroring) — caught by filterItemsStrict's
+		// Empty selector rather than erroring) — caught by kstore.FilterItemsStrict's
 		// explicit Empty() check instead.
 		{"empty fieldSelector segment", "?fieldSelector=%2C"},
 		// Whitespace-only selectors parse successfully to an Empty selector in
@@ -2014,7 +2016,7 @@ func TestOverlay_DeleteCollection_InvalidSelectorRejected(t *testing.T) {
 // TestOverlay_DeleteCollection_NonListCaptureBodyIsBestEffort verifies
 // deletecollection doesn't hard-fail when the captured body at the list path
 // isn't list-shaped (e.g. a Table-format snapshot) — it's treated as zero
-// captured items (best-effort, matching CaptureStore.ReconstructAt's own
+// captured items (best-effort, matching kstore.CaptureStore.ReconstructAt's own
 // tolerance of non-list bodies), and overlay-owned items still delete cleanly.
 func TestOverlay_DeleteCollection_NonListCaptureBodyIsBestEffort(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
@@ -2206,7 +2208,7 @@ func TestOverlay_CRDMergesIntoCapturedDiscovery(t *testing.T) {
 			{"name":"gateways","namespaced":true,"kind":"Gateway","verbs":["create","delete","get","list","patch","update","watch"]}
 		]}`),
 	})
-	store.discoveryEnrichmentDone.Wait() // deterministically wait for the async enrichment pass
+	store.Close() // deterministically wait for the async enrichment pass
 
 	// No fake replay clock here: buildTestStore stamps captured records with
 	// the real wall-clock time, so a clock pinned to an arbitrary past instant
@@ -2289,7 +2291,7 @@ func TestOverlay_CRDNewVersionMergesIntoCapturedGroup(t *testing.T) {
 			{"name":"gateways","namespaced":true,"kind":"Gateway"}
 		]}`),
 	})
-	store.discoveryEnrichmentDone.Wait()
+	store.Close()
 
 	h := newHandler(store, time.Time{}, false) // see TestOverlay_CRDMergesIntoCapturedDiscovery for why no fake clock
 	h.overlay = newOverlay()
@@ -2355,7 +2357,7 @@ func TestOverlay_CRDNewVersionMergesIntoCapturedGroup(t *testing.T) {
 // spec.names.kind is missing (a malformed body a real apiserver's OpenAPI
 // validation would reject, but registerCRDResourceInfo is deliberately
 // best-effort) doesn't get registered in discovery at all — falling through
-// to mergeResourceInfo's resourceToKind heuristic would guess a Kind that's
+// to mergeResourceInfo's kstore.ResourceToKind heuristic would guess a Kind that's
 // almost certainly wrong for a CRD (the heuristic is only reliable for
 // built-in types), polluting discovery with bad data. Found via Copilot
 // review.
@@ -2386,8 +2388,8 @@ func TestOverlay_CRDMissingKindSkipsDiscoveryRegistration(t *testing.T) {
 // TestOverlay_CRDRegistersDiscoveryOnCreate verifies a freshly created CRD is
 // immediately visible via the discovery endpoints (/apis and
 // /apis/<group>/<version>), not just via a plain object read (`kubectl get
-// crd`). CaptureStore.resourceInfo is otherwise a snapshot built once from the
-// capture archive at startup (see LoadStore/buildResourceInfo), so without
+// crd`). kstore.CaptureStore.resourceInfo is otherwise a snapshot built once from the
+// capture archive at startup (see kstore.LoadStore/buildResourceInfo), so without
 // registering the CRD's defined type on create, a CRD applied at runtime
 // (e.g. `istioctl install`) never shows up in `kubectl api-resources` or
 // `istioctl analyze`, both of which walk discovery rather than reading the

--- a/internal/store/malformed_watch_index_test.go
+++ b/internal/store/malformed_watch_index_test.go
@@ -1,4 +1,4 @@
-package server_test
+package store_test
 
 import (
 	"archive/zip"
@@ -10,7 +10,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/redact"
-	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 	"github.com/phenixblue/k8shark/internal/transitions"
 )
 
@@ -97,13 +97,13 @@ func TestAllReaders_RejectMalformedWatchIndex(t *testing.T) {
 		}
 	}
 
-	t.Run("server.LoadStore", func(t *testing.T) {
+	t.Run("store.LoadStore", func(t *testing.T) {
 		ar, err := archive.Open(path)
 		if err != nil {
 			t.Fatalf("archive.Open: %v", err)
 		}
 		defer ar.Close()
-		_, err = server.LoadStore(ar)
+		_, err = store.LoadStore(ar)
 		assertWatchIndexError(t, err)
 	})
 

--- a/internal/store/responses_codec.go
+++ b/internal/store/responses_codec.go
@@ -1,4 +1,4 @@
-package server
+package store
 
 import (
 	"bytes"
@@ -6,6 +6,10 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+
+	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/runtime/serializer/protobuf"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 // Response content negotiation for a uniform apiserver surface (issue #150).
@@ -20,22 +24,33 @@ import (
 // scheme decode and pass through as JSON — exactly as a real apiserver does
 // (CRDs have no protobuf).
 
-const protobufMediaType = "application/vnd.kubernetes.protobuf"
+const ProtobufMediaType = "application/vnd.kubernetes.protobuf"
 
-// isNonProtobufPath reports request paths that never return a Kubernetes
+// scheme.Scheme registers all built-in Kubernetes types; both serializers are
+// stateless over it and safe for concurrent use. internal/server's
+// writes_codec.go needs the same pair for the opposite direction (decoding a
+// protobuf write body to JSON) and declares its own instances rather than
+// importing this package for two lines of construction.
+var (
+	protobufSerializer = protobuf.NewSerializer(scheme.Scheme, scheme.Scheme)
+	jsonSerializer     = kjson.NewSerializerWithOptions(
+		kjson.DefaultMetaFactory, scheme.Scheme, scheme.Scheme, kjson.SerializerOptions{})
+)
+
+// IsNonProtobufPath reports request paths that never return a Kubernetes
 // protobuf object and may be large or streamed — OpenAPI documents (multi-MB
 // JSON) and pod log subresources (text/plain). The protobuf response wrapper
 // skips these so they aren't buffered in memory only to pass through unchanged.
-func isNonProtobufPath(path string) bool {
+func IsNonProtobufPath(path string) bool {
 	return strings.HasPrefix(path, "/openapi") || strings.HasSuffix(path, "/log")
 }
 
-// wantsProtobuf reports whether the client's Accept header selects Kubernetes
+// WantsProtobuf reports whether the client's Accept header selects Kubernetes
 // protobuf over JSON. It mirrors apiserver negotiation: among acceptable (q>0)
 // media types, the highest q wins, and header order breaks ties. So
 // `protobuf,json` (both q=1) picks protobuf, `json,protobuf` picks JSON, a
 // higher-q entry always wins, and `…protobuf;q=0` / Table requests yield JSON.
-func wantsProtobuf(r *http.Request) bool {
+func WantsProtobuf(r *http.Request) bool {
 	accept := r.Header.Get("Accept")
 	if accept == "" {
 		return false
@@ -52,7 +67,7 @@ func wantsProtobuf(r *http.Request) bool {
 		}
 		var isProto, isJSON bool
 		switch mt {
-		case protobufMediaType:
+		case ProtobufMediaType:
 			isProto = true
 		case "application/json", "application/*", "*/*":
 			isJSON = true
@@ -92,26 +107,26 @@ func jsonToProtobuf(body []byte) ([]byte, bool) {
 	return buf.Bytes(), true
 }
 
-// protobufResponseWriter buffers a response so a JSON body of a built-in type
+// ProtobufResponseWriter buffers a response so a JSON body of a built-in type
 // can be re-encoded as protobuf on flush. It is only used for non-watch requests
 // whose client prefers protobuf.
-type protobufResponseWriter struct {
+type ProtobufResponseWriter struct {
 	http.ResponseWriter
 	status int
 	buf    bytes.Buffer
 }
 
-func newProtobufResponseWriter(w http.ResponseWriter) *protobufResponseWriter {
-	return &protobufResponseWriter{ResponseWriter: w}
+func NewProtobufResponseWriter(w http.ResponseWriter) *ProtobufResponseWriter {
+	return &ProtobufResponseWriter{ResponseWriter: w}
 }
 
-func (p *protobufResponseWriter) WriteHeader(code int) { p.status = code }
+func (p *ProtobufResponseWriter) WriteHeader(code int) { p.status = code }
 
-func (p *protobufResponseWriter) Write(b []byte) (int, error) { return p.buf.Write(b) }
+func (p *ProtobufResponseWriter) Write(b []byte) (int, error) { return p.buf.Write(b) }
 
-// flush writes the buffered response, transcoding a JSON built-in-object body to
+// Flush writes the buffered response, transcoding a JSON built-in-object body to
 // protobuf when possible; otherwise it passes the JSON through unchanged.
-func (p *protobufResponseWriter) flush() {
+func (p *ProtobufResponseWriter) Flush() {
 	status := p.status
 	if status == 0 {
 		status = http.StatusOK
@@ -125,7 +140,7 @@ func (p *protobufResponseWriter) flush() {
 	ct := p.Header().Get("Content-Type")
 	if strings.HasPrefix(ct, "application/json") {
 		if pb, ok := jsonToProtobuf(body); ok {
-			p.Header().Set("Content-Type", protobufMediaType)
+			p.Header().Set("Content-Type", ProtobufMediaType)
 			p.Header().Del("Content-Length") // length changed; let net/http recompute
 			p.ResponseWriter.WriteHeader(status)
 			_, _ = p.ResponseWriter.Write(pb)

--- a/internal/store/responses_codec_test.go
+++ b/internal/store/responses_codec_test.go
@@ -1,11 +1,8 @@
-package server
+package store
 
 import (
-	"io"
 	"net/http"
-	"net/http/httptest"
 	"testing"
-	"time"
 )
 
 func TestWantsProtobuf(t *testing.T) {
@@ -28,8 +25,8 @@ func TestWantsProtobuf(t *testing.T) {
 		if accept != "" {
 			r.Header.Set("Accept", accept)
 		}
-		if got := wantsProtobuf(r); got != want {
-			t.Errorf("wantsProtobuf(Accept=%q) = %v, want %v", accept, got, want)
+		if got := WantsProtobuf(r); got != want {
+			t.Errorf("WantsProtobuf(Accept=%q) = %v, want %v", accept, got, want)
 		}
 	}
 }
@@ -49,62 +46,6 @@ func TestJSONToProtobuf(t *testing.T) {
 	}
 }
 
-// getWithAccept issues a GET with an Accept header and returns status, the
-// response Content-Type, and the raw body.
-func getWithAccept(t *testing.T, url, accept string) (int, string, []byte) {
-	t.Helper()
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		t.Fatalf("new request: %v", err)
-	}
-	req.Header.Set("Accept", accept)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("GET %s: %v", url, err)
-	}
-	defer resp.Body.Close()
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("reading body: %v", err)
-	}
-	return resp.StatusCode, resp.Header.Get("Content-Type"), b
-}
-
-// A protobuf-preferring client gets a protobuf response for a built-in list; a
-// JSON client still gets JSON. (issue #150)
-func TestProtobufResponseNegotiation(t *testing.T) {
-	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
-	store := buildTestStoreWithWatch(t,
-		map[string]watchTestRecord{podsPath: {id: "s", at: from, body: podList("pod-base")}}, nil)
-	h := newHandler(store, from, false)
-	srv := httptest.NewServer(h)
-	t.Cleanup(srv.Close)
-
-	// Protobuf-preferring client: protobuf response that decodes back to a List.
-	code, ct, body := getWithAccept(t, srv.URL+podsPath, "application/vnd.kubernetes.protobuf,application/json")
-	if code != http.StatusOK {
-		t.Fatalf("protobuf GET: status %d, want 200", code)
-	}
-	if ct != protobufMediaType {
-		t.Errorf("Content-Type = %q, want %q", ct, protobufMediaType)
-	}
-	if len(body) < 4 || string(body[:4]) != "k8s\x00" {
-		t.Errorf("protobuf framing missing, got %q", body[:min(4, len(body))])
-	}
-	if obj, _, err := protobufSerializer.Decode(body, nil, nil); err != nil || obj == nil {
-		t.Errorf("protobuf body did not decode: %v", err)
-	}
-
-	// JSON client: unchanged JSON response.
-	code, ct, _ = getWithAccept(t, srv.URL+podsPath, "application/json")
-	if code != http.StatusOK {
-		t.Fatalf("json GET: status %d, want 200", code)
-	}
-	if ct != "application/json" {
-		t.Errorf("Content-Type = %q, want application/json", ct)
-	}
-}
-
 func TestIsNonProtobufPath(t *testing.T) {
 	cases := map[string]bool{
 		"/openapi/v2":                                  true,
@@ -116,8 +57,8 @@ func TestIsNonProtobufPath(t *testing.T) {
 		"/apis/apps/v1/namespaces/default/deployments": false,
 	}
 	for path, want := range cases {
-		if got := isNonProtobufPath(path); got != want {
-			t.Errorf("isNonProtobufPath(%q) = %v, want %v", path, got, want)
+		if got := IsNonProtobufPath(path); got != want {
+			t.Errorf("IsNonProtobufPath(%q) = %v, want %v", path, got, want)
 		}
 	}
 }

--- a/internal/store/selector.go
+++ b/internal/store/selector.go
@@ -22,9 +22,9 @@ type K8sObject struct {
 
 // LabelRequirement is one parsed segment of a labelSelector.
 type LabelRequirement struct {
-	key    string
-	op     string // "=", "!=", "in", "notin", "exists", "doesnotexist"
-	values []string
+	Key    string
+	Op     string // "=", "!=", "in", "notin", "exists", "doesnotexist"
+	Values []string
 }
 
 // ParseRequirements parses a comma-separated labelSelector string into requirements.
@@ -54,44 +54,44 @@ func parseOneRequirement(seg string) (LabelRequirement, error) {
 	var r LabelRequirement
 	// key notin (v1,v2)
 	if i := strings.Index(seg, " notin "); i >= 0 {
-		r.key = strings.TrimSpace(seg[:i])
-		r.op = "notin"
-		r.values = parseParenList(seg[i+7:])
+		r.Key = strings.TrimSpace(seg[:i])
+		r.Op = "notin"
+		r.Values = parseParenList(seg[i+7:])
 		return r, nil
 	}
 	// key in (v1,v2)
 	if i := strings.Index(seg, " in "); i >= 0 {
-		r.key = strings.TrimSpace(seg[:i])
-		r.op = "in"
-		r.values = parseParenList(seg[i+4:])
+		r.Key = strings.TrimSpace(seg[:i])
+		r.Op = "in"
+		r.Values = parseParenList(seg[i+4:])
 		return r, nil
 	}
 	// key!=val
 	if i := strings.Index(seg, "!="); i >= 0 {
-		r.key = strings.TrimSpace(seg[:i])
-		r.op = "!="
-		r.values = []string{strings.TrimSpace(seg[i+2:])}
+		r.Key = strings.TrimSpace(seg[:i])
+		r.Op = "!="
+		r.Values = []string{strings.TrimSpace(seg[i+2:])}
 		return r, nil
 	}
 	// key==val or key=val
 	for _, eq := range []string{"==", "="} {
 		if i := strings.Index(seg, eq); i >= 0 {
-			r.key = strings.TrimSpace(seg[:i])
-			r.op = "="
-			r.values = []string{strings.TrimSpace(seg[i+len(eq):])}
+			r.Key = strings.TrimSpace(seg[:i])
+			r.Op = "="
+			r.Values = []string{strings.TrimSpace(seg[i+len(eq):])}
 			return r, nil
 		}
 	}
 	// !key (non-existence)
 	if strings.HasPrefix(seg, "!") {
-		r.key = strings.TrimSpace(seg[1:])
-		r.op = "doesnotexist"
+		r.Key = strings.TrimSpace(seg[1:])
+		r.Op = "doesnotexist"
 		return r, nil
 	}
 	// key (existence check)
 	if seg != "" {
-		r.key = seg
-		r.op = "exists"
+		r.Key = seg
+		r.Op = "exists"
 		return r, nil
 	}
 	return r, fmt.Errorf("empty requirement segment")
@@ -134,14 +134,14 @@ func splitRespectingParens(s string) []string {
 // MatchesLabels returns true if the object's labels satisfy all requirements.
 func MatchesLabels(obj *K8sObject, reqs []LabelRequirement) bool {
 	for _, r := range reqs {
-		val, exists := obj.Metadata.Labels[r.key]
-		switch r.op {
+		val, exists := obj.Metadata.Labels[r.Key]
+		switch r.Op {
 		case "=":
-			if !exists || val != r.values[0] {
+			if !exists || val != r.Values[0] {
 				return false
 			}
 		case "!=":
-			if exists && val == r.values[0] {
+			if exists && val == r.Values[0] {
 				return false
 			}
 		case "in":
@@ -149,7 +149,7 @@ func MatchesLabels(obj *K8sObject, reqs []LabelRequirement) bool {
 				return false
 			}
 			found := false
-			for _, v := range r.values {
+			for _, v := range r.Values {
 				if val == v {
 					found = true
 					break
@@ -159,7 +159,7 @@ func MatchesLabels(obj *K8sObject, reqs []LabelRequirement) bool {
 				return false
 			}
 		case "notin":
-			for _, v := range r.values {
+			for _, v := range r.Values {
 				if exists && val == v {
 					return false
 				}
@@ -179,9 +179,9 @@ func MatchesLabels(obj *K8sObject, reqs []LabelRequirement) bool {
 
 // FieldSelectorReq is one parsed field= or field!= requirement.
 type FieldSelectorReq struct {
-	field string
-	op    string // "=" or "!="
-	value string
+	Field string
+	Op    string // "=" or "!="
+	Value string
 }
 
 // parseFieldSelectorSegment parses one fieldSelector segment ("key=val",
@@ -326,7 +326,7 @@ func FilterItemsStrict(items []json.RawMessage, labelSelector, fieldSelector str
 func MatchesFields(obj *K8sObject, reqs []FieldSelectorReq) bool {
 	for _, r := range reqs {
 		var actual string
-		switch r.field {
+		switch r.Field {
 		case "metadata.name":
 			actual = obj.Metadata.Name
 		case "metadata.namespace":
@@ -335,13 +335,13 @@ func MatchesFields(obj *K8sObject, reqs []FieldSelectorReq) bool {
 			// Unknown field — skip (generous, avoids false negatives on unsupported fields).
 			continue
 		}
-		switch r.op {
+		switch r.Op {
 		case "=":
-			if actual != r.value {
+			if actual != r.Value {
 				return false
 			}
 		case "!=":
-			if actual == r.value {
+			if actual == r.Value {
 				return false
 			}
 		}

--- a/internal/store/selector.go
+++ b/internal/store/selector.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-// k8s object shape we inspect for filtering.
+// K8sObject is the k8s object shape we inspect for filtering.
 type K8sObject struct {
 	Metadata struct {
 		Name      string            `json:"name"`
@@ -20,8 +20,8 @@ type K8sObject struct {
 	Status map[string]any `json:"status"`
 }
 
-// labelRequirement is one parsed segment of a labelSelector.
-type labelRequirement struct {
+// LabelRequirement is one parsed segment of a labelSelector.
+type LabelRequirement struct {
 	key    string
 	op     string // "=", "!=", "in", "notin", "exists", "doesnotexist"
 	values []string
@@ -31,11 +31,11 @@ type labelRequirement struct {
 // Supports: key=val, key==val, key!=val, key in (v1,v2), key notin (v1,v2),
 //
 //	key (existence), !key (non-existence).
-func ParseRequirements(selector string) ([]labelRequirement, error) {
+func ParseRequirements(selector string) ([]LabelRequirement, error) {
 	if selector == "" {
 		return nil, nil
 	}
-	var reqs []labelRequirement
+	var reqs []LabelRequirement
 	for _, seg := range splitRespectingParens(selector) {
 		seg = strings.TrimSpace(seg)
 		if seg == "" {
@@ -50,8 +50,8 @@ func ParseRequirements(selector string) ([]labelRequirement, error) {
 	return reqs, nil
 }
 
-func parseOneRequirement(seg string) (labelRequirement, error) {
-	var r labelRequirement
+func parseOneRequirement(seg string) (LabelRequirement, error) {
+	var r LabelRequirement
 	// key notin (v1,v2)
 	if i := strings.Index(seg, " notin "); i >= 0 {
 		r.key = strings.TrimSpace(seg[:i])
@@ -132,7 +132,7 @@ func splitRespectingParens(s string) []string {
 }
 
 // MatchesLabels returns true if the object's labels satisfy all requirements.
-func MatchesLabels(obj *K8sObject, reqs []labelRequirement) bool {
+func MatchesLabels(obj *K8sObject, reqs []LabelRequirement) bool {
 	for _, r := range reqs {
 		val, exists := obj.Metadata.Labels[r.key]
 		switch r.op {
@@ -177,8 +177,8 @@ func MatchesLabels(obj *K8sObject, reqs []labelRequirement) bool {
 	return true
 }
 
-// fieldSelectorReq is one parsed field= or field!= requirement.
-type fieldSelectorReq struct {
+// FieldSelectorReq is one parsed field= or field!= requirement.
+type FieldSelectorReq struct {
 	field string
 	op    string // "=" or "!="
 	value string
@@ -187,17 +187,17 @@ type fieldSelectorReq struct {
 // parseFieldSelectorSegment parses one fieldSelector segment ("key=val",
 // "key==val", or "key!=val") into a requirement. ok is false if the segment
 // matches none of those forms.
-func parseFieldSelectorSegment(seg string) (fieldSelectorReq, bool) {
+func parseFieldSelectorSegment(seg string) (FieldSelectorReq, bool) {
 	if i := strings.Index(seg, "!="); i >= 0 {
-		return fieldSelectorReq{strings.TrimSpace(seg[:i]), "!=", strings.TrimSpace(seg[i+2:])}, true
+		return FieldSelectorReq{strings.TrimSpace(seg[:i]), "!=", strings.TrimSpace(seg[i+2:])}, true
 	}
 	if i := strings.Index(seg, "=="); i >= 0 {
-		return fieldSelectorReq{strings.TrimSpace(seg[:i]), "=", strings.TrimSpace(seg[i+2:])}, true
+		return FieldSelectorReq{strings.TrimSpace(seg[:i]), "=", strings.TrimSpace(seg[i+2:])}, true
 	}
 	if i := strings.Index(seg, "="); i >= 0 {
-		return fieldSelectorReq{strings.TrimSpace(seg[:i]), "=", strings.TrimSpace(seg[i+1:])}, true
+		return FieldSelectorReq{strings.TrimSpace(seg[:i]), "=", strings.TrimSpace(seg[i+1:])}, true
 	}
-	return fieldSelectorReq{}, false
+	return FieldSelectorReq{}, false
 }
 
 // ParseFieldSelector parses a comma-separated fieldSelector for reads.
@@ -208,11 +208,11 @@ func parseFieldSelectorSegment(seg string) (fieldSelectorReq, bool) {
 // FilterItemsStrict instead (see below), which parses with apimachinery's
 // real selector grammar rather than this lenient one, since the same
 // leniency there would risk deleting more than the caller asked for.
-func ParseFieldSelector(selector string) []fieldSelectorReq {
+func ParseFieldSelector(selector string) []FieldSelectorReq {
 	if selector == "" {
 		return nil
 	}
-	var reqs []fieldSelectorReq
+	var reqs []FieldSelectorReq
 	for _, seg := range strings.Split(selector, ",") {
 		if req, ok := parseFieldSelectorSegment(strings.TrimSpace(seg)); ok {
 			reqs = append(reqs, req)
@@ -323,7 +323,7 @@ func FilterItemsStrict(items []json.RawMessage, labelSelector, fieldSelector str
 
 // MatchesFields returns true if the object satisfies all field selector requirements.
 // Only metadata.name and metadata.namespace are supported.
-func MatchesFields(obj *K8sObject, reqs []fieldSelectorReq) bool {
+func MatchesFields(obj *K8sObject, reqs []FieldSelectorReq) bool {
 	for _, r := range reqs {
 		var actual string
 		switch r.field {

--- a/internal/store/selector.go
+++ b/internal/store/selector.go
@@ -1,4 +1,4 @@
-package server
+package store
 
 import (
 	"encoding/json"
@@ -10,7 +10,7 @@ import (
 )
 
 // k8s object shape we inspect for filtering.
-type k8sObject struct {
+type K8sObject struct {
 	Metadata struct {
 		Name      string            `json:"name"`
 		Namespace string            `json:"namespace"`
@@ -27,11 +27,11 @@ type labelRequirement struct {
 	values []string
 }
 
-// parseRequirements parses a comma-separated labelSelector string into requirements.
+// ParseRequirements parses a comma-separated labelSelector string into requirements.
 // Supports: key=val, key==val, key!=val, key in (v1,v2), key notin (v1,v2),
 //
 //	key (existence), !key (non-existence).
-func parseRequirements(selector string) ([]labelRequirement, error) {
+func ParseRequirements(selector string) ([]labelRequirement, error) {
 	if selector == "" {
 		return nil, nil
 	}
@@ -131,8 +131,8 @@ func splitRespectingParens(s string) []string {
 	return parts
 }
 
-// matchesLabels returns true if the object's labels satisfy all requirements.
-func matchesLabels(obj *k8sObject, reqs []labelRequirement) bool {
+// MatchesLabels returns true if the object's labels satisfy all requirements.
+func MatchesLabels(obj *K8sObject, reqs []labelRequirement) bool {
 	for _, r := range reqs {
 		val, exists := obj.Metadata.Labels[r.key]
 		switch r.op {
@@ -200,15 +200,15 @@ func parseFieldSelectorSegment(seg string) (fieldSelectorReq, bool) {
 	return fieldSelectorReq{}, false
 }
 
-// parseFieldSelector parses a comma-separated fieldSelector for reads.
+// ParseFieldSelector parses a comma-separated fieldSelector for reads.
 // Supported fields: metadata.name, metadata.namespace. An unparseable segment
-// is silently skipped — best-effort, matching matchesFields' generous
+// is silently skipped — best-effort, matching MatchesFields' generous
 // handling of unsupported keys — safe for a read, where "matches more than
 // intended" only affects display fidelity. deletecollection uses
-// filterItemsStrict instead (see below), which parses with apimachinery's
+// FilterItemsStrict instead (see below), which parses with apimachinery's
 // real selector grammar rather than this lenient one, since the same
 // leniency there would risk deleting more than the caller asked for.
-func parseFieldSelector(selector string) []fieldSelectorReq {
+func ParseFieldSelector(selector string) []fieldSelectorReq {
 	if selector == "" {
 		return nil
 	}
@@ -221,18 +221,18 @@ func parseFieldSelector(selector string) []fieldSelectorReq {
 	return reqs
 }
 
-// supportedFieldSelectorKeys are the metadata fields matchesFields (and
-// fieldsAdapter, below) actually filter on; filterItemsStrict rejects any
+// supportedFieldSelectorKeys are the metadata fields MatchesFields (and
+// fieldsAdapter, below) actually filter on; FilterItemsStrict rejects any
 // other key.
 var supportedFieldSelectorKeys = map[string]bool{
 	"metadata.name":      true,
 	"metadata.namespace": true,
 }
 
-// fieldsAdapter exposes a k8sObject's supported field-selector keys through
+// fieldsAdapter exposes a K8sObject's supported field-selector keys through
 // k8s.io/apimachinery/pkg/fields.Fields, so fields.Selector.Matches can
 // evaluate it directly.
-type fieldsAdapter struct{ obj *k8sObject }
+type fieldsAdapter struct{ obj *K8sObject }
 
 func (f fieldsAdapter) Has(field string) bool { return supportedFieldSelectorKeys[field] }
 
@@ -247,23 +247,23 @@ func (f fieldsAdapter) Get(field string) string {
 	}
 }
 
-// filterItemsStrict filters items for deletecollection using
+// FilterItemsStrict filters items for deletecollection using
 // k8s.io/apimachinery's own label/field selector grammar and matching
-// (labels.Parse, fields.ParseSelector) instead of filterItems' best-effort,
+// (labels.Parse, fields.ParseSelector) instead of FilterItems' best-effort,
 // hand-rolled parser. Multiple rounds of review turned up ever-more-specific
 // ways the hand-rolled parser leniently accepted a malformed selector as
 // "matches everything" (empty keys, empty segments, unbalanced set syntax,
 // invalid key characters, ...) — using the real, exhaustively-validated
 // parser closes off that entire class of gaps at once rather than patching
-// one shape of malformed input at a time. The read path (applySelectors,
-// filterTableRows) is unaffected — it keeps its existing best-effort
-// filterItems, where "matches more than intended" only affects display
+// one shape of malformed input at a time. The read path (ApplySelectors,
+// FilterTableRows) is unaffected — it keeps its existing best-effort
+// FilterItems, where "matches more than intended" only affects display
 // fidelity, not what gets deleted.
 //
 // Returns an error message suitable for a 400 response (with items nil), or
 // ("", filtered) on success — filtered is items unchanged if both selectors
 // are empty.
-func filterItemsStrict(items []json.RawMessage, labelSelector, fieldSelector string) (string, []json.RawMessage) {
+func FilterItemsStrict(items []json.RawMessage, labelSelector, fieldSelector string) (string, []json.RawMessage) {
 	var labelSel labels.Selector
 	if labelSelector != "" {
 		sel, err := labels.Parse(labelSelector)
@@ -305,9 +305,9 @@ func filterItemsStrict(items []json.RawMessage, labelSelector, fieldSelector str
 
 	filtered := items[:0]
 	for _, raw := range items {
-		var obj k8sObject
+		var obj K8sObject
 		if err := json.Unmarshal(raw, &obj); err != nil {
-			filtered = append(filtered, raw) // can't parse — keep, don't hide (matches filterItems' convention)
+			filtered = append(filtered, raw) // can't parse — keep, don't hide (matches FilterItems' convention)
 			continue
 		}
 		if labelSel != nil && !labelSel.Matches(labels.Set(obj.Metadata.Labels)) {
@@ -321,9 +321,9 @@ func filterItemsStrict(items []json.RawMessage, labelSelector, fieldSelector str
 	return "", filtered
 }
 
-// matchesFields returns true if the object satisfies all field selector requirements.
+// MatchesFields returns true if the object satisfies all field selector requirements.
 // Only metadata.name and metadata.namespace are supported.
-func matchesFields(obj *k8sObject, reqs []fieldSelectorReq) bool {
+func MatchesFields(obj *K8sObject, reqs []fieldSelectorReq) bool {
 	for _, r := range reqs {
 		var actual string
 		switch r.field {
@@ -349,20 +349,20 @@ func matchesFields(obj *k8sObject, reqs []fieldSelectorReq) bool {
 	return true
 }
 
-// filterTableRows applies label/field selectors to a Table-format response,
+// FilterTableRows applies label/field selectors to a Table-format response,
 // keeping only rows whose embedded object satisfies both selectors. Returns the
 // original body unchanged if selectors are empty, the body cannot be decoded as
 // a Table, or the rows array is absent.
-func filterTableRows(tableBody []byte, labelSelector, fieldSelector string) ([]byte, error) {
+func FilterTableRows(tableBody []byte, labelSelector, fieldSelector string) ([]byte, error) {
 	if labelSelector == "" && fieldSelector == "" {
 		return tableBody, nil
 	}
 
-	labelReqs, err := parseRequirements(labelSelector)
+	labelReqs, err := ParseRequirements(labelSelector)
 	if err != nil {
 		return tableBody, nil // malformed selector — serve unfiltered (best-effort)
 	}
-	fieldReqs := parseFieldSelector(fieldSelector)
+	fieldReqs := ParseFieldSelector(fieldSelector)
 
 	var table struct {
 		APIVersion        json.RawMessage   `json:"apiVersion"`
@@ -378,13 +378,13 @@ func filterTableRows(tableBody []byte, labelSelector, fieldSelector string) ([]b
 	filtered := make([]json.RawMessage, 0, len(table.Rows))
 	for _, row := range table.Rows {
 		var r struct {
-			Object k8sObject `json:"object"`
+			Object K8sObject `json:"object"`
 		}
 		if err := json.Unmarshal(row, &r); err != nil {
 			filtered = append(filtered, row) // can't inspect — include to avoid data loss
 			continue
 		}
-		if matchesLabels(&r.Object, labelReqs) && matchesFields(&r.Object, fieldReqs) {
+		if MatchesLabels(&r.Object, labelReqs) && MatchesFields(&r.Object, fieldReqs) {
 			filtered = append(filtered, row)
 		}
 	}
@@ -392,43 +392,43 @@ func filterTableRows(tableBody []byte, labelSelector, fieldSelector string) ([]b
 	return json.Marshal(table)
 }
 
-// filterItems returns the subset of items matching both labelSelector and
-// fieldSelector. Best-effort, matching applySelectors (the only caller): a
+// FilterItems returns the subset of items matching both labelSelector and
+// fieldSelector. Best-effort, matching ApplySelectors (the only caller): a
 // malformed labelSelector returns items unfiltered rather than erroring, and
 // an item that fails to unmarshal is kept (never silently hidden) — safe for
 // a read, where "matches more than intended" only affects display fidelity.
-// The writable overlay's deletecollection uses the stricter filterItemsStrict
+// The writable overlay's deletecollection uses the stricter FilterItemsStrict
 // instead (below), where the same leniency would risk deleting more than the
 // caller asked for.
-func filterItems(items []json.RawMessage, labelSelector, fieldSelector string) []json.RawMessage {
+func FilterItems(items []json.RawMessage, labelSelector, fieldSelector string) []json.RawMessage {
 	if labelSelector == "" && fieldSelector == "" {
 		return items
 	}
-	labelReqs, err := parseRequirements(labelSelector)
+	labelReqs, err := ParseRequirements(labelSelector)
 	if err != nil {
-		return items // malformed selector — best-effort, same as applySelectors
+		return items // malformed selector — best-effort, same as ApplySelectors
 	}
-	fieldReqs := parseFieldSelector(fieldSelector)
+	fieldReqs := ParseFieldSelector(fieldSelector)
 
 	filtered := items[:0]
 	for _, raw := range items {
-		var obj k8sObject
+		var obj K8sObject
 		if err := json.Unmarshal(raw, &obj); err != nil {
 			// Can't parse this item; include it to avoid hiding data.
 			filtered = append(filtered, raw)
 			continue
 		}
-		if matchesLabels(&obj, labelReqs) && matchesFields(&obj, fieldReqs) {
+		if MatchesLabels(&obj, labelReqs) && MatchesFields(&obj, fieldReqs) {
 			filtered = append(filtered, raw)
 		}
 	}
 	return filtered
 }
 
-// applySelectors filters a JSON list body keeping only items that match both
+// ApplySelectors filters a JSON list body keeping only items that match both
 // labelSelector and fieldSelector. Returns the original body unchanged if
 // both selectors are empty or if the body is not a list.
-func applySelectors(body []byte, labelSelector, fieldSelector string) ([]byte, error) {
+func ApplySelectors(body []byte, labelSelector, fieldSelector string) ([]byte, error) {
 	if labelSelector == "" && fieldSelector == "" {
 		return body, nil
 	}
@@ -445,6 +445,6 @@ func applySelectors(body []byte, labelSelector, fieldSelector string) ([]byte, e
 		return body, nil
 	}
 
-	list.Items = filterItems(list.Items, labelSelector, fieldSelector)
+	list.Items = FilterItems(list.Items, labelSelector, fieldSelector)
 	return json.Marshal(list)
 }

--- a/internal/store/selector_test.go
+++ b/internal/store/selector_test.go
@@ -32,16 +32,16 @@ func TestParseRequirements(t *testing.T) {
 			continue
 		}
 		r := reqs[0]
-		if r.key != tc.key {
-			t.Errorf("[%q] key: got %q, want %q", tc.sel, r.key, tc.key)
+		if r.Key != tc.key {
+			t.Errorf("[%q] key: got %q, want %q", tc.sel, r.Key, tc.key)
 		}
-		if r.op != tc.op {
-			t.Errorf("[%q] op: got %q, want %q", tc.sel, r.op, tc.op)
+		if r.Op != tc.op {
+			t.Errorf("[%q] op: got %q, want %q", tc.sel, r.Op, tc.op)
 		}
 		if tc.values != nil {
 			for i, v := range tc.values {
-				if i >= len(r.values) || r.values[i] != v {
-					t.Errorf("[%q] values[%d]: got %v, want %q", tc.sel, i, r.values, v)
+				if i >= len(r.Values) || r.Values[i] != v {
+					t.Errorf("[%q] values[%d]: got %v, want %q", tc.sel, i, r.Values, v)
 				}
 			}
 		}

--- a/internal/store/selector_test.go
+++ b/internal/store/selector_test.go
@@ -1,4 +1,4 @@
-package server
+package store
 
 import (
 	"encoding/json"
@@ -22,13 +22,13 @@ func TestParseRequirements(t *testing.T) {
 		{"!app", 1, "doesnotexist", "app", nil},
 	}
 	for _, tc := range cases {
-		reqs, err := parseRequirements(tc.sel)
+		reqs, err := ParseRequirements(tc.sel)
 		if err != nil {
-			t.Errorf("parseRequirements(%q) error: %v", tc.sel, err)
+			t.Errorf("ParseRequirements(%q) error: %v", tc.sel, err)
 			continue
 		}
 		if len(reqs) != tc.count {
-			t.Errorf("parseRequirements(%q): got %d reqs, want %d", tc.sel, len(reqs), tc.count)
+			t.Errorf("ParseRequirements(%q): got %d reqs, want %d", tc.sel, len(reqs), tc.count)
 			continue
 		}
 		r := reqs[0]
@@ -49,7 +49,7 @@ func TestParseRequirements(t *testing.T) {
 }
 
 func TestMultiRequirement(t *testing.T) {
-	reqs, err := parseRequirements("app=nginx,env=prod")
+	reqs, err := ParseRequirements("app=nginx,env=prod")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestMultiRequirement(t *testing.T) {
 }
 
 func TestInWithCommas(t *testing.T) {
-	reqs, err := parseRequirements("app in (nginx,redis),env=prod")
+	reqs, err := ParseRequirements("app in (nginx,redis),env=prod")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestApplySelectors_LabelFilter(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		filtered, err := applySelectors(list, tc.sel, "")
+		filtered, err := ApplySelectors(list, tc.sel, "")
 		if err != nil {
 			t.Fatalf("[%q] error: %v", tc.sel, err)
 		}
@@ -123,7 +123,7 @@ func TestApplySelectors_FieldFilter(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		filtered, err := applySelectors(list, "", tc.sel)
+		filtered, err := ApplySelectors(list, "", tc.sel)
 		if err != nil {
 			t.Fatalf("[%q] error: %v", tc.sel, err)
 		}
@@ -136,7 +136,7 @@ func TestApplySelectors_FieldFilter(t *testing.T) {
 
 func TestApplySelectors_EmptySelector(t *testing.T) {
 	list := listWithPods([]podSpec{{name: "nginx", labels: map[string]string{"app": "nginx"}}})
-	out, err := applySelectors(list, "", "")
+	out, err := ApplySelectors(list, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +148,7 @@ func TestApplySelectors_EmptySelector(t *testing.T) {
 
 func TestApplySelectors_NotAList(t *testing.T) {
 	body := []byte(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"nginx"}}`)
-	out, err := applySelectors(body, "app=nginx", "")
+	out, err := ApplySelectors(body, "app=nginx", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +222,7 @@ func stringSliceEqual(a, b []string) bool {
 	return true
 }
 
-// ── filterTableRows tests ─────────────────────────────────────────────────────
+// ── FilterTableRows tests ─────────────────────────────────────────────────────
 
 // tableWithPods builds a meta.k8s.io/v1 Table JSON from a slice of podSpecs,
 // mirroring the structure the mock server stores from a real cluster capture.
@@ -304,7 +304,7 @@ func TestFilterTableRows_LabelFilter(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		filtered, err := filterTableRows(table, tc.sel, "")
+		filtered, err := FilterTableRows(table, tc.sel, "")
 		if err != nil {
 			t.Fatalf("[%q] error: %v", tc.sel, err)
 		}
@@ -331,7 +331,7 @@ func TestFilterTableRows_FieldFilter(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		filtered, err := filterTableRows(table, "", tc.sel)
+		filtered, err := FilterTableRows(table, "", tc.sel)
 		if err != nil {
 			t.Fatalf("[%q] error: %v", tc.sel, err)
 		}
@@ -344,7 +344,7 @@ func TestFilterTableRows_FieldFilter(t *testing.T) {
 
 func TestFilterTableRows_EmptySelector(t *testing.T) {
 	table := tableWithPods([]podSpec{{name: "nginx", labels: map[string]string{"app": "nginx"}}})
-	out, err := filterTableRows(table, "", "")
+	out, err := FilterTableRows(table, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -355,7 +355,7 @@ func TestFilterTableRows_EmptySelector(t *testing.T) {
 
 func TestFilterTableRows_NotATable(t *testing.T) {
 	body := []byte(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"nginx"}}`)
-	out, err := filterTableRows(body, "app=nginx", "")
+	out, err := FilterTableRows(body, "app=nginx", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,4 +1,4 @@
-package server
+package store
 
 import (
 	"container/list"
@@ -31,26 +31,26 @@ type CaptureStore struct {
 	// wait for it before the caller closes the archive out from under it.
 	discoveryEnrichmentDone sync.WaitGroup
 
-	// Record LRU cache (bounded by recordCacheMaxBytes total body bytes).
+	// Record LRU cache (bounded by RecordCacheMaxBytes total body bytes).
 	recordCacheMu    sync.Mutex
 	recordCacheMap   map[recordKey]*list.Element
 	recordCacheList  *list.List
 	recordCacheBytes int64
 
 	// Response cache: (path, at) → marshalled body + code.
-	// Entries are valid for responseCacheTTL, bounded by responseCacheMaxBytes.
+	// Entries are valid for responseCacheTTL, bounded by ResponseCacheMaxBytes.
 	responseCacheMu    sync.RWMutex
 	responseCacheMap   map[responseCacheKey]*responseCacheEntry
 	responseCacheBytes int64
 }
 
-// recordCacheMaxBytes caps the total in-memory size of cached record bodies.
+// RecordCacheMaxBytes caps the total in-memory size of cached record bodies.
 // Large cluster captures can have response bodies of hundreds of KB each;
 // a count-based cap of 2048 was the primary driver of the v0.2.0 memory regression.
-const recordCacheMaxBytes = 128 * 1024 * 1024 // 128 MiB
+const RecordCacheMaxBytes = 128 * 1024 * 1024 // 128 MiB
 
-// responseCacheMaxBytes caps the total in-memory size of cached response bodies.
-const responseCacheMaxBytes = 32 * 1024 * 1024 // 32 MiB
+// ResponseCacheMaxBytes caps the total in-memory size of cached response bodies.
+const ResponseCacheMaxBytes = 32 * 1024 * 1024 // 32 MiB
 
 type recordKey struct {
 	apiPath string
@@ -128,7 +128,7 @@ func LoadStore(ar *archive.Archive) (*CaptureStore, error) {
 
 	// Enrich ResourceInfo from discovery records asynchronously — this also
 	// creates entries for resources listed in a captured discovery document
-	// that have zero captured objects (see mergeResourceInfo), so a known kind
+	// that have zero captured objects (see MergeResourceInfo), so a known kind
 	// with nothing captured is distinguishable from a genuinely unknown one.
 	s.discoveryEnrichmentDone.Add(1)
 	go s.enrichResourceInfoFromDiscovery()
@@ -145,7 +145,7 @@ func (s *CaptureStore) buildResourceInfo() {
 		if strings.Contains(path, "?") {
 			continue
 		}
-		g, v, r, ns := parseAPIPath(path)
+		g, v, r, ns := ParseAPIPath(path)
 		if r == "" {
 			continue
 		}
@@ -160,13 +160,13 @@ func (s *CaptureStore) buildResourceInfo() {
 			Group:      g,
 			Version:    v,
 			Resource:   r,
-			Kind:       resourceToKind(r),
+			Kind:       ResourceToKind(r),
 			Namespaced: ns != "",
 		}
 	}
 }
 
-// mergeResourceInfo inserts or enriches the ResourceInfo for group/version/
+// MergeResourceInfo inserts or enriches the ResourceInfo for group/version/
 // resource from a captured discovery document, creating a new entry (zero
 // captured objects) if one doesn't already exist from the index. Safe for
 // concurrent use. namespaced always overwrites: discovery is the authoritative
@@ -176,7 +176,7 @@ func (s *CaptureStore) buildResourceInfo() {
 // (/api/v1/pods, no namespaces: in config) would otherwise report a
 // namespaced resource as cluster-scoped in the regenerated discovery
 // document.
-func (s *CaptureStore) mergeResourceInfo(group, version, resource string, namespaced bool, kind, singularName string, shortNames []string) {
+func (s *CaptureStore) MergeResourceInfo(group, version, resource string, namespaced bool, kind, singularName string, shortNames []string) {
 	s.resourceInfoMu.Lock()
 	defer s.resourceInfoMu.Unlock()
 	key := group + "/" + version + "/" + resource
@@ -189,7 +189,7 @@ func (s *CaptureStore) mergeResourceInfo(group, version, resource string, namesp
 	if kind != "" {
 		ri.Kind = kind
 	} else if ri.Kind == "" {
-		ri.Kind = resourceToKind(resource)
+		ri.Kind = ResourceToKind(resource)
 	}
 	if singularName != "" {
 		ri.SingularName = singularName
@@ -207,9 +207,16 @@ func (s *CaptureStore) Close() {
 	s.discoveryEnrichmentDone.Wait()
 }
 
+// Archive returns the archive.Archive backing this store, for callers (e.g.
+// internal/server's poll-only replay-timeline inference) that need to read
+// records the store doesn't already expose through Read/Latest/SnapshotAt.
+func (s *CaptureStore) Archive() *archive.Archive {
+	return s.ar
+}
+
 // enrichResourceInfoFromDiscovery reads captured APIResourceList bodies from
 // the archive and back-fills Kind, ShortNames, SingularName into resourceInfo
-// — creating a new entry (via mergeResourceInfo) for a resource the discovery
+// — creating a new entry (via MergeResourceInfo) for a resource the discovery
 // document lists but that has zero captured objects, so it's still reported
 // as a known kind rather than "not found in capture" (#177). Runs in a
 // background goroutine; store is usable before this completes.
@@ -265,14 +272,14 @@ func (s *CaptureStore) enrichResourceInfoFromDiscovery() {
 			if strings.Contains(res.Name, "/") {
 				continue // a subresource entry (e.g. "pods/status"), not a top-level resource
 			}
-			s.mergeResourceInfo(g, v, res.Name, res.Namespaced, res.Kind, res.SingularName, res.ShortNames)
+			s.MergeResourceInfo(g, v, res.Name, res.Namespaced, res.Kind, res.SingularName, res.ShortNames)
 		}
 	}
 }
 
 // Resources returns a snapshot of all distinct ResourceInfo entries, fully
 // decoupled from internal storage. Each element is a value copy taken under
-// the lock, not the pointer stored in the map — mergeResourceInfo can mutate
+// the lock, not the pointer stored in the map — MergeResourceInfo can mutate
 // an existing entry's fields (Kind/SingularName/ShortNames/Namespaced) from
 // the background discovery enrichment goroutine at any time, so returning the
 // original pointers would let a caller observe a struct being concurrently
@@ -294,27 +301,27 @@ func (s *CaptureStore) Resources() []ResourceInfo {
 	return out
 }
 
-// isKnownResource reports whether group/version/resource is a real API type
+// IsKnownResource reports whether group/version/resource is a real API type
 // the captured cluster exposed — present in a captured discovery document or
 // the archive index — even if zero objects of it were ever captured. Used to
 // distinguish "known kind, nothing captured" (should read like an empty live
 // collection) from a genuinely unknown/misconfigured kind (#177).
-func (s *CaptureStore) isKnownResource(group, version, resource string) bool {
+func (s *CaptureStore) IsKnownResource(group, version, resource string) bool {
 	s.resourceInfoMu.RLock()
 	defer s.resourceInfoMu.RUnlock()
 	_, ok := s.resourceInfo[group+"/"+version+"/"+resource]
 	return ok
 }
 
-// resourceKind returns the authoritative Kind for a known group/version/
-// resource (from captured discovery, or resourceToKind's heuristic if only
-// seen in the index — see buildResourceInfo/mergeResourceInfo), or "" if the
-// resource isn't known at all. Prefer this over calling resourceToKind
+// ResourceKind returns the authoritative Kind for a known group/version/
+// resource (from captured discovery, or ResourceToKind's heuristic if only
+// seen in the index — see buildResourceInfo/MergeResourceInfo), or "" if the
+// resource isn't known at all. Prefer this over calling ResourceToKind
 // directly when a resource might be known: the heuristic guesses wrong for
 // built-in types whose Kind doesn't follow simple depluralization (e.g.
 // "endpointslices" -> "Endpointslice", not the real "EndpointSlice") and for
 // most CRDs.
-func (s *CaptureStore) resourceKind(group, version, resource string) string {
+func (s *CaptureStore) ResourceKind(group, version, resource string) string {
 	s.resourceInfoMu.RLock()
 	defer s.resourceInfoMu.RUnlock()
 	if ri, ok := s.resourceInfo[group+"/"+version+"/"+resource]; ok {
@@ -376,7 +383,7 @@ func (s *CaptureStore) readRecord(apiPath string, seq int) (capture.Record, erro
 
 	s.recordCacheMu.Lock()
 	// Evict LRU entries until the new entry fits within the byte budget.
-	for s.recordCacheBytes+entry.size > recordCacheMaxBytes {
+	for s.recordCacheBytes+entry.size > RecordCacheMaxBytes {
 		back := s.recordCacheList.Back()
 		if back == nil {
 			break
@@ -445,11 +452,11 @@ func (s *CaptureStore) NamespaceItemCountsAt(at time.Time) map[string]map[string
 		if strings.Contains(path, "?") {
 			continue
 		}
-		_, _, resource, ns := parseAPIPath(path)
+		_, _, resource, ns := ParseAPIPath(path)
 		if resource == "" || ns == "" {
 			continue
 		}
-		// Skip per-item paths (e.g. .../pods/<name>) — parseAPIPath returns
+		// Skip per-item paths (e.g. .../pods/<name>) — ParseAPIPath returns
 		// resource="" for these in this codebase, but be defensive.
 
 		// Pick the latest record at or before `at`.
@@ -522,7 +529,7 @@ func (s *CaptureStore) ReconstructAt(apiPath string, at time.Time) ([]byte, int,
 	s.responseCacheMap[cacheKey] = &responseCacheEntry{body: body, code: code, created: time.Now()}
 	s.responseCacheBytes += int64(len(body))
 	// Evict expired entries when over the byte budget.
-	if s.responseCacheBytes > responseCacheMaxBytes {
+	if s.responseCacheBytes > ResponseCacheMaxBytes {
 		now := time.Now()
 		for k, v := range s.responseCacheMap {
 			if now.Sub(v.created) > responseCacheTTL {
@@ -558,7 +565,7 @@ func (s *CaptureStore) reconstructAt(apiPath string, at time.Time) ([]byte, int,
 			return snapBody, snapCode, nil
 		}
 	} else {
-		group, version, resource, _ := parseAPIPath(apiPath)
+		group, version, resource, _ := ParseAPIPath(apiPath)
 		if resource == "" {
 			return nil, 404, nil
 		}
@@ -567,7 +574,7 @@ func (s *CaptureStore) reconstructAt(apiPath string, at time.Time) ([]byte, int,
 		} else {
 			snapList.APIVersion = group + "/" + version
 		}
-		snapList.Kind = resourceToKind(resource) + "List"
+		snapList.Kind = ResourceToKind(resource) + "List"
 		snapList.Metadata = json.RawMessage(`{"resourceVersion":"0"}`)
 	}
 
@@ -699,7 +706,7 @@ var aggregateItemCap = 10_000
 
 // AggregateAcrossNamespaces aggregates list items from all namespaced paths.
 func (s *CaptureStore) AggregateAcrossNamespaces(clusterPath string, at time.Time) ([]byte, int, error) {
-	g, v, resource, _ := parseAPIPath(clusterPath)
+	g, v, resource, _ := ParseAPIPath(clusterPath)
 	var pathPrefix string
 	if g == "" {
 		pathPrefix = "/api/" + v + "/namespaces/"
@@ -776,7 +783,7 @@ func (s *CaptureStore) AggregateAcrossNamespaces(clusterPath string, at time.Tim
 	}
 
 	if listKind == "" {
-		listKind = resourceToKind(resource) + "List"
+		listKind = ResourceToKind(resource) + "List"
 	}
 	if apiVersion == "" {
 		if g == "" {
@@ -819,7 +826,7 @@ func tableRowDedupeKey(row json.RawMessage) string {
 
 // AggregateTableAcrossNamespaces merges per-namespace Table responses.
 func (s *CaptureStore) AggregateTableAcrossNamespaces(clusterPath string, at time.Time) ([]byte, int, error) {
-	g, v, resource, _ := parseAPIPath(clusterPath)
+	g, v, resource, _ := ParseAPIPath(clusterPath)
 	var pathPrefix string
 	if g == "" {
 		pathPrefix = "/api/" + v + "/namespaces/"
@@ -893,7 +900,7 @@ func (s *CaptureStore) AggregateTableAcrossNamespaces(clusterPath string, at tim
 	return out, 200, nil
 }
 
-// parseAPIPath extracts (group, version, resource, namespace) from a REST
+// ParseAPIPath extracts (group, version, resource, namespace) from a REST
 // path. Deliberately NOT internal/k8spath.Parse (see #235): this rigid,
 // exact-segment-count form doubles as handler.go's "is this a list-level
 // path, or something with more segments (an item GET)?" sentinel — an
@@ -903,7 +910,7 @@ func (s *CaptureStore) AggregateTableAcrossNamespaces(clusterPath string, at tim
 // paths (including the object name). Unifying this with k8spath.Parse's
 // looser, subresource-tolerant matching changes that sentinel and breaks
 // item-level GET 404 handling — see the regression this caused when tried.
-func parseAPIPath(path string) (group, version, resource, namespace string) {
+func ParseAPIPath(path string) (group, version, resource, namespace string) {
 	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
 	switch {
 	case len(parts) >= 3 && parts[0] == "api":
@@ -954,8 +961,8 @@ func buildBuiltinKindByResource() map[string]string {
 	return m
 }
 
-// resourceToKind maps a plural resource name to its Kind string.
-func resourceToKind(resource string) string {
+// ResourceToKind maps a plural resource name to its Kind string.
+func ResourceToKind(resource string) string {
 	if k, ok := builtinKindByResource[resource]; ok {
 		return k
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,4 +1,4 @@
-package server
+package store
 
 import (
 	"bytes"
@@ -31,9 +31,9 @@ func TestParseAPIPath(t *testing.T) {
 		{"/apis/batch/v1/namespaces/ci/jobs", "batch", "v1", "jobs", "ci"},
 	}
 	for _, tc := range cases {
-		g, v, r, ns := parseAPIPath(tc.path)
+		g, v, r, ns := ParseAPIPath(tc.path)
 		if g != tc.group || v != tc.version || r != tc.resource || ns != tc.namespace {
-			t.Errorf("parseAPIPath(%q): got (%q,%q,%q,%q), want (%q,%q,%q,%q)",
+			t.Errorf("ParseAPIPath(%q): got (%q,%q,%q,%q), want (%q,%q,%q,%q)",
 				tc.path, g, v, r, ns, tc.group, tc.version, tc.resource, tc.namespace)
 		}
 	}
@@ -65,8 +65,8 @@ func TestResourceToKind(t *testing.T) {
 		"widgets":                           "Widget",                   // unknown resource: naive fallback
 	}
 	for resource, want := range cases {
-		if got := resourceToKind(resource); got != want {
-			t.Errorf("resourceToKind(%q) = %q, want %q", resource, got, want)
+		if got := ResourceToKind(resource); got != want {
+			t.Errorf("ResourceToKind(%q) = %q, want %q", resource, got, want)
 		}
 	}
 }
@@ -84,7 +84,7 @@ func TestEnrichResourceInfoFromDiscovery_KnownButUncaptured(t *testing.T) {
 	})
 	store.discoveryEnrichmentDone.Wait()
 
-	if !store.isKnownResource("networking.k8s.io", "v1", "ingresses") {
+	if !store.IsKnownResource("networking.k8s.io", "v1", "ingresses") {
 		t.Fatal("ingresses should be a known resource after discovery enrichment")
 	}
 	resources := store.Resources()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -201,6 +201,7 @@ func buildTestStore(t *testing.T, records map[string][]byte) *CaptureStore {
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}
+	t.Cleanup(store.Close)
 	return store
 }
 
@@ -577,6 +578,7 @@ func TestStore_Latest_AtTimestamp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}
+	t.Cleanup(store.Close)
 
 	body, code, err := store.Latest(path, t1.Add(time.Minute))
 	if err != nil {
@@ -697,6 +699,7 @@ func buildTestStoreWithWatch(t *testing.T, snapshots map[string]watchTestRecord,
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}
+	t.Cleanup(store.Close)
 	return store
 }
 

--- a/internal/ui/v2/history_test.go
+++ b/internal/ui/v2/history_test.go
@@ -62,11 +62,11 @@ func buildV2WatchStore(t *testing.T, events []v2WatchEvent, captureStart time.Ti
 		t.Fatalf("archive.Open: %v", err)
 	}
 	t.Cleanup(func() { ar.Close() })
-	store, err := store.LoadStore(ar)
+	cs, err := store.LoadStore(ar)
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}
-	return store
+	return cs
 }
 
 func TestServeObjectHistory(t *testing.T) {

--- a/internal/ui/v2/history_test.go
+++ b/internal/ui/v2/history_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
-	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 )
 
 type v2WatchEvent struct {
@@ -21,7 +21,7 @@ type v2WatchEvent struct {
 // buildV2WatchStore writes watch event records plus a watch index, mirroring
 // the watch-store helper in internal/server's tests. Seqs are assigned per path
 // in write order, matching how StreamWriter numbers records.
-func buildV2WatchStore(t *testing.T, events []v2WatchEvent, captureStart time.Time) *server.CaptureStore {
+func buildV2WatchStore(t *testing.T, events []v2WatchEvent, captureStart time.Time) *store.CaptureStore {
 	t.Helper()
 	out := filepath.Join(t.TempDir(), "watch.kshrk")
 	sw, err := archive.NewStreamWriter(out)
@@ -62,7 +62,7 @@ func buildV2WatchStore(t *testing.T, events []v2WatchEvent, captureStart time.Ti
 		t.Fatalf("archive.Open: %v", err)
 	}
 	t.Cleanup(func() { ar.Close() })
-	store, err := server.LoadStore(ar)
+	store, err := store.LoadStore(ar)
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}

--- a/internal/ui/v2/history_test.go
+++ b/internal/ui/v2/history_test.go
@@ -66,6 +66,7 @@ func buildV2WatchStore(t *testing.T, events []v2WatchEvent, captureStart time.Ti
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}
+	t.Cleanup(cs.Close)
 	return cs
 }
 

--- a/internal/ui/v2/objects.go
+++ b/internal/ui/v2/objects.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 )
 
 // ObjectDetail is the response from /v2/api/object — a single captured object
@@ -316,22 +316,24 @@ func (h *Handler) serveResourceCatalog(w http.ResponseWriter, r *http.Request) {
 	for k, row := range agg {
 		zeroIndexCount[k] = row.Count == 0
 	}
-	for _, sc := range h.Overlay.OverlayScopes() {
-		k := key{sc.Group, sc.Version, sc.Resource}
-		row := agg[k]
-		if row == nil {
-			row = &ResourceCatalogRow{
-				Group: sc.Group, Version: sc.Version, Resource: sc.Resource,
-				Kind: kindFromSample(sc.Sample, sc.Resource), Link: resourceLink(sc.Resource, ""),
+	if h.Overlay != nil {
+		for _, sc := range h.Overlay.OverlayScopes() {
+			k := key{sc.Group, sc.Version, sc.Resource}
+			row := agg[k]
+			if row == nil {
+				row = &ResourceCatalogRow{
+					Group: sc.Group, Version: sc.Version, Resource: sc.Resource,
+					Kind: kindFromSample(sc.Sample, sc.Resource), Link: resourceLink(sc.Resource, ""),
+				}
+				agg[k] = row
+				zeroIndexCount[k] = true // brand-new row — nothing from the index at all
 			}
-			agg[k] = row
-			zeroIndexCount[k] = true // brand-new row — nothing from the index at all
-		}
-		if sc.Namespace != "" {
-			row.Namespaced = true
-		}
-		if zeroIndexCount[k] {
-			row.Count += sc.Count
+			if sc.Namespace != "" {
+				row.Namespaced = true
+			}
+			if zeroIndexCount[k] {
+				row.Count += sc.Count
+			}
 		}
 	}
 
@@ -376,7 +378,7 @@ func (h *Handler) discoveryResourceMeta() map[string]discMeta {
 	return h.discoveryMetaCache
 }
 
-func buildDiscoveryResourceMeta(store *server.CaptureStore) map[string]discMeta {
+func buildDiscoveryResourceMeta(store *store.CaptureStore) map[string]discMeta {
 	m := map[string]discMeta{}
 	for path, entry := range store.Index {
 		if entry == nil || len(entry.Seqs) == 0 {
@@ -481,9 +483,11 @@ func (h *Handler) resourceKind(resource string) string {
 	if dm, ok := h.discoveryResourceMeta()[resource]; ok && dm.Kind != "" {
 		return dm.Kind
 	}
-	for _, sc := range h.Overlay.OverlayScopes() {
-		if sc.Resource == resource {
-			return kindFromSample(sc.Sample, resource)
+	if h.Overlay != nil {
+		for _, sc := range h.Overlay.OverlayScopes() {
+			if sc.Resource == resource {
+				return kindFromSample(sc.Sample, resource)
+			}
 		}
 	}
 	return kindFromResource(resource)

--- a/internal/ui/v2/objects_test.go
+++ b/internal/ui/v2/objects_test.go
@@ -281,5 +281,6 @@ func buildV2TestStore(t *testing.T, recs []*capture.Record, idx capture.Index, m
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}
+	t.Cleanup(cs.Close)
 	return cs
 }

--- a/internal/ui/v2/objects_test.go
+++ b/internal/ui/v2/objects_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
-	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 )
 
 // ── normalizeObjectBody (pure) ───────────────────────────────────────────────
@@ -257,7 +257,7 @@ func newObjectTestHandler(t *testing.T) *Handler {
 
 // buildV2TestStore writes records to a temp archive and loads a CaptureStore,
 // mirroring the helper used by the legacy UI tests.
-func buildV2TestStore(t *testing.T, recs []*capture.Record, idx capture.Index, meta *capture.CaptureMetadata) *server.CaptureStore {
+func buildV2TestStore(t *testing.T, recs []*capture.Record, idx capture.Index, meta *capture.CaptureMetadata) *store.CaptureStore {
 	t.Helper()
 	out := filepath.Join(t.TempDir(), "capture.kshrk")
 	sw, err := archive.NewStreamWriter(out)
@@ -277,7 +277,7 @@ func buildV2TestStore(t *testing.T, recs []*capture.Record, idx capture.Index, m
 		t.Fatalf("archive.Open: %v", err)
 	}
 	t.Cleanup(func() { ar.Close() })
-	store, err := server.LoadStore(ar)
+	store, err := store.LoadStore(ar)
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}

--- a/internal/ui/v2/objects_test.go
+++ b/internal/ui/v2/objects_test.go
@@ -277,9 +277,9 @@ func buildV2TestStore(t *testing.T, recs []*capture.Record, idx capture.Index, m
 		t.Fatalf("archive.Open: %v", err)
 	}
 	t.Cleanup(func() { ar.Close() })
-	store, err := store.LoadStore(ar)
+	cs, err := store.LoadStore(ar)
 	if err != nil {
 		t.Fatalf("LoadStore: %v", err)
 	}
-	return store
+	return cs
 }

--- a/internal/ui/v2/overview.go
+++ b/internal/ui/v2/overview.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/phenixblue/k8shark/internal/capture"
 	"github.com/phenixblue/k8shark/internal/k8spath"
-	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 )
 
 const (
@@ -97,9 +97,11 @@ func (h *Handler) buildOverview(at time.Time) (*Overview, error) {
 	// Fold in resource kinds/namespaces that exist only because of overlay
 	// writes (a CRD's custom resources, or a namespace + its contents created
 	// mid-replay) — the index-based counts above never see these.
-	if scopes := h.Overlay.OverlayScopes(); len(scopes) > 0 {
-		mergeOverlayNamespaceCounts(counts, scopes)
-		mergeOverlayClusterCounts(clusterCounts, scopes)
+	if h.Overlay != nil {
+		if scopes := h.Overlay.OverlayScopes(); len(scopes) > 0 {
+			mergeOverlayNamespaceCounts(counts, scopes)
+			mergeOverlayClusterCounts(clusterCounts, scopes)
+		}
 	}
 
 	// Aggregate KPIs + per-resource totals.
@@ -319,7 +321,7 @@ func latestIndex(entry *capture.IndexEntry, at time.Time) int {
 
 // buildSparkline groups watch-event timestamps into sparkBucketCount equal
 // buckets across the capture window.
-func buildSparkline(store *server.CaptureStore, _ time.Time, buckets int) SparklineData {
+func buildSparkline(store *store.CaptureStore, _ time.Time, buckets int) SparklineData {
 	start := store.Metadata.CapturedAt.UTC()
 	end := store.Metadata.CapturedUntil.UTC()
 	if !end.After(start) || buckets <= 0 {
@@ -376,7 +378,7 @@ func buildSparkline(store *server.CaptureStore, _ time.Time, buckets int) Sparkl
 
 // recentTransitions returns the last `n` watch events captured anywhere in
 // the archive (across all paths), most recent first.
-func recentTransitions(store *server.CaptureStore, at time.Time, n int) []Transition {
+func recentTransitions(store *store.CaptureStore, at time.Time, n int) []Transition {
 	type entry struct {
 		t         time.Time
 		eventType string

--- a/internal/ui/v2/v2.go
+++ b/internal/ui/v2/v2.go
@@ -6,20 +6,35 @@ package v2
 
 import (
 	"embed"
+	"encoding/json"
 	"io/fs"
 	"net/http"
 	"sync"
 	"time"
 
 	"github.com/phenixblue/k8shark/internal/server"
+	"github.com/phenixblue/k8shark/internal/store"
 )
 
 //go:embed static
 var staticFS embed.FS
 
+// OverlayReader is the read-only subset of *server.Server's overlay
+// accessors the v2 dashboard depends on, so Handler.Overlay can be satisfied
+// by anything providing overlay reads/merges instead of requiring the
+// concrete HTTP mock apiserver type (#234).
+type OverlayReader interface {
+	// OverlayScopes returns every distinct group/version/resource/namespace
+	// scope with at least one live overlay entry.
+	OverlayScopes() []server.OverlayScope
+	// MergeOverlayList merges overlay writes for (group, version, resource,
+	// namespace) over base, "overlay wins".
+	MergeOverlayList(group, version, resource, namespace string, base []json.RawMessage) []json.RawMessage
+}
+
 // Handler holds the shared state for v2 endpoints.
 type Handler struct {
-	Store       *server.CaptureStore
+	Store       *store.CaptureStore
 	At          time.Time
 	ArchivePath string
 	Verbose     bool
@@ -34,7 +49,7 @@ type Handler struct {
 	// *Server (plain `open`, or a caller that didn't wire one up) and a
 	// Server without a writable overlay — callers here can call them on
 	// h.Overlay directly without checking either case first.
-	Overlay *server.Server
+	Overlay OverlayReader
 
 	// discoveryMetaOnce/discoveryMetaCache memoize discoveryResourceMeta
 	// (objects.go): it's derived purely from the capture's own discovery

--- a/internal/ui/v2/v2.go
+++ b/internal/ui/v2/v2.go
@@ -44,11 +44,14 @@ type Handler struct {
 	// Overlay is the mock API server backing this same archive. Every
 	// list/detail read merges its writable-overlay writes (kubectl/helm/kwok/
 	// controller-manager) over the captured state, so the dashboard shows
-	// live changes instead of only what was captured. Its accessor methods
-	// (OverlayScopes, MergeOverlayList, ...) are nil-safe on both a nil
-	// *Server (plain `open`, or a caller that didn't wire one up) and a
-	// Server without a writable overlay — callers here can call them on
-	// h.Overlay directly without checking either case first.
+	// live changes instead of only what was captured. *server.Server's own
+	// accessor methods (OverlayScopes, MergeOverlayList, ...) are nil-safe on
+	// both a nil *Server (plain `open`, or a caller that didn't wire one up)
+	// and a Server without a writable overlay — but Overlay is an interface,
+	// and a nil OverlayReader panics on any method call regardless of
+	// whether the underlying concrete type would have been nil-safe. Every
+	// call site in this package nil-checks h.Overlay itself before calling
+	// through it.
 	Overlay OverlayReader
 
 	// discoveryMetaOnce/discoveryMetaCache memoize discoveryResourceMeta


### PR DESCRIPTION
## Summary

- Extracts `CaptureStore`/`LoadStore`, the label/field selector helpers, and the response protobuf-negotiation codec out of `internal/server` into a new `internal/store` package, so `internal/diagnose`, `internal/query`, and `internal/diff` no longer need to import the HTTP mock apiserver package just to read an archive.
- `internal/server` now imports `internal/store` back (aliased `kstore`, since several of its functions/methods use a local/field variable literally named `store`) for the mock apiserver's own reads/writes.
- Defines an `OverlayReader` interface in `internal/ui/v2` so `Handler.Overlay` depends on an interface instead of the concrete `*server.Server` type. Because a nil `OverlayReader` interface panics on any method call (unlike `*server.Server`'s nil-safe methods), every `h.Overlay.OverlayScopes()`/`MergeOverlayList` call site now nil-checks `h.Overlay` first — this was a real regression caught by `TestServeOverview` during development, now fixed.
- No behavior change; existing tests pass unmodified except for the (test-only) helpers that had to move or be duplicated across the new package boundary (see below).

## Notes on scope

- `buildTestStore`/`buildTestStoreWithWatch`/`listWithPods`/`itemNames` were duplicated into a new `internal/server/teststore_test.go`, since Go test helpers aren't visible across package boundaries — `internal/server`'s HTTP-layer tests need a real `*store.CaptureStore` to drive the mock apiserver against.
- A few store-internal methods needed new exported accessors for cross-package callers that used to be same-package: `CaptureStore.ResourceKind`, `IsKnownResource`, `MergeResourceInfo`, `Archive()`, and `RecordCacheMaxBytes`/`ResponseCacheMaxBytes`.
- `replay_rv.go`'s `buildReplayTimeline`/`watchIndexPaths`/`snapshotPaths` were converted from `*CaptureStore` methods to free functions taking `*kstore.CaptureStore` (Go doesn't allow defining new methods on an imported type).

Closes #234.

## Test plan
- [x] `make fmt` (clean)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `go mod tidy` (no diff)
- [x] `golangci-lint run` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)