### PR TITLE
fix(release): emit cosign certificate, migrate brews: to a cask, -trimpath, fix provenance subject

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           HOMEBREW_TAP_NAME: homebrew-tap
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
-      - name: Attest release checksums
+      - name: Attest release archives
         uses: actions/attest-build-provenance@v4
         with:
-          subject-path: ./dist/checksums.txt
+          subject-path: dist/*.tar.gz,dist/*.zip

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,9 @@ builds:
     goarch:
       - amd64
       - arm64
+    flags:
+      - -trimpath
+    mod_timestamp: '{{ .CommitTimestamp }}'
     ldflags:
       - -s -w -X github.com/phenixblue/k8shark/cmd.Version={{ .Version }}
 
@@ -42,6 +45,8 @@ sboms:
 signs:
   - artifacts: checksum
     cmd: cosign
+    certificate: '${artifact}.pem'
+    output: true
     args:
       - sign-blob
       - --yes
@@ -49,15 +54,23 @@ signs:
       - --output-certificate=${certificate}
       - ${artifact}
 
-brews:
-  # Stable channel: `brew install phenixblue/tap/k8shark`. skip_upload=auto keeps
-  # the tap on the latest non-prerelease — a prerelease tag (e.g. -rc.1) does not
-  # overwrite k8shark.rb.
+homebrew_casks:
+  # Stable channel: `brew install --cask phenixblue/tap/k8shark`. Migrated from a
+  # brews: (Homebrew formula) entry to a cask because GoReleaser deprecated
+  # formula generation in favor of casks as of v2.16 (see
+  # https://goreleaser.com/deprecations#brews) — `goreleaser check` fails on
+  # `brews:` now. The old k8shark.rb formula should be deleted from the tap repo
+  # directly; homebrew_casks.conflicts.formula is NOT the way to reference it —
+  # that field was a no-op Homebrew has since removed entirely. skip_upload=auto
+  # keeps the tap on the latest non-prerelease — a prerelease tag (e.g. -rc.1)
+  # does not overwrite k8shark.rb.
   - name: k8shark
     homepage: https://github.com/phenixblue/k8shark
     description: Kubernetes cluster state capture and mock API replay tool
     license: Apache-2.0
     skip_upload: auto
+    binaries:
+      - kshrk
     repository:
       owner: "{{ .Env.HOMEBREW_TAP_OWNER }}"
       name: "{{ .Env.HOMEBREW_TAP_NAME }}"
@@ -65,18 +78,13 @@ brews:
     commit_author:
       name: github-actions[bot]
       email: github-actions[bot]@users.noreply.github.com
-    test: |
-      system "#{bin}/kshrk", "version"
-    install: |
-      bin.install "kshrk"
 
-homebrew_casks:
   # Prerelease channel: `brew install --cask phenixblue/tap/k8shark@rc`. This must be
   # a cask, not a brews: entry — brews generates `class K8shark@rc < Formula`, and "@"
   # is not a legal Ruby class-name character (this shipped broken in #189/#190; see
   # https://github.com/phenixblue/k8shark/issues for the report). Casks instead
   # generate `cask "k8shark@rc" do ... end`, a plain string argument, so "@" is fine.
-  # skip_upload mirrors the brews entry: uploads only for prerelease tags, so
+  # skip_upload mirrors the stable cask: uploads only for prerelease tags, so
   # k8shark@rc.rb tracks the latest RC while stable releases leave it untouched.
   - name: k8shark@rc
     homepage: https://github.com/phenixblue/k8shark

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ flowchart LR
 
 ```sh
 # Install
-brew install phenixblue/tap/k8shark
+brew install --cask phenixblue/tap/k8shark
 
 # Capture cluster state for 10 minutes
 kshrk capture --config k8shark.yaml

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -41,8 +41,8 @@ Only the latest minor receives patch releases; see the stability policy's
 2. **GoReleaser** — builds cross-platform binaries, packages archives, generates a checksum file, and publishes the GitHub Release.
 3. **SBOM** — [Syft](https://github.com/anchore/syft) generates a Software Bill of Materials for each archive artifact.
 4. **Signing** — the `checksums.txt` file is signed with [cosign](https://github.com/sigstore/cosign) using keyless OIDC signing (no long-lived keys). The signature and certificate are attached to the release.
-5. **Attestation** — GitHub's `attest-build-provenance` action attaches a build provenance attestation to the checksum file.
-6. **Homebrew tap** — GoReleaser pushes an updated formula to `phenixblue/homebrew-tap`, so `brew upgrade k8shark` picks up the new version automatically.
+5. **Attestation** — GitHub's `attest-build-provenance` action attaches a build provenance attestation to each release archive (`.tar.gz`/`.zip`).
+6. **Homebrew tap** — GoReleaser pushes an updated cask to `phenixblue/homebrew-tap`, so `brew upgrade --cask k8shark` picks up the new version automatically.
 
 ## Build matrix
 
@@ -61,7 +61,7 @@ Archives are named `k8shark_<version>_<os>_<arch>.tar.gz` (`.zip` on Windows).
 | Secret | Description |
 |--------|-------------|
 | `GITHUB_TOKEN` | Provided automatically by GitHub Actions; used to create the GitHub Release. |
-| `HOMEBREW_TAP_GITHUB_TOKEN` | A GitHub PAT with `repo` scope on `phenixblue/homebrew-tap`, used to push the Homebrew formula. |
+| `HOMEBREW_TAP_GITHUB_TOKEN` | A GitHub PAT with `repo` scope on `phenixblue/homebrew-tap`, used to push the Homebrew cask. |
 
 The cosign signing uses GitHub's OIDC token — no additional secret is needed.
 
@@ -91,7 +91,7 @@ sha256sum --check --ignore-missing checksums.txt
 ### Verify the build attestation
 
 ```sh
-gh attestation verify kshrk_linux_amd64.tar.gz \
+gh attestation verify k8shark_<version>_linux_amd64.tar.gz \
   --repo phenixblue/k8shark
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,7 +11,7 @@
 ### Homebrew
 
 ```sh
-brew install phenixblue/tap/k8shark
+brew install --cask phenixblue/tap/k8shark
 ```
 
 To follow the **prerelease (release-candidate) channel** instead of stable:
@@ -22,9 +22,10 @@ brew install --cask phenixblue/tap/k8shark@rc
 
 `k8shark@rc` tracks the latest `-rc` release; `k8shark` tracks the latest stable.
 They install the same `kshrk` binary, so use one or the other (not both at once).
-The prerelease channel is a Homebrew *cask*, not a formula — `@` in a Ruby class
-name is invalid, so `k8shark@rc` can only be distributed as a cask (which uses a
-`cask "name" do` string, not a class name). Hence the `--cask` flag.
+Both channels are Homebrew *casks*, not formulae — GoReleaser deprecated formula
+generation in favor of casks, and `@` in a Ruby class name is invalid regardless
+(`k8shark@rc` could only ever be a cask, which uses a `cask "name" do` string, not
+a class name) — hence `--cask` on both.
 
 ### go install
 


### PR DESCRIPTION
## Summary
- **#223** — `signs.certificate` was never set, so cosign's `--output-certificate=${certificate}` expanded to empty and no `.pem` was ever published. Every release's `cosign verify-blob --certificate` instructions in `docs/releases.md` have been unverifiable since the signing step was added. Adds `certificate: '${artifact}.pem'` + `output: true`.
- **#224** — `brews:` is deprecated by GoReleaser (formula generation dropped entirely since v2.16, in favor of casks — confirmed against the current schema and GoReleaser's own deprecation notes; there is **no** `homebrew_formulae:` key, contrary to what the issue assumed). Migrated the stable channel to a `homebrew_casks` entry alongside the existing `k8shark@rc` cask.
  - **User-facing change**: stable install goes from `brew install phenixblue/tap/k8shark` to `brew install --cask phenixblue/tap/k8shark` — README and `docs/usage.md` updated.
  - The old `k8shark.rb` formula still living in `phenixblue/homebrew-tap` needs manual deletion — that's a different repo, out of scope for this PR.
- **#227** — added `-trimpath` + `mod_timestamp: '{{ .CommitTimestamp }}'` so released binaries don't embed the CI runner's absolute paths and rebuild reproducibly.
- **#228** — `attest-build-provenance`'s `subject-path` covered only `checksums.txt`, not the archives the docs tell users to verify (`gh attestation verify <tarball>`). Pointed it at `dist/*.tar.gz,dist/*.zip`, and fixed the wrong example filename in `docs/releases.md` (`kshrk_...` → `k8shark_<version>_...`, matching the real `name_template`).

Closes #223
Closes #224
Closes #227
Closes #228

## Test plan
- [x] `goreleaser check` — passes clean (was failing on the deprecated `brews:` key before this change)
- [x] `goreleaser release --snapshot --clean --skip=sign,publish` — full local dry-run succeeds, both casks render correctly, `go version -m` on the built binary confirms `-trimpath=true`
- [x] Full gate: `gofmt -l .`, `go build ./...`, `go vet ./...`, `go mod tidy` (no diff), `go test ./...`
- [ ] Cut a real RC tag once this merges and run the actual `cosign verify-blob` / `gh attestation verify` commands from `docs/releases.md` against the published artifacts (tracked separately — part of "prove the pipeline")

🤖 Generated with [Claude Code](https://claude.com/claude-code)