### PR TITLE
fix(k8sbin): reject tar entries with a leading "/" on Windows too

### DIFF
--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -473,15 +473,16 @@ func extractTarGz(tarGzPath, destDir string) error {
 		// independent check before target is ever used in a filesystem
 		// operation below.
 		//
-		// path.IsAbs(hdr.Name) (checked on the raw, always-forward-slash tar
-		// name, before filepath.Clean rewrites it with the host separator) is
-		// deliberately in addition to filepath.IsAbs(cleanedName): a tar entry
-		// like "/etc/passwd" is unambiguously absolute by the tar format's own
-		// (Unix, forward-slash) convention, but filepath.IsAbs on Windows
-		// requires a drive letter or UNC prefix and doesn't consider a bare
-		// leading "/" absolute — so without this check that entry would slip
-		// past filepath.IsAbs and get silently remapped to destDir/etc/passwd
-		// instead of rejected.
+		// path.IsAbs(hdr.Name) is checked in addition to
+		// filepath.IsAbs(cleanedName), on the raw tar name rather than the
+		// host-Clean'd one: tar entry names are always forward-slash by the
+		// format's own convention, regardless of the host OS extracting them,
+		// so a name like "/etc/passwd" must be judged absolute by that
+		// convention — not by whatever the host platform's own absolute-path
+		// rule happens to require (e.g. a drive letter). Without this check,
+		// an entry judged non-absolute by host rules alone could slip past
+		// and get silently remapped under destDir instead of rejected
+		// (caught by TestExtractTarGz_PathTraversalRejected on Windows CI).
 		cleanedName := filepath.Clean(hdr.Name)
 		if cleanedName == ".." || strings.HasPrefix(cleanedName, ".."+string(filepath.Separator)) || filepath.IsAbs(cleanedName) || path.IsAbs(hdr.Name) {
 			continue

--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -471,8 +472,18 @@ func extractTarGz(tarGzPath, destDir string) error {
 		// re-verifies containment on the joined result as a second,
 		// independent check before target is ever used in a filesystem
 		// operation below.
+		//
+		// path.IsAbs(hdr.Name) (checked on the raw, always-forward-slash tar
+		// name, before filepath.Clean rewrites it with the host separator) is
+		// deliberately in addition to filepath.IsAbs(cleanedName): a tar entry
+		// like "/etc/passwd" is unambiguously absolute by the tar format's own
+		// (Unix, forward-slash) convention, but filepath.IsAbs on Windows
+		// requires a drive letter or UNC prefix and doesn't consider a bare
+		// leading "/" absolute — so without this check that entry would slip
+		// past filepath.IsAbs and get silently remapped to destDir/etc/passwd
+		// instead of rejected.
 		cleanedName := filepath.Clean(hdr.Name)
-		if cleanedName == ".." || strings.HasPrefix(cleanedName, ".."+string(filepath.Separator)) || filepath.IsAbs(cleanedName) {
+		if cleanedName == ".." || strings.HasPrefix(cleanedName, ".."+string(filepath.Separator)) || filepath.IsAbs(cleanedName) || path.IsAbs(hdr.Name) {
 			continue
 		}
 		target := filepath.Join(cleanDestDir, cleanedName)


### PR DESCRIPTION
## Summary

The last of the Windows-only failures surfaced by #291's new `windows-latest` CI leg — `TestExtractTarGz_PathTraversalRejected//etc/passwd` failed with "entry \"/etc/passwd\" extracted inside destDir = true, want false".

`extractTarGz`'s Zip Slip guard rejects an absolute-looking tar entry name via `filepath.IsAbs(cleanedName)`. But `filepath.IsAbs` on Windows requires a drive letter (`C:\`) or UNC prefix (`\\server\share`) — it doesn't consider a bare leading `/` or `\` absolute. A tar entry named `/etc/passwd` is unambiguously absolute by the tar format's own convention (always forward-slash, Unix-style), but on Windows it slipped past `filepath.IsAbs` and got silently remapped to `destDir/etc/passwd` instead of rejected — a real, CI-caught behavior difference, not just a test artifact.

To be precise: this was never a true Zip-Slip *escape* — `filepath.Join`/`filepath.Rel`'s containment check still kept the write inside `destDir`. But it violates the function's own documented contract (see its doc comment and `TestExtractTarGz_PathTraversalRejected`'s docstring): an absolute path should be **rejected outright, not silently remapped** into destDir.

## Fix

Add `path.IsAbs(hdr.Name)` — checked on the *raw* tar entry name (always forward-slash, before `filepath.Clean` rewrites it using the host separator) — alongside the existing `filepath.IsAbs(cleanedName)` check. `path.IsAbs` only ever looks for a literal leading `/`, so it correctly flags `/etc/passwd` regardless of host OS.

## Test plan
- [x] `go test ./internal/k8sbin/... -run TestExtractTarGz -v` — all 8 `TestExtractTarGz_PathTraversalRejected` subtests plus `TestExtractTarGz` pass, including the previously-failing `/etc/passwd` case
- [x] Full local gate: `gofmt -l .`, `go build ./...`, `go vet ./...`, `go mod tidy` (no diff), `go test ./...`
- [ ] Final confirmation is #291's `windows-latest` CI run with this fix included

🤖 Generated with [Claude Code](https://claude.com/claude-code)