### PR TITLE
docs: add RBAC guide and a compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ flowchart LR
 2. **Open** — `kshrk open capture.kshrk` reads the archive, starts a local mock HTTPS API server, and writes a kubeconfig. Set `KUBECONFIG` and use `kubectl` normally.
 3. **Diagnose** — `kshrk diagnose capture.kshrk` analyzes the capture offline and prints severity-ranked findings (crashing pods, unschedulable workloads, unbound PVCs, version skew, …). Also available in the web UI's Diagnostics tab.
 
+Which Kubernetes/kubectl versions and platforms are supported? See the
+[compatibility matrix](docs/usage.md#compatibility-matrix). Deciding what
+RBAC a capture needs? See the [RBAC guide](docs/rbac.md).
+
 ## Quick start
 
 ```sh
@@ -81,6 +85,7 @@ timeline, and a time-travel scrubber. See **[docs/web-ui.md](docs/web-ui.md)** f
 | [docs/encryption-threat-model.md](docs/encryption-threat-model.md) | What `--encrypt` protects (and doesn't), key-handling rules, passphrase vs. recipient keys |
 | [docs/kwok.md](docs/kwok.md) | Closed-loop controller dev: `--writable` replay driven by KWOK and kube-controller-manager |
 | [docs/conformance.md](docs/conformance.md) | Mock-server conformance methodology and accepted divergences from a real API server |
+| [docs/rbac.md](docs/rbac.md) | What RBAC permissions a capture needs — minimal explicit-resource grant, the broader `all: true` grant, and what a partial-permissions capture looks like |
 
 ## License
 

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -19,8 +19,13 @@ metadata:
   name: k8shark-capture
 rules:
   - apiGroups: [""]
-    resources: ["pods", "pods/log", "services"]
+    resources: ["pods", "services"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    # pods/log is only ever fetched one container at a time via a single GET
+    # (see fetchOnePodLog in internal/capture/engine.go) — never list/watch.
+    resources: ["pods/log"]
+    verbs: ["get"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch"]
@@ -103,9 +108,9 @@ gracefully, because the engine cannot proceed at all without them:
   server.
 - **Namespace discovery** — only when a resource uses a wildcard namespace
   (`namespaces: ['*']`) or `all: true`/`autoDiscover: true` needs to expand
-  namespaces itself; a `403` listing namespaces fails with "namespace
-  discovery failed: check cluster permissions" rather than silently
-  capturing zero namespaces.
+  namespaces itself; a `403` listing namespaces fails with a "namespace
+  discovery failed (HTTP 403): check cluster permissions" error rather than
+  silently capturing zero namespaces.
 
 In short: check `kshrk inspect <archive>` after a capture to confirm every
 resource you expected actually has real data, not a captured `403` — a

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -1,0 +1,113 @@
+# RBAC: what a capture needs
+
+`kshrk capture` is **read-only** — it never creates, updates, or deletes
+anything in the source cluster. Every request it makes is a `GET` (list a
+resource, fetch a pod log) or a `WATCH` (for resources configured with
+`watch: true`). This page states exactly what to grant so a customer (or
+your own security review) can approve a capture without reading source.
+
+## Minimal grant: an explicit resource list
+
+If your capture config lists specific resources (the common case — see
+[docs/config.md](config.md)), grant exactly those, nothing more. For example,
+a config capturing `pods`, `pods/log`, `deployments`, and `services`:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8shark-capture
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "services"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8shark-capture
+subjects:
+  - kind: ServiceAccount
+    name: k8shark-capture
+    namespace: default # wherever the capturing identity lives
+roleRef:
+  kind: ClusterRole
+  name: k8shark-capture
+  apiGroup: rbac.authorization.k8s.io
+```
+
+A `ClusterRole` + `ClusterRoleBinding` is simplest even when every resource in
+the config is scoped to specific `namespaces:` — it avoids managing one
+`Role`/`RoleBinding` pair per namespace. If cluster-wide access to these
+resource *types* is a concern regardless of namespace scoping, use a `Role` +
+`RoleBinding` per target namespace instead; the verbs and resources are the
+same either way.
+
+`watch: true` needs no additional verb beyond `watch` itself — already
+included above.
+
+## Broader grant: `all: true` / `autoDiscover: true`
+
+Full-cluster capture (`resources: [{all: true}]` or the legacy
+`autoDiscover: true`, see [docs/config.md](config.md)) walks every API group
+and resource type the cluster exposes, so it needs read access to
+effectively everything:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8shark-capture-all
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  # Discovery/OpenAPI endpoints (/api, /apis, /openapi/*, /version) are
+  # non-resource URLs — only expressible in a ClusterRole, never a Role.
+  # Most clusters already grant these to every authenticated user via the
+  # built-in system:discovery ClusterRole; include this rule explicitly if
+  # your cluster has that default binding removed.
+  - nonResourceURLs: ["/api", "/api/*", "/apis", "/apis/*", "/openapi/*", "/version"]
+    verbs: ["get"]
+```
+
+This is the access level to scrutinize hardest in a security review: it's
+read-only, but it's read-only *everything*, including Secrets (capture
+records Secret `data`/`stringData` unless you also pass `--redact-secrets` or
+configure [redaction rules](config.md#redaction)). If the concern is
+specifically Secrets rather than the read-only breadth itself, redacting at
+capture time is the better answer than narrowing RBAC — a `ClusterRole` that
+excludes `secrets` still lets discovery enumerate them (list/watch would just
+403), which produces confusing partial results (see below) rather than a
+clean exclusion.
+
+## What partial RBAC failures look like
+
+A capture doesn't abort just because one resource type is forbidden.
+Per-resource fetches record whatever the API server actually returned —
+including a `403` — and the capture continues with everything else. On
+replay, `kubectl get <that-resource>` against the mock server returns the
+same `403` it would have during the real capture; `kshrk inspect` lists the
+resource with its captured record(s), which will show the error response
+rather than real objects.
+
+Two things fail the *entire* capture outright, rather than degrading
+gracefully, because the engine cannot proceed at all without them:
+
+- **The initial preflight check** (`GET /version`) — if the provided
+  kubeconfig/context can't authenticate at all, capture exits immediately
+  with a clear "capture preflight failed" error naming the kubeconfig and
+  server.
+- **Namespace discovery** — only when a resource uses a wildcard namespace
+  (`namespaces: ['*']`) or `all: true`/`autoDiscover: true` needs to expand
+  namespaces itself; a `403` listing namespaces fails with "namespace
+  discovery failed: check cluster permissions" rather than silently
+  capturing zero namespaces.
+
+In short: check `kshrk inspect <archive>` after a capture to confirm every
+resource you expected actually has real data, not a captured `403` — a
+successful (exit 0) `kshrk capture` run does not by itself guarantee every
+requested resource was actually readable.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,7 +2,7 @@
 
 ## Compatibility matrix
 
-| | Supported |
+| Component | Supported |
 |---|---|
 | **Kubernetes server** (for `capture`) | Tracked via `k8s.io/client-go` in `go.mod` (currently `v0.36.x`); actively validated each release against a pinned `kindest/node:v1.36.1` in the [conformance workflow](../.github/workflows/conformance.yml). k8shark captures through the generic REST/discovery surface rather than version-specific APIs, so other server versions generally work too — only the pinned minor is actively tested. |
 | **kubectl** (against `kshrk open`/`replay`) | Any reasonably recent version — the mock server speaks plain REST/JSON over HTTPS and doesn't depend on a specific `kubectl` release. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,17 @@
 # Usage
 
+## Compatibility matrix
+
+| | Supported |
+|---|---|
+| **Kubernetes server** (for `capture`) | Tracked via `k8s.io/client-go` in `go.mod` (currently `v0.36.x`); actively validated each release against a pinned `kindest/node:v1.36.1` in the [conformance workflow](../.github/workflows/conformance.yml). k8shark captures through the generic REST/discovery surface rather than version-specific APIs, so other server versions generally work too — only the pinned minor is actively tested. |
+| **kubectl** (against `kshrk open`/`replay`) | Any reasonably recent version — the mock server speaks plain REST/JSON over HTTPS and doesn't depend on a specific `kubectl` release. |
+| **OS / architecture** (released binaries) | linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, windows/arm64 — see [docs/releases.md](releases.md#build-matrix). Unit tests run on all three OS families in CI. |
+| **KWOK / kube-controller-manager** (`replay --with-kwok --with-controller-manager`) | Matched to the *capture's* recorded Kubernetes version at replay time, not the version `kshrk` itself was built against — see [docs/kwok.md](kwok.md). |
+
+See [docs/stability-policy.md](stability-policy.md#supported-kubernetes--kubectl-version-window)
+for the full policy this matrix summarizes.
+
 ## Prerequisites
 
 - `kubectl` in your `PATH`


### PR DESCRIPTION
## Summary

#247 identified two gaps blocking the product's stated "customer hands a support engineer one file" workflow: for that customer, "what am I granting?" is the gating question for a security review, and nothing stated it; and "which versions?" is the first question a support org asks, stated only in passing as release-engineering trivia in `docs/releases.md`.

- **`docs/rbac.md`** — a minimal `ClusterRole` for an explicit resource list, the broader `all: true`/`autoDiscover` grant (including the `nonResourceURLs` rule the discovery/OpenAPI endpoints need), and — verified against `internal/capture/engine.go`'s actual behavior — what a partial-RBAC capture looks like: a forbidden resource records its `403` and the capture continues, but namespace discovery and the initial preflight check are hard failures since the engine can't proceed at all without them.
- **A compatibility matrix** (`docs/usage.md`, linked from the README) — Kubernetes server, kubectl, and OS/arch support, kept honest by pointing at the same sources of truth the stability policy already cites (client-go version in `go.mod`, the conformance workflow's pinned `kindest/node`, `.goreleaser.yaml`'s build matrix) rather than restating them as a second copy that can drift out of sync.

Closes #247

## Test plan
- [x] Verified the partial-RBAC-failure claims against `internal/capture/engine.go` directly (per-resource `403`s are recorded and capture continues; namespace discovery and preflight are hard failures)
- [x] Cross-checked all anchors (`docs/usage.md#compatibility-matrix`, `docs/stability-policy.md#supported-kubernetes--kubectl-version-window`, `docs/releases.md#build-matrix`, `docs/config.md#redaction`)
- [x] Full gate: `gofmt -l .`, `go build ./...`, `go vet ./...`, `go mod tidy` (no diff), `go test ./...` — docs-only change, no Go source touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)