### PR TITLE
ci: run the test job on ubuntu, macos, and windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,11 @@ jobs:
 
   test:
     needs: contract
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -198,7 +198,7 @@ func (w *StreamWriter) WriteRecord(rec *format.Record) (int, error) {
 	defer w.mu.Unlock()
 
 	seq := w.pathSeq[rec.APIPath]
-	entryName := filepath.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq))
+	entryName := path.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq))
 
 	if err := writeBytes(w.zw, entryName, compressed); err != nil {
 		return 0, err
@@ -227,7 +227,7 @@ func (w *StreamWriter) WriteRecordRaw(apiPath string, data any) (int, error) {
 
 	seq := w.pathSeq[apiPath]
 	w.pathSeq[apiPath] = seq + 1
-	entryName := filepath.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq))
+	entryName := path.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq))
 	if err := writeBytes(w.zw, entryName, compressed); err != nil {
 		return 0, err
 	}
@@ -571,7 +571,7 @@ func (a *Archive) ReadWatchIndex() (format.WatchIndex, bool, error) {
 // seq is 0-based and matches the order records were written for that path.
 func (a *Archive) ReadRecord(apiPath string, seq int) ([]byte, error) {
 	dir := pathDir(apiPath)
-	name := filepath.ToSlash(filepath.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq)))
+	name := path.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq))
 	data, err := a.readZstd(name)
 	if err != nil {
 		return nil, fmt.Errorf("reading record path=%s seq=%d: %w", apiPath, seq, err)
@@ -586,7 +586,7 @@ func (a *Archive) RecordsForPath(apiPath string) ([][]byte, error) {
 	dir := pathDir(apiPath)
 	var out [][]byte
 	for seq := 0; ; seq++ {
-		name := filepath.ToSlash(filepath.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq)))
+		name := path.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq))
 		if _, ok := a.byName[name]; !ok {
 			break
 		}

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -50,6 +50,33 @@ func pathDir(apiPath string) string {
 	return fmt.Sprintf("%x", sum[:8])
 }
 
+// quotePath wraps p in double quotes for a human-readable error message,
+// without treating it as a Go string literal the way %q does — %q escapes
+// every "\" as "\\", which turns an ordinary Windows path (built entirely of
+// backslashes) into visibly doubled separators in every error message. Only
+// the characters that would otherwise make the quoted output ambiguous or
+// multi-line (a literal '"' or a newline) are escaped; a backslash is never
+// touched, so the path renders exactly as passed in on any OS.
+func quotePath(p string) string {
+	var b strings.Builder
+	b.Grow(len(p) + 2)
+	b.WriteByte('"')
+	for _, r := range p {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
 // zstdEncoder is a package-level encoder pool for compressing record data.
 var zstdEncoderPool = sync.Pool{
 	New: func() any {
@@ -153,7 +180,7 @@ func NewEncryptedStreamWriter(outputPath string, recipients []age.Recipient) (*S
 func newStreamWriter(outputPath string, recipients []age.Recipient) (*StreamWriter, error) {
 	f, err := os.Create(outputPath)
 	if err != nil {
-		return nil, fmt.Errorf("creating output file \"%s\": %w", outputPath, err)
+		return nil, fmt.Errorf("creating output file %s: %w", quotePath(outputPath), err)
 	}
 	sw := &StreamWriter{f: f, pathSeq: make(map[string]int)}
 	var dst io.Writer = f
@@ -432,25 +459,25 @@ func OpenWithIdentities(archivePath string, identities []age.Identity) (*Archive
 // stream before it's ever encrypted.
 func wrapZipFormatErr(archivePath string, err error) error {
 	if errors.Is(err, zip.ErrFormat) {
-		return fmt.Errorf("archive \"%s\" is corrupt or incomplete: not a valid zip file — this can happen if a capture was interrupted (e.g. Ctrl+C) or the file was truncated in transfer: %w", archivePath, err)
+		return fmt.Errorf("archive %s is corrupt or incomplete: not a valid zip file — this can happen if a capture was interrupted (e.g. Ctrl+C) or the file was truncated in transfer: %w", quotePath(archivePath), err)
 	}
-	return fmt.Errorf("opening zip archive \"%s\": %w", archivePath, err)
+	return fmt.Errorf("opening zip archive %s: %w", quotePath(archivePath), err)
 }
 
 func openArchive(archivePath string, identities []age.Identity) (*Archive, error) {
 	fi, err := os.Stat(archivePath)
 	if err != nil {
-		return nil, fmt.Errorf("stat \"%s\": %w", archivePath, err)
+		return nil, fmt.Errorf("stat %s: %w", quotePath(archivePath), err)
 	}
 	f, err := os.Open(archivePath)
 	if err != nil {
-		return nil, fmt.Errorf("opening archive \"%s\": %w", archivePath, err)
+		return nil, fmt.Errorf("opening archive %s: %w", quotePath(archivePath), err)
 	}
 
 	encrypted, err := isAgeEncrypted(f)
 	if err != nil {
 		f.Close()
-		return nil, fmt.Errorf("reading \"%s\": %w", archivePath, err)
+		return nil, fmt.Errorf("reading %s: %w", quotePath(archivePath), err)
 	}
 
 	var zr *zip.Reader
@@ -463,15 +490,15 @@ func openArchive(archivePath string, identities []age.Identity) (*Archive, error
 	} else {
 		if len(identities) == 0 {
 			f.Close()
-			return nil, fmt.Errorf("archive \"%s\" is encrypted: supply a decryption key", archivePath)
+			return nil, fmt.Errorf("archive %s is encrypted: supply a decryption key", quotePath(archivePath))
 		}
 		ra, plainSize, err := age.DecryptReaderAt(f, fi.Size(), identities...)
 		if err != nil {
 			f.Close()
 			if isNoIdentityMatch(err) {
-				return nil, fmt.Errorf("failed to decrypt archive \"%s\": incorrect passphrase or key", archivePath)
+				return nil, fmt.Errorf("failed to decrypt archive %s: incorrect passphrase or key", quotePath(archivePath))
 			}
-			return nil, fmt.Errorf("decrypting archive \"%s\": %w", archivePath, err)
+			return nil, fmt.Errorf("decrypting archive %s: %w", quotePath(archivePath), err)
 		}
 		zr, err = zip.NewReader(ra, plainSize)
 		if err != nil {
@@ -493,7 +520,7 @@ func openArchive(archivePath string, identities []age.Identity) (*Archive, error
 	}
 	if err := json.Unmarshal(metaData, &ar.meta); err != nil {
 		f.Close()
-		return nil, fmt.Errorf("parsing metadata.json in archive \"%s\": %w", archivePath, err)
+		return nil, fmt.Errorf("parsing metadata.json in archive %s: %w", quotePath(archivePath), err)
 	}
 	if err := format.CheckFormatVersion(ar.meta); err != nil {
 		f.Close()
@@ -529,7 +556,7 @@ func (a *Archive) ReadIndex() (format.Index, error) {
 	}
 	var idx format.Index
 	if err := json.Unmarshal(data, &idx); err != nil {
-		return nil, fmt.Errorf("parsing index.json.zst in archive \"%s\": %w", a.path, err)
+		return nil, fmt.Errorf("parsing index.json.zst in archive %s: %w", quotePath(a.path), err)
 	}
 	return idx, nil
 }
@@ -547,13 +574,13 @@ func (a *Archive) ReadWatchIndex() (format.WatchIndex, bool, error) {
 	}
 	var wi format.WatchIndex
 	if err := json.Unmarshal(data, &wi); err != nil {
-		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive \"%s\": %w", a.path, err)
+		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %s: %w", quotePath(a.path), err)
 	}
 	// The writer always emits at least "{}" (never a bare "null") for
 	// watch-index.json.zst, so a top-level JSON null here — which unmarshals
 	// to a nil map without error — is corrupt, not simply an empty index.
 	if wi == nil {
-		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive \"%s\": top-level null", a.path)
+		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %s: top-level null", quotePath(a.path))
 	}
 	// A well-formed watch-index.json never has a null entry for a path — the
 	// writer only ever inserts a populated *WatchIndexEntry. A null entry here
@@ -561,7 +588,7 @@ func (a *Archive) ReadWatchIndex() (format.WatchIndex, bool, error) {
 	// reader dereferences the entry (e.g. entry.Seqs) without a nil check.
 	for apiPath, entry := range wi {
 		if entry == nil {
-			return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive \"%s\": null entry for path %q", a.path, apiPath)
+			return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %s: null entry for path %q", quotePath(a.path), apiPath)
 		}
 	}
 	return wi, true, nil
@@ -632,16 +659,16 @@ func PathDir(apiPath string) string { return pathDir(apiPath) }
 func (a *Archive) readRaw(name string) ([]byte, error) {
 	zf, ok := a.byName[name]
 	if !ok {
-		return nil, fmt.Errorf("entry %q not found in archive \"%s\"", name, a.path)
+		return nil, fmt.Errorf("entry %q not found in archive %s", name, quotePath(a.path))
 	}
 	rc, err := zf.Open()
 	if err != nil {
-		return nil, fmt.Errorf("opening entry %q in archive \"%s\": %w", name, a.path, err)
+		return nil, fmt.Errorf("opening entry %q in archive %s: %w", name, quotePath(a.path), err)
 	}
 	defer rc.Close()
 	data, err := readAllLimited(rc, maxEntryBytes)
 	if err != nil {
-		return nil, fmt.Errorf("reading entry %q in archive \"%s\": %w", name, a.path, err)
+		return nil, fmt.Errorf("reading entry %q in archive %s: %w", name, quotePath(a.path), err)
 	}
 	return data, nil
 }
@@ -654,7 +681,7 @@ func (a *Archive) readZstd(name string) ([]byte, error) {
 	}
 	data, err := zstdDecompress(compressed)
 	if err != nil {
-		return nil, fmt.Errorf("decompressing entry %q in archive \"%s\": %w", name, a.path, err)
+		return nil, fmt.Errorf("decompressing entry %q in archive %s: %w", name, quotePath(a.path), err)
 	}
 	return data, nil
 }

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -61,8 +61,12 @@ func quotePath(p string) string {
 	var b strings.Builder
 	b.Grow(len(p) + 2)
 	b.WriteByte('"')
-	for _, r := range p {
-		switch r {
+	// Iterate bytes, not runes: a filesystem path isn't guaranteed to be
+	// valid UTF-8, and ranging over it as runes would replace any invalid
+	// byte sequence with U+FFFD — silently corrupting the very bytes this
+	// function's contract promises to render unchanged.
+	for i := 0; i < len(p); i++ {
+		switch p[i] {
 		case '"':
 			b.WriteString(`\"`)
 		case '\n':
@@ -70,7 +74,7 @@ func quotePath(p string) string {
 		case '\r':
 			b.WriteString(`\r`)
 		default:
-			b.WriteRune(r)
+			b.WriteByte(p[i])
 		}
 	}
 	b.WriteByte('"')

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -55,8 +55,8 @@ func pathDir(apiPath string) string {
 // every "\" as "\\", which turns an ordinary Windows path (built entirely of
 // backslashes) into visibly doubled separators in every error message. Only
 // the characters that would otherwise make the quoted output ambiguous or
-// multi-line (a literal '"' or a newline) are escaped; a backslash is never
-// touched, so the path renders exactly as passed in on any OS.
+// multi-line (a literal '"', '\n', or '\r') are escaped; a backslash is
+// never touched, so the path renders exactly as passed in on any OS.
 func quotePath(p string) string {
 	var b strings.Builder
 	b.Grow(len(p) + 2)

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -153,7 +153,7 @@ func NewEncryptedStreamWriter(outputPath string, recipients []age.Recipient) (*S
 func newStreamWriter(outputPath string, recipients []age.Recipient) (*StreamWriter, error) {
 	f, err := os.Create(outputPath)
 	if err != nil {
-		return nil, fmt.Errorf("creating output file %q: %w", outputPath, err)
+		return nil, fmt.Errorf("creating output file \"%s\": %w", outputPath, err)
 	}
 	sw := &StreamWriter{f: f, pathSeq: make(map[string]int)}
 	var dst io.Writer = f
@@ -432,25 +432,25 @@ func OpenWithIdentities(archivePath string, identities []age.Identity) (*Archive
 // stream before it's ever encrypted.
 func wrapZipFormatErr(archivePath string, err error) error {
 	if errors.Is(err, zip.ErrFormat) {
-		return fmt.Errorf("archive %q is corrupt or incomplete: not a valid zip file — this can happen if a capture was interrupted (e.g. Ctrl+C) or the file was truncated in transfer: %w", archivePath, err)
+		return fmt.Errorf("archive \"%s\" is corrupt or incomplete: not a valid zip file — this can happen if a capture was interrupted (e.g. Ctrl+C) or the file was truncated in transfer: %w", archivePath, err)
 	}
-	return fmt.Errorf("opening zip archive %q: %w", archivePath, err)
+	return fmt.Errorf("opening zip archive \"%s\": %w", archivePath, err)
 }
 
 func openArchive(archivePath string, identities []age.Identity) (*Archive, error) {
 	fi, err := os.Stat(archivePath)
 	if err != nil {
-		return nil, fmt.Errorf("stat %q: %w", archivePath, err)
+		return nil, fmt.Errorf("stat \"%s\": %w", archivePath, err)
 	}
 	f, err := os.Open(archivePath)
 	if err != nil {
-		return nil, fmt.Errorf("opening archive %q: %w", archivePath, err)
+		return nil, fmt.Errorf("opening archive \"%s\": %w", archivePath, err)
 	}
 
 	encrypted, err := isAgeEncrypted(f)
 	if err != nil {
 		f.Close()
-		return nil, fmt.Errorf("reading %q: %w", archivePath, err)
+		return nil, fmt.Errorf("reading \"%s\": %w", archivePath, err)
 	}
 
 	var zr *zip.Reader
@@ -463,15 +463,15 @@ func openArchive(archivePath string, identities []age.Identity) (*Archive, error
 	} else {
 		if len(identities) == 0 {
 			f.Close()
-			return nil, fmt.Errorf("archive %q is encrypted: supply a decryption key", archivePath)
+			return nil, fmt.Errorf("archive \"%s\" is encrypted: supply a decryption key", archivePath)
 		}
 		ra, plainSize, err := age.DecryptReaderAt(f, fi.Size(), identities...)
 		if err != nil {
 			f.Close()
 			if isNoIdentityMatch(err) {
-				return nil, fmt.Errorf("failed to decrypt archive %q: incorrect passphrase or key", archivePath)
+				return nil, fmt.Errorf("failed to decrypt archive \"%s\": incorrect passphrase or key", archivePath)
 			}
-			return nil, fmt.Errorf("decrypting archive %q: %w", archivePath, err)
+			return nil, fmt.Errorf("decrypting archive \"%s\": %w", archivePath, err)
 		}
 		zr, err = zip.NewReader(ra, plainSize)
 		if err != nil {
@@ -493,7 +493,7 @@ func openArchive(archivePath string, identities []age.Identity) (*Archive, error
 	}
 	if err := json.Unmarshal(metaData, &ar.meta); err != nil {
 		f.Close()
-		return nil, fmt.Errorf("parsing metadata.json in archive %q: %w", archivePath, err)
+		return nil, fmt.Errorf("parsing metadata.json in archive \"%s\": %w", archivePath, err)
 	}
 	if err := format.CheckFormatVersion(ar.meta); err != nil {
 		f.Close()
@@ -529,7 +529,7 @@ func (a *Archive) ReadIndex() (format.Index, error) {
 	}
 	var idx format.Index
 	if err := json.Unmarshal(data, &idx); err != nil {
-		return nil, fmt.Errorf("parsing index.json.zst in archive %q: %w", a.path, err)
+		return nil, fmt.Errorf("parsing index.json.zst in archive \"%s\": %w", a.path, err)
 	}
 	return idx, nil
 }
@@ -547,13 +547,13 @@ func (a *Archive) ReadWatchIndex() (format.WatchIndex, bool, error) {
 	}
 	var wi format.WatchIndex
 	if err := json.Unmarshal(data, &wi); err != nil {
-		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %q: %w", a.path, err)
+		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive \"%s\": %w", a.path, err)
 	}
 	// The writer always emits at least "{}" (never a bare "null") for
 	// watch-index.json.zst, so a top-level JSON null here — which unmarshals
 	// to a nil map without error — is corrupt, not simply an empty index.
 	if wi == nil {
-		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %q: top-level null", a.path)
+		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive \"%s\": top-level null", a.path)
 	}
 	// A well-formed watch-index.json never has a null entry for a path — the
 	// writer only ever inserts a populated *WatchIndexEntry. A null entry here
@@ -561,7 +561,7 @@ func (a *Archive) ReadWatchIndex() (format.WatchIndex, bool, error) {
 	// reader dereferences the entry (e.g. entry.Seqs) without a nil check.
 	for apiPath, entry := range wi {
 		if entry == nil {
-			return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %q: null entry for path %q", a.path, apiPath)
+			return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive \"%s\": null entry for path %q", a.path, apiPath)
 		}
 	}
 	return wi, true, nil
@@ -632,16 +632,16 @@ func PathDir(apiPath string) string { return pathDir(apiPath) }
 func (a *Archive) readRaw(name string) ([]byte, error) {
 	zf, ok := a.byName[name]
 	if !ok {
-		return nil, fmt.Errorf("entry %q not found in archive %q", name, a.path)
+		return nil, fmt.Errorf("entry %q not found in archive \"%s\"", name, a.path)
 	}
 	rc, err := zf.Open()
 	if err != nil {
-		return nil, fmt.Errorf("opening entry %q in archive %q: %w", name, a.path, err)
+		return nil, fmt.Errorf("opening entry %q in archive \"%s\": %w", name, a.path, err)
 	}
 	defer rc.Close()
 	data, err := readAllLimited(rc, maxEntryBytes)
 	if err != nil {
-		return nil, fmt.Errorf("reading entry %q in archive %q: %w", name, a.path, err)
+		return nil, fmt.Errorf("reading entry %q in archive \"%s\": %w", name, a.path, err)
 	}
 	return data, nil
 }
@@ -654,7 +654,7 @@ func (a *Archive) readZstd(name string) ([]byte, error) {
 	}
 	data, err := zstdDecompress(compressed)
 	if err != nil {
-		return nil, fmt.Errorf("decompressing entry %q in archive %q: %w", name, a.path, err)
+		return nil, fmt.Errorf("decompressing entry %q in archive \"%s\": %w", name, a.path, err)
 	}
 	return data, nil
 }

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -82,9 +82,9 @@ func isNoIdentityMatch(err error) bool {
 func classifyDecryptCopyError(srcPath string, err error) error {
 	var pathErr *fs.PathError
 	if errors.As(err, &pathErr) {
-		return fmt.Errorf("decrypting %q: %w", srcPath, err)
+		return fmt.Errorf("decrypting \"%s\": %w", srcPath, err)
 	}
-	return fmt.Errorf("decrypting %q: tampered or corrupt archive: %w", srcPath, err)
+	return fmt.Errorf("decrypting \"%s\": tampered or corrupt archive: %w", srcPath, err)
 }
 
 // createLike creates a fresh temporary file in dstPath's directory — never
@@ -119,17 +119,17 @@ func classifyDecryptCopyError(srcPath string, err error) error {
 func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, commit func() error, err error) {
 	srcInfo, err := src.Stat()
 	if err != nil {
-		return nil, 0, nil, fmt.Errorf("stat %q: %w", src.Name(), err)
+		return nil, 0, nil, fmt.Errorf("stat \"%s\": %w", src.Name(), err)
 	}
 	mode = srcInfo.Mode().Perm()
 
 	switch existing, statErr := os.Lstat(dstPath); {
 	case statErr == nil:
 		if !existing.Mode().IsRegular() {
-			return nil, 0, nil, fmt.Errorf("output %q exists and is not a regular file (mode %s)", dstPath, existing.Mode())
+			return nil, 0, nil, fmt.Errorf("output \"%s\" exists and is not a regular file (mode %s)", dstPath, existing.Mode())
 		}
 		if os.SameFile(srcInfo, existing) {
-			return nil, 0, nil, fmt.Errorf("output %q must not be the same file as the input", dstPath)
+			return nil, 0, nil, fmt.Errorf("output \"%s\" must not be the same file as the input", dstPath)
 		}
 	case errors.Is(statErr, fs.ErrNotExist):
 		// The common case: no output exists yet, nothing to check.
@@ -138,12 +138,12 @@ func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, c
 		// I/O error, ...) is a real failure — don't silently treat it the
 		// same as "doesn't exist" and proceed without having enforced the
 		// non-regular/same-file checks above.
-		return nil, 0, nil, fmt.Errorf("checking existing output %q: %w", dstPath, statErr)
+		return nil, 0, nil, fmt.Errorf("checking existing output \"%s\": %w", dstPath, statErr)
 	}
 
 	tmp, err := os.CreateTemp(filepath.Dir(dstPath), "."+filepath.Base(dstPath)+".tmp-*")
 	if err != nil {
-		return nil, 0, nil, fmt.Errorf("creating temporary file for %q: %w", dstPath, err)
+		return nil, 0, nil, fmt.Errorf("creating temporary file for \"%s\": %w", dstPath, err)
 	}
 	tmpPath := tmp.Name()
 	// Deliberately left at os.CreateTemp's default 0600 (not widened to
@@ -158,13 +158,13 @@ func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, c
 
 	commit = func() error {
 		if err := tmp.Chmod(mode); err != nil {
-			return fmt.Errorf("setting permissions on %q: %w", tmpPath, err)
+			return fmt.Errorf("setting permissions on \"%s\": %w", tmpPath, err)
 		}
 		if err := tmp.Close(); err != nil {
-			return fmt.Errorf("closing %q: %w", tmpPath, err)
+			return fmt.Errorf("closing \"%s\": %w", tmpPath, err)
 		}
 		if err := os.Rename(tmpPath, dstPath); err != nil {
-			return fmt.Errorf("renaming temporary file into place as %q: %w", dstPath, err)
+			return fmt.Errorf("renaming temporary file into place as \"%s\": %w", dstPath, err)
 		}
 		return nil
 	}
@@ -182,10 +182,10 @@ func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, c
 func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error) {
 	encrypted, err := IsEncrypted(srcPath)
 	if err != nil {
-		return fmt.Errorf("reading %q: %w", srcPath, err)
+		return fmt.Errorf("reading \"%s\": %w", srcPath, err)
 	}
 	if encrypted {
-		return fmt.Errorf("%q is already encrypted", srcPath)
+		return fmt.Errorf("\"%s\" is already encrypted", srcPath)
 	}
 	if len(recipients) == 0 {
 		return fmt.Errorf("archive encryption requires at least one recipient")
@@ -193,7 +193,7 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 
 	src, err := os.Open(srcPath)
 	if err != nil {
-		return fmt.Errorf("opening %q: %w", srcPath, err)
+		return fmt.Errorf("opening \"%s\": %w", srcPath, err)
 	}
 	defer src.Close()
 
@@ -218,10 +218,10 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 	}
 	if _, err = io.Copy(w, src); err != nil {
 		_ = w.Close() // best-effort: attempt to finalize before the deferred cleanup discards the temp file
-		return fmt.Errorf("encrypting %q: %w", srcPath, err)
+		return fmt.Errorf("encrypting \"%s\": %w", srcPath, err)
 	}
 	if err = w.Close(); err != nil {
-		return fmt.Errorf("finishing encryption of %q: %w", srcPath, err)
+		return fmt.Errorf("finishing encryption of \"%s\": %w", srcPath, err)
 	}
 	if err = commit(); err != nil {
 		return err
@@ -239,10 +239,10 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error) {
 	encrypted, err := IsEncrypted(srcPath)
 	if err != nil {
-		return fmt.Errorf("reading %q: %w", srcPath, err)
+		return fmt.Errorf("reading \"%s\": %w", srcPath, err)
 	}
 	if !encrypted {
-		return fmt.Errorf("%q is not encrypted", srcPath)
+		return fmt.Errorf("\"%s\" is not encrypted", srcPath)
 	}
 	if len(identities) == 0 {
 		return fmt.Errorf("archive decryption requires at least one identity")
@@ -250,16 +250,16 @@ func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error)
 
 	src, err := os.Open(srcPath)
 	if err != nil {
-		return fmt.Errorf("opening %q: %w", srcPath, err)
+		return fmt.Errorf("opening \"%s\": %w", srcPath, err)
 	}
 	defer src.Close()
 
 	r, err := age.Decrypt(src, identities...)
 	if err != nil {
 		if isNoIdentityMatch(err) {
-			return fmt.Errorf("failed to decrypt %q: incorrect passphrase or key", srcPath)
+			return fmt.Errorf("failed to decrypt \"%s\": incorrect passphrase or key", srcPath)
 		}
-		return fmt.Errorf("decrypting %q: %w", srcPath, err)
+		return fmt.Errorf("decrypting \"%s\": %w", srcPath, err)
 	}
 
 	dst, _, commit, err := createLike(dstPath, src)

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -82,9 +82,9 @@ func isNoIdentityMatch(err error) bool {
 func classifyDecryptCopyError(srcPath string, err error) error {
 	var pathErr *fs.PathError
 	if errors.As(err, &pathErr) {
-		return fmt.Errorf("decrypting \"%s\": %w", srcPath, err)
+		return fmt.Errorf("decrypting %s: %w", quotePath(srcPath), err)
 	}
-	return fmt.Errorf("decrypting \"%s\": tampered or corrupt archive: %w", srcPath, err)
+	return fmt.Errorf("decrypting %s: tampered or corrupt archive: %w", quotePath(srcPath), err)
 }
 
 // createLike creates a fresh temporary file in dstPath's directory — never
@@ -119,17 +119,17 @@ func classifyDecryptCopyError(srcPath string, err error) error {
 func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, commit func() error, err error) {
 	srcInfo, err := src.Stat()
 	if err != nil {
-		return nil, 0, nil, fmt.Errorf("stat \"%s\": %w", src.Name(), err)
+		return nil, 0, nil, fmt.Errorf("stat %s: %w", quotePath(src.Name()), err)
 	}
 	mode = srcInfo.Mode().Perm()
 
 	switch existing, statErr := os.Lstat(dstPath); {
 	case statErr == nil:
 		if !existing.Mode().IsRegular() {
-			return nil, 0, nil, fmt.Errorf("output \"%s\" exists and is not a regular file (mode %s)", dstPath, existing.Mode())
+			return nil, 0, nil, fmt.Errorf("output %s exists and is not a regular file (mode %s)", quotePath(dstPath), existing.Mode())
 		}
 		if os.SameFile(srcInfo, existing) {
-			return nil, 0, nil, fmt.Errorf("output \"%s\" must not be the same file as the input", dstPath)
+			return nil, 0, nil, fmt.Errorf("output %s must not be the same file as the input", quotePath(dstPath))
 		}
 	case errors.Is(statErr, fs.ErrNotExist):
 		// The common case: no output exists yet, nothing to check.
@@ -138,12 +138,12 @@ func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, c
 		// I/O error, ...) is a real failure — don't silently treat it the
 		// same as "doesn't exist" and proceed without having enforced the
 		// non-regular/same-file checks above.
-		return nil, 0, nil, fmt.Errorf("checking existing output \"%s\": %w", dstPath, statErr)
+		return nil, 0, nil, fmt.Errorf("checking existing output %s: %w", quotePath(dstPath), statErr)
 	}
 
 	tmp, err := os.CreateTemp(filepath.Dir(dstPath), "."+filepath.Base(dstPath)+".tmp-*")
 	if err != nil {
-		return nil, 0, nil, fmt.Errorf("creating temporary file for \"%s\": %w", dstPath, err)
+		return nil, 0, nil, fmt.Errorf("creating temporary file for %s: %w", quotePath(dstPath), err)
 	}
 	tmpPath := tmp.Name()
 	// Deliberately left at os.CreateTemp's default 0600 (not widened to
@@ -158,13 +158,13 @@ func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, c
 
 	commit = func() error {
 		if err := tmp.Chmod(mode); err != nil {
-			return fmt.Errorf("setting permissions on \"%s\": %w", tmpPath, err)
+			return fmt.Errorf("setting permissions on %s: %w", quotePath(tmpPath), err)
 		}
 		if err := tmp.Close(); err != nil {
-			return fmt.Errorf("closing \"%s\": %w", tmpPath, err)
+			return fmt.Errorf("closing %s: %w", quotePath(tmpPath), err)
 		}
 		if err := os.Rename(tmpPath, dstPath); err != nil {
-			return fmt.Errorf("renaming temporary file into place as \"%s\": %w", dstPath, err)
+			return fmt.Errorf("renaming temporary file into place as %s: %w", quotePath(dstPath), err)
 		}
 		return nil
 	}
@@ -182,10 +182,10 @@ func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, c
 func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error) {
 	encrypted, err := IsEncrypted(srcPath)
 	if err != nil {
-		return fmt.Errorf("reading \"%s\": %w", srcPath, err)
+		return fmt.Errorf("reading %s: %w", quotePath(srcPath), err)
 	}
 	if encrypted {
-		return fmt.Errorf("\"%s\" is already encrypted", srcPath)
+		return fmt.Errorf("%s is already encrypted", quotePath(srcPath))
 	}
 	if len(recipients) == 0 {
 		return fmt.Errorf("archive encryption requires at least one recipient")
@@ -193,7 +193,7 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 
 	src, err := os.Open(srcPath)
 	if err != nil {
-		return fmt.Errorf("opening \"%s\": %w", srcPath, err)
+		return fmt.Errorf("opening %s: %w", quotePath(srcPath), err)
 	}
 	defer src.Close()
 
@@ -218,10 +218,10 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 	}
 	if _, err = io.Copy(w, src); err != nil {
 		_ = w.Close() // best-effort: attempt to finalize before the deferred cleanup discards the temp file
-		return fmt.Errorf("encrypting \"%s\": %w", srcPath, err)
+		return fmt.Errorf("encrypting %s: %w", quotePath(srcPath), err)
 	}
 	if err = w.Close(); err != nil {
-		return fmt.Errorf("finishing encryption of \"%s\": %w", srcPath, err)
+		return fmt.Errorf("finishing encryption of %s: %w", quotePath(srcPath), err)
 	}
 	if err = commit(); err != nil {
 		return err
@@ -239,10 +239,10 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error) {
 	encrypted, err := IsEncrypted(srcPath)
 	if err != nil {
-		return fmt.Errorf("reading \"%s\": %w", srcPath, err)
+		return fmt.Errorf("reading %s: %w", quotePath(srcPath), err)
 	}
 	if !encrypted {
-		return fmt.Errorf("\"%s\" is not encrypted", srcPath)
+		return fmt.Errorf("%s is not encrypted", quotePath(srcPath))
 	}
 	if len(identities) == 0 {
 		return fmt.Errorf("archive decryption requires at least one identity")
@@ -250,16 +250,16 @@ func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error)
 
 	src, err := os.Open(srcPath)
 	if err != nil {
-		return fmt.Errorf("opening \"%s\": %w", srcPath, err)
+		return fmt.Errorf("opening %s: %w", quotePath(srcPath), err)
 	}
 	defer src.Close()
 
 	r, err := age.Decrypt(src, identities...)
 	if err != nil {
 		if isNoIdentityMatch(err) {
-			return fmt.Errorf("failed to decrypt \"%s\": incorrect passphrase or key", srcPath)
+			return fmt.Errorf("failed to decrypt %s: incorrect passphrase or key", quotePath(srcPath))
 		}
-		return fmt.Errorf("decrypting \"%s\": %w", srcPath, err)
+		return fmt.Errorf("decrypting %s: %w", quotePath(srcPath), err)
 	}
 
 	dst, _, commit, err := createLike(dstPath, src)

--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -473,15 +473,16 @@ func extractTarGz(tarGzPath, destDir string) error {
 		// independent check before target is ever used in a filesystem
 		// operation below.
 		//
-		// path.IsAbs(hdr.Name) (checked on the raw, always-forward-slash tar
-		// name, before filepath.Clean rewrites it with the host separator) is
-		// deliberately in addition to filepath.IsAbs(cleanedName): a tar entry
-		// like "/etc/passwd" is unambiguously absolute by the tar format's own
-		// (Unix, forward-slash) convention, but filepath.IsAbs on Windows
-		// requires a drive letter or UNC prefix and doesn't consider a bare
-		// leading "/" absolute — so without this check that entry would slip
-		// past filepath.IsAbs and get silently remapped to destDir/etc/passwd
-		// instead of rejected.
+		// path.IsAbs(hdr.Name) is checked in addition to
+		// filepath.IsAbs(cleanedName), on the raw tar name rather than the
+		// host-Clean'd one: tar entry names are always forward-slash by the
+		// format's own convention, regardless of the host OS extracting them,
+		// so a name like "/etc/passwd" must be judged absolute by that
+		// convention — not by whatever the host platform's own absolute-path
+		// rule happens to require (e.g. a drive letter). Without this check,
+		// an entry judged non-absolute by host rules alone could slip past
+		// and get silently remapped under destDir instead of rejected
+		// (caught by TestExtractTarGz_PathTraversalRejected on Windows CI).
 		cleanedName := filepath.Clean(hdr.Name)
 		if cleanedName == ".." || strings.HasPrefix(cleanedName, ".."+string(filepath.Separator)) || filepath.IsAbs(cleanedName) || path.IsAbs(hdr.Name) {
 			continue

--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -471,8 +472,18 @@ func extractTarGz(tarGzPath, destDir string) error {
 		// re-verifies containment on the joined result as a second,
 		// independent check before target is ever used in a filesystem
 		// operation below.
+		//
+		// path.IsAbs(hdr.Name) (checked on the raw, always-forward-slash tar
+		// name, before filepath.Clean rewrites it with the host separator) is
+		// deliberately in addition to filepath.IsAbs(cleanedName): a tar entry
+		// like "/etc/passwd" is unambiguously absolute by the tar format's own
+		// (Unix, forward-slash) convention, but filepath.IsAbs on Windows
+		// requires a drive letter or UNC prefix and doesn't consider a bare
+		// leading "/" absolute — so without this check that entry would slip
+		// past filepath.IsAbs and get silently remapped to destDir/etc/passwd
+		// instead of rejected.
 		cleanedName := filepath.Clean(hdr.Name)
-		if cleanedName == ".." || strings.HasPrefix(cleanedName, ".."+string(filepath.Separator)) || filepath.IsAbs(cleanedName) {
+		if cleanedName == ".." || strings.HasPrefix(cleanedName, ".."+string(filepath.Separator)) || filepath.IsAbs(cleanedName) || path.IsAbs(hdr.Name) {
 			continue
 		}
 		target := filepath.Join(cleanDestDir, cleanedName)


### PR DESCRIPTION
## Summary
- Every job across `ci.yml`, `e2e.yml`, `conformance.yml`, and `bench.yml` runs on `ubuntu-latest`, but `.goreleaser.yaml` ships `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64` binaries — none of which has ever had a test executed against it.
- Added a matrix (`fail-fast: false`, so one OS's failure doesn't hide the others) to the `test` job: `ubuntu-latest`, `macos-latest`, `windows-latest`. E2E/conformance/bench stay Linux-only — those need a real KinD cluster and aren't part of the shipped binary matrix.

Closes #226

## Why this branch also touches internal/archive and internal/k8sbin

Turning on the Windows leg immediately found three real, pre-existing bugs — this is exactly what #226 was for. Rather than land those fixes silently inside this PR, each is its own focused PR with its own description and rationale:

- **#292** — zip entry names built with `filepath.Join` instead of `path.Join` (archives written on Windows were physically unreadable on any OS), plus `%q` doubling every backslash in path-valued error messages.
- **#293** — `extractTarGz`'s Zip Slip guard didn't reject a tar entry with a leading `/` on Windows, since `filepath.IsAbs` there requires a drive letter/UNC prefix.

Those two commits are cherry-picked onto **this** branch too, purely so this PR's own `windows-latest` CI leg could verify the fixes end-to-end before either of those PRs merged (confirmed: full green, 7m55s). Once #292 and #293 merge, this branch will be rebased onto `main` — the cherry-picked commits will already be present there and drop out on their own, leaving this PR as the CI-matrix change alone, as originally scoped.

## Test plan
- [x] Full local gate on this machine (darwin/arm64, a stand-in for the macos-latest leg): `gofmt -l .`, `go build ./...`, `go vet ./...`, `go mod tidy` (no diff), `go test -race ./...` — all green
- [x] This branch's own `windows-latest` CI run: full green (7m55s) with #292 and #293's fixes included
- [ ] After #292/#293 merge: rebase this branch onto `main` so its diff returns to just the CI-matrix change

🤖 Generated with [Claude Code](https://claude.com/claude-code)