### PR TITLE
ci: SHA-pin all GitHub Actions refs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,10 +12,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
@@ -38,7 +38,7 @@ jobs:
         run: go test -bench=. -benchmem -run=^$ -count=5 ./... | tee bench-output.txt
 
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: k8shark benchmarks
           tool: go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
@@ -65,10 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
@@ -83,10 +83,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
@@ -101,10 +101,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/e2e-kwok.yml
+++ b/.github/workflows/e2e-kwok.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,26 +16,26 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
       - name: Setup Cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
       - name: Setup Syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Run tests
         run: go test ./...
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -54,6 +54,6 @@ jobs:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
       - name: Attest release archives
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: dist/*.tar.gz,dist/*.zip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,16 @@ explicit versions, **not `@latest`**, for reproducible runs. Dependabot's
 `github-actions` ecosystem only bumps `uses:` action refs, so these pins need
 manual bumps. Pin any new CI tool the same way.
 
+Every `uses:` line in `.github/workflows/` is pinned to a full 40-char commit
+SHA with a trailing `# vX.Y.Z` comment (not a floating major tag like `@v4`) —
+`release.yml` holds `contents: write`, `id-token: write`, `attestations:
+write`, and the `HOMEBREW_TAP_GITHUB_TOKEN` secret, so a compromised tag on
+any action it uses would get all of it, including the Sigstore signing
+identity (#229). Dependabot's `github-actions` ecosystem (already configured
+in `.github/dependabot.yml`) opens PRs to bump these SHAs and keeps the
+version comment in sync — no manual maintenance needed once pinned. Pin any
+new action the same way when adding one.
+
 ## Archive lifecycle (gotcha)
 
 `archive.Open` returns a `*zip.ReadCloser` that holds a real OS file handle, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,13 @@ manual bumps. Pin any new CI tool the same way.
 
 Every `uses:` line in `.github/workflows/` is pinned to a full 40-char commit
 SHA with a trailing `# vX.Y.Z` comment (not a floating major tag like `@v4`) —
-`release.yml` holds `contents: write`, `id-token: write`, `attestations:
-write`, and the `HOMEBREW_TAP_GITHUB_TOKEN` secret, so a compromised tag on
-any action it uses would get all of it, including the Sigstore signing
-identity (#229). Dependabot's `github-actions` ecosystem (already configured
-in `.github/dependabot.yml`) opens PRs to bump these SHAs and keeps the
-version comment in sync — no manual maintenance needed once pinned. Pin any
-new action the same way when adding one.
+`release.yml` holds `contents: write`, `id-token: write`, `attestations: write`,
+and the `HOMEBREW_TAP_GITHUB_TOKEN` secret, so a compromised tag on any action
+it uses would get all of it, including the Sigstore signing identity (#229).
+Dependabot's `github-actions` ecosystem (already configured in
+`.github/dependabot.yml`) opens PRs to bump these SHAs and keeps the version
+comment in sync — no manual maintenance needed once pinned. Pin any new action
+the same way when adding one.
 
 ## Archive lifecycle (gotcha)
 


### PR DESCRIPTION
## Summary
- None of the `uses:` refs across the 6 workflow files were SHA-pinned — every action was a floating major-version tag (`actions/checkout@v7`, `actions/setup-go@v7`, `sigstore/cosign-installer@v3`, `anchore/sbom-action/download-syft@v0`, `goreleaser/goreleaser-action@v7`, `actions/attest-build-provenance@v4`, `benchmark-action/github-action-benchmark@v1`).
- `release.yml` holds `contents: write` + `id-token: write` + `attestations: write` + `HOMEBREW_TAP_GITHUB_TOKEN` — a compromised tag on any action it uses gets all of it, including the Sigstore signing identity. `anchore/sbom-action`'s `@v0` major tag on a third-party action was the weakest link.
- Pinned every `uses:` line to the exact commit its current tag resolves to, with a trailing `# vX.Y.Z` comment (matching the convention CLAUDE.md already documents for `go install`-based CI tools).
- Extended `CLAUDE.md`'s existing tool-pinning policy note to explicitly cover Actions.

Dependabot's `github-actions` ecosystem is already configured in `.github/dependabot.yml`, so it will open PRs to bump these SHAs (and keep the version comment in sync) going forward — no new ongoing maintenance cost.

Closes #229

## Test plan
- [x] All 6 workflow YAML files parse (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Full gate: `gofmt -l .`, `go build ./...`, `go vet ./...`, `go mod tidy` (no diff), `go test ./...`
- [ ] CI itself is the real test — this PR's own CI run exercises every pinned ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)