### PR TITLE
docs: add SECURITY.md, CONTRIBUTING.md, and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Something isn't working as documented or expected
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear description of what's wrong.
+
+**To reproduce**
+The exact command(s) that trigger it, and a minimal capture config or
+`.kshrk` archive if relevant (redact anything sensitive first — or mention
+that you can't share the archive and describe its shape instead).
+
+```sh
+kshrk ...
+```
+
+**Expected behavior**
+What you expected to happen instead.
+
+**Actual behavior**
+What actually happened — paste the full output/error, not a summary.
+
+**Environment**
+- k8shark version: `kshrk version`
+- OS/architecture:
+- Installed via: Homebrew / `go install` / built from source
+
+**Additional context**
+Anything else — a link to a relevant capture config, whether this started
+after an upgrade, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Report a security vulnerability
     url: https://github.com/phenixblue/k8shark/security/advisories/new

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/phenixblue/k8shark/security/advisories/new
+    about: Please do not report security vulnerabilities as a public issue — see SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea or improvement for k8shark
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**What problem does this solve?**
+Describe the use case or gap — what are you trying to do that k8shark
+doesn't support today?
+
+**Proposed solution**
+What you'd like to see happen. A rough sketch of the CLI flag / config key /
+behavior is helpful even if you're not sure of the exact shape.
+
+**Alternatives considered**
+Any workarounds you're using now, or other approaches you considered.
+
+**Additional context**
+Anything else — links to related issues, a real-world scenario this came
+from, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- What does this change, and why? -->
+
+Closes #<!-- issue number, if any -->
+
+## Test plan
+
+<!-- How did you verify this? Commands run, tests added, manual steps taken. -->
+
+- [ ] `make fmt` (no diff)
+- [ ] `go test ./...` passes
+- [ ] `make lint-ci` passes (or `go vet ./...` at minimum)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,5 +9,5 @@ Closes #<!-- issue number, if any -->
 <!-- How did you verify this? Commands run, tests added, manual steps taken. -->
 
 - [ ] `make fmt` (no diff)
-- [ ] `go test ./...` passes
-- [ ] `make lint-ci` passes (or `go vet ./...` at minimum)
+- [ ] `make test` passes
+- [ ] `make lint-ci` passes (or `make lint` at minimum)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+Release notes are published on the [GitHub Releases page](https://github.com/phenixblue/k8shark/releases),
+generated from merged pull request titles for each tag. See
+[docs/releases.md](docs/releases.md) for how releases are cut.
+
+This file is intentionally not a duplicate changelog — see the Releases page
+for the authoritative, per-version history.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing
+
+Thanks for considering a contribution to k8shark. This covers the essentials
+to get a change through CI on the first try; see
+[docs/development.md](docs/development.md) for the full dev setup (building,
+the KinD dev cluster, E2E tests, package layout).
+
+## Before you start
+
+For anything beyond a small, obvious fix, please open an issue first to
+discuss the approach — it saves rework on both sides. Check
+[existing issues](https://github.com/phenixblue/k8shark/issues) for
+duplicates.
+
+## Building, testing, linting
+
+```sh
+make build           # compiles ./kshrk
+make test            # go test ./...
+make test-race        # go test -race ./...
+make fmt              # gofmt -w . — run before every push
+make lint             # go vet ./...
+make lint-ci-install   # one-time: install golangci-lint at the pinned version
+make lint-ci           # golangci-lint run, exactly as CI runs it
+```
+
+## The format/tidy contract
+
+CI's `contract` job runs `gofmt -w . && git diff --exit-code` and
+`go mod tidy` with a diff check. **This is the most common cause of red CI.**
+Always run `make fmt` and make sure `go.mod`/`go.sum` are tidy before
+pushing:
+
+```sh
+make fmt
+go mod tidy
+git diff --exit-code go.mod go.sum
+```
+
+## Conventions
+
+- **American English** everywhere — docs, code comments, identifiers,
+  log/error strings, and commit messages (`color`, `behavior`, `canceled`,
+  not `colour`, `behaviour`, `cancelled`).
+- Prefer editing existing files and following the patterns already in the
+  surrounding code over introducing a new style.
+- Comments explain *why*, not *what* — skip a comment if the code already
+  says what it does.
+- Keep pull requests scoped to one logical change; unrelated cleanup makes
+  review harder and the diff riskier to land.
+
+## CI tool versions
+
+Tools installed via `go install` in CI (`golangci-lint`, `govulncheck`) and
+every GitHub Action referenced in `.github/workflows/` are pinned to an
+explicit version (a commit SHA for Actions), never `@latest` or a floating
+major tag — see [CLAUDE.md](CLAUDE.md#ci-tool-versions) for why. Pin any new
+CI tool or Action the same way.
+
+## Commit messages and pull requests
+
+- Write commit messages that explain *why*, not just *what changed* — the
+  diff already shows what changed.
+- Squash-worthy fixup commits are fine locally; keep the final PR history
+  reasonably clean.
+- Make sure `go test ./...` and `make lint-ci` pass locally before opening a
+  PR — CI will run both, but catching it locally is faster.
+- Reference the issue a PR closes with `Closes #123` in the description so it
+  auto-closes on merge.
+
+## Reporting bugs and requesting features
+
+Use the issue templates when opening a new issue — they prompt for the
+information that's actually needed to act on a report (version, repro steps,
+expected vs. actual behavior).
+
+**Security vulnerabilities**: see [SECURITY.md](SECURITY.md) instead of
+opening a public issue.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under
+the project's [Apache License 2.0](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ CI tool or Action the same way.
   diff already shows what changed.
 - Squash-worthy fixup commits are fine locally; keep the final PR history
   reasonably clean.
-- Make sure `go test ./...` and `make lint-ci` pass locally before opening a
+- Make sure `make test` and `make lint-ci` pass locally before opening a
   PR — CI will run both, but catching it locally is faster.
 - Reference the issue a PR closes with `Closes #123` in the description so it
   auto-closes on merge.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+Issues are public by default, and a vulnerability report filed that way
+discloses it to everyone before a fix exists.
+
+Instead, use GitHub's private vulnerability reporting for this repository:
+
+1. Go to the [Security tab](https://github.com/phenixblue/k8shark/security).
+2. Click **Report a vulnerability**.
+3. Describe the issue, affected version(s), and reproduction steps if you
+   have them.
+
+This opens a private draft security advisory visible only to you and the
+maintainers — nothing is public until a fix is ready and you and the
+maintainers agree to disclose.
+
+## What to expect
+
+- **Acknowledgment**: within 5 business days.
+- **Fix timeline**: depends on severity and complexity; we'll share an
+  estimate once the report is triaged.
+- **Credit**: reporters are credited in the published advisory unless they
+  ask not to be.
+
+## Scope
+
+k8shark captures Kubernetes cluster state into a `.kshrk` archive and replays
+it through a local mock API server. Vulnerability reports are especially
+relevant if they involve:
+
+- The archive format or its parsing (`internal/archive`) — a `.kshrk` file is
+  designed to be handed between organizations, so a maliciously crafted
+  archive is a real threat model (decompression bombs, path traversal on
+  extraction, malformed ZIP/JSON handling).
+- Archive encryption (`--encrypt`/`--encrypt-recipient`) — see
+  [docs/encryption-threat-model.md](docs/encryption-threat-model.md) for what
+  it's designed to protect against; a gap relative to that model is a
+  security bug.
+- The mock API server (`internal/server`) — request handling, the writable
+  overlay, or anything that could let a client escape the sandboxed,
+  localhost-only server.
+- Redaction (`internal/redact`) — a redaction rule that fails to remove
+  sensitive data it claims to remove.
+
+## Supported versions
+
+Only the latest released version (including release candidates) receives
+security fixes — see the [backport policy](docs/stability-policy.md#backport--patch-policy).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,5 +47,7 @@ relevant if they involve:
 
 ## Supported versions
 
-Only the latest released version (including release candidates) receives
-security fixes — see the [backport policy](docs/stability-policy.md#backport--patch-policy).
+Only the latest `1.x` minor line (including its release candidates) receives
+security fixes, delivered as a patch release on that line — there are no
+long-term-support branches. See the [backport
+policy](docs/stability-policy.md#backport--patch-policy).


### PR DESCRIPTION
## Summary

The repo had none of the standard community-health files. `SECURITY.md` is the sharpest gap — issues are public (`hasIssuesEnabled: true`), so a vulnerability report filed the obvious way (as a GitHub issue) currently discloses it to everyone before a fix exists.

- **`SECURITY.md`** — points to GitHub's private vulnerability reporting (Security tab → Report a vulnerability), which is already enabled for this repo, so no personal email needs to be published. States a 5-business-day acknowledgment target and the areas most relevant to a report (archive parsing/encryption — a `.kshrk` file is handed between organizations, so a crafted archive is a real threat model — the mock server, redaction).
- **`CONTRIBUTING.md`** — captures the build/test/lint commands and the format/tidy contract that's the most common cause of red CI, both already documented for Claude Code in `CLAUDE.md` and for humans in `docs/development.md`, but never in a `CONTRIBUTING.md` a human contributor would actually look for.
- **Issue templates** — bug report + feature request, plus a `config.yml` routing security reports to the private channel instead of a public issue.
- **PR template** — summary/test-plan skeleton.
- **`CHANGELOG.md`** — a pointer to GitHub Releases rather than a duplicate, hand-maintained log — the "legitimate answer" the issue itself named as an option.

Closes #246

## Test plan
- [x] Verified `.github/ISSUE_TEMPLATE/config.yml` is valid YAML
- [x] Full gate: `gofmt -l .`, `go build ./...`, `go vet ./...`, `go mod tidy` (no diff), `go test ./...` — docs/templates-only change, no Go source touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)