### PR TITLE
refactor(cli): reserve -o for output format, move file destinations to --out

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -23,7 +23,7 @@ single .kshrk capture file for later replay.
 
 Resources, namespaces, and intervals come from the --config file. Use
 --auto-discover to capture every available API resource without listing them,
---output - to stream records as NDJSON to stdout, --redact-secrets to scrub
+--out - to stream records as NDJSON to stdout, --redact-secrets to scrub
 Secret values from the archive after capture, and --encrypt (passphrase) or
 --encrypt-recipient (age public keys) to write the archive as an encrypted
 (age) envelope.`,
@@ -34,7 +34,7 @@ Secret values from the archive after capture, and --encrypt (passphrase) or
   kshrk capture --auto-discover --duration 5m
 
   # Stream records as NDJSON to stdout instead of writing an archive
-  kshrk capture --config k8shark.yaml --output -
+  kshrk capture --config k8shark.yaml --out -
 
   # Capture, then redact Secret values from the archive
   kshrk capture --config k8shark.yaml --redact-secrets
@@ -52,7 +52,7 @@ Secret values from the archive after capture, and --encrypt (passphrase) or
 
 func init() {
 	rootCmd.AddCommand(captureCmd)
-	captureCmd.Flags().StringP("output", "o", "", "output file path (default: ./k8shark-<timestamp>.kshrk)")
+	captureCmd.Flags().String("out", "", "output file path (default: ./k8shark-<timestamp>.kshrk)")
 	captureCmd.Flags().String("kubeconfig", "", "path to kubeconfig (defaults to KUBECONFIG env, then ~/.kube/config)")
 	captureCmd.Flags().String("duration", "", "capture duration, overrides config file value (e.g. 10m, 1h)")
 	captureCmd.Flags().Bool("auto-discover", false, "auto-discover and capture all available API resources")
@@ -60,13 +60,15 @@ func init() {
 	captureCmd.Flags().StringArray("allow-secret", nil, "namespace/name of secret to preserve when --redact-secrets is set (repeatable)")
 	captureCmd.Flags().StringArray("redact-field", nil, "field redaction rule applied after capture: <fieldPath>:<Kind>:<replacement>[:<valueType>] (repeatable)")
 	addEncryptFlags(captureCmd)
-	_ = viper.BindPFlag("output", captureCmd.Flags().Lookup("output"))
+	// The viper key stays "output" (matching the config file's own `output:`
+	// field) even though the CLI flag is now spelled --out — see #215.
+	_ = viper.BindPFlag("output", captureCmd.Flags().Lookup("out"))
 	_ = viper.BindPFlag("kubeconfig", captureCmd.Flags().Lookup("kubeconfig"))
 	_ = viper.BindPFlag("duration", captureCmd.Flags().Lookup("duration"))
 	_ = viper.BindPFlag("auto_discover", captureCmd.Flags().Lookup("auto-discover"))
-	// --output writes a *.kshrk archive, but also accepts "-" to stream NDJSON
+	// --out writes a *.kshrk archive, but also accepts "-" to stream NDJSON
 	// to stdout. Scope file completion to *.kshrk while still offering "-".
-	_ = captureCmd.RegisterFlagCompletionFunc("output", func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = captureCmd.RegisterFlagCompletionFunc("out", func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if strings.HasPrefix(toComplete, "-") {
 			return []string{"-\tstream NDJSON to stdout"}, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -80,7 +82,7 @@ func runCapture(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
-	if v, _ := cmd.Flags().GetString("output"); v != "" {
+	if v, _ := cmd.Flags().GetString("out"); v != "" {
 		cfg.Output = v
 	}
 	if v, _ := cmd.Flags().GetString("kubeconfig"); v != "" {
@@ -110,7 +112,7 @@ func runCapture(cmd *cobra.Command, args []string) error {
 	// prompt so users aren't asked for a secret only to be told it can't be
 	// used. These helpers check the flags without prompting.
 	if (encryptRequested(cmd) || recipientsRequested(cmd)) && streamingStdout {
-		return fmt.Errorf("archive encryption cannot be combined with --output - (NDJSON streaming to stdout is not encrypted)")
+		return fmt.Errorf("archive encryption cannot be combined with --out - (NDJSON streaming to stdout is not encrypted)")
 	}
 
 	// Resolve redaction inputs up front: whether the capture will be redacted
@@ -121,7 +123,7 @@ func runCapture(cmd *cobra.Command, args []string) error {
 	}
 	willRedact := doRedactSecrets || len(fieldRules) > 0
 	if willRedact && streamingStdout {
-		return fmt.Errorf("redaction (--redact-secrets / --redact-field) cannot be combined with --output - (redaction rewrites the archive file, which NDJSON streaming to stdout does not produce)")
+		return fmt.Errorf("redaction (--redact-secrets / --redact-field) cannot be combined with --out - (redaction rewrites the archive file, which NDJSON streaming to stdout does not produce)")
 	}
 
 	// Resolve encryption before the (potentially long) capture starts so a bad

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -63,7 +63,10 @@ func TestCompleteArchiveArg(t *testing.T) {
 }
 
 func TestPositionalArchiveCompletionRegistered(t *testing.T) {
-	for _, name := range []string{"inspect", "open", "ui", "transitions"} {
+	// redact switched from a --in flag to a positional archive argument in
+	// this change (#215); cover it here so a regression in its Args/
+	// ValidArgsFunction wiring is caught the same way as the others.
+	for _, name := range []string{"inspect", "open", "ui", "transitions", "redact"} {
 		comps, directive := runCompletion(t, name, "")
 		if !contains(comps, captureExt) {
 			t.Errorf("%s positional completion = %v, want it to include %q", name, comps, captureExt)

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -94,16 +94,14 @@ func TestOutputFlagEnumCompletion(t *testing.T) {
 }
 
 func TestArchiveFlagFilenameCompletion(t *testing.T) {
-	// diff's --before/--after/--archive, redact's --in/--out, and capture's
-	// --output are scoped to *.kshrk, which yields a file-extension-filter
-	// directive.
+	// diff's --before/--after/--archive, redact's --out, and capture's --out
+	// are scoped to *.kshrk, which yields a file-extension-filter directive.
 	for _, c := range [][2]string{
 		{"diff", "--before"},
 		{"diff", "--after"},
 		{"diff", "--archive"},
-		{"redact", "--in"},
 		{"redact", "--out"},
-		{"capture", "--output"},
+		{"capture", "--out"},
 	} {
 		comps, directive := runCompletion(t, c[0], c[1], "")
 		if !contains(comps, captureExt) {
@@ -120,12 +118,12 @@ func TestCaptureOutputCompletesStdout(t *testing.T) {
 	// typing it, even though plain completion is scoped to *.kshrk files.
 	// A dash-prefixed flag value is completed via the "--flag=value" form
 	// (Cobra can't tell a space-separated "-" from the start of a new flag).
-	comps, directive := runCompletion(t, "capture", "--output=-")
+	comps, directive := runCompletion(t, "capture", "--out=-")
 	if !contains(comps, "-") {
-		t.Errorf("capture --output completion = %v, want it to include %q", comps, "-")
+		t.Errorf("capture --out completion = %v, want it to include %q", comps, "-")
 	}
 	if directive&cobra.ShellCompDirectiveNoFileComp == 0 {
-		t.Errorf("capture --output - directive = %d, want the NoFileComp bit set", directive)
+		t.Errorf("capture --out - directive = %d, want the NoFileComp bit set", directive)
 	}
 }
 

--- a/cmd/decrypt.go
+++ b/cmd/decrypt.go
@@ -27,7 +27,7 @@ re-encrypting to a different key/recipient set.`,
   kshrk decrypt capture.kshrk --decrypt-identity-file ./key.txt
 
   # Choose the output path explicitly
-  kshrk decrypt capture.kshrk --output plain.kshrk --decrypt-passphrase-file ./pass.txt`,
+  kshrk decrypt capture.kshrk --out plain.kshrk --decrypt-passphrase-file ./pass.txt`,
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: completeArchiveArg,
 	RunE:              runDecrypt,
@@ -35,13 +35,13 @@ re-encrypting to a different key/recipient set.`,
 
 func init() {
 	rootCmd.AddCommand(decryptCmd)
-	decryptCmd.Flags().StringP("output", "o", "", "output archive path (default: <in>-decrypted.kshrk)")
-	_ = decryptCmd.MarkFlagFilename("output", captureExt)
+	decryptCmd.Flags().String("out", "", "output archive path (default: <in>-decrypted.kshrk)")
+	_ = decryptCmd.MarkFlagFilename("out", captureExt)
 }
 
 func runDecrypt(cmd *cobra.Command, args []string) error {
 	in := args[0]
-	out, _ := cmd.Flags().GetString("output")
+	out, _ := cmd.Flags().GetString("out")
 	if out == "" {
 		out = defaultCryptOutput(in, "decrypted")
 	}

--- a/cmd/decrypt_test.go
+++ b/cmd/decrypt_test.go
@@ -12,7 +12,7 @@ import (
 
 func newTestDecryptCmdCommand() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Flags().StringP("output", "o", "", "")
+	cmd.Flags().String("out", "", "")
 	addDecryptFlags(cmd)
 	// PersistentFlags on a standalone command aren't merged into Flags() until
 	// execution via cmd.Execute(); tests call runDecrypt directly, so merge
@@ -94,7 +94,7 @@ func TestRunDecrypt_SameOutputRejected(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	cmd := newTestDecryptCmdCommand()
-	if err := cmd.Flags().Set("output", in); err != nil {
+	if err := cmd.Flags().Set("out", in); err != nil {
 		t.Fatalf("set flag: %v", err)
 	}
 	if err := cmd.Flags().Set("decrypt-passphrase-file", passFile); err != nil {
@@ -102,6 +102,6 @@ func TestRunDecrypt_SameOutputRejected(t *testing.T) {
 	}
 
 	if err := runDecrypt(cmd, []string{in}); err == nil {
-		t.Fatal("expected an error when --output equals the input path")
+		t.Fatal("expected an error when --out equals the input path")
 	}
 }

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -30,7 +30,7 @@ archive you already have (e.g. before sharing it), as an alternative to
   kshrk encrypt capture.kshrk --encrypt-recipient age1abc...
 
   # Choose the output path explicitly
-  kshrk encrypt capture.kshrk --output shared.kshrk --encrypt-recipient age1abc...`,
+  kshrk encrypt capture.kshrk --out shared.kshrk --encrypt-recipient age1abc...`,
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: completeArchiveArg,
 	RunE:              runEncrypt,
@@ -38,14 +38,14 @@ archive you already have (e.g. before sharing it), as an alternative to
 
 func init() {
 	rootCmd.AddCommand(encryptCmd)
-	encryptCmd.Flags().StringP("output", "o", "", "output archive path (default: <in>-encrypted.kshrk)")
-	_ = encryptCmd.MarkFlagFilename("output", captureExt)
+	encryptCmd.Flags().String("out", "", "output archive path (default: <in>-encrypted.kshrk)")
+	_ = encryptCmd.MarkFlagFilename("out", captureExt)
 	addEncryptFlags(encryptCmd)
 }
 
 func runEncrypt(cmd *cobra.Command, args []string) error {
 	in := args[0]
-	out, _ := cmd.Flags().GetString("output")
+	out, _ := cmd.Flags().GetString("out")
 	if out == "" {
 		out = defaultCryptOutput(in, "encrypted")
 	}

--- a/cmd/encrypt_test.go
+++ b/cmd/encrypt_test.go
@@ -14,7 +14,7 @@ import (
 
 func newTestEncryptCmdCommand() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Flags().StringP("output", "o", "", "")
+	cmd.Flags().String("out", "", "")
 	addEncryptFlags(cmd)
 	// These tests assert on disk state and returned errors, not the printed
 	// summary, so discard stdout rather than letting it leak to os.Stdout.
@@ -61,7 +61,7 @@ func TestRunEncrypt_ExplicitOutput(t *testing.T) {
 	out := filepath.Join(filepath.Dir(in), "custom.kshrk")
 
 	cmd := newTestEncryptCmdCommand()
-	if err := cmd.Flags().Set("output", out); err != nil {
+	if err := cmd.Flags().Set("out", out); err != nil {
 		t.Fatalf("set flag: %v", err)
 	}
 	if err := cmd.Flags().Set("encrypt-recipient", mustGenerateRecipient(t)); err != nil {
@@ -117,14 +117,14 @@ func TestRunEncrypt_RejectsAlreadyEncrypted(t *testing.T) {
 func TestRunEncrypt_SameOutputRejected(t *testing.T) {
 	in := buildDiffArchive(t, healthyPodList)
 	cmd := newTestEncryptCmdCommand()
-	if err := cmd.Flags().Set("output", in); err != nil {
+	if err := cmd.Flags().Set("out", in); err != nil {
 		t.Fatalf("set flag: %v", err)
 	}
 	if err := cmd.Flags().Set("encrypt-recipient", mustGenerateRecipient(t)); err != nil {
 		t.Fatalf("set flag: %v", err)
 	}
 	if err := runEncrypt(cmd, []string{in}); err == nil {
-		t.Fatal("expected an error when --output equals the input path")
+		t.Fatal("expected an error when --out equals the input path")
 	}
 }
 

--- a/cmd/redact.go
+++ b/cmd/redact.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/phenixblue/k8shark/internal/archive"
@@ -13,7 +12,7 @@ import (
 )
 
 var redactCmd = &cobra.Command{
-	Use:   "redact --in <capture.kshrk> [--out <redacted.kshrk>]",
+	Use:   "redact <capture.kshrk> [--out <redacted.kshrk>]",
 	Short: "Redact Secret data and arbitrary fields from a capture archive",
 	Long: `Produces a new capture archive with Kubernetes Secret data replaced by
 "REDACTED" and any configured field-level redaction rules applied. The original
@@ -24,30 +23,29 @@ Field rules can be supplied via --redact-field (repeatable) with the format:
 
 Rules may also be loaded from a config file's redaction.rules block via --config.`,
 	Example: `  # Redact all Secret data and stringData values
-  kshrk redact --in capture.kshrk --redact-secrets
+  kshrk redact capture.kshrk --redact-secrets
 
   # Apply a single field-level redaction rule
-  kshrk redact --in capture.kshrk --redact-field "data.api-key:ConfigMap:REDACTED"
+  kshrk redact capture.kshrk --redact-field "data.api-key:ConfigMap:REDACTED"
 
   # Use redaction.rules from a config file, writing to a chosen path
-  kshrk redact --in capture.kshrk --out safe.kshrk --config k8shark.yaml
+  kshrk redact capture.kshrk --out safe.kshrk --config k8shark.yaml
 
   # Redact and encrypt the output to an age recipient (decrypt an encrypted
   # source with --decrypt-passphrase-file / --decrypt-identity-file)
-  kshrk redact --in capture.kshrk --redact-secrets --encrypt-recipient age1abc...`,
-	RunE: runRedact,
+  kshrk redact capture.kshrk --redact-secrets --encrypt-recipient age1abc...`,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeArchiveArg,
+	RunE:              runRedact,
 }
 
 func init() {
 	rootCmd.AddCommand(redactCmd)
-	redactCmd.Flags().String("in", "", "source capture archive (required)")
 	redactCmd.Flags().String("out", "", "output archive path (default: <in>-redacted.kshrk)")
 	redactCmd.Flags().Bool("redact-secrets", false, "redact all Kubernetes Secret data and stringData values")
 	redactCmd.Flags().StringArray("allow-secret", nil, "namespace/name of secret to preserve (repeatable)")
 	redactCmd.Flags().StringArray("redact-field", nil, "field redaction rule: <fieldPath>:<Kind>:<replacement>[:<valueType>] (repeatable)")
 	redactCmd.Flags().String("config", "", "capture config file whose redaction.rules block is applied")
-	_ = redactCmd.MarkFlagRequired("in")
-	_ = redactCmd.MarkFlagFilename("in", captureExt)
 	_ = redactCmd.MarkFlagFilename("out", captureExt)
 	_ = redactCmd.MarkFlagFilename("config", configExts...)
 	// Write-side encryption for the redacted output (read-side --decrypt-* are
@@ -73,8 +71,8 @@ func parseRedactField(s string) (config.RedactionRule, error) {
 	return rule, nil
 }
 
-func runRedact(cmd *cobra.Command, _ []string) error {
-	in, _ := cmd.Flags().GetString("in")
+func runRedact(cmd *cobra.Command, args []string) error {
+	in := args[0]
 	out, _ := cmd.Flags().GetString("out")
 	doRedactSecrets, _ := cmd.Flags().GetBool("redact-secrets")
 	allows, _ := cmd.Flags().GetStringArray("allow-secret")
@@ -90,10 +88,8 @@ func runRedact(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Refuse to overwrite the source.
-	inAbs, _ := filepath.Abs(in)
-	outAbs, _ := filepath.Abs(out)
-	if inAbs == outAbs {
-		return fmt.Errorf("--out must differ from --in")
+	if err := rejectSamePath(in, out); err != nil {
+		return err
 	}
 
 	allowList := make(map[string]bool, len(allows))

--- a/docs/archive-format.md
+++ b/docs/archive-format.md
@@ -260,7 +260,7 @@ usable with `kshrk open` — `kubectl get secret` will show the secret names and
 types, but all values will be `REDACTED`.
 
 ```sh
-kshrk redact --in capture.kshrk --out capture-redacted.kshrk
+kshrk redact capture.kshrk --out capture-redacted.kshrk
 ```
 
 ## Encryption
@@ -314,16 +314,16 @@ with the manual ZIP/Zstd commands shown below.
 
 ## Streaming mode (NDJSON stdout)
 
-When `output: "-"` is set in the configuration (or `--output -` on the command line), k8shark writes records to stdout in **newline-delimited JSON (NDJSON)** format instead of writing a `.kshrk` file. Each line is a complete JSON record object identical to the individual record files described above.
+When `output: "-"` is set in the configuration (or `--out -` on the command line), k8shark writes records to stdout in **newline-delimited JSON (NDJSON)** format instead of writing a `.kshrk` file. Each line is a complete JSON record object identical to the individual record files described above.
 
 ```sh
-kshrk capture --config capture.yaml --output - | jq 'select(.api_path == "/api/v1/namespaces/default/pods")'
+kshrk capture --config capture.yaml --out - | jq 'select(.api_path == "/api/v1/namespaces/default/pods")'
 ```
 
 No `metadata.json` or `index.json` is written in streaming mode — only the raw record stream. Pipe to a file or processing tool:
 
 ```sh
-kshrk capture --config capture.yaml --output - > records.ndjson
+kshrk capture --config capture.yaml --out - > records.ndjson
 ```
 
 In streaming mode, SIGTERM or SIGINT causes the engine to stop polling and flush all in-flight records before exiting. Every line in the stream is a complete JSON object.

--- a/docs/config.md
+++ b/docs/config.md
@@ -448,7 +448,7 @@ redaction:
 The same config can be passed to `kshrk redact` to apply exactly the same rules to an existing archive:
 
 ```bash
-kshrk redact --in capture.kshrk --out redacted.kshrk --config k8shark.yaml
+kshrk redact capture.kshrk --out redacted.kshrk --config k8shark.yaml
 ```
 
 ---

--- a/docs/encryption-threat-model.md
+++ b/docs/encryption-threat-model.md
@@ -98,8 +98,8 @@ Use `kshrk decrypt` followed by `kshrk encrypt` to rotate a passphrase, move
 from a passphrase to recipient keys, or add/remove recipients:
 
 ```sh
-kshrk decrypt old.kshrk --decrypt-passphrase-file old-pass.txt --output plain.kshrk
-kshrk encrypt plain.kshrk --encrypt-recipient age1newrecipient... --output new.kshrk
+kshrk decrypt old.kshrk --decrypt-passphrase-file old-pass.txt --out plain.kshrk
+kshrk encrypt plain.kshrk --encrypt-recipient age1newrecipient... --out new.kshrk
 ```
 
 The intermediate `plain.kshrk` is a real plaintext file on disk between the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,9 +49,9 @@ make build
 
 `kshrk` ships tab-completion for `bash`, `zsh`, `fish`, and PowerShell. It
 completes subcommand and `--flag` names, scopes positional and archive-valued
-flags (`--in`, `--out`, `--before`, `--after`, `--archive`, and `capture
---output`) to `*.kshrk` files, restricts `--config` to YAML files, and offers
-the valid choices for output formats (e.g. `-o table|json|yaml`).
+flags (`--out`, `--before`, `--after`, `--archive`, and `capture --out`) to
+`*.kshrk` files, restricts `--config` to YAML files, and offers the valid
+choices for output formats (e.g. `-o table|json|yaml`).
 
 Generate the script for your shell with `kshrk completion <shell>`:
 
@@ -106,7 +106,7 @@ Capture complete
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--config` | | `./config.yaml`, then `~/.config/kshrk/config.yaml` | Path to config file |
-| `--output` | `-o` | `./k8shark-<timestamp>.kshrk` | Output archive path |
+| `--out` | | `./k8shark-<timestamp>.kshrk` | Output archive path |
 | `--duration` | | from config | Override capture duration (e.g. `5m`) |
 | `--kubeconfig` | | `$KUBECONFIG` / `~/.kube/config` | Source cluster kubeconfig |
 | `--auto-discover` | | false | Auto-discover and capture all available API resources |
@@ -669,18 +669,18 @@ Produces a **new** archive with Kubernetes Secret data replaced and any configur
 
 ```sh
 # Redact secrets only
-kshrk redact --in capture.kshrk --redact-secrets
+kshrk redact capture.kshrk --redact-secrets
 
 # Redact secrets + specific fields via CLI flags
-kshrk redact --in capture.kshrk --redact-secrets \
+kshrk redact capture.kshrk --redact-secrets \
   --redact-field "data.api-key:ConfigMap:REDACTED" \
   --redact-field "spec.containers[*].env[*].value:Pod:REDACTED:string"
 
 # Reuse the redaction rules from your capture config
-kshrk redact --in capture.kshrk --out safe-capture.kshrk --config k8shark.yaml
+kshrk redact capture.kshrk --out safe-capture.kshrk --config k8shark.yaml
 
 # Preserve specific secrets from redaction
-kshrk redact --in capture.kshrk --redact-secrets \
+kshrk redact capture.kshrk --redact-secrets \
   --allow-secret default/pull-secret \
   --allow-secret kube-system/bootstrap-token
 ```
@@ -727,14 +727,14 @@ Examples:
 
 | Flag | Command | Default | Description |
 |------|---------|---------|-------------|
-| `--in` | `redact` | (required) | Source capture archive |
+| *(positional)* | `redact` | (required) | Source capture archive, e.g. `kshrk redact capture.kshrk` |
 | `--out` | `redact` | `<in>-redacted.kshrk` | Output archive path |
 | `--redact-secrets` | both | `false` | Redact all Secret `data`/`stringData` values |
 | `--allow-secret` | both | | `namespace/name` of secret to preserve (repeatable) |
 | `--redact-field` | both | | Field redaction rule (repeatable). Format: `<path>:<Kind>:<replacement>[:<type>]` |
 | `--config` | `redact` | | Capture config file — applies `redaction.rules` and `redaction.redactSecrets` |
 | `--encrypt`, `--encrypt-passphrase-file`, `--encrypt-recipient`, `--encrypt-recipients-file` | `redact` | | Encrypt the output archive — see [Encryption](#encryption) |
-| `--decrypt-passphrase-file`, `--decrypt-identity-file` | `redact` | | Decrypt an encrypted `--in` archive — see [Encryption](#encryption) |
+| `--decrypt-passphrase-file`, `--decrypt-identity-file` | `redact` | | Decrypt an encrypted source archive — see [Encryption](#encryption) |
 
 Secret metadata (name, namespace, labels, annotations, type) is always preserved so you can still count and identify secrets by kind.
 
@@ -816,7 +816,7 @@ key`), not a raw crypto failure.
 re-encrypt the output with `--encrypt-*`:
 
 ```sh
-kshrk redact --in capture.kshrk --redact-secrets \
+kshrk redact capture.kshrk --redact-secrets \
   --decrypt-passphrase-file old-pass.txt \
   --encrypt-recipient age1abc...
 ```
@@ -847,8 +847,8 @@ kshrk encrypt capture.kshrk --encrypt-recipient age1abc...
 kshrk decrypt capture-encrypted.kshrk --decrypt-passphrase-file ./pass.txt
 
 # Rotate from a passphrase to a recipient key
-kshrk decrypt old.kshrk --decrypt-passphrase-file old-pass.txt --output plain.kshrk
-kshrk encrypt plain.kshrk --encrypt-recipient age1new... --output new.kshrk
+kshrk decrypt old.kshrk --decrypt-passphrase-file old-pass.txt --out plain.kshrk
+kshrk encrypt plain.kshrk --encrypt-recipient age1new... --out new.kshrk
 ```
 
 `kshrk encrypt` refuses to run against an archive that's already encrypted,

--- a/internal/archive/ndjson_test.go
+++ b/internal/archive/ndjson_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // failingWriter returns an error from every Write, simulating a broken pipe
-// (e.g. `kshrk capture --output -` piped into a process that exits early).
+// (e.g. `kshrk capture --out -` piped into a process that exits early).
 type failingWriter struct{ err error }
 
 func (w *failingWriter) Write(p []byte) (int, error) { return 0, w.err }

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -415,7 +415,7 @@ INLINE_REDACTED_FILE="${CAPTURE_FILE%.tar.gz}-inline-redacted.tar.gz"
 "$BINARY" --config "$CAPTURE_CONFIG" capture \
   --redact-secrets \
   --allow-secret "k8shark-test/app-secret" \
-  --output "$INLINE_REDACTED_FILE"
+  --out "$INLINE_REDACTED_FILE"
 
 if [[ -s "$INLINE_REDACTED_FILE" ]]; then
   pass "capture --redact-secrets: output archive created"
@@ -500,7 +500,7 @@ INLINE_FIELD_SERVER_PID=""
 # untouched so we can assert field-level selectivity.
 "$BINARY" --config "$CAPTURE_CONFIG" capture \
   --redact-field "data.env:ConfigMap:REDACTED" \
-  --output "$INLINE_FIELD_FILE"
+  --out "$INLINE_FIELD_FILE"
 
 if [[ -s "$INLINE_FIELD_FILE" ]]; then
   pass "capture --redact-field: output archive created"
@@ -697,8 +697,7 @@ REDACTED_SERVER_PID=""
 
 # Run redact on the original (un-redacted) capture without an allowlist so
 # all secrets (including app-secret) are redacted.
-redact_out=$("$BINARY" redact \
-  --in "$CAPTURE_FILE" \
+redact_out=$("$BINARY" redact "$CAPTURE_FILE" \
   --out "$REDACTED_FILE" \
   --redact-secrets 2>&1) || true
 assert_contains "redact: success message present"       "$redact_out" "Redacted"
@@ -777,8 +776,7 @@ FIELD_REDACTED_KC="/tmp/k8shark-field-redacted-kc-$$.yaml"
 FIELD_REDACTED_SERVER_PID=""
 
 # Target only data.env in ConfigMaps; leave data.log-level and all secrets alone.
-field_redact_out=$("$BINARY" redact \
-  --in "$CAPTURE_FILE" \
+field_redact_out=$("$BINARY" redact "$CAPTURE_FILE" \
   --out "$FIELD_REDACTED_FILE" \
   --redact-field "data.env:ConfigMap:REDACTED" \
   2>&1) || true
@@ -876,8 +874,7 @@ redaction:
 YAML
 pass "config-redact: redaction config written"
 
-cfg_redact_out=$("$BINARY" redact \
-  --in "$CAPTURE_FILE" \
+cfg_redact_out=$("$BINARY" redact "$CAPTURE_FILE" \
   --out "$CFGREDACT_FILE" \
   --config "$CFGREDACT_CONFIG" \
   2>&1) || true
@@ -1101,7 +1098,7 @@ echo "definitely-the-wrong-passphrase" >"$ENC_WRONG_PASS_FILE"
 ENC_FILE="/tmp/k8shark-e2e-encrypted-$$.kshrk"
 "$BINARY" --config "$CAPTURE_CONFIG" capture \
   --encrypt-passphrase-file "$ENC_PASS_FILE" \
-  --output "$ENC_FILE"
+  --out "$ENC_FILE"
 if [[ -s "$ENC_FILE" ]]; then
   pass "capture --encrypt-passphrase-file: encrypted archive created"
 else
@@ -1122,7 +1119,7 @@ assert_contains "inspect (correct passphrase): succeeds" "$out" "Capture ID:"
 
 # kshrk decrypt to a standalone plaintext archive.
 DEC_FILE="/tmp/k8shark-e2e-decrypted-$$.kshrk"
-"$BINARY" decrypt "$ENC_FILE" --decrypt-passphrase-file "$ENC_PASS_FILE" --output "$DEC_FILE"
+"$BINARY" decrypt "$ENC_FILE" --decrypt-passphrase-file "$ENC_PASS_FILE" --out "$DEC_FILE"
 if [[ -s "$DEC_FILE" ]]; then
   pass "kshrk decrypt: plaintext archive created"
 else
@@ -1255,7 +1252,7 @@ GOEOF
     ENC_RECIPIENT_FILE="/tmp/k8shark-e2e-encrypted-recipient-$$.kshrk"
     "$BINARY" --config "$CAPTURE_CONFIG" capture \
       --encrypt-recipient "$AGE_RECIPIENT" \
-      --output "$ENC_RECIPIENT_FILE"
+      --out "$ENC_RECIPIENT_FILE"
     if [[ -s "$ENC_RECIPIENT_FILE" ]]; then
       pass "capture --encrypt-recipient: encrypted archive created"
     else
@@ -1265,7 +1262,7 @@ GOEOF
     DEC_RECIPIENT_FILE="/tmp/k8shark-e2e-decrypted-recipient-$$.kshrk"
     "$BINARY" decrypt "$ENC_RECIPIENT_FILE" \
       --decrypt-identity-file "$AGE_IDENTITY_FILE" \
-      --output "$DEC_RECIPIENT_FILE"
+      --out "$DEC_RECIPIENT_FILE"
     if [[ -s "$DEC_RECIPIENT_FILE" ]]; then
       pass "kshrk decrypt --decrypt-identity-file: plaintext archive created"
     else

--- a/scripts/kind-chaos.sh
+++ b/scripts/kind-chaos.sh
@@ -303,8 +303,8 @@ printf '    kubectl get pods -n %s -o wide\n' "$NS"
 printf '    kubectl get events -n %s --sort-by=.lastTimestamp\n\n' "$NS"
 info "Capture it with k8shark (run for a few minutes so events keep flowing):"
 printf '    make build\n'
-printf '    ./kshrk capture --kubeconfig %s --auto-discover --duration 3m -o chaos.kshrk\n\n' "$KIND_KUBECONFIG"
+printf '    ./kshrk capture --kubeconfig %s --auto-discover --duration 3m --out chaos.kshrk\n\n' "$KIND_KUBECONFIG"
 info "Then explore the capture (UI on 18080/18081):"
-printf '    ./kshrk ui chaos.kshrk --port 18080 --api-port 18081\n\n'
+printf '    ./kshrk ui chaos.kshrk --ui-port 18080 --api-port 18081\n\n'
 info "Tear down when finished:"
 printf '    make kind-down\n\n'

--- a/scripts/kind-chaos.sh
+++ b/scripts/kind-chaos.sh
@@ -305,6 +305,6 @@ info "Capture it with k8shark (run for a few minutes so events keep flowing):"
 printf '    make build\n'
 printf '    ./kshrk capture --kubeconfig %s --auto-discover --duration 3m --out chaos.kshrk\n\n' "$KIND_KUBECONFIG"
 info "Then explore the capture (UI on 18080/18081):"
-printf '    ./kshrk ui chaos.kshrk --ui-port 18080 --api-port 18081\n\n'
+printf '    ./kshrk ui chaos.kshrk --port 18080 --api-port 18081\n\n'
 info "Tear down when finished:"
 printf '    make kind-down\n\n'

--- a/scripts/kind-scale.sh
+++ b/scripts/kind-scale.sh
@@ -197,6 +197,6 @@ info "Capture it with k8shark:"
 printf '    make build\n'
 printf '    ./kshrk capture --kubeconfig %s --auto-discover --duration 5m --out scale.kshrk\n\n' "$KIND_KUBECONFIG"
 info "Then explore the capture (UI on 18080/18081):"
-printf '    ./kshrk ui scale.kshrk --ui-port 18080 --api-port 18081\n\n'
+printf '    ./kshrk ui scale.kshrk --port 18080 --api-port 18081\n\n'
 info "Tear down when finished:"
 printf '    make kind-down\n\n'

--- a/scripts/kind-scale.sh
+++ b/scripts/kind-scale.sh
@@ -195,8 +195,8 @@ printf '    kubectl get ns -l k8shark.io/suite=scale\n'
 printf '    kubectl get pods -A -l k8shark.io/suite=scale -o wide\n\n'
 info "Capture it with k8shark:"
 printf '    make build\n'
-printf '    ./kshrk capture --kubeconfig %s --auto-discover --duration 5m -o scale.kshrk\n\n' "$KIND_KUBECONFIG"
+printf '    ./kshrk capture --kubeconfig %s --auto-discover --duration 5m --out scale.kshrk\n\n' "$KIND_KUBECONFIG"
 info "Then explore the capture (UI on 18080/18081):"
-printf '    ./kshrk ui scale.kshrk --port 18080 --api-port 18081\n\n'
+printf '    ./kshrk ui scale.kshrk --ui-port 18080 --api-port 18081\n\n'
 info "Tear down when finished:"
 printf '    make kind-down\n\n'


### PR DESCRIPTION
## Summary

`-o`/`--output` carried two incompatible meanings across the CLI: output **format** (`inspect`, `diagnose`, `query`, `transitions`, `diff`) and output **file path** (`capture`, `encrypt`, `decrypt`), while `redact` already used `--out`. `kshrk encrypt x.kshrk -o json` would silently write an archive to a file literally named `json`.

- `capture`/`encrypt`/`decrypt`: rename the file-destination flag from `-o`/`--output` to `--out` (no shorthand — matches `redact`'s existing convention). `capture`'s viper config key stays `"output"` (the config file's own `output:` field is a separate, unaffected concept — out of scope here, tracked for #218/#220).
- `redact`: take the source archive as a positional argument instead of `--in`, matching `encrypt`/`decrypt`'s shape (positional input + `--out`), and reuse `encrypt.go`'s `rejectSamePath` helper instead of a duplicated same-path check.
- Updated flag completion tests, `docs/usage.md`, `docs/config.md`, `docs/archive-format.md`, `docs/encryption-threat-model.md`, and `scripts/e2e.sh` accordingly.

No deprecated alias was kept for the old spellings — this is pre-v1.0, and the whole point of #266 is to lock down the CLI contract before the compatibility guarantee kicks in.

Closes #215.

## Test plan
- [x] `make fmt` (clean)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -race ./cmd/... ./internal/archive/...`
- [x] `go mod tidy` (no diff)
- [x] `golangci-lint run` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)