### PR TITLE
feat(cli): define an exit-code contract (0 clean / 1 findings / 2 error)

### DIFF
--- a/cmd/diagnose.go
+++ b/cmd/diagnose.go
@@ -96,7 +96,7 @@ func runDiagnose(cmd *cobra.Command, args []string) error {
 	if failOn != "" {
 		for _, f := range report.Findings {
 			if diagnose.SeverityAtLeast(f.Severity, failOn) {
-				return exitError{code: exitCodeFindings}
+				return exitError{}
 			}
 		}
 	}

--- a/cmd/diagnose.go
+++ b/cmd/diagnose.go
@@ -96,7 +96,7 @@ func runDiagnose(cmd *cobra.Command, args []string) error {
 	if failOn != "" {
 		for _, f := range report.Findings {
 			if diagnose.SeverityAtLeast(f.Severity, failOn) {
-				return exitError{msg: "", code: 1}
+				return exitError{code: exitCodeFindings}
 			}
 		}
 	}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -107,7 +107,7 @@ func runDiff(cmd *cobra.Command, _ []string) error {
 	}
 
 	if hasDiff {
-		return exitError{code: 1}
+		return exitError{code: exitCodeFindings}
 	}
 	return nil
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -10,13 +10,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// exitError signals that a command ran successfully but found something (a
+// diagnose --fail-on gate trip, a diff with differences) — exit code 1 per
+// the contract documented in root.go. It always carries that exit code (not
+// an arbitrary caller-supplied one) so a future call site can't accidentally
+// violate the 0/1/2 contract by passing an unrelated code.
 type exitError struct {
-	msg  string
-	code int
+	msg string
 }
 
 func (e exitError) Error() string { return e.msg }
-func (e exitError) ExitCode() int { return e.code }
+func (e exitError) ExitCode() int { return exitCodeFindings }
 
 var diffCmd = &cobra.Command{
 	Use:   "diff",
@@ -107,7 +111,7 @@ func runDiff(cmd *cobra.Command, _ []string) error {
 	}
 
 	if hasDiff {
-		return exitError{code: exitCodeFindings}
+		return exitError{}
 	}
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,7 +39,7 @@ environment without direct connectivity.`,
 //	    --fail-on gate trip, a diff with differences)
 //	2 - the command failed (bad archive, invalid flags, I/O error, ...)
 //
-// A command signals exit code 1 by returning an exitError{code: exitCodeFindings};
+// A command signals exit code 1 by returning an exitError{} (see diff.go);
 // any other error (including a plain error from fmt.Errorf) falls through to
 // the exit code 2 case below.
 const (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,9 +49,14 @@ const (
 // Execute is the entry point called from main.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		var exitErr interface{ ExitCode() int }
+		// Match specifically on the internal exitError type, not any error
+		// implementing ExitCode() int — os/exec.ExitError also satisfies
+		// that shape, and matching it here would let a failing subprocess
+		// (kwok, kube-controller-manager, ...) escape with an arbitrary
+		// exit code instead of the documented 0/1/2 contract.
+		var exitErr exitError
 		if errors.As(err, &exitErr) {
-			if err.Error() != "" {
+			if exitErr.msg != "" {
 				fmt.Fprintln(os.Stderr, err)
 			}
 			os.Exit(exitErr.ExitCode())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,9 +22,10 @@ environment without direct connectivity.`,
 	// "Error: ..." + usage-block printing for every subcommand (cobra checks
 	// both the executing command's and the root's flag — see ExecuteC), so
 	// Execute below is the single place that prints an error. Without this,
-	// a command whose exitError carries an empty message (a clean --fail-on
-	// gate trip) printed a bare "Error: " followed by a full usage dump, and
-	// every other error printed twice (once by cobra, once here) (#217).
+	// a command whose exitError carries an empty message (a --fail-on gate
+	// trip with nothing more to say than "findings exist") printed a bare
+	// "Error: " followed by a full usage dump, and every other error printed
+	// twice (once by cobra, once here) (#217).
 	SilenceErrors: true,
 	SilenceUsage:  true,
 }
@@ -49,21 +50,29 @@ const (
 // Execute is the entry point called from main.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		// Match specifically on the internal exitError type, not any error
-		// implementing ExitCode() int — os/exec.ExitError also satisfies
-		// that shape, and matching it here would let a failing subprocess
-		// (kwok, kube-controller-manager, ...) escape with an arbitrary
-		// exit code instead of the documented 0/1/2 contract.
-		var exitErr exitError
-		if errors.As(err, &exitErr) {
-			if exitErr.msg != "" {
-				fmt.Fprintln(os.Stderr, err)
-			}
-			os.Exit(exitErr.ExitCode())
+		code, printErr := exitCodeAndMessage(err)
+		if printErr {
+			fmt.Fprintln(os.Stderr, err)
 		}
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(exitCodeFailure)
+		os.Exit(code)
 	}
+}
+
+// exitCodeAndMessage decides the process exit code and whether err should be
+// printed to stderr, for a non-nil error returned by rootCmd.Execute(). It's
+// split out from Execute so the 0/1/2 dispatch contract is testable without
+// an actual os.Exit.
+func exitCodeAndMessage(err error) (code int, printErr bool) {
+	// Match specifically on the internal exitError type, not any error
+	// implementing ExitCode() int — os/exec.ExitError also satisfies that
+	// shape, and matching it here would let a failing subprocess (kwok,
+	// kube-controller-manager, ...) escape with an arbitrary exit code
+	// instead of the documented 0/1/2 contract.
+	var exitErr exitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode(), exitErr.msg != ""
+	}
+	return exitCodeFailure, true
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,33 @@ var rootCmd = &cobra.Command{
 	Long: `k8shark captures a Kubernetes cluster's state over time and replays
 it through a mock API server, letting support engineers query a customer's
 environment without direct connectivity.`,
+	// SilenceErrors/SilenceUsage on the root command suppress cobra's own
+	// "Error: ..." + usage-block printing for every subcommand (cobra checks
+	// both the executing command's and the root's flag — see ExecuteC), so
+	// Execute below is the single place that prints an error. Without this,
+	// a command whose exitError carries an empty message (a clean --fail-on
+	// gate trip) printed a bare "Error: " followed by a full usage dump, and
+	// every other error printed twice (once by cobra, once here) (#217).
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
+
+// Exit codes follow the diff(1)/git diff --exit-code convention, so CI can
+// tell "the command ran and found something" apart from "the command
+// couldn't run at all" (#217):
+//
+//	0 - clean: no findings/differences
+//	1 - the command ran successfully and found something (a diagnose
+//	    --fail-on gate trip, a diff with differences)
+//	2 - the command failed (bad archive, invalid flags, I/O error, ...)
+//
+// A command signals exit code 1 by returning an exitError{code: 1}; any
+// other error (including a plain error from fmt.Errorf) falls through to the
+// exit code 2 case below.
+const (
+	exitCodeFindings = 1
+	exitCodeFailure  = 2
+)
 
 // Execute is the entry point called from main.
 func Execute() {
@@ -31,7 +57,7 @@ func Execute() {
 			os.Exit(exitErr.ExitCode())
 		}
 		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		os.Exit(exitCodeFailure)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,9 +38,9 @@ environment without direct connectivity.`,
 //	    --fail-on gate trip, a diff with differences)
 //	2 - the command failed (bad archive, invalid flags, I/O error, ...)
 //
-// A command signals exit code 1 by returning an exitError{code: 1}; any
-// other error (including a plain error from fmt.Errorf) falls through to the
-// exit code 2 case below.
+// A command signals exit code 1 by returning an exitError{code: exitCodeFindings};
+// any other error (including a plain error from fmt.Errorf) falls through to
+// the exit code 2 case below.
 const (
 	exitCodeFindings = 1
 	exitCodeFailure  = 2

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -29,19 +29,19 @@ func TestExitCodeAndMessage(t *testing.T) {
 		},
 		{
 			name:         "findings with no message stays silent",
-			err:          exitError{code: exitCodeFindings},
+			err:          exitError{},
 			wantCode:     exitCodeFindings,
 			wantPrintErr: false,
 		},
 		{
 			name:         "findings with a message is printed",
-			err:          exitError{code: exitCodeFindings, msg: "3 differences found"},
+			err:          exitError{msg: "3 differences found"},
 			wantCode:     exitCodeFindings,
 			wantPrintErr: true,
 		},
 		{
 			name:         "wrapped exitError is still matched",
-			err:          fmt.Errorf("wrapping: %w", exitError{code: exitCodeFindings}),
+			err:          fmt.Errorf("wrapping: %w", exitError{}),
 			wantCode:     exitCodeFindings,
 			wantPrintErr: false,
 		},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+)
+
+// fakeExitCoder satisfies interface{ ExitCode() int } like os/exec.ExitError
+// does, but is deliberately not the internal exitError type — it must NOT be
+// matched by exitCodeAndMessage's errors.As check (#217 review comment: a
+// failing subprocess must not escape the documented 0/1/2 contract).
+type fakeExitCoder struct{ code int }
+
+func (e fakeExitCoder) Error() string { return "fake exit coder" }
+func (e fakeExitCoder) ExitCode() int { return e.code }
+
+func TestExitCodeAndMessage(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		wantCode     int
+		wantPrintErr bool
+	}{
+		{
+			name:         "plain error",
+			err:          fmt.Errorf("boom"),
+			wantCode:     exitCodeFailure,
+			wantPrintErr: true,
+		},
+		{
+			name:         "findings with no message stays silent",
+			err:          exitError{code: exitCodeFindings},
+			wantCode:     exitCodeFindings,
+			wantPrintErr: false,
+		},
+		{
+			name:         "findings with a message is printed",
+			err:          exitError{code: exitCodeFindings, msg: "3 differences found"},
+			wantCode:     exitCodeFindings,
+			wantPrintErr: true,
+		},
+		{
+			name:         "wrapped exitError is still matched",
+			err:          fmt.Errorf("wrapping: %w", exitError{code: exitCodeFindings}),
+			wantCode:     exitCodeFindings,
+			wantPrintErr: false,
+		},
+		{
+			name:         "unrelated ExitCode()-satisfying type does not leak its code",
+			err:          fakeExitCoder{code: 7},
+			wantCode:     exitCodeFailure,
+			wantPrintErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, printErr := exitCodeAndMessage(tt.err)
+			if code != tt.wantCode {
+				t.Errorf("code = %d, want %d", code, tt.wantCode)
+			}
+			if printErr != tt.wantPrintErr {
+				t.Errorf("printErr = %v, want %v", printErr, tt.wantPrintErr)
+			}
+		})
+	}
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -257,6 +257,12 @@ kshrk diagnose capture.kshrk --severity warning --category scheduling -o json
 kshrk diagnose capture.kshrk --fail-on critical
 ```
 
+Exit codes follow the `diff(1)`/`git diff --exit-code` convention:
+
+- `0` — no findings at or above `--fail-on` (or `--fail-on` not set)
+- `1` — `--fail-on` tripped: at least one finding at or above the given severity
+- `2` — the command failed (bad archive, invalid flags, ...)
+
 ### Rules
 
 | rule_id | Severity | Category | Detects |
@@ -577,10 +583,11 @@ kshrk diff --before before.kshrk --after after.kshrk --output json
 | `--namespace` | | Limit diff to one namespace |
 | `--output`, `-o` | `text` | Output format: `text` or `json` |
 
-Exit codes follow the usual diff convention:
+Exit codes follow the `diff(1)`/`git diff --exit-code` convention:
 
-- `0` when no differences are found
-- `1` when differences are found
+- `0` — no differences found
+- `1` — differences found
+- `2` — the command failed (bad archive, invalid flags, ...)
 
 ---
 


### PR DESCRIPTION
## Summary

Exit code 1 meant two different things: "the command ran and found something" (`diagnose --fail-on` tripped, `diff` found differences) and "the command failed to run at all" (missing archive, invalid flags). A CI job couldn't distinguish a tripped gate from a broken pipeline — the exact failure mode where a broken pipeline silently reads as a passing one.

- Adopted the `diff(1)`/`git diff --exit-code` convention: `0` clean, `1` findings, `2` error. Root-caused in `cmd/root.go`'s `Execute()`: the plain-error fallback now exits `2` instead of `1`, so every ordinary `fmt.Errorf` return in `diagnose`/`diff` automatically gets the right code with no per-call-site changes — only the existing `exitError{code: 1}` "findings" paths needed renaming to a new `exitCodeFindings` constant.
- Fixed a related bug along the way: neither `diagnoseCmd` nor `diffCmd` silenced cobra's own error printing, so **every** error printed twice — once as cobra's `Error: <msg>` + a full usage-flag dump, once via `root.go`'s own clean print — and a tripped `--fail-on` gate (whose `exitError` deliberately carries an empty message, since the findings table was already printed) showed a bare `Error: ` line followed by the usage dump for no reason. Setting `SilenceErrors`/`SilenceUsage` on `rootCmd` fixes this for every subcommand (cobra's `ExecuteC` checks both the executing command's and the root's flag), not just `diagnose`/`diff`, since `root.go`'s `Execute()` is already the single correct place to print.
- Documented the exit-code contract in `docs/usage.md` for both `diagnose` and `diff`.

Verified against real fixture archives (built via a throwaway scratch program, not checked in): `diagnose --fail-on` on a critical finding now prints only the findings table and exits `1`; `diff` on two archives with real differences prints only the diff and exits `1`; a missing-archive error on either command (and on other commands, e.g. `inspect`) now prints one clean line and exits `2` — previously a double-printed `Error:` + full usage dump + exit `1`.

Closes #217.

## Test plan
- [x] `make fmt` (clean)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `go mod tidy` (no diff)
- [x] `golangci-lint run` (clean)
- [x] Manual verification against real fixture archives for both the "findings" and "error" paths on `diagnose` and `diff`, plus a spot-check on `inspect`/unknown-command to confirm the SilenceErrors fix didn't regress other commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)