### PR TITLE
fix(config): namespace env vars under KSHRK_, reject unknown/misspelled keys

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -65,7 +65,7 @@ func init() {
 	_ = viper.BindPFlag("output", captureCmd.Flags().Lookup("out"))
 	_ = viper.BindPFlag("kubeconfig", captureCmd.Flags().Lookup("kubeconfig"))
 	_ = viper.BindPFlag("duration", captureCmd.Flags().Lookup("duration"))
-	_ = viper.BindPFlag("auto_discover", captureCmd.Flags().Lookup("auto-discover"))
+	_ = viper.BindPFlag("autoDiscover", captureCmd.Flags().Lookup("auto-discover"))
 	// --out writes a *.kshrk archive, but also accepts "-" to stream NDJSON
 	// to stdout. Scope file completion to *.kshrk while still offering "-".
 	_ = captureCmd.RegisterFlagCompletionFunc("out", func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -60,6 +61,12 @@ func initConfig() {
 		viper.SetConfigName("config")
 		viper.SetConfigType("yaml")
 	}
+	// Environment variables must be namespaced under KSHRK_ — an unprefixed
+	// AutomaticEnv() claims common bare names like DURATION/OUTPUT/VERBOSE
+	// globally, which is indefensible in CI environments where those are
+	// already in use for something else (#218).
+	viper.SetEnvPrefix("KSHRK")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 	_ = viper.ReadInConfig()
 }

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -64,7 +64,7 @@ func runUI(cmd *cobra.Command, args []string) error {
 	at, _ := cmd.Flags().GetString("at")
 	verbose, _ := cmd.Root().PersistentFlags().GetBool("verbose")
 
-	// Fall back to config-file ui.port / ui.api_port when the flags were left at
+	// Fall back to config-file ui.port / ui.apiPort when the flags were left at
 	// their default; an explicitly-passed flag always wins.
 	if cfg, err := config.Load(viper.ConfigFileUsed()); err == nil && cfg != nil {
 		if !cmd.Flags().Changed("port") && cfg.UI.Port != "" {

--- a/docs/config.md
+++ b/docs/config.md
@@ -2,17 +2,41 @@
 
 k8shark reads a YAML config file that controls what gets captured, from which namespaces, and for how long.
 
+## Naming convention
+
+Multi-word config keys are **camelCase** (`autoDiscover`, `previousLogs`,
+`redactSecrets`, `fieldPath`, ...) — this is the one consistent convention
+across the whole schema. A handful of keys predate this convention and were
+spelled `snake_case` (`auto_discover`, `auto_discover_exclude_groups`,
+`ui.api_port`); those legacy spellings are still accepted for one minor
+release as a deprecated alias, but new configs should use the camelCase
+form. `kshrk validate` rejects any other unrecognized key by name — a typo
+like `previouslogs` (wrong case, not a legacy alias) fails validation
+instead of being silently ignored.
+
 ## Top-level fields
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `version` | int | `1` | Config schema version. Omit for version 1; a version newer than this build of `kshrk` understands fails validation with an "upgrade kshrk" error. |
 | `duration` | duration string | `10m` | Total time to run the capture. Polling continues until time runs out. |
 | `output` | string | `./k8shark-<timestamp>.kshrk` | Path for the output archive. |
 | `kubeconfig` | string | `$KUBECONFIG` → `~/.kube/config` | Path to the kubeconfig for the source cluster. |
 | `resources` | list | required | Resource types to capture. See below. |
-| `auto_discover` | bool | `false` | Legacy global discovery toggle. Prefer `resources: - all: true` for fine-grained control. |
+| `autoDiscover` | bool | `false` | Legacy global discovery toggle. Prefer `resources: - all: true` for fine-grained control. (Legacy alias: `auto_discover`.) |
 | `redaction` | object | — | Optional field-level redaction rules applied after capture. See [Redaction](#redaction). |
 | `ui` | object | — | Ports for the `kshrk ui` web explorer. See [Web UI ports](#web-ui-ports). |
+
+## Environment variable overrides
+
+`duration`, `output`, `kubeconfig`, and `autoDiscover` can each be overridden
+by a `KSHRK_`-prefixed environment variable — `KSHRK_DURATION`,
+`KSHRK_OUTPUT`, `KSHRK_KUBECONFIG`, `KSHRK_AUTODISCOVER` (camelCase keys
+collapse to one uppercase word — no underscore). Precedence, highest first:
+CLI flag > environment variable > config file > default. An **unprefixed**
+variable (bare `DURATION`, `OUTPUT`, ...) is never read — only `KSHRK_`-
+prefixed names claim anything, so k8shark doesn't collide with unrelated
+environment variables already in use (e.g. in CI).
 
 ## Web UI ports
 
@@ -21,14 +45,14 @@ both bind a random free port. Set the `ui` block to pin consistent ports:
 
 ```yaml
 ui:
-  port: "8080"       # local web UI server
-  api_port: "8081"   # mock Kubernetes API server
+  port: "8080"      # local web UI server
+  apiPort: "8081"   # mock Kubernetes API server
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `ui.port` | string | `0` (random) | Port for the local web UI. |
-| `ui.api_port` | string | `0` (random) | Port for the mock Kubernetes API server. |
+| `ui.apiPort` | string | `0` (random) | Port for the mock Kubernetes API server. (Legacy alias: `ui.api_port`.) |
 
 The `--port` and `--api-port` flags on `kshrk ui` override these when provided.
 
@@ -536,14 +560,14 @@ resources:
 
 ### Auto-discovery (capture all installed CRDs automatically)
 
-Instead of enumerating every CRD in the config, set `auto_discover: true` to
+Instead of enumerating every CRD in the config, set `autoDiscover: true` to
 have k8shark walk the cluster's `/apis` endpoint at capture time and
 automatically add every non-core resource type it finds.
 
 ```yaml
 duration: 10m
 output: ./full-capture.kshrk
-auto_discover: true
+autoDiscover: true
 
 # Explicit entries are still captured and take precedence over auto-discovered
 # duplicates.  You can combine the two approaches.
@@ -578,11 +602,11 @@ resources:
   | `authentication.k8s.io` | Token review — live-only |
   | `authorization.k8s.io` | Access review — live-only |
 
-- Add your own exclusions with `auto_discover_exclude_groups`:
+- Add your own exclusions with `autoDiscoverExcludeGroups`:
 
 ```yaml
-auto_discover: true
-auto_discover_exclude_groups:
+autoDiscover: true
+autoDiscoverExcludeGroups:
   - metrics.k8s.io
   - my-internal.company.io
 ```
@@ -592,8 +616,8 @@ auto_discover_exclude_groups:
 #### Flux CD
 
 ```yaml
-auto_discover: true
-auto_discover_exclude_groups:
+autoDiscover: true
+autoDiscoverExcludeGroups:
   - metrics.k8s.io
 
 resources:
@@ -606,12 +630,12 @@ resources:
 
 Flux CRDs (`kustomizations.kustomize.toolkit.fluxcd.io`,
 `helmreleases.helm.toolkit.fluxcd.io`, etc.) will be picked up automatically
-by `auto_discover: true`.
+by `autoDiscover: true`.
 
 #### ArgoCD
 
 ```yaml
-auto_discover: true
+autoDiscover: true
 
 resources:
   - group: ""
@@ -622,4 +646,4 @@ resources:
 ```
 
 ArgoCD CRDs (`applications.argoproj.io`, `appprojects.argoproj.io`) are
-captured automatically via `auto_discover`.
+captured automatically via `autoDiscover`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -524,7 +524,7 @@ screenshots, see **[docs/web-ui.md](web-ui.md)**.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--port` | from config (`ui.port`), else random | Port for the local UI server |
-| `--api-port` | from config (`ui.api_port`), else random | Port for the mock API server |
+| `--api-port` | from config (`ui.apiPort`), else random | Port for the mock API server |
 | `--kubeconfig-out` | `~/.kube/k8shark-<id>.yaml` | Where to write the generated kubeconfig |
 | `--at` | latest records | Pin UI data to a specific timestamp (RFC3339 or relative duration) |
 
@@ -994,7 +994,7 @@ These operations work against any k8shark archive with no special config:
 ### Requires CRD resources to be captured
 
 These tools or commands require CRD-backed resources to be present in the
-archive. Use `auto_discover: true` or explicit config entries (see
+archive. Use `autoDiscover: true` or explicit config entries (see
 [Capturing CRD-backed resources](config.md#capturing-crd-backed-resources)).
 
 | Client / Command | Required resources |

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -43,8 +43,8 @@ override the config:
 
 ```yaml
 ui:
-  port: "8080"       # local web UI
-  api_port: "8081"   # mock Kubernetes API server
+  port: "8080"      # local web UI
+  apiPort: "8081"   # mock Kubernetes API server
 ```
 
 See [docs/config.md](config.md#web-ui-ports) for details.

--- a/examples/auto-discovery/README.md
+++ b/examples/auto-discovery/README.md
@@ -4,7 +4,7 @@ A capture config with **zero** `group`/`version`/`resource` entries. A single
 `all: true` directive walks the cluster's API discovery at capture time and
 captures every resource type present in one namespace — built-in Kubernetes
 resources and a custom resource (CRD) alike — without listing any of them by
-name. Demonstrates the `all: true` / `auto_discover` config field described in
+name. Demonstrates the `all: true` / `autoDiscover` config field described in
 [docs/config.md](../../docs/config.md#simplified-discovery-with-all-true) and
 [Capturing CRD-backed resources](../../docs/config.md#capturing-crd-backed-resources).
 
@@ -102,5 +102,5 @@ a namespace you plan to share.
 
 This is the last stop in the example tour. From here,
 [docs/config.md](../../docs/config.md) covers the full config reference,
-including redaction rules and ecosystem-specific `auto_discover` recipes for
+including redaction rules and ecosystem-specific `autoDiscover` recipes for
 Flux, ArgoCD, and other CRD-heavy setups.

--- a/examples/k8shark.yaml
+++ b/examples/k8shark.yaml
@@ -21,8 +21,8 @@ output: ./capture.kshrk
 # these to pin consistent ports across runs. The --port / --api-port CLI flags
 # override these when provided.
 # ui:
-#   port: "8080"       # local web UI
-#   api_port: "8081"   # mock Kubernetes API server
+#   port: "8080"      # local web UI
+#   apiPort: "8081"   # mock Kubernetes API server
 
 resources:
   # ── Core workloads ───────────────────────────────────────────────────────────

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.5
 
 require (
 	filippo.io/age v1.3.1
+	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/google/uuid v1.6.0
 	github.com/klauspost/compress v1.19.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
@@ -29,7 +30,6 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,6 +211,12 @@ func Load(configFile string) (*Config, error) {
 		cfg.AutoDiscover = viper.GetBool("autoDiscover")
 	}
 
+	// A missing version: key means version 1, not 0 — normalize so the
+	// in-memory config matches what's documented, and so a future version 2
+	// can tell "predates versioning" apart from an explicit (invalid) 0.
+	if cfg.Version == 0 {
+		cfg.Version = 1
+	}
 	if cfg.Version > CurrentConfigVersion {
 		return nil, fmt.Errorf("config version %d is newer than this build of kshrk understands (max %d) — upgrade kshrk", cfg.Version, CurrentConfigVersion)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,10 +6,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 const minDiscoveryStartupDuration = 5 * time.Second
+
+// CurrentConfigVersion is the config schema version this build understands.
+// Bump only on a breaking, structurally-incompatible schema change — an
+// additive field never needs a bump (mirrors the .kshrk archive format's
+// CurrentFormatVersion convention; see internal/archive/format).
+const CurrentConfigVersion = 1
 
 // Resource describes a single Kubernetes resource type to capture.
 type Resource struct {
@@ -106,6 +114,11 @@ type RedactionConfig struct {
 
 // Config holds the full capture configuration.
 type Config struct {
+	// Version pins this config to a schema version, letting the schema
+	// evolve without silently misinterpreting an older or newer file. Omit
+	// for version 1 (the implicit default for every config predating this
+	// field). See CurrentConfigVersion.
+	Version int `mapstructure:"version"`
 	// DurationRaw is the human-readable total capture duration (e.g. "10m").
 	DurationRaw string `mapstructure:"duration"`
 	// Duration is parsed from DurationRaw.
@@ -119,12 +132,12 @@ type Config struct {
 	// AutoDiscover, when true, causes the capture engine to walk /apis at
 	// capture time and automatically add every discovered non-core resource
 	// type to the poll loop, supplementing any explicit Resources entries.
-	AutoDiscover bool `mapstructure:"auto_discover"`
+	AutoDiscover bool `mapstructure:"autoDiscover"`
 	// AutoDiscoverExcludeGroups is an optional list of API groups to skip
 	// during auto-discovery (e.g. "metrics.k8s.io"). System groups that
 	// produce noisy or unusable data are excluded by default regardless of
 	// this setting; see defaultAutoDiscoverExcludeGroups.
-	AutoDiscoverExcludeGroups []string `mapstructure:"auto_discover_exclude_groups"`
+	AutoDiscoverExcludeGroups []string `mapstructure:"autoDiscoverExcludeGroups"`
 	// Redaction holds field-level redaction rules applied during capture and
 	// post-capture redact workflows.
 	Redaction RedactionConfig `mapstructure:"redaction"`
@@ -140,25 +153,160 @@ type UIConfig struct {
 	// Port is the local web UI port. Empty or "0" means a random port.
 	Port string `mapstructure:"port"`
 	// APIPort is the mock Kubernetes API server port. Empty or "0" means random.
-	APIPort string `mapstructure:"api_port"`
+	APIPort string `mapstructure:"apiPort"`
 }
 
-// Load reads k8shark capture config. If configFile is empty, viper uses
-// whatever was already loaded via initConfig in cmd/.
+// Load reads k8shark capture config from configFile, an explicit source
+// (not the global viper singleton — see the override step below for the one
+// deliberate, narrow exception). An empty configFile means no config file
+// at all (e.g. an --auto-discover-only capture with no resources: list);
+// Load then returns a config built purely from env/flag overrides and
+// defaults.
 func Load(configFile string) (*Config, error) {
+	var cfg Config
+
 	if configFile != "" {
-		viper.SetConfigFile(configFile)
-		if err := viper.ReadInConfig(); err != nil {
+		data, err := os.ReadFile(configFile)
+		if err != nil {
 			return nil, fmt.Errorf("reading config file %q: %w", configFile, err)
+		}
+		var raw map[string]any
+		if err := yaml.Unmarshal(data, &raw); err != nil {
+			return nil, fmt.Errorf("parsing config file %q: %w", configFile, err)
+		}
+		applyLegacyKeyAliases(raw)
+
+		// Decode twice from the same alias-normalized map: once strictly, so
+		// a typo'd or misspelled key (e.g. "previouslogs" instead of
+		// "previousLogs") fails validation by name instead of being
+		// silently ignored (#220), and once tolerantly to actually populate
+		// cfg (case-insensitive, matching this package's historical
+		// leniency — safe here since the strict pass already proved every
+		// key is a known one spelled correctly).
+		if err := strictDecode(raw); err != nil {
+			return nil, fmt.Errorf("config file %q: %w", configFile, err)
+		}
+		if err := mapstructure.Decode(raw, &cfg); err != nil {
+			return nil, fmt.Errorf("parsing config file %q: %w", configFile, err)
 		}
 	}
 
-	var cfg Config
-	if err := viper.Unmarshal(&cfg); err != nil {
-		return nil, fmt.Errorf("unmarshalling config: %w", err)
+	// Layer KSHRK_-prefixed environment variable overrides on top of the file
+	// (see cmd/root.go's initConfig for the SetEnvPrefix/AutomaticEnv setup).
+	// CLI flags are applied by each command after Load returns (see
+	// cmd/capture.go), so the effective precedence is flag > env > file >
+	// default. Deliberately reads the global viper singleton only for this
+	// narrow purpose — env/flag override resolution — not for the config
+	// file's own content, which is parsed directly above (#220).
+	if v := viper.GetString("output"); v != "" {
+		cfg.Output = v
+	}
+	if v := viper.GetString("kubeconfig"); v != "" {
+		cfg.Kubeconfig = v
+	}
+	if v := viper.GetString("duration"); v != "" {
+		cfg.DurationRaw = v
+	}
+	if viper.IsSet("autoDiscover") {
+		cfg.AutoDiscover = viper.GetBool("autoDiscover")
+	}
+
+	if cfg.Version > CurrentConfigVersion {
+		return nil, fmt.Errorf("config version %d is newer than this build of kshrk understands (max %d) — upgrade kshrk", cfg.Version, CurrentConfigVersion)
 	}
 
 	return &cfg, nil
+}
+
+// legacyConfigKeyAliases maps a deprecated config key (dot-path for a
+// nested section) to its current, camelCase replacement. Both spellings are
+// accepted for one minor release (#220); a future release will drop the
+// legacy spelling.
+var legacyConfigKeyAliases = map[string]string{
+	"auto_discover":                "autoDiscover",
+	"auto_discover_exclude_groups": "autoDiscoverExcludeGroups",
+	"ui.api_port":                  "ui.apiPort",
+}
+
+// applyLegacyKeyAliases renames every legacy key present in raw (see
+// legacyConfigKeyAliases) to its canonical spelling in place, preferring an
+// already-present canonical value if both are somehow set. raw's keys and
+// nesting come directly from yaml.Unmarshal, so casing is exactly as
+// written in the file (unlike viper's internal settings, which are
+// lowercased — see strictDecode's doc comment for why that matters). Keys
+// are dot-paths (e.g. "ui.api_port"); only one level of nesting is
+// supported, which is all legacyConfigKeyAliases currently needs.
+func applyLegacyKeyAliases(raw map[string]any) {
+	for legacyPath, canonicalPath := range legacyConfigKeyAliases {
+		m, legacy := resolveParent(raw, legacyPath)
+		if m == nil {
+			continue
+		}
+		v, ok := m[legacy]
+		if !ok {
+			continue
+		}
+		cm, canonical := ensureParent(raw, canonicalPath)
+		if _, exists := cm[canonical]; !exists {
+			cm[canonical] = v
+		}
+		delete(m, legacy)
+	}
+}
+
+// resolveParent walks a dot-path (e.g. "ui.apiPort") from raw and returns
+// the map holding the final segment plus that segment's own key, or (nil,
+// "") if an intermediate segment doesn't exist or isn't itself a map.
+func resolveParent(raw map[string]any, path string) (map[string]any, string) {
+	parts := strings.Split(path, ".")
+	m := raw
+	for _, p := range parts[:len(parts)-1] {
+		next, ok := m[p].(map[string]any)
+		if !ok {
+			return nil, ""
+		}
+		m = next
+	}
+	return m, parts[len(parts)-1]
+}
+
+// ensureParent is resolveParent, but creates any missing intermediate map
+// instead of failing — used for the canonical (destination) side of an
+// alias, where the legacy key's presence doesn't guarantee the canonical
+// key's parent section already exists in raw.
+func ensureParent(raw map[string]any, path string) (map[string]any, string) {
+	parts := strings.Split(path, ".")
+	m := raw
+	for _, p := range parts[:len(parts)-1] {
+		next, ok := m[p].(map[string]any)
+		if !ok {
+			next = map[string]any{}
+			m[p] = next
+		}
+		m = next
+	}
+	return m, parts[len(parts)-1]
+}
+
+// strictDecode decodes raw against a throwaway Config with ErrorUnused, so
+// an unknown key is reported by name, and with exact (case-sensitive) key
+// matching, so a wrongly-cased key like "previouslogs" is caught as unknown
+// too rather than silently case-folding onto "previousLogs" — mapstructure's
+// (and therefore viper's) default MatchName is case-insensitive, which would
+// otherwise defeat "one consistent naming convention" by quietly accepting
+// any casing. Deliberately does not use viper for this: viper lowercases
+// every key it reads, which would destroy the very case information this
+// check depends on.
+func strictDecode(raw map[string]any) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		ErrorUnused: true,
+		Result:      &Config{},
+		MatchName:   func(mapKey, fieldName string) bool { return mapKey == fieldName },
+	})
+	if err != nil {
+		return fmt.Errorf("building config decoder: %w", err)
+	}
+	return decoder.Decode(raw)
 }
 
 // Validate parses duration/interval raw strings and checks required fields.
@@ -184,12 +332,12 @@ func (c *Config) Validate() error {
 	}
 
 	if len(c.Resources) == 0 && !c.AutoDiscover {
-		return fmt.Errorf("no resources defined in config; add at least one entry under 'resources:' or set 'auto_discover: true'")
+		return fmt.Errorf("no resources defined in config; add at least one entry under 'resources:' or set 'autoDiscover: true'")
 	}
 
 	if c.requiresDiscoveryStartup() && c.Duration < minDiscoveryStartupDuration {
 		return fmt.Errorf(
-			"duration %q is too short when using discovery/wildcard capture; set duration >= %s or disable auto_discover, all=true, and namespaces ['*']",
+			"duration %q is too short when using discovery/wildcard capture; set duration >= %s or disable autoDiscover, all=true, and namespaces ['*']",
 			c.DurationRaw,
 			minDiscoveryStartupDuration,
 		)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -189,6 +189,14 @@ func Load(configFile string) (*Config, error) {
 		if err := mapstructure.Decode(raw, &cfg); err != nil {
 			return nil, fmt.Errorf("parsing config file %q: %w", configFile, err)
 		}
+		// An explicit version: key must be a positive schema version — 0 (or
+		// negative) is never valid, even though an *absent* key defaults to 1
+		// below. Catch it here, while we can still tell "key present" apart
+		// from "key absent", rather than let it fall through and silently be
+		// normalized to 1 like a predates-versioning config.
+		if v, ok := raw["version"]; ok && cfg.Version <= 0 {
+			return nil, fmt.Errorf("config file %q: version %v is invalid — version must be a positive integer", configFile, v)
+		}
 	}
 
 	// Layer KSHRK_-prefixed environment variable overrides on top of the file

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -165,6 +165,17 @@ autoDiscover: true
 	}
 }
 
+func TestLoad_MissingVersionDefaultsToOne(t *testing.T) {
+	path := writeConfigFile(t, `duration: 5m`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Version != 1 {
+		t.Errorf("Version = %d, want 1 (the implicit default for a config with no version: key)", cfg.Version)
+	}
+}
+
 func TestLoad_VersionTooNew(t *testing.T) {
 	path := writeConfigFile(t, `
 version: 999
@@ -182,7 +193,10 @@ duration: 5m
 func TestLoad_EnvOverride(t *testing.T) {
 	// Mirrors cmd/root.go's initConfig wiring, scoped to this test via the
 	// global viper singleton (config.Load reads it for env/flag overrides
-	// only — see Load's doc comment).
+	// only — see Load's doc comment). Reset afterward so this doesn't leak
+	// SetEnvPrefix/AutomaticEnv state into other tests in this package,
+	// whose execution order isn't guaranteed.
+	t.Cleanup(viper.Reset)
 	viper.SetEnvPrefix("KSHRK")
 	viper.AutomaticEnv()
 	t.Setenv("KSHRK_DURATION", "99h")
@@ -205,6 +219,9 @@ output: ./capture.kshrk
 }
 
 func TestLoad_UnprefixedEnvVarIgnored(t *testing.T) {
+	// See TestLoad_EnvOverride: reset afterward so SetEnvPrefix/AutomaticEnv
+	// doesn't leak into other tests in this package.
+	t.Cleanup(viper.Reset)
 	viper.SetEnvPrefix("KSHRK")
 	viper.AutomaticEnv()
 	t.Setenv("DURATION", "99h") // bare, unprefixed — must NOT override (#218)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,9 +2,222 @@ package config
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/spf13/viper"
 )
+
+// writeConfigFile writes contents to a temp *.yaml file and returns its path.
+func writeConfigFile(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "k8shark.yaml")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+	return path
+}
+
+func TestLoad_BasicFile(t *testing.T) {
+	path := writeConfigFile(t, `
+duration: 5m
+output: ./capture.kshrk
+resources:
+  - group: ""
+    version: v1
+    resource: pods
+    namespaces: [default]
+    interval: 30s
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.DurationRaw != "5m" {
+		t.Errorf("DurationRaw = %q, want 5m", cfg.DurationRaw)
+	}
+	if cfg.Output != "./capture.kshrk" {
+		t.Errorf("Output = %q, want ./capture.kshrk", cfg.Output)
+	}
+	if len(cfg.Resources) != 1 || cfg.Resources[0].Resource != "pods" {
+		t.Fatalf("unexpected Resources: %+v", cfg.Resources)
+	}
+}
+
+func TestLoad_NoConfigFile(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load(\"\"): %v", err)
+	}
+	if cfg.DurationRaw != "" || cfg.Output != "" || len(cfg.Resources) != 0 {
+		t.Errorf("expected a zero-value config, got %+v", cfg)
+	}
+}
+
+func TestLoad_UnknownKeyRejected(t *testing.T) {
+	path := writeConfigFile(t, `
+duration: 5m
+outptu: ./capture.kshrk
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected an error for the unknown key 'outptu'")
+	}
+	if !strings.Contains(err.Error(), "outptu") {
+		t.Errorf("error = %v, want it to name the unknown key 'outptu'", err)
+	}
+}
+
+func TestLoad_WrongCaseKeyRejected(t *testing.T) {
+	// "previouslogs" is a real, case-insensitively-matchable key one letter
+	// away from valid — exactly the kind of typo #220 exists to catch. A
+	// case-insensitive decode would silently accept this as previousLogs.
+	path := writeConfigFile(t, `
+duration: 5m
+resources:
+  - group: ""
+    version: v1
+    resource: pods
+    namespaces: [default]
+    interval: 30s
+    previouslogs: true
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected an error for the wrongly-cased key 'previouslogs'")
+	}
+	if !strings.Contains(err.Error(), "previouslogs") {
+		t.Errorf("error = %v, want it to name the unknown key 'previouslogs'", err)
+	}
+}
+
+func TestLoad_CorrectlyCasedKeyAccepted(t *testing.T) {
+	path := writeConfigFile(t, `
+duration: 5m
+resources:
+  - group: ""
+    version: v1
+    resource: pods
+    namespaces: [default]
+    interval: 30s
+    previousLogs: true
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Resources[0].PreviousLogs {
+		t.Error("expected PreviousLogs=true")
+	}
+}
+
+func TestLoad_LegacyTopLevelKeyAlias(t *testing.T) {
+	path := writeConfigFile(t, `
+duration: 5m
+auto_discover: true
+auto_discover_exclude_groups: ["metrics.k8s.io"]
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.AutoDiscover {
+		t.Error("expected AutoDiscover=true from legacy auto_discover key")
+	}
+	if len(cfg.AutoDiscoverExcludeGroups) != 1 || cfg.AutoDiscoverExcludeGroups[0] != "metrics.k8s.io" {
+		t.Errorf("unexpected AutoDiscoverExcludeGroups: %v", cfg.AutoDiscoverExcludeGroups)
+	}
+}
+
+func TestLoad_LegacyNestedKeyAlias(t *testing.T) {
+	path := writeConfigFile(t, `
+duration: 5m
+ui:
+  port: "8080"
+  api_port: "8081"
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.UI.Port != "8080" {
+		t.Errorf("UI.Port = %q, want 8080", cfg.UI.Port)
+	}
+	if cfg.UI.APIPort != "8081" {
+		t.Errorf("UI.APIPort = %q, want 8081 (from legacy api_port)", cfg.UI.APIPort)
+	}
+}
+
+func TestLoad_CanonicalKeyWinsOverLegacyAlias(t *testing.T) {
+	path := writeConfigFile(t, `
+duration: 5m
+auto_discover: false
+autoDiscover: true
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.AutoDiscover {
+		t.Error("expected the canonical autoDiscover=true to win over the legacy auto_discover=false")
+	}
+}
+
+func TestLoad_VersionTooNew(t *testing.T) {
+	path := writeConfigFile(t, `
+version: 999
+duration: 5m
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected an error for a config version newer than this build understands")
+	}
+	if !strings.Contains(err.Error(), "upgrade kshrk") {
+		t.Errorf("error = %v, want it to suggest upgrading kshrk", err)
+	}
+}
+
+func TestLoad_EnvOverride(t *testing.T) {
+	// Mirrors cmd/root.go's initConfig wiring, scoped to this test via the
+	// global viper singleton (config.Load reads it for env/flag overrides
+	// only — see Load's doc comment).
+	viper.SetEnvPrefix("KSHRK")
+	viper.AutomaticEnv()
+	t.Setenv("KSHRK_DURATION", "99h")
+	t.Setenv("KSHRK_OUTPUT", "from-env.kshrk")
+
+	path := writeConfigFile(t, `
+duration: 5m
+output: ./capture.kshrk
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.DurationRaw != "99h" {
+		t.Errorf("DurationRaw = %q, want 99h (from KSHRK_DURATION)", cfg.DurationRaw)
+	}
+	if cfg.Output != "from-env.kshrk" {
+		t.Errorf("Output = %q, want from-env.kshrk (from KSHRK_OUTPUT)", cfg.Output)
+	}
+}
+
+func TestLoad_UnprefixedEnvVarIgnored(t *testing.T) {
+	viper.SetEnvPrefix("KSHRK")
+	viper.AutomaticEnv()
+	t.Setenv("DURATION", "99h") // bare, unprefixed — must NOT override (#218)
+
+	path := writeConfigFile(t, `duration: 5m`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.DurationRaw != "5m" {
+		t.Errorf("DurationRaw = %q, want 5m (unprefixed DURATION must not apply)", cfg.DurationRaw)
+	}
+}
 
 func validatedCfg(t *testing.T, dur string, resources []Resource) *Config {
 	t.Helper()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -52,7 +52,10 @@ func TestLoad_NoConfigFile(t *testing.T) {
 		t.Fatalf("Load(\"\"): %v", err)
 	}
 	if cfg.DurationRaw != "" || cfg.Output != "" || len(cfg.Resources) != 0 {
-		t.Errorf("expected a zero-value config, got %+v", cfg)
+		t.Errorf("expected every file-sourced field to stay at its zero value, got %+v", cfg)
+	}
+	if cfg.Version != 1 {
+		t.Errorf("Version = %d, want 1 (the implicit default when there's no config file at all)", cfg.Version)
 	}
 }
 
@@ -173,6 +176,34 @@ func TestLoad_MissingVersionDefaultsToOne(t *testing.T) {
 	}
 	if cfg.Version != 1 {
 		t.Errorf("Version = %d, want 1 (the implicit default for a config with no version: key)", cfg.Version)
+	}
+}
+
+func TestLoad_ExplicitVersionZeroRejected(t *testing.T) {
+	path := writeConfigFile(t, `
+version: 0
+duration: 5m
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected an error for an explicit version: 0 (0 is not a valid schema version)")
+	}
+	if !strings.Contains(err.Error(), "invalid") {
+		t.Errorf("error = %v, want it to say the version is invalid", err)
+	}
+}
+
+func TestLoad_NegativeVersionRejected(t *testing.T) {
+	path := writeConfigFile(t, `
+version: -1
+duration: 5m
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected an error for a negative version")
+	}
+	if !strings.Contains(err.Error(), "invalid") {
+		t.Errorf("error = %v, want it to say the version is invalid", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

**#218 — unprefixed env vars.** `viper.AutomaticEnv()` had no `SetEnvPrefix`, so bare shell variables named `DURATION`, `OUTPUT`, or `VERBOSE` (all common in CI) silently overrode the config file. Namespaced every config-related env var under `KSHRK_` in `cmd/root.go`'s `initConfig` — matching the `KSHRK_ENCRYPT_PASSPHRASE`/`KSHRK_DECRYPT_PASSPHRASE` convention already used elsewhere.

**#220 — silent unknown/misspelled keys, inconsistent naming, no version.** `config.Load` was a plain `viper.Unmarshal` with no unused-key detection, so `previouslogs: true` (meant to be `previousLogs`) was silently ignored — `kshrk validate` still printed a green check. Fixed by having `Load` parse the config file directly (not through the global viper singleton, which also carries CLI-flag bindings like `--verbose` that aren't part of the config schema — this is also what makes `Load` take an explicit source now) and strict-decode it with **case-sensitive** key matching. Case-insensitive matching alone isn't sufficient: without it, any casing of a key would still silently succeed, defeating the point of picking one naming convention.

Also:
- Picked **camelCase** as the config schema's one consistent convention (already used by `previousLogs`, `redactSecrets`, `fieldPath`, ...). Renamed the three snake_case outliers — `auto_discover` → `autoDiscover`, `auto_discover_exclude_groups` → `autoDiscoverExcludeGroups`, `ui.api_port` → `ui.apiPort` — keeping the old spellings as accepted (not "unknown") aliases for one minor release.
- Added a `version:` key (default `1`) so the schema can evolve without misinterpreting an old or new file — mirrors the `.kshrk` archive format's own version-check convention (`internal/archive/format`).
- Documented the naming convention and env-var precedence (`CLI flag > env var > config file > default`) in `docs/config.md`.

Closes #218. Closes #220.

## Test plan
- [x] `make fmt` (clean)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `go mod tidy` (no diff beyond promoting `go-viper/mapstructure/v2` to a direct dependency)
- [x] `golangci-lint run` (clean)
- [x] New `internal/config` tests: unknown-key rejection, wrong-case rejection (the `previouslogs` case specifically), correct-case acceptance, both legacy aliases (top-level and nested `ui.api_port`), canonical-wins-over-legacy-when-both-set, version-too-new rejection, `KSHRK_`-prefixed env override, and unprefixed-env-var-is-ignored
- [x] Manual end-to-end verification against the compiled binary: `DURATION=99h` has no effect, `KSHRK_DURATION=99h` does, and a real `previouslogs: true` config fails validation naming the key

🤖 Generated with [Claude Code](https://claude.com/claude-code)