### PR TITLE
fix(ui): unify the kind display map with the mock server's scheme-derived one

### DIFF
--- a/internal/ui/v2/issues.go
+++ b/internal/ui/v2/issues.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/phenixblue/k8shark/internal/store"
 )
 
 // groupKey identifies a deduplicated bucket of unhealthy pods.
@@ -164,67 +166,14 @@ func escapeHash(s string) string {
 	return r.Replace(s)
 }
 
-// kindFromResource is a small dictionary keeping the dashboard tiles and
-// recent-transitions labels human-readable. Falls back to titlecasing the
-// resource name.
+// kindFromResource maps a plural resource name to its display Kind for the
+// dashboard tiles and recent-transitions labels. Delegates to
+// store.ResourceToKind — the same scheme-derived mapping the mock server
+// uses — rather than keeping a second, hand-maintained table that silently
+// drifts from it (#236).
 func kindFromResource(resource string) string {
-	known := map[string]string{
-		"deployments":               "Deployment",
-		"statefulsets":              "StatefulSet",
-		"daemonsets":                "DaemonSet",
-		"jobs":                      "Job",
-		"cronjobs":                  "CronJob",
-		"replicasets":               "ReplicaSet",
-		"pods":                      "Pod",
-		"services":                  "Service",
-		"configmaps":                "ConfigMap",
-		"secrets":                   "Secret",
-		"persistentvolumeclaims":    "PersistentVolumeClaim",
-		"persistentvolumes":         "PersistentVolume",
-		"nodes":                     "Node",
-		"ingresses":                 "Ingress",
-		"customresourcedefinitions": "CRD",
-		"virtualmachines":           "VirtualMachine",
-		"virtualmachineinstances":   "VirtualMachineInstance",
-		"events":                    "Event",
-		"storageclasses":            "StorageClass",
-		"namespaces":                "Namespace",
-		"endpoints":                 "Endpoints",
-		"componentstatuses":         "ComponentStatus",
-		"serviceaccounts":           "ServiceAccount",
-		"replicationcontrollers":    "ReplicationController",
-		"networkpolicies":           "NetworkPolicy",
-		"poddisruptionbudgets":      "PodDisruptionBudget",
-	}
-	if k, ok := known[resource]; ok {
-		return k
-	}
 	if resource == "" {
 		return ""
 	}
-	return titleCase(singularize(resource))
-}
-
-// singularize converts a plural resource name to a best-effort singular using
-// common English rules (authoritative kinds come from API discovery; this is
-// only a fallback for callers that have just the resource name).
-func singularize(s string) string {
-	switch {
-	case strings.HasSuffix(s, "ies"):
-		return s[:len(s)-3] + "y" // policies -> policy
-	case strings.HasSuffix(s, "sses"), strings.HasSuffix(s, "shes"), strings.HasSuffix(s, "ches"),
-		strings.HasSuffix(s, "xes"), strings.HasSuffix(s, "zes"), strings.HasSuffix(s, "ses"):
-		return s[:len(s)-2] // statuses -> status, ingresses -> ingress, classes -> class
-	case strings.HasSuffix(s, "s") && len(s) > 1:
-		return s[:len(s)-1]
-	default:
-		return s
-	}
-}
-
-func titleCase(s string) string {
-	if s == "" {
-		return s
-	}
-	return strings.ToUpper(s[:1]) + s[1:]
+	return store.ResourceToKind(resource)
 }

--- a/internal/ui/v2/kind_test.go
+++ b/internal/ui/v2/kind_test.go
@@ -1,26 +1,61 @@
 package v2
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/phenixblue/k8shark/internal/store"
+)
 
 func TestKindFromResource(t *testing.T) {
 	cases := map[string]string{
-		// Known map entries.
 		"pods":              "Pod",
 		"configmaps":        "ConfigMap",
 		"componentstatuses": "ComponentStatus",
 		"endpoints":         "Endpoints",
 		"networkpolicies":   "NetworkPolicy",
-		// Generic singularization fallback (not in the known map).
-		"widgets":  "Widget",  // simple plural
-		"gateways": "Gateway", // ...s
-		"policies": "Policy",  // ...ies -> y
-		"classes":  "Class",   // ...sses -> ...ss
-		"foxes":    "Fox",     // ...xes -> ...x  (best-effort; discovery is authoritative)
-		"":         "",
+		"leases":            "Lease",
+		// Not in client-go's built-in scheme: falls through to
+		// store.ResourceToKind's naive depluralization heuristic, same as
+		// every other caller of it (see internal/server/handler.go's
+		// ResourceKind comment) — not something this package special-cases.
+		"widgets": "Widget",
+		"":        "",
 	}
 	for in, want := range cases {
 		if got := kindFromResource(in); got != want {
 			t.Errorf("kindFromResource(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+// TestKindFromResource_AgreesWithStore guards #236: the UI previously kept a
+// second, hand-maintained resource->Kind table (23 of 47 entries disagreed
+// with the mock server's scheme-derived one). Walk every resource client-go's
+// built-in scheme knows about — the same set internal/store derives its map
+// from — and assert kindFromResource never disagrees with store.ResourceToKind.
+// This fails immediately if issues.go ever grows its own table again.
+func TestKindFromResource_AgreesWithStore(t *testing.T) {
+	seen := map[string]bool{}
+	for gvk := range clientgoscheme.Scheme.AllKnownTypes() {
+		if gvk.Kind == "" || strings.HasSuffix(gvk.Kind, "List") || strings.HasSuffix(gvk.Kind, "Options") {
+			continue
+		}
+		gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+		if gvr.Resource == "" || seen[gvr.Resource] {
+			continue
+		}
+		seen[gvr.Resource] = true
+
+		want := store.ResourceToKind(gvr.Resource)
+		if got := kindFromResource(gvr.Resource); got != want {
+			t.Errorf("kindFromResource(%q) = %q, want %q (store.ResourceToKind)", gvr.Resource, got, want)
+		}
+	}
+	if len(seen) < 40 {
+		t.Fatalf("only checked %d resources from the scheme, expected 40+ — scheme registration may be broken", len(seen))
 	}
 }


### PR DESCRIPTION
## Summary
- `internal/ui/v2` kept a hand-maintained resource→Kind table alongside `internal/store`'s scheme-derived one (`ResourceToKind`), and 23 of 47 entries disagreed — the visible symptom was `leases` rendering as `Leas` in the dashboard.
- Deletes the hand-maintained map and its `singularize`/`titleCase` helpers; `kindFromResource` now delegates directly to `store.ResourceToKind`, so there's exactly one place in the codebase mapping resource names to Kinds.
- Adds `TestKindFromResource_AgreesWithStore`, which walks every resource in client-go's built-in scheme and asserts the UI never disagrees with the mock server's mapping — this fails immediately if a second hand-rolled table is ever reintroduced.

Closes #236

## Test plan
- [x] `make fmt` (no diff)
- [x] `go build ./...` / `go vet ./...`
- [x] `go mod tidy` (no diff)
- [x] `go test ./...`
- [x] `leases` now maps to `Lease` (asserted in `TestKindFromResource`)