### PR TITLE
docs: write the v1.0 compatibility, stability, and deprecation policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ timeline, and a time-travel scrubber. See **[docs/web-ui.md](docs/web-ui.md)** f
 | [docs/releases.md](docs/releases.md) | How to cut a release, GoReleaser pipeline, signing, Homebrew tap |
 | [docs/development.md](docs/development.md) | Building, testing, linting, KinD dev cluster, E2E tests, package layout |
 | [docs/archive-format.md](docs/archive-format.md) | Internal `.kshrk` (ZIP+Zstd) layout, record and index JSON schemas, and the format-compatibility guarantee |
+| [docs/stability-policy.md](docs/stability-policy.md) | What's covered by semver from `v1.0.0` on — CLI surface, exit codes, JSON output, config schema, kubeconfig, deprecation and backport policy |
 | [docs/encryption-threat-model.md](docs/encryption-threat-model.md) | What `--encrypt` protects (and doesn't), key-handling rules, passphrase vs. recipient keys |
 
 ## License

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -5,18 +5,32 @@
 Releases are cut by pushing a version tag to `main`. The tag triggers the [release workflow](../.github/workflows/release.yml) which runs [GoReleaser](https://goreleaser.com) to build and publish everything.
 
 ```sh
-git tag v0.2.0-rc.1
-git push origin v0.2.0-rc.1
+git tag v1.0.0-rc.1
+git push origin v1.0.0-rc.1
 ```
 
-Use [semantic versioning](https://semver.org): `vMAJOR.MINOR.PATCH`. Tags that contain a pre-release identifier (e.g. `v0.2.0-rc.1`) are automatically marked as pre-release on GitHub.
+Use [semantic versioning](https://semver.org): `vMAJOR.MINOR.PATCH`. Tags that contain a pre-release identifier (e.g. `v1.0.0-rc.1`) are automatically marked as pre-release on GitHub.
 
-### Current versioning policy (pre-1.0)
+### Versioning policy
 
-While `k8shark` is pre-`v1.0.0`, backward-incompatible changes are released by bumping the **minor** version. The current line is:
+**Pre-`v1.0.0`** (every release up to and including the current `v0.x` line):
+backward-incompatible changes are released by bumping the **minor** version —
+there is no stability promise on any surface yet.
 
-- `v0.2.0-rc.N` for release candidates
-- `v0.2.0` for GA
+**`v1.0.0` and later**: what a MAJOR/MINOR/PATCH bump means, and exactly what
+is and isn't allowed to change without one, is defined in
+[docs/stability-policy.md](stability-policy.md) — see that page rather than
+this one for the compatibility contract itself. In short:
+
+- **PATCH** (`v1.0.1`) — bug fixes only, no behavior change to a documented
+  surface.
+- **MINOR** (`v1.1.0`) — new, backward-compatible features (flags, config
+  keys, subcommands).
+- **MAJOR** (`v2.0.0`) — a breaking change to anything listed as a stable
+  surface in the stability policy.
+
+Only the latest minor receives patch releases; see the stability policy's
+[backport section](stability-policy.md#backport--patch-policy).
 
 ## What the release workflow does
 
@@ -54,7 +68,7 @@ The cosign signing uses GitHub's OIDC token — no additional secret is needed.
 
 ```sh
 # Download the release artifacts
-gh release download v0.2.0-rc.1 --repo phenixblue/k8shark
+gh release download v1.0.0-rc.1 --repo phenixblue/k8shark
 
 # Verify the cosign signature
 cosign verify-blob \

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -22,8 +22,8 @@ is and isn't allowed to change without one, is defined in
 [docs/stability-policy.md](stability-policy.md) — see that page rather than
 this one for the compatibility contract itself. In short:
 
-- **PATCH** (`v1.0.1`) — bug fixes only, no behavior change to a documented
-  surface.
+- **PATCH** (`v1.0.1`) — bug fixes only, no *intentional* behavior change to
+  a documented surface (correcting a bug in one is what a patch is for).
 - **MINOR** (`v1.1.0`) — new, backward-compatible features (flags, config
   keys, subcommands).
 - **MAJOR** (`v2.0.0`) — a breaking change to anything listed as a stable

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -15,7 +15,10 @@ Use [semantic versioning](https://semver.org): `vMAJOR.MINOR.PATCH`. Tags that c
 
 **Pre-`v1.0.0`** (every release up to and including the current `v0.x` line):
 backward-incompatible changes are released by bumping the **minor** version —
-there is no stability promise on any surface yet.
+there is no stability promise on any CLI-facing surface yet. The one
+exception is the `.kshrk` archive format, which already carries its own
+version-gated stability promise independent of the CLI's own version — see
+[docs/archive-format.md](archive-format.md#format-version--compatibility).
 
 **`v1.0.0` and later**: what a MAJOR/MINOR/PATCH bump means, and exactly what
 is and isn't allowed to change without one, is defined in

--- a/docs/stability-policy.md
+++ b/docs/stability-policy.md
@@ -1,0 +1,197 @@
+# Compatibility, Stability, and Deprecation Policy
+
+This page states what `kshrk` promises to keep working, for how long, and what
+is explicitly exempt — so a script, CI pipeline, or muscle-memory habit built
+against one `1.x` release keeps working against the next. It takes effect at
+`v1.0.0`; everything below describes the `1.x` line. Before `v1.0.0`,
+backward-incompatible changes can land in any release.
+
+k8shark follows [Semantic Versioning](https://semver.org): `vMAJOR.MINOR.PATCH`.
+
+- **MAJOR** — a breaking change to any surface listed under
+  [Stable surfaces](#stable-surfaces) below.
+- **MINOR** — new features, new flags, new config keys, new subcommands.
+  Backward-compatible.
+- **PATCH** — bug fixes only. No new flags, no behavior changes to a
+  documented surface.
+
+This is a policy for **behavior**, not for source code: nothing in
+`internal/` is covered (see [What is NOT covered](#what-is-not-covered)),
+and refactoring the package layout is always a non-breaking change as long
+as the surfaces below hold.
+
+## Stable surfaces
+
+### Archive format
+
+Covered in full by [docs/archive-format.md](archive-format.md#format-version--compatibility)
+— the entry layout, the JSON schemas, and the reader-compatibility promise
+("the `1.x` line reads all version-1 archives for the life of the `1.x`
+series"). That page is the authority; this policy just points to it.
+
+### CLI surface
+
+Every subcommand name, flag name and spelling, and flag semantic documented in
+[docs/usage.md](usage.md) is stable for the `1.x` line:
+
+| Command | Purpose |
+|---------|---------|
+| `capture` | Poll a live cluster and write a `.kshrk` archive |
+| `validate` | Validate a capture config file without connecting to a cluster |
+| `inspect` | Summarize an archive's contents |
+| `open` | Start a static (non-replaying) mock API server from an archive |
+| `replay` | Start a time-advancing mock API server, optionally with KWOK/controller-manager |
+| `ui` | Start the web dashboard (and, optionally, replay) |
+| `diagnose` | Analyze an archive offline and report likely problems |
+| `diff` | Compare two archives, or two points in time within one archive |
+| `query` | JSONPath / text / regex search across an archive |
+| `transitions` | List watch-event (ADDED/MODIFIED/DELETED) history |
+| `redact` | Re-write an archive with Secret/field redaction applied |
+| `encrypt` / `decrypt` | Re-write an archive's encryption envelope |
+| `completion` | Generate shell completion scripts |
+| `version` | Print the `kshrk` version |
+
+A flag's **name and meaning** won't change or disappear within `1.x` without
+going through [deprecation](#deprecation-policy) first. Flags may gain new
+optional values or new sibling flags in a minor release; a required flag never
+becomes optional-with-different-default (or vice versa) without a major bump.
+
+`docs/usage.md` is the single source of truth for the current flag list —
+this policy intentionally doesn't duplicate it, to avoid the two drifting
+out of sync.
+
+### Exit codes
+
+Every command follows the `diff(1)`-style contract documented in
+[`cmd/root.go`](../cmd/root.go):
+
+| Code | Meaning |
+|------|---------|
+| `0` | Clean — the command ran and found nothing (or isn't a findings-style command) |
+| `1` | The command ran successfully and found something (`diagnose --fail-on`, `diff` with differences) |
+| `2` | The command failed to run (bad archive, invalid flags, I/O error, …) |
+
+Only `diagnose` and `diff` currently ever exit `1`; every other command exits
+`0` or `2`. Adding exit code `1` to another command in a future minor is
+additive (a script that only checks `if err != nil` / `$? != 0` keeps
+working); repurposing what `1` or `2` mean is a major-version change.
+
+### Structured output (`-o json` / `-o yaml`)
+
+`inspect`, `diagnose`, `diff`, `query`, and `transitions` all support `-o
+json` (some also support `-o yaml`). **This output is a stable, scriptable
+interface, not an implementation detail** — it follows the same evolution
+rule as the archive format:
+
+- Adding a new field is a minor-version change. Consumers must ignore
+  fields they don't recognize.
+- Removing a field, renaming a field, or changing a field's type/meaning is
+  a major-version change.
+
+Table/text output (the human-facing default, no `-o` flag) is explicitly
+**not** covered — column layout, spacing, and wording can change in any
+release. Scripts must pass `-o json` (or `-o yaml`, where offered) to get a
+stability guarantee.
+
+### Config file schema
+
+Covered by [docs/config.md](config.md). The schema carries its own
+`version:` key (`internal/config.CurrentConfigVersion`) precisely so it can
+evolve independently of the CLI's own version — see that page's
+[Naming convention](config.md#naming-convention) section for the current
+camelCase-vs-legacy-alias rules. A config file that validates against
+schema version *N* keeps validating against every `1.x` build that
+understands version *N* or higher.
+
+### Generated kubeconfig
+
+`kshrk open` / `kshrk replay` / `kshrk ui` write a kubeconfig usable by any
+standard Kubernetes client (`kubectl`, `client-go`, `k9s`, …). What's
+covered:
+
+- **Default path**: `~/.kube/k8shark-<capture-id>.yaml`, overridable with
+  `--kubeconfig-out`.
+- **Validity**: the file is always a well-formed kubeconfig (`apiVersion:
+  v1`, `kind: Config`) pointing at the locally-running mock server, usable
+  without further edits.
+
+Internal details — the exact context/user/cluster names, the placeholder
+bearer token value, and `insecure-skip-tls-verify` being set (the mock
+server's self-signed cert has no meaningful trust boundary to protect) — are
+**not** covered and may change at any time; don't parse or diff the file's
+contents, just point a client at it.
+
+## What is NOT covered
+
+- **Anything under `internal/`.** Nothing there is an importable API;
+  `internal/store`, `internal/server`, `internal/config`, etc. can be
+  restructured, renamed, or have their exported (from Go's perspective)
+  identifiers changed at any time. Only `internal/config` and
+  `internal/archive/format`'s *on-disk/on-wire* output are covered, via the
+  config-schema and archive-format policies above — not their Go APIs.
+- **The web UI** (`kshrk ui`, `internal/ui`). Explicitly marked
+  **experimental** in the [README](../README.md#web-ui-experimental); its
+  HTTP API (`/v2/api/...`), DOM structure, and behavior can change in any
+  release, including a patch.
+- **Mock-server conformance gaps.** [docs/conformance.md](conformance.md)
+  lists currently-accepted divergences from a real API server (e.g. 404
+  body shape, `/version` field completeness). Closing one of those gaps —
+  making the mock *more* faithful — is not a breaking change even though it
+  changes response bytes, since nothing in this policy promises
+  byte-for-byte fidelity to those specific divergences.
+- **Human-facing table/text output** (see [Structured
+  output](#structured-output--o-json---o-yaml) above).
+- **Supported build/runtime environment specifics** beyond the Kubernetes
+  compatibility window below — e.g. the exact Go toolchain version used to
+  build releases (see [docs/development.md](development.md)) can change in
+  any release.
+
+## Deprecation policy
+
+Deprecating part of a stable surface (a flag, a config key, a subcommand)
+takes at least one full minor release cycle:
+
+1. **Announce** — the deprecation is called out in that release's notes,
+   naming the replacement.
+2. **Coexist** — the deprecated spelling keeps working, unchanged in
+   behavior, for at least one minor release after the announcement.
+3. **Remove** — earliest possible removal is the *next* minor release after
+   the one where the replacement became available (i.e. announce in `1.N`,
+   remove no sooner than `1.(N+2)`), never a patch release.
+
+This mirrors the precedent already set for the `snake_case` config-key
+aliases (`auto_discover`, `ui.api_port`, …) documented in
+[docs/config.md](config.md#naming-convention): accepted alongside the
+canonical spelling for at least one minor release before their removal is
+even considered.
+
+## Supported Kubernetes / kubectl version window
+
+- **`kubectl`**: any reasonably recent version. `kshrk`'s mock server speaks
+  plain REST/JSON over HTTPS; it doesn't depend on a specific `kubectl`
+  release.
+- **Kubernetes server (for `capture`)**: tracked via `k8s.io/client-go` in
+  `go.mod` (currently `v0.36.x`) and validated against a pinned `kindest/node`
+  image in the [conformance workflow](../.github/workflows/conformance.yml).
+  k8shark captures via the generic REST/discovery surface rather than
+  version-specific APIs, so older and newer clusters than the pinned
+  conformance target generally work — but only the minor matching the
+  pinned `client-go` version is actively tested per release.
+- **KWOK / kube-controller-manager** (`replay --with-kwok
+  --with-controller-manager`): downloaded to match the *capture's* recorded
+  Kubernetes version (see [docs/kwok.md](kwok.md)), not the version `kshrk`
+  itself was built against.
+
+## Backport / patch policy
+
+`kshrk` maintains a single active line: **only the latest minor receives
+patch releases.** There are no long-term-support branches. Upgrading to pick
+up a fix means upgrading to the latest `1.x` minor.
+
+## Changing this policy
+
+Narrowing what's covered (removing something from [Stable
+surfaces](#stable-surfaces)) is itself a breaking change and requires a
+major-version bump and an entry in this document explaining what changed and
+why. Widening coverage (documenting a previously-uncovered surface as
+stable) can happen in a minor release.

--- a/docs/stability-policy.md
+++ b/docs/stability-policy.md
@@ -3,8 +3,13 @@
 This page states what `kshrk` promises to keep working, for how long, and what
 is explicitly exempt — so a script, CI pipeline, or muscle-memory habit built
 against one `1.x` release keeps working against the next. It takes effect at
-`v1.0.0`; everything below describes the `1.x` line. Before `v1.0.0`,
-backward-incompatible changes can land in any release.
+`v1.0.0`; everything below describes the `1.x` line. The one exception is the
+[archive format](#archive-format), which already carries its own
+version-gated stability promise today (see
+[docs/archive-format.md](archive-format.md#format-version--compatibility))
+and isn't affected by the CLI's own `v1.0.0` milestone. Every other surface
+below is unpromised before `v1.0.0` — backward-incompatible changes there can
+land in any pre-`1.0.0` release.
 
 k8shark follows [Semantic Versioning](https://semver.org): `vMAJOR.MINOR.PATCH`.
 

--- a/docs/stability-policy.md
+++ b/docs/stability-policy.md
@@ -31,8 +31,8 @@ series"). That page is the authority; this policy just points to it.
 
 ### CLI surface
 
-Every subcommand name, flag name and spelling, and flag semantic documented in
-[docs/usage.md](usage.md) is stable for the `1.x` line:
+Every subcommand name, flag name and spelling, and flag semantics documented in
+[docs/usage.md](usage.md) are stable for the `1.x` line:
 
 | Command | Purpose |
 |---------|---------|
@@ -109,8 +109,8 @@ understands version *N* or higher.
 standard Kubernetes client (`kubectl`, `client-go`, `k9s`, …). What's
 covered:
 
-- **Default path**: `~/.kube/k8shark-<capture-id>.yaml`, overridable with
-  `--kubeconfig-out`.
+- **Default path**: `~/.kube/k8shark-<id>.yaml`, where `<id>` is the
+  capture's ID, overridable with `--kubeconfig-out`.
 - **Validity**: the file is always a well-formed kubeconfig (`apiVersion:
   v1`, `kind: Config`) pointing at the locally-running mock server, usable
   without further edits.

--- a/docs/stability-policy.md
+++ b/docs/stability-policy.md
@@ -12,8 +12,10 @@ k8shark follows [Semantic Versioning](https://semver.org): `vMAJOR.MINOR.PATCH`.
   [Stable surfaces](#stable-surfaces) below.
 - **MINOR** — new features, new flags, new config keys, new subcommands.
   Backward-compatible.
-- **PATCH** — bug fixes only. No new flags, no behavior changes to a
-  documented surface.
+- **PATCH** — bug fixes only. No new flags, no *intentional* behavior
+  change to a documented surface — correcting a bug in one (making it match
+  what's documented, or fixing an unambiguous defect) is exactly what a
+  patch release is for.
 
 This is a policy for **behavior**, not for source code: nothing in
 `internal/` is covered (see [What is NOT covered](#what-is-not-covered)),
@@ -67,14 +69,22 @@ Every command follows the `diff(1)`-style contract documented in
 
 | Code | Meaning |
 |------|---------|
-| `0` | Clean — the command ran and found nothing (or isn't a findings-style command) |
-| `1` | The command ran successfully and found something (`diagnose --fail-on`, `diff` with differences) |
+| `0` | The command ran and didn't trip a findings/differences gate (`diagnose` without `--fail-on`, or with `--fail-on` but nothing met that severity; `diff` with no differences) — or the command has no such gate at all |
+| `1` | The command ran and *did* trip a findings/differences gate (`diagnose --fail-on <severity>` matched, `diff` found differences) |
 | `2` | The command failed to run (bad archive, invalid flags, I/O error, …) |
 
-Only `diagnose` and `diff` currently ever exit `1`; every other command exits
-`0` or `2`. Adding exit code `1` to another command in a future minor is
-additive (a script that only checks `if err != nil` / `$? != 0` keeps
-working); repurposing what `1` or `2` mean is a major-version change.
+`diagnose` without `--fail-on` always exits `0` regardless of what it
+found — printing findings and gating on them are separate; exit `1` is
+opt-in via `--fail-on`. Only `diagnose` and `diff` currently ever exit `1`;
+every other command exits `0` or `2`.
+
+Giving another command an **opt-in** flag that can trigger exit `1` (the
+`diagnose --fail-on` pattern) is a minor-version change — a script that
+doesn't pass the new flag keeps seeing the command's existing exit codes.
+Making an *existing* command start exiting `1` unconditionally, or
+repurposing what `1` or `2` mean, is a major-version change — plenty of
+scripts treat any non-zero exit as failure, so silently turning some of a
+command's current successes into exit `1` would break them.
 
 ### Structured output (`-o json` / `-o yaml`)
 


### PR DESCRIPTION
## Summary
- Adds `docs/stability-policy.md`: what's covered by semver from `v1.0.0` on — CLI surface (subcommand/flag names and semantics), the `0`/`1`/`2` exit-code contract, `-o json`/`-o yaml` output (declared a stable scriptable interface, resolving the ambiguity the issue called out), the config-file schema, and the generated kubeconfig path/validity. Also states what's explicitly **not** covered: `internal/`, the experimental web UI, human-facing table/text output, and the accepted conformance divergences.
- Adds a deprecation policy (announce → coexist for ≥1 minor → remove no sooner than the next minor), matching the precedent already set for the `snake_case` config-key aliases.
- States the Kubernetes/kubectl support window and the backport policy (latest minor only — no LTS branches, matching the repo's actual single-branch release model).
- Rewrites `docs/releases.md`'s pre-1.0 versioning section to describe the `1.x` policy and defer to the new doc for the contract itself; updates its stale `v0.2.0` example tags.
- Links the new doc from the README's documentation table.

Closes #222

## Test plan
- [x] Docs-only change; full gate run anyway: `gofmt -l .`, `go build ./...`, `go vet ./...`, `go mod tidy` (no diff), `go test ./...` — all clean.
- [ ] Review the policy's stated decisions (deprecation window, backport policy, JSON-output stability, Kubernetes support window) for correctness against maintainer intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)