### PR TITLE
refactor(capture): deduplicate NewEngine and newEngineWith field init

### DIFF
--- a/internal/capture/engine.go
+++ b/internal/capture/engine.go
@@ -129,6 +129,29 @@ type Engine struct {
 
 const maxConcurrentWatchStreams = 256
 
+// newEngineBase builds an Engine from already-constructed HTTP/dynamic
+// clients, initializing every other field. NewEngine and newEngineWith each
+// build their clients differently but must agree on everything else — this
+// is the one place that does, so adding a field here can't be forgotten in
+// one constructor and only done in the other (#238).
+func newEngineBase(cfg *config.Config, verbose bool, httpClient *http.Client, dynClient dynamic.Interface, baseURL string) *Engine {
+	return &Engine{
+		cfg:                       cfg,
+		verbose:                   verbose,
+		httpClient:                httpClient,
+		dynClient:                 dynClient,
+		baseURL:                   baseURL,
+		index:                     make(Index),
+		watchIndex:                make(WatchIndex),
+		discoveryCache:            make(map[string][]byte),
+		lastHash:                  make(map[string][32]byte),
+		warnedFallback:            make(map[string]bool),
+		fetchSem:                  make(chan struct{}, maxConcurrentFetches),
+		fetchTimeout:              perFetchTimeout,
+		clusterListNamespacesSeen: make(map[string]map[string]bool),
+	}
+}
+
 // NewEngine creates a capture Engine from validated config.
 func NewEngine(cfg *config.Config, verbose bool) (*Engine, error) {
 	var restCfg *rest.Config
@@ -161,21 +184,7 @@ func NewEngine(cfg *config.Config, verbose bool) (*Engine, error) {
 		return nil, fmt.Errorf("building dynamic client: %w", err)
 	}
 
-	return &Engine{
-		cfg:                       cfg,
-		verbose:                   verbose,
-		httpClient:                httpClient,
-		dynClient:                 dynClient,
-		baseURL:                   restCfg.Host,
-		index:                     make(Index),
-		watchIndex:                make(WatchIndex),
-		discoveryCache:            make(map[string][]byte),
-		lastHash:                  make(map[string][32]byte),
-		warnedFallback:            make(map[string]bool),
-		fetchSem:                  make(chan struct{}, maxConcurrentFetches),
-		fetchTimeout:              perFetchTimeout,
-		clusterListNamespacesSeen: make(map[string]map[string]bool),
-	}, nil
+	return newEngineBase(cfg, verbose, httpClient, dynClient, restCfg.Host), nil
 }
 
 // SetEncryption makes Run() write the output archive as an age-encrypted
@@ -194,21 +203,7 @@ func newEngineWith(cfg *config.Config, client *http.Client, baseURL string, verb
 	// the watch-streaming tests that need it construct against a valid baseURL;
 	// non-watch tests never touch dynClient.
 	dynClient, _ := dynamic.NewForConfigAndClient(&rest.Config{Host: baseURL}, client)
-	return &Engine{
-		cfg:                       cfg,
-		verbose:                   verbose,
-		httpClient:                client,
-		dynClient:                 dynClient,
-		baseURL:                   baseURL,
-		index:                     make(Index),
-		watchIndex:                make(WatchIndex),
-		discoveryCache:            make(map[string][]byte),
-		lastHash:                  make(map[string][32]byte),
-		warnedFallback:            make(map[string]bool),
-		fetchSem:                  make(chan struct{}, maxConcurrentFetches),
-		fetchTimeout:              perFetchTimeout,
-		clusterListNamespacesSeen: make(map[string]map[string]bool),
-	}
+	return newEngineBase(cfg, verbose, client, dynClient, baseURL)
 }
 
 // Run executes the capture and writes the output archive.

--- a/internal/capture/engine_ctor_test.go
+++ b/internal/capture/engine_ctor_test.go
@@ -1,0 +1,86 @@
+package capture
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/config"
+)
+
+// TestNewEngine_NoNilMapOrChanFields guards #238: NewEngine and
+// newEngineWith independently initialized the same thirteen struct fields,
+// so adding a field to one constructor and forgetting the other shipped a
+// nil-map panic (or a zero-value timeout) on the very first real capture,
+// with a fully green test suite — every other test goes through
+// newEngineWith, never NewEngine. Drive NewEngine itself (0% coverage
+// before this) via a temp kubeconfig pointing at an httptest server, and
+// assert no map or channel field is left nil.
+func TestNewEngine_NoNilMapOrChanFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	e, err := NewEngine(&config.Config{Kubeconfig: writeTestKubeconfig(t, srv.URL)}, false)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	// reflect.ValueOf(e).Elem(), not reflect.ValueOf(*e) — dereferencing *e
+	// would copy the whole struct, including its embedded sync.Mutex, which
+	// go vet correctly flags as a lock-copy.
+	v := reflect.ValueOf(e).Elem()
+	typ := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		switch f.Kind() { //nolint:exhaustive // only map/chan fields can be nil in a way that matters here
+		case reflect.Map, reflect.Chan:
+			if f.IsNil() {
+				t.Errorf("field %s is nil after NewEngine — newEngineBase must initialize it", typ.Field(i).Name)
+			}
+		}
+	}
+
+	if e.baseURL != srv.URL {
+		t.Errorf("baseURL = %q, want %q", e.baseURL, srv.URL)
+	}
+	if e.httpClient == nil {
+		t.Error("httpClient is nil")
+	}
+	if e.dynClient == nil {
+		t.Error("dynClient is nil")
+	}
+	if e.fetchTimeout != perFetchTimeout {
+		t.Errorf("fetchTimeout = %v, want the default %v (zero value would silently disable the per-fetch cap)", e.fetchTimeout, perFetchTimeout)
+	}
+}
+
+func writeTestKubeconfig(t *testing.T, server string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	contents := fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: %s
+  name: test
+contexts:
+- context:
+    cluster: test
+    user: test
+  name: test
+current-context: test
+users:
+- name: test
+  user: {}
+`, server)
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("writing kubeconfig: %v", err)
+	}
+	return path
+}


### PR DESCRIPTION
## Summary
- `NewEngine` (0% coverage — every engine test goes through `newEngineWith` instead) and `newEngineWith` independently initialized the same thirteen `*Engine` struct fields (`index`, `watchIndex`, `discoveryCache`, `lastHash`, `warnedFallback`, `fetchSem`, `fetchTimeout`, `clusterListNamespacesSeen`, ...). Add a field to one constructor and forget the other, and the first real capture gets a nil-map panic or a zero-value timeout — with a fully green test suite.
- Extracts the shared initialization into `newEngineBase(cfg, verbose, httpClient, dynClient, baseURL)`, called by both constructors.
- Adds `TestNewEngine_NoNilMapOrChanFields`, which drives `NewEngine` itself (via a temp kubeconfig pointing at an `httptest` server) and fails if any map or channel field of `*Engine` is left nil — this fails immediately if a new field is ever added to only one constructor again.

Closes #238

## Test plan
- [x] `make fmt` (no diff)
- [x] `go build ./...` / `go vet ./...`
- [x] `go mod tidy` (no diff)
- [x] `go test ./...`
- [x] `go test -race ./internal/capture/...`
- [x] `NewEngine` coverage: 0% → 71.4%; `newEngineBase` (the shared logic) at 100%