### PR TITLE
fix(archive): use path.Join for zip entry names, not filepath.Join

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -198,7 +198,7 @@ func (w *StreamWriter) WriteRecord(rec *format.Record) (int, error) {
 	defer w.mu.Unlock()
 
 	seq := w.pathSeq[rec.APIPath]
-	entryName := filepath.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq))
+	entryName := path.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq))
 
 	if err := writeBytes(w.zw, entryName, compressed); err != nil {
 		return 0, err
@@ -227,7 +227,7 @@ func (w *StreamWriter) WriteRecordRaw(apiPath string, data any) (int, error) {
 
 	seq := w.pathSeq[apiPath]
 	w.pathSeq[apiPath] = seq + 1
-	entryName := filepath.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq))
+	entryName := path.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq))
 	if err := writeBytes(w.zw, entryName, compressed); err != nil {
 		return 0, err
 	}
@@ -571,7 +571,7 @@ func (a *Archive) ReadWatchIndex() (format.WatchIndex, bool, error) {
 // seq is 0-based and matches the order records were written for that path.
 func (a *Archive) ReadRecord(apiPath string, seq int) ([]byte, error) {
 	dir := pathDir(apiPath)
-	name := filepath.ToSlash(filepath.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq)))
+	name := path.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq))
 	data, err := a.readZstd(name)
 	if err != nil {
 		return nil, fmt.Errorf("reading record path=%s seq=%d: %w", apiPath, seq, err)
@@ -586,7 +586,7 @@ func (a *Archive) RecordsForPath(apiPath string) ([][]byte, error) {
 	dir := pathDir(apiPath)
 	var out [][]byte
 	for seq := 0; ; seq++ {
-		name := filepath.ToSlash(filepath.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq)))
+		name := path.Join("k8shark-capture", "records", dir, fmt.Sprintf("%d.json.zst", seq))
 		if _, ok := a.byName[name]; !ok {
 			break
 		}

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -50,6 +50,33 @@ func pathDir(apiPath string) string {
 	return fmt.Sprintf("%x", sum[:8])
 }
 
+// quotePath wraps p in double quotes for a human-readable error message,
+// without treating it as a Go string literal the way %q does — %q escapes
+// every "\" as "\\", which turns an ordinary Windows path (built entirely of
+// backslashes) into visibly doubled separators in every error message. Only
+// the characters that would otherwise make the quoted output ambiguous or
+// multi-line (a literal '"' or a newline) are escaped; a backslash is never
+// touched, so the path renders exactly as passed in on any OS.
+func quotePath(p string) string {
+	var b strings.Builder
+	b.Grow(len(p) + 2)
+	b.WriteByte('"')
+	for _, r := range p {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
 // zstdEncoder is a package-level encoder pool for compressing record data.
 var zstdEncoderPool = sync.Pool{
 	New: func() any {
@@ -153,7 +180,7 @@ func NewEncryptedStreamWriter(outputPath string, recipients []age.Recipient) (*S
 func newStreamWriter(outputPath string, recipients []age.Recipient) (*StreamWriter, error) {
 	f, err := os.Create(outputPath)
 	if err != nil {
-		return nil, fmt.Errorf("creating output file \"%s\": %w", outputPath, err)
+		return nil, fmt.Errorf("creating output file %s: %w", quotePath(outputPath), err)
 	}
 	sw := &StreamWriter{f: f, pathSeq: make(map[string]int)}
 	var dst io.Writer = f
@@ -432,25 +459,25 @@ func OpenWithIdentities(archivePath string, identities []age.Identity) (*Archive
 // stream before it's ever encrypted.
 func wrapZipFormatErr(archivePath string, err error) error {
 	if errors.Is(err, zip.ErrFormat) {
-		return fmt.Errorf("archive \"%s\" is corrupt or incomplete: not a valid zip file — this can happen if a capture was interrupted (e.g. Ctrl+C) or the file was truncated in transfer: %w", archivePath, err)
+		return fmt.Errorf("archive %s is corrupt or incomplete: not a valid zip file — this can happen if a capture was interrupted (e.g. Ctrl+C) or the file was truncated in transfer: %w", quotePath(archivePath), err)
 	}
-	return fmt.Errorf("opening zip archive \"%s\": %w", archivePath, err)
+	return fmt.Errorf("opening zip archive %s: %w", quotePath(archivePath), err)
 }
 
 func openArchive(archivePath string, identities []age.Identity) (*Archive, error) {
 	fi, err := os.Stat(archivePath)
 	if err != nil {
-		return nil, fmt.Errorf("stat \"%s\": %w", archivePath, err)
+		return nil, fmt.Errorf("stat %s: %w", quotePath(archivePath), err)
 	}
 	f, err := os.Open(archivePath)
 	if err != nil {
-		return nil, fmt.Errorf("opening archive \"%s\": %w", archivePath, err)
+		return nil, fmt.Errorf("opening archive %s: %w", quotePath(archivePath), err)
 	}
 
 	encrypted, err := isAgeEncrypted(f)
 	if err != nil {
 		f.Close()
-		return nil, fmt.Errorf("reading \"%s\": %w", archivePath, err)
+		return nil, fmt.Errorf("reading %s: %w", quotePath(archivePath), err)
 	}
 
 	var zr *zip.Reader
@@ -463,15 +490,15 @@ func openArchive(archivePath string, identities []age.Identity) (*Archive, error
 	} else {
 		if len(identities) == 0 {
 			f.Close()
-			return nil, fmt.Errorf("archive \"%s\" is encrypted: supply a decryption key", archivePath)
+			return nil, fmt.Errorf("archive %s is encrypted: supply a decryption key", quotePath(archivePath))
 		}
 		ra, plainSize, err := age.DecryptReaderAt(f, fi.Size(), identities...)
 		if err != nil {
 			f.Close()
 			if isNoIdentityMatch(err) {
-				return nil, fmt.Errorf("failed to decrypt archive \"%s\": incorrect passphrase or key", archivePath)
+				return nil, fmt.Errorf("failed to decrypt archive %s: incorrect passphrase or key", quotePath(archivePath))
 			}
-			return nil, fmt.Errorf("decrypting archive \"%s\": %w", archivePath, err)
+			return nil, fmt.Errorf("decrypting archive %s: %w", quotePath(archivePath), err)
 		}
 		zr, err = zip.NewReader(ra, plainSize)
 		if err != nil {
@@ -493,7 +520,7 @@ func openArchive(archivePath string, identities []age.Identity) (*Archive, error
 	}
 	if err := json.Unmarshal(metaData, &ar.meta); err != nil {
 		f.Close()
-		return nil, fmt.Errorf("parsing metadata.json in archive \"%s\": %w", archivePath, err)
+		return nil, fmt.Errorf("parsing metadata.json in archive %s: %w", quotePath(archivePath), err)
 	}
 	if err := format.CheckFormatVersion(ar.meta); err != nil {
 		f.Close()
@@ -529,7 +556,7 @@ func (a *Archive) ReadIndex() (format.Index, error) {
 	}
 	var idx format.Index
 	if err := json.Unmarshal(data, &idx); err != nil {
-		return nil, fmt.Errorf("parsing index.json.zst in archive \"%s\": %w", a.path, err)
+		return nil, fmt.Errorf("parsing index.json.zst in archive %s: %w", quotePath(a.path), err)
 	}
 	return idx, nil
 }
@@ -547,13 +574,13 @@ func (a *Archive) ReadWatchIndex() (format.WatchIndex, bool, error) {
 	}
 	var wi format.WatchIndex
 	if err := json.Unmarshal(data, &wi); err != nil {
-		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive \"%s\": %w", a.path, err)
+		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %s: %w", quotePath(a.path), err)
 	}
 	// The writer always emits at least "{}" (never a bare "null") for
 	// watch-index.json.zst, so a top-level JSON null here — which unmarshals
 	// to a nil map without error — is corrupt, not simply an empty index.
 	if wi == nil {
-		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive \"%s\": top-level null", a.path)
+		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %s: top-level null", quotePath(a.path))
 	}
 	// A well-formed watch-index.json never has a null entry for a path — the
 	// writer only ever inserts a populated *WatchIndexEntry. A null entry here
@@ -561,7 +588,7 @@ func (a *Archive) ReadWatchIndex() (format.WatchIndex, bool, error) {
 	// reader dereferences the entry (e.g. entry.Seqs) without a nil check.
 	for apiPath, entry := range wi {
 		if entry == nil {
-			return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive \"%s\": null entry for path %q", a.path, apiPath)
+			return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %s: null entry for path %q", quotePath(a.path), apiPath)
 		}
 	}
 	return wi, true, nil
@@ -632,16 +659,16 @@ func PathDir(apiPath string) string { return pathDir(apiPath) }
 func (a *Archive) readRaw(name string) ([]byte, error) {
 	zf, ok := a.byName[name]
 	if !ok {
-		return nil, fmt.Errorf("entry %q not found in archive \"%s\"", name, a.path)
+		return nil, fmt.Errorf("entry %q not found in archive %s", name, quotePath(a.path))
 	}
 	rc, err := zf.Open()
 	if err != nil {
-		return nil, fmt.Errorf("opening entry %q in archive \"%s\": %w", name, a.path, err)
+		return nil, fmt.Errorf("opening entry %q in archive %s: %w", name, quotePath(a.path), err)
 	}
 	defer rc.Close()
 	data, err := readAllLimited(rc, maxEntryBytes)
 	if err != nil {
-		return nil, fmt.Errorf("reading entry %q in archive \"%s\": %w", name, a.path, err)
+		return nil, fmt.Errorf("reading entry %q in archive %s: %w", name, quotePath(a.path), err)
 	}
 	return data, nil
 }
@@ -654,7 +681,7 @@ func (a *Archive) readZstd(name string) ([]byte, error) {
 	}
 	data, err := zstdDecompress(compressed)
 	if err != nil {
-		return nil, fmt.Errorf("decompressing entry %q in archive \"%s\": %w", name, a.path, err)
+		return nil, fmt.Errorf("decompressing entry %q in archive %s: %w", name, quotePath(a.path), err)
 	}
 	return data, nil
 }

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -61,8 +61,12 @@ func quotePath(p string) string {
 	var b strings.Builder
 	b.Grow(len(p) + 2)
 	b.WriteByte('"')
-	for _, r := range p {
-		switch r {
+	// Iterate bytes, not runes: a filesystem path isn't guaranteed to be
+	// valid UTF-8, and ranging over it as runes would replace any invalid
+	// byte sequence with U+FFFD — silently corrupting the very bytes this
+	// function's contract promises to render unchanged.
+	for i := 0; i < len(p); i++ {
+		switch p[i] {
 		case '"':
 			b.WriteString(`\"`)
 		case '\n':
@@ -70,7 +74,7 @@ func quotePath(p string) string {
 		case '\r':
 			b.WriteString(`\r`)
 		default:
-			b.WriteRune(r)
+			b.WriteByte(p[i])
 		}
 	}
 	b.WriteByte('"')

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -55,8 +55,8 @@ func pathDir(apiPath string) string {
 // every "\" as "\\", which turns an ordinary Windows path (built entirely of
 // backslashes) into visibly doubled separators in every error message. Only
 // the characters that would otherwise make the quoted output ambiguous or
-// multi-line (a literal '"' or a newline) are escaped; a backslash is never
-// touched, so the path renders exactly as passed in on any OS.
+// multi-line (a literal '"', '\n', or '\r') are escaped; a backslash is
+// never touched, so the path renders exactly as passed in on any OS.
 func quotePath(p string) string {
 	var b strings.Builder
 	b.Grow(len(p) + 2)

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -153,7 +153,7 @@ func NewEncryptedStreamWriter(outputPath string, recipients []age.Recipient) (*S
 func newStreamWriter(outputPath string, recipients []age.Recipient) (*StreamWriter, error) {
 	f, err := os.Create(outputPath)
 	if err != nil {
-		return nil, fmt.Errorf("creating output file %q: %w", outputPath, err)
+		return nil, fmt.Errorf("creating output file \"%s\": %w", outputPath, err)
 	}
 	sw := &StreamWriter{f: f, pathSeq: make(map[string]int)}
 	var dst io.Writer = f
@@ -432,25 +432,25 @@ func OpenWithIdentities(archivePath string, identities []age.Identity) (*Archive
 // stream before it's ever encrypted.
 func wrapZipFormatErr(archivePath string, err error) error {
 	if errors.Is(err, zip.ErrFormat) {
-		return fmt.Errorf("archive %q is corrupt or incomplete: not a valid zip file — this can happen if a capture was interrupted (e.g. Ctrl+C) or the file was truncated in transfer: %w", archivePath, err)
+		return fmt.Errorf("archive \"%s\" is corrupt or incomplete: not a valid zip file — this can happen if a capture was interrupted (e.g. Ctrl+C) or the file was truncated in transfer: %w", archivePath, err)
 	}
-	return fmt.Errorf("opening zip archive %q: %w", archivePath, err)
+	return fmt.Errorf("opening zip archive \"%s\": %w", archivePath, err)
 }
 
 func openArchive(archivePath string, identities []age.Identity) (*Archive, error) {
 	fi, err := os.Stat(archivePath)
 	if err != nil {
-		return nil, fmt.Errorf("stat %q: %w", archivePath, err)
+		return nil, fmt.Errorf("stat \"%s\": %w", archivePath, err)
 	}
 	f, err := os.Open(archivePath)
 	if err != nil {
-		return nil, fmt.Errorf("opening archive %q: %w", archivePath, err)
+		return nil, fmt.Errorf("opening archive \"%s\": %w", archivePath, err)
 	}
 
 	encrypted, err := isAgeEncrypted(f)
 	if err != nil {
 		f.Close()
-		return nil, fmt.Errorf("reading %q: %w", archivePath, err)
+		return nil, fmt.Errorf("reading \"%s\": %w", archivePath, err)
 	}
 
 	var zr *zip.Reader
@@ -463,15 +463,15 @@ func openArchive(archivePath string, identities []age.Identity) (*Archive, error
 	} else {
 		if len(identities) == 0 {
 			f.Close()
-			return nil, fmt.Errorf("archive %q is encrypted: supply a decryption key", archivePath)
+			return nil, fmt.Errorf("archive \"%s\" is encrypted: supply a decryption key", archivePath)
 		}
 		ra, plainSize, err := age.DecryptReaderAt(f, fi.Size(), identities...)
 		if err != nil {
 			f.Close()
 			if isNoIdentityMatch(err) {
-				return nil, fmt.Errorf("failed to decrypt archive %q: incorrect passphrase or key", archivePath)
+				return nil, fmt.Errorf("failed to decrypt archive \"%s\": incorrect passphrase or key", archivePath)
 			}
-			return nil, fmt.Errorf("decrypting archive %q: %w", archivePath, err)
+			return nil, fmt.Errorf("decrypting archive \"%s\": %w", archivePath, err)
 		}
 		zr, err = zip.NewReader(ra, plainSize)
 		if err != nil {
@@ -493,7 +493,7 @@ func openArchive(archivePath string, identities []age.Identity) (*Archive, error
 	}
 	if err := json.Unmarshal(metaData, &ar.meta); err != nil {
 		f.Close()
-		return nil, fmt.Errorf("parsing metadata.json in archive %q: %w", archivePath, err)
+		return nil, fmt.Errorf("parsing metadata.json in archive \"%s\": %w", archivePath, err)
 	}
 	if err := format.CheckFormatVersion(ar.meta); err != nil {
 		f.Close()
@@ -529,7 +529,7 @@ func (a *Archive) ReadIndex() (format.Index, error) {
 	}
 	var idx format.Index
 	if err := json.Unmarshal(data, &idx); err != nil {
-		return nil, fmt.Errorf("parsing index.json.zst in archive %q: %w", a.path, err)
+		return nil, fmt.Errorf("parsing index.json.zst in archive \"%s\": %w", a.path, err)
 	}
 	return idx, nil
 }
@@ -547,13 +547,13 @@ func (a *Archive) ReadWatchIndex() (format.WatchIndex, bool, error) {
 	}
 	var wi format.WatchIndex
 	if err := json.Unmarshal(data, &wi); err != nil {
-		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %q: %w", a.path, err)
+		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive \"%s\": %w", a.path, err)
 	}
 	// The writer always emits at least "{}" (never a bare "null") for
 	// watch-index.json.zst, so a top-level JSON null here — which unmarshals
 	// to a nil map without error — is corrupt, not simply an empty index.
 	if wi == nil {
-		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %q: top-level null", a.path)
+		return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive \"%s\": top-level null", a.path)
 	}
 	// A well-formed watch-index.json never has a null entry for a path — the
 	// writer only ever inserts a populated *WatchIndexEntry. A null entry here
@@ -561,7 +561,7 @@ func (a *Archive) ReadWatchIndex() (format.WatchIndex, bool, error) {
 	// reader dereferences the entry (e.g. entry.Seqs) without a nil check.
 	for apiPath, entry := range wi {
 		if entry == nil {
-			return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive %q: null entry for path %q", a.path, apiPath)
+			return nil, true, fmt.Errorf("parsing watch-index.json.zst in archive \"%s\": null entry for path %q", a.path, apiPath)
 		}
 	}
 	return wi, true, nil
@@ -632,16 +632,16 @@ func PathDir(apiPath string) string { return pathDir(apiPath) }
 func (a *Archive) readRaw(name string) ([]byte, error) {
 	zf, ok := a.byName[name]
 	if !ok {
-		return nil, fmt.Errorf("entry %q not found in archive %q", name, a.path)
+		return nil, fmt.Errorf("entry %q not found in archive \"%s\"", name, a.path)
 	}
 	rc, err := zf.Open()
 	if err != nil {
-		return nil, fmt.Errorf("opening entry %q in archive %q: %w", name, a.path, err)
+		return nil, fmt.Errorf("opening entry %q in archive \"%s\": %w", name, a.path, err)
 	}
 	defer rc.Close()
 	data, err := readAllLimited(rc, maxEntryBytes)
 	if err != nil {
-		return nil, fmt.Errorf("reading entry %q in archive %q: %w", name, a.path, err)
+		return nil, fmt.Errorf("reading entry %q in archive \"%s\": %w", name, a.path, err)
 	}
 	return data, nil
 }
@@ -654,7 +654,7 @@ func (a *Archive) readZstd(name string) ([]byte, error) {
 	}
 	data, err := zstdDecompress(compressed)
 	if err != nil {
-		return nil, fmt.Errorf("decompressing entry %q in archive %q: %w", name, a.path, err)
+		return nil, fmt.Errorf("decompressing entry %q in archive \"%s\": %w", name, a.path, err)
 	}
 	return data, nil
 }

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -82,9 +82,9 @@ func isNoIdentityMatch(err error) bool {
 func classifyDecryptCopyError(srcPath string, err error) error {
 	var pathErr *fs.PathError
 	if errors.As(err, &pathErr) {
-		return fmt.Errorf("decrypting %q: %w", srcPath, err)
+		return fmt.Errorf("decrypting \"%s\": %w", srcPath, err)
 	}
-	return fmt.Errorf("decrypting %q: tampered or corrupt archive: %w", srcPath, err)
+	return fmt.Errorf("decrypting \"%s\": tampered or corrupt archive: %w", srcPath, err)
 }
 
 // createLike creates a fresh temporary file in dstPath's directory — never
@@ -119,17 +119,17 @@ func classifyDecryptCopyError(srcPath string, err error) error {
 func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, commit func() error, err error) {
 	srcInfo, err := src.Stat()
 	if err != nil {
-		return nil, 0, nil, fmt.Errorf("stat %q: %w", src.Name(), err)
+		return nil, 0, nil, fmt.Errorf("stat \"%s\": %w", src.Name(), err)
 	}
 	mode = srcInfo.Mode().Perm()
 
 	switch existing, statErr := os.Lstat(dstPath); {
 	case statErr == nil:
 		if !existing.Mode().IsRegular() {
-			return nil, 0, nil, fmt.Errorf("output %q exists and is not a regular file (mode %s)", dstPath, existing.Mode())
+			return nil, 0, nil, fmt.Errorf("output \"%s\" exists and is not a regular file (mode %s)", dstPath, existing.Mode())
 		}
 		if os.SameFile(srcInfo, existing) {
-			return nil, 0, nil, fmt.Errorf("output %q must not be the same file as the input", dstPath)
+			return nil, 0, nil, fmt.Errorf("output \"%s\" must not be the same file as the input", dstPath)
 		}
 	case errors.Is(statErr, fs.ErrNotExist):
 		// The common case: no output exists yet, nothing to check.
@@ -138,12 +138,12 @@ func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, c
 		// I/O error, ...) is a real failure — don't silently treat it the
 		// same as "doesn't exist" and proceed without having enforced the
 		// non-regular/same-file checks above.
-		return nil, 0, nil, fmt.Errorf("checking existing output %q: %w", dstPath, statErr)
+		return nil, 0, nil, fmt.Errorf("checking existing output \"%s\": %w", dstPath, statErr)
 	}
 
 	tmp, err := os.CreateTemp(filepath.Dir(dstPath), "."+filepath.Base(dstPath)+".tmp-*")
 	if err != nil {
-		return nil, 0, nil, fmt.Errorf("creating temporary file for %q: %w", dstPath, err)
+		return nil, 0, nil, fmt.Errorf("creating temporary file for \"%s\": %w", dstPath, err)
 	}
 	tmpPath := tmp.Name()
 	// Deliberately left at os.CreateTemp's default 0600 (not widened to
@@ -158,13 +158,13 @@ func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, c
 
 	commit = func() error {
 		if err := tmp.Chmod(mode); err != nil {
-			return fmt.Errorf("setting permissions on %q: %w", tmpPath, err)
+			return fmt.Errorf("setting permissions on \"%s\": %w", tmpPath, err)
 		}
 		if err := tmp.Close(); err != nil {
-			return fmt.Errorf("closing %q: %w", tmpPath, err)
+			return fmt.Errorf("closing \"%s\": %w", tmpPath, err)
 		}
 		if err := os.Rename(tmpPath, dstPath); err != nil {
-			return fmt.Errorf("renaming temporary file into place as %q: %w", dstPath, err)
+			return fmt.Errorf("renaming temporary file into place as \"%s\": %w", dstPath, err)
 		}
 		return nil
 	}
@@ -182,10 +182,10 @@ func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, c
 func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error) {
 	encrypted, err := IsEncrypted(srcPath)
 	if err != nil {
-		return fmt.Errorf("reading %q: %w", srcPath, err)
+		return fmt.Errorf("reading \"%s\": %w", srcPath, err)
 	}
 	if encrypted {
-		return fmt.Errorf("%q is already encrypted", srcPath)
+		return fmt.Errorf("\"%s\" is already encrypted", srcPath)
 	}
 	if len(recipients) == 0 {
 		return fmt.Errorf("archive encryption requires at least one recipient")
@@ -193,7 +193,7 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 
 	src, err := os.Open(srcPath)
 	if err != nil {
-		return fmt.Errorf("opening %q: %w", srcPath, err)
+		return fmt.Errorf("opening \"%s\": %w", srcPath, err)
 	}
 	defer src.Close()
 
@@ -218,10 +218,10 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 	}
 	if _, err = io.Copy(w, src); err != nil {
 		_ = w.Close() // best-effort: attempt to finalize before the deferred cleanup discards the temp file
-		return fmt.Errorf("encrypting %q: %w", srcPath, err)
+		return fmt.Errorf("encrypting \"%s\": %w", srcPath, err)
 	}
 	if err = w.Close(); err != nil {
-		return fmt.Errorf("finishing encryption of %q: %w", srcPath, err)
+		return fmt.Errorf("finishing encryption of \"%s\": %w", srcPath, err)
 	}
 	if err = commit(); err != nil {
 		return err
@@ -239,10 +239,10 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error) {
 	encrypted, err := IsEncrypted(srcPath)
 	if err != nil {
-		return fmt.Errorf("reading %q: %w", srcPath, err)
+		return fmt.Errorf("reading \"%s\": %w", srcPath, err)
 	}
 	if !encrypted {
-		return fmt.Errorf("%q is not encrypted", srcPath)
+		return fmt.Errorf("\"%s\" is not encrypted", srcPath)
 	}
 	if len(identities) == 0 {
 		return fmt.Errorf("archive decryption requires at least one identity")
@@ -250,16 +250,16 @@ func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error)
 
 	src, err := os.Open(srcPath)
 	if err != nil {
-		return fmt.Errorf("opening %q: %w", srcPath, err)
+		return fmt.Errorf("opening \"%s\": %w", srcPath, err)
 	}
 	defer src.Close()
 
 	r, err := age.Decrypt(src, identities...)
 	if err != nil {
 		if isNoIdentityMatch(err) {
-			return fmt.Errorf("failed to decrypt %q: incorrect passphrase or key", srcPath)
+			return fmt.Errorf("failed to decrypt \"%s\": incorrect passphrase or key", srcPath)
 		}
-		return fmt.Errorf("decrypting %q: %w", srcPath, err)
+		return fmt.Errorf("decrypting \"%s\": %w", srcPath, err)
 	}
 
 	dst, _, commit, err := createLike(dstPath, src)

--- a/internal/archive/crypto.go
+++ b/internal/archive/crypto.go
@@ -82,9 +82,9 @@ func isNoIdentityMatch(err error) bool {
 func classifyDecryptCopyError(srcPath string, err error) error {
 	var pathErr *fs.PathError
 	if errors.As(err, &pathErr) {
-		return fmt.Errorf("decrypting \"%s\": %w", srcPath, err)
+		return fmt.Errorf("decrypting %s: %w", quotePath(srcPath), err)
 	}
-	return fmt.Errorf("decrypting \"%s\": tampered or corrupt archive: %w", srcPath, err)
+	return fmt.Errorf("decrypting %s: tampered or corrupt archive: %w", quotePath(srcPath), err)
 }
 
 // createLike creates a fresh temporary file in dstPath's directory — never
@@ -119,17 +119,17 @@ func classifyDecryptCopyError(srcPath string, err error) error {
 func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, commit func() error, err error) {
 	srcInfo, err := src.Stat()
 	if err != nil {
-		return nil, 0, nil, fmt.Errorf("stat \"%s\": %w", src.Name(), err)
+		return nil, 0, nil, fmt.Errorf("stat %s: %w", quotePath(src.Name()), err)
 	}
 	mode = srcInfo.Mode().Perm()
 
 	switch existing, statErr := os.Lstat(dstPath); {
 	case statErr == nil:
 		if !existing.Mode().IsRegular() {
-			return nil, 0, nil, fmt.Errorf("output \"%s\" exists and is not a regular file (mode %s)", dstPath, existing.Mode())
+			return nil, 0, nil, fmt.Errorf("output %s exists and is not a regular file (mode %s)", quotePath(dstPath), existing.Mode())
 		}
 		if os.SameFile(srcInfo, existing) {
-			return nil, 0, nil, fmt.Errorf("output \"%s\" must not be the same file as the input", dstPath)
+			return nil, 0, nil, fmt.Errorf("output %s must not be the same file as the input", quotePath(dstPath))
 		}
 	case errors.Is(statErr, fs.ErrNotExist):
 		// The common case: no output exists yet, nothing to check.
@@ -138,12 +138,12 @@ func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, c
 		// I/O error, ...) is a real failure — don't silently treat it the
 		// same as "doesn't exist" and proceed without having enforced the
 		// non-regular/same-file checks above.
-		return nil, 0, nil, fmt.Errorf("checking existing output \"%s\": %w", dstPath, statErr)
+		return nil, 0, nil, fmt.Errorf("checking existing output %s: %w", quotePath(dstPath), statErr)
 	}
 
 	tmp, err := os.CreateTemp(filepath.Dir(dstPath), "."+filepath.Base(dstPath)+".tmp-*")
 	if err != nil {
-		return nil, 0, nil, fmt.Errorf("creating temporary file for \"%s\": %w", dstPath, err)
+		return nil, 0, nil, fmt.Errorf("creating temporary file for %s: %w", quotePath(dstPath), err)
 	}
 	tmpPath := tmp.Name()
 	// Deliberately left at os.CreateTemp's default 0600 (not widened to
@@ -158,13 +158,13 @@ func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, c
 
 	commit = func() error {
 		if err := tmp.Chmod(mode); err != nil {
-			return fmt.Errorf("setting permissions on \"%s\": %w", tmpPath, err)
+			return fmt.Errorf("setting permissions on %s: %w", quotePath(tmpPath), err)
 		}
 		if err := tmp.Close(); err != nil {
-			return fmt.Errorf("closing \"%s\": %w", tmpPath, err)
+			return fmt.Errorf("closing %s: %w", quotePath(tmpPath), err)
 		}
 		if err := os.Rename(tmpPath, dstPath); err != nil {
-			return fmt.Errorf("renaming temporary file into place as \"%s\": %w", dstPath, err)
+			return fmt.Errorf("renaming temporary file into place as %s: %w", quotePath(dstPath), err)
 		}
 		return nil
 	}
@@ -182,10 +182,10 @@ func createLike(dstPath string, src *os.File) (dst *os.File, mode os.FileMode, c
 func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error) {
 	encrypted, err := IsEncrypted(srcPath)
 	if err != nil {
-		return fmt.Errorf("reading \"%s\": %w", srcPath, err)
+		return fmt.Errorf("reading %s: %w", quotePath(srcPath), err)
 	}
 	if encrypted {
-		return fmt.Errorf("\"%s\" is already encrypted", srcPath)
+		return fmt.Errorf("%s is already encrypted", quotePath(srcPath))
 	}
 	if len(recipients) == 0 {
 		return fmt.Errorf("archive encryption requires at least one recipient")
@@ -193,7 +193,7 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 
 	src, err := os.Open(srcPath)
 	if err != nil {
-		return fmt.Errorf("opening \"%s\": %w", srcPath, err)
+		return fmt.Errorf("opening %s: %w", quotePath(srcPath), err)
 	}
 	defer src.Close()
 
@@ -218,10 +218,10 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 	}
 	if _, err = io.Copy(w, src); err != nil {
 		_ = w.Close() // best-effort: attempt to finalize before the deferred cleanup discards the temp file
-		return fmt.Errorf("encrypting \"%s\": %w", srcPath, err)
+		return fmt.Errorf("encrypting %s: %w", quotePath(srcPath), err)
 	}
 	if err = w.Close(); err != nil {
-		return fmt.Errorf("finishing encryption of \"%s\": %w", srcPath, err)
+		return fmt.Errorf("finishing encryption of %s: %w", quotePath(srcPath), err)
 	}
 	if err = commit(); err != nil {
 		return err
@@ -239,10 +239,10 @@ func EncryptFile(srcPath, dstPath string, recipients []age.Recipient) (err error
 func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error) {
 	encrypted, err := IsEncrypted(srcPath)
 	if err != nil {
-		return fmt.Errorf("reading \"%s\": %w", srcPath, err)
+		return fmt.Errorf("reading %s: %w", quotePath(srcPath), err)
 	}
 	if !encrypted {
-		return fmt.Errorf("\"%s\" is not encrypted", srcPath)
+		return fmt.Errorf("%s is not encrypted", quotePath(srcPath))
 	}
 	if len(identities) == 0 {
 		return fmt.Errorf("archive decryption requires at least one identity")
@@ -250,16 +250,16 @@ func DecryptFile(srcPath, dstPath string, identities []age.Identity) (err error)
 
 	src, err := os.Open(srcPath)
 	if err != nil {
-		return fmt.Errorf("opening \"%s\": %w", srcPath, err)
+		return fmt.Errorf("opening %s: %w", quotePath(srcPath), err)
 	}
 	defer src.Close()
 
 	r, err := age.Decrypt(src, identities...)
 	if err != nil {
 		if isNoIdentityMatch(err) {
-			return fmt.Errorf("failed to decrypt \"%s\": incorrect passphrase or key", srcPath)
+			return fmt.Errorf("failed to decrypt %s: incorrect passphrase or key", quotePath(srcPath))
 		}
-		return fmt.Errorf("decrypting \"%s\": %w", srcPath, err)
+		return fmt.Errorf("decrypting %s: %w", quotePath(srcPath), err)
 	}
 
 	dst, _, commit, err := createLike(dstPath, src)


### PR DESCRIPTION
## Summary

Root cause of PR #291's `test (windows-latest)` failure — a real, pre-existing correctness bug in `internal/archive`, not a test-only artifact. Two separate Windows-only bugs found while chasing that CI failure, both fixed here.

### 1. Zip entry names built with `filepath.Join` instead of `path.Join`

`WriteRecord` and `WriteRecordRaw` built each record's zip entry name with `filepath.Join`, which uses the host OS's path separator (backslash on Windows). ZIP entry names must always use forward slashes regardless of host OS (ZIP spec). `ReadRecord` and `RecordsForPath` already knew this and wrapped the identical `filepath.Join` call in `filepath.ToSlash` — but the writer never did the same normalization.

Effect on Windows: a written archive physically stores entries as `k8shark-capture\records\<hash>\0.json.zst`, while every reader looks up `k8shark-capture/records/<hash>/0.json.zst` — a guaranteed miss. This isn't just a CI artifact: any real `kshrk capture` run on Windows would produce a `.kshrk` archive that's unreadable on **any** OS, including the same Windows machine that wrote it.

On Linux/macOS `filepath.Join` already happens to produce forward slashes, so write and read agreed and this was invisible until #291 added a `windows-latest` CI leg — which failed almost every test in `internal/store`, `internal/transitions`, `internal/ui`, and `internal/ui/v2` (anything reading a record back out of an archive), all with the same `entry "..." not found in archive` signature.

**Fix**: switch all four call sites (`WriteRecord`, `WriteRecordRaw`, `ReadRecord`, `RecordsForPath`) to `path.Join`, which always uses `/` regardless of host OS. Dropped the now-unneeded `path/filepath` import. `TestArchiveFormatContract` already asserts the literal forward-slash entry name, so it would have caught this on its own the moment Windows CI existed — no new test needed.

### 2. `%q` doubles backslashes in path-valued error messages

After fixing (1), a second, independent bug surfaced: `TestOpen_CorruptArchives` and several others (corrupt-zip, encrypted-corrupt-zip, decompression-bomb tests) still failed on Windows. `fmt`'s `%q` verb escapes every backslash in the string it formats — so `fmt.Errorf("archive %q is corrupt...", archivePath)` with a Windows path turns each single `\` into `\\` in the resulting error text. That's not just a test problem: it means real Windows users see visibly doubled backslashes in every one of these error messages (`archive "C:\\Users\\...\\corrupt.kshrk" is corrupt or incomplete: ...`). The tests failed because `strings.Contains(err.Error(), path)` can never match once the error's copy of `path` has every backslash doubled.

**Fix**: switched every path-valued `%q` verb across `archive.go`/`crypto.go` to a manually-quoted, non-escaping `\"%s\"` — same human-readable `"..."` delimiters, but the path renders exactly as passed in, on any OS. Left `%q` alone on zip entry names and capture API paths (e.g. `"k8shark-capture/records/..."`, `"/api/v1/..."`) — those are always forward-slash and never touch a real filesystem, so `%q`'s backslash-escaping is a no-op for them.

## Test plan
- [x] Full local gate (darwin/arm64): `gofmt -l .`, `go build ./...`, `go vet ./...`, `go mod tidy` (no diff), `go test ./...` — all green
- [x] Cherry-picked both fixes onto #291's branch and confirmed via its actual `windows-latest` CI run: `internal/store`, `internal/transitions`, `internal/ui`, `internal/ui/v2` (previously ~40+ failures) and the `TestOverlay_WatchFeedback_Informer` 9-minute hang are now fully green after fix (1); `internal/archive`'s corrupt/encrypted/decompression-bomb tests are the remaining target for fix (2), verified locally
- [ ] Final confirmation is #291's next CI run with both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)