### PR TITLE
fix(server): generic statusObj omits reason, so client-go error helpers don't work

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -261,8 +261,7 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		// A single-object GET in a namespace deleted in the overlay is gone
 		// (cascade), even for captured objects.
 		if name != "" && h.overlay.isNamespaceDeleted(ns) {
-			h.writeStatus(w, http.StatusNotFound,
-				fmt.Sprintf("%q not found: namespace %q was deleted in the writable overlay", path, ns))
+			writeJSON(w, http.StatusNotFound, notFoundStatus("", "namespaces", ns))
 			return
 		}
 		// Serve overlay-owned objects for a single-object GET (and GET .../status,
@@ -270,7 +269,7 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		if name != "" && (sub == "" || sub == "status") {
 			if e, ok := h.overlay.get(g, v, res, ns, name); ok {
 				if e.deleted {
-					h.writeStatus(w, http.StatusNotFound, fmt.Sprintf("%q was deleted in the writable overlay", path))
+					writeJSON(w, http.StatusNotFound, notFoundStatus(g, res, name))
 					return
 				}
 				// Honor Table format (kubectl get <name>) for overlay objects.

--- a/internal/server/scale.go
+++ b/internal/server/scale.go
@@ -19,7 +19,7 @@ import (
 // objectForRead instead of currentObject.
 func (h *handler) serveScale(w http.ResponseWriter, group, version, resource, namespace, name string, at time.Time) {
 	if !scaleSubresourceResources[resource] {
-		h.writeStatus(w, http.StatusNotFound, resource+" has no scale subresource")
+		writeJSON(w, http.StatusNotFound, noScaleSubresourceStatus(resource))
 		return
 	}
 	obj, ok := h.objectForRead(group, version, resource, namespace, name, at)
@@ -43,6 +43,25 @@ var scaleSubresourceResources = map[string]bool{
 	"replicasets":            true,
 	"statefulsets":           true,
 	"replicationcontrollers": true,
+}
+
+// noScaleSubresourceStatus builds the 404 for a resource with no /scale
+// subresource. This is an ordinary "the requested resource doesn't exist"
+// case (a real apiserver never registers a /scale route for these kinds at
+// all), not the "unknown to the capture" case statusObj's 404 exclusion is
+// about — so, like notFoundStatus, it carries reason: "NotFound". Doesn't use
+// notFoundStatus directly: its message format ("<resource>.<group> \"<name>\"
+// not found") would misleadingly imply the object itself is missing, when
+// it's the subresource that doesn't exist.
+func noScaleSubresourceStatus(resource string) map[string]any {
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Status",
+		"status":     "Failure",
+		"message":    resource + " has no scale subresource",
+		"reason":     "NotFound",
+		"code":       http.StatusNotFound,
+	}
 }
 
 // scaleSelectorString renders a resource's .spec.selector as the label-query
@@ -160,7 +179,7 @@ func setSpecReplicas(body json.RawMessage, replicas int32) json.RawMessage {
 // underlying resource's own body shape, not a Scale request.
 func (h *handler) overlayScaleWrite(w http.ResponseWriter, r *http.Request, group, version, resource, namespace, name string) {
 	if !scaleSubresourceResources[resource] {
-		h.writeStatus(w, http.StatusNotFound, resource+" has no scale subresource")
+		writeJSON(w, http.StatusNotFound, noScaleSubresourceStatus(resource))
 		return
 	}
 	current := h.currentObject(group, version, resource, namespace, name)

--- a/internal/server/scale.go
+++ b/internal/server/scale.go
@@ -165,7 +165,7 @@ func (h *handler) overlayScaleWrite(w http.ResponseWriter, r *http.Request, grou
 	}
 	current := h.currentObject(group, version, resource, namespace, name)
 	if current == nil {
-		h.writeStatus(w, http.StatusNotFound, "object not found: "+name)
+		writeJSON(w, http.StatusNotFound, notFoundStatus(group, resource, name))
 		return
 	}
 

--- a/internal/server/status.go
+++ b/internal/server/status.go
@@ -23,13 +23,84 @@ func writeJSON(w http.ResponseWriter, code int, v any) {
 	_, _ = w.Write(data)
 }
 
+// statusObj builds a generic Kubernetes Status object for an error response.
+// Includes reason (when code maps to one) alongside code — client-go's
+// apierrors helpers (IsForbidden, IsBadRequest, IsMethodNotSupported,
+// IsInternalError, ...) key off reason, not code, the same requirement
+// notFoundStatus already handles for 404 (#177). Any controller or operator
+// replayed against the mock depends on this to handle errors correctly.
 func statusObj(code int, msg string) map[string]any {
-	return map[string]any{
+	obj := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Status",
 		"status":     "Failure",
 		"message":    msg,
 		"code":       code,
+	}
+	if reason := statusReasonForCode(code); reason != "" {
+		obj["reason"] = reason
+	}
+	return obj
+}
+
+// statusReasonForCode maps an HTTP status code to the metav1.StatusReason
+// string a real apiserver would set, for the status codes this mock server
+// actually returns (see statusObj callers). Codes with no well-known reason
+// map to "" (metav1.StatusReasonUnknown), matching upstream.
+//
+// Deliberately excludes http.StatusNotFound. A plain writeStatus/statusObj
+// 404 is used for two different things, and only one of them should carry
+// reason: "NotFound":
+//   - A resource genuinely unknown to the capture (wrong group/resource
+//     entirely, not in discovery or the index) — this must NOT carry
+//     reason: "NotFound", or apierrors.IsNotFound() would treat a
+//     capture-config problem as an ordinary "object doesn't exist" (#177).
+//   - An ordinary missing object on a known resource (e.g. PUT/PATCH/DELETE
+//     against a name that doesn't exist in the overlay or replay state) —
+//     these should carry reason: "NotFound", so call sites for this case
+//     use the dedicated notFoundStatus instead of statusObj, which sets
+//     reason (and details) itself.
+//
+// If a new writeStatus(w, http.StatusNotFound, ...) call site is added,
+// decide which of the two it is and use notFoundStatus if it's the latter —
+// don't assume every 404 belongs to the "genuinely unknown" case above.
+//
+// Also deliberately excludes http.StatusGone: the one 410 this mock server
+// produces (a stale watch resourceVersion, replay_rv.go's writeGone) is
+// reason: "Expired" per real kube-apiserver semantics — not the generic
+// "Gone" — and it builds its own Status map directly rather than calling
+// statusObj. Mapping 410 to "Gone" here would be wrong the moment any
+// future statusObj(410, ...) call site is added for that case.
+func statusReasonForCode(code int) string {
+	switch code {
+	case http.StatusBadRequest:
+		return "BadRequest"
+	case http.StatusUnauthorized:
+		return "Unauthorized"
+	case http.StatusForbidden:
+		return "Forbidden"
+	case http.StatusConflict:
+		return "Conflict"
+	case http.StatusUnprocessableEntity:
+		return "Invalid"
+	case http.StatusMethodNotAllowed:
+		return "MethodNotAllowed"
+	case http.StatusNotAcceptable:
+		return "NotAcceptable"
+	case http.StatusRequestEntityTooLarge:
+		return "RequestEntityTooLarge"
+	case http.StatusUnsupportedMediaType:
+		return "UnsupportedMediaType"
+	case http.StatusInternalServerError:
+		return "InternalError"
+	case http.StatusServiceUnavailable:
+		return "ServiceUnavailable"
+	case http.StatusGatewayTimeout:
+		return "Timeout"
+	case http.StatusTooManyRequests:
+		return "TooManyRequests"
+	default:
+		return ""
 	}
 }
 

--- a/internal/server/status.go
+++ b/internal/server/status.go
@@ -46,7 +46,9 @@ func statusObj(code int, msg string) map[string]any {
 // statusReasonForCode maps an HTTP status code to the metav1.StatusReason
 // string a real apiserver would set, for the status codes this mock server
 // actually returns (see statusObj callers). Codes with no well-known reason
-// map to "" (metav1.StatusReasonUnknown), matching upstream.
+// return "" (metav1.StatusReasonUnknown), which statusObj treats as "omit
+// the reason field from the JSON body" rather than emitting reason:"" —
+// matching upstream, where metav1.Status.Reason is `json:",omitempty"` too.
 //
 // Deliberately excludes http.StatusNotFound. A plain writeStatus/statusObj
 // 404 is used for two different things, and only one of them should carry

--- a/internal/server/status_test.go
+++ b/internal/server/status_test.go
@@ -57,6 +57,9 @@ func TestStatusReasonForCode(t *testing.T) {
 		// Deliberately excluded, not just missing: a plain 404 must NOT get
 		// reason: "NotFound" — see statusReasonForCode's doc comment (#177).
 		http.StatusNotFound: "",
+		// Deliberately excluded: this server's one 410 (replay_rv.go's
+		// writeGone) is reason: "Expired", not the generic "Gone".
+		http.StatusGone: "",
 	}
 	for code, want := range cases {
 		if got := statusReasonForCode(code); got != want {

--- a/internal/server/status_test.go
+++ b/internal/server/status_test.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestStatusObj_ReasonMatchesClientGo guards #255: statusObj previously
+// omitted "reason", so client-go's apierrors helpers — which key off reason,
+// not code — always returned false against the mock server. Round-trip
+// statusObj through JSON into a real metav1.Status wrapped in a StatusError,
+// the same shape client-go builds from a response body, and assert the
+// matching apierrors.Is* helper recognizes it.
+func TestStatusObj_ReasonMatchesClientGo(t *testing.T) {
+	cases := []struct {
+		code  int
+		check func(error) bool
+	}{
+		{http.StatusBadRequest, apierrors.IsBadRequest},
+		{http.StatusForbidden, apierrors.IsForbidden},
+		{http.StatusMethodNotAllowed, apierrors.IsMethodNotSupported},
+		{http.StatusInternalServerError, apierrors.IsInternalError},
+		{http.StatusConflict, apierrors.IsConflict},
+		{http.StatusUnprocessableEntity, apierrors.IsInvalid},
+	}
+	for _, c := range cases {
+		obj := statusObj(c.code, "boom")
+		data, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("marshal statusObj(%d): %v", c.code, err)
+		}
+		var status metav1.Status
+		if err := json.Unmarshal(data, &status); err != nil {
+			t.Fatalf("unmarshal into metav1.Status: %v", err)
+		}
+		statusErr := &apierrors.StatusError{ErrStatus: status}
+		if !c.check(statusErr) {
+			t.Errorf("code %d: apierrors helper returned false for reason %q — statusObj is missing/wrong reason", c.code, status.Reason)
+		}
+	}
+}
+
+func TestStatusReasonForCode(t *testing.T) {
+	cases := map[int]string{
+		http.StatusBadRequest:          "BadRequest",
+		http.StatusUnauthorized:        "Unauthorized",
+		http.StatusForbidden:           "Forbidden",
+		http.StatusConflict:            "Conflict",
+		http.StatusUnprocessableEntity: "Invalid",
+		http.StatusMethodNotAllowed:    "MethodNotAllowed",
+		http.StatusInternalServerError: "InternalError",
+		http.StatusTeapot:              "", // no well-known reason
+		// Deliberately excluded, not just missing: a plain 404 must NOT get
+		// reason: "NotFound" — see statusReasonForCode's doc comment (#177).
+		http.StatusNotFound: "",
+	}
+	for code, want := range cases {
+		if got := statusReasonForCode(code); got != want {
+			t.Errorf("statusReasonForCode(%d) = %q, want %q", code, got, want)
+		}
+	}
+}

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -33,7 +33,7 @@ func (h *handler) handleWrite(w http.ResponseWriter, r *http.Request, path strin
 	// namespace and everything in it are logically gone. Deleting the namespace
 	// object itself has namespace=="" here, so it isn't caught by this check.
 	if namespace != "" && h.overlay.isNamespaceDeleted(namespace) {
-		h.writeStatus(w, http.StatusNotFound, "namespace "+namespace+" was deleted in the writable overlay")
+		writeJSON(w, http.StatusNotFound, notFoundStatus("", "namespaces", namespace))
 		return
 	}
 

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -270,7 +270,7 @@ func (h *handler) overlayReplace(w http.ResponseWriter, r *http.Request, group, 
 	// matching the kube-apiserver.
 	current := h.currentObject(group, version, resource, namespace, name)
 	if current == nil {
-		h.writeStatus(w, http.StatusNotFound, "object not found: "+name)
+		writeJSON(w, http.StatusNotFound, notFoundStatus(group, resource, name))
 		return
 	}
 	var next json.RawMessage
@@ -318,7 +318,7 @@ func (h *handler) overlayPatch(w http.ResponseWriter, r *http.Request, group, ve
 			h.overlayApplyCreate(w, group, version, resource, namespace, name, patch)
 			return
 		}
-		h.writeStatus(w, http.StatusNotFound, "object not found: "+name)
+		writeJSON(w, http.StatusNotFound, notFoundStatus(group, resource, name))
 		return
 	}
 	next, perr := applyPatch(current, patch, r.Header.Get("Content-Type"), group, version, resource)
@@ -405,7 +405,7 @@ func (h *handler) deleteOneObject(group, version, resource, namespace, name stri
 func (h *handler) overlayDelete(w http.ResponseWriter, group, version, resource, namespace, name string) {
 	if h.deleteOneObject(group, version, resource, namespace, name,
 		h.replayFloorRV(group, version, resource, namespace)) == nil {
-		h.writeStatus(w, http.StatusNotFound, "object not found: "+name)
+		writeJSON(w, http.StatusNotFound, notFoundStatus(group, resource, name))
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -2632,3 +2632,47 @@ func TestEnsureSchedulableNode_NodelessCaptureSynthesizes(t *testing.T) {
 		t.Errorf("nodeless capture should synthesize %s", defaultSyntheticNode)
 	}
 }
+
+// TestOverlayWrite_MissingObjectGetsNotFoundReason guards a follow-up to
+// #255: PUT/PATCH/DELETE (and a scale write) against an object that doesn't
+// exist in the overlay or replay state is an ordinary "the object isn't
+// there" 404, not the "resource unknown to the capture" case — so it must
+// carry reason: "NotFound" (via notFoundStatus), not the bare, reason-less
+// statusObj those two cases used to share.
+func TestOverlayWrite_MissingObjectGetsNotFoundReason(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	cases := []struct {
+		name   string
+		method string
+		url    string
+		ctype  string
+		body   string
+	}{
+		{"PUT missing object", http.MethodPut, srv.URL + podsPath + "/ghost", "application/json", podBody("ghost")},
+		{"PATCH missing object", http.MethodPatch, srv.URL + podsPath + "/ghost", "application/merge-patch+json", `{"spec":{}}`},
+		{"DELETE missing object", http.MethodDelete, srv.URL + podsPath + "/ghost", "", ""},
+		{"scale write on missing object", http.MethodPut,
+			srv.URL + "/apis/apps/v1/namespaces/default/deployments/ghost/scale", "application/json",
+			`{"apiVersion":"autoscaling/v1","kind":"Scale","spec":{"replicas":2}}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			code, body := doReq(t, c.method, c.url, c.ctype, c.body)
+			if code != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404", code)
+			}
+			var status struct {
+				Reason string `json:"reason"`
+			}
+			if err := json.Unmarshal(body, &status); err != nil {
+				t.Fatalf("expected a JSON Status body: %v", err)
+			}
+			if status.Reason != "NotFound" {
+				t.Errorf("reason = %q, want %q", status.Reason, "NotFound")
+			}
+		})
+	}
+}

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -2712,3 +2712,27 @@ func TestOverlayRead_DeletedObjectAndNamespaceGetNotFoundReason(t *testing.T) {
 		assertNotFoundReason(t, code, body)
 	})
 }
+
+// TestScale_NoScaleSubresourceGetsNotFoundReason guards a follow-up to #255:
+// a resource with no /scale subresource (a real apiserver never registers
+// that route for it) is an ordinary "the requested resource doesn't exist"
+// case, not the "unknown to the capture" case statusObj's 404 exclusion is
+// about — so both the GET and PUT paths must carry reason: "NotFound".
+func TestScale_NoScaleSubresourceGetsNotFoundReason(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	doReq(t, http.MethodPost, srv.URL+"/api/v1/namespaces/default/configmaps", "application/json",
+		`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm","namespace":"default"}}`)
+
+	t.Run("GET .../scale", func(t *testing.T) {
+		code, body := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/default/configmaps/cm/scale", "", "")
+		assertNotFoundReason(t, code, body)
+	})
+	t.Run("PUT .../scale", func(t *testing.T) {
+		code, body := doReq(t, http.MethodPut, srv.URL+"/api/v1/namespaces/default/configmaps/cm/scale", "application/json",
+			`{"apiVersion":"autoscaling/v1","kind":"Scale","spec":{"replicas":2}}`)
+		assertNotFoundReason(t, code, body)
+	})
+}

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -2661,18 +2661,54 @@ func TestOverlayWrite_MissingObjectGetsNotFoundReason(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			code, body := doReq(t, c.method, c.url, c.ctype, c.body)
-			if code != http.StatusNotFound {
-				t.Fatalf("status = %d, want 404", code)
-			}
-			var status struct {
-				Reason string `json:"reason"`
-			}
-			if err := json.Unmarshal(body, &status); err != nil {
-				t.Fatalf("expected a JSON Status body: %v", err)
-			}
-			if status.Reason != "NotFound" {
-				t.Errorf("reason = %q, want %q", status.Reason, "NotFound")
-			}
+			assertNotFoundReason(t, code, body)
 		})
 	}
+}
+
+// assertNotFoundReason asserts code is 404 and body is a Status object with
+// reason: "NotFound".
+func assertNotFoundReason(t *testing.T, code int, body []byte) {
+	t.Helper()
+	if code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", code)
+	}
+	var status struct {
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal(body, &status); err != nil {
+		t.Fatalf("expected a JSON Status body: %v", err)
+	}
+	if status.Reason != "NotFound" {
+		t.Errorf("reason = %q, want %q", status.Reason, "NotFound")
+	}
+}
+
+// TestOverlayRead_DeletedObjectAndNamespaceGetNotFoundReason guards two more
+// follow-ups to #255, both on the read path (internal/server/handler.go's
+// serveResource): a single-object GET for an object explicitly tombstoned
+// in the overlay (created then deleted), and a single-object GET for a
+// resource whose namespace itself was deleted (cascade) — both are ordinary
+// "the object isn't there" 404s and must carry reason: "NotFound".
+func TestOverlayRead_DeletedObjectAndNamespaceGetNotFoundReason(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock)
+
+	t.Run("GET a tombstoned object", func(t *testing.T) {
+		doReq(t, http.MethodPost, srv.URL+podsPath, "application/json", podBody("pod-gone"))
+		doReq(t, http.MethodDelete, srv.URL+podsPath+"/pod-gone", "", "")
+		code, body := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-gone", "", "")
+		assertNotFoundReason(t, code, body)
+	})
+
+	t.Run("GET an object in a deleted namespace", func(t *testing.T) {
+		doReq(t, http.MethodPost, srv.URL+"/api/v1/namespaces", "application/json",
+			`{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"ns-gone"}}`)
+		doReq(t, http.MethodPost, srv.URL+"/api/v1/namespaces/ns-gone/configmaps", "application/json",
+			`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm","namespace":"ns-gone"}}`)
+		doReq(t, http.MethodDelete, srv.URL+"/api/v1/namespaces/ns-gone", "", "")
+		code, body := doReq(t, http.MethodGet, srv.URL+"/api/v1/namespaces/ns-gone/configmaps/cm", "", "")
+		assertNotFoundReason(t, code, body)
+	})
 }


### PR DESCRIPTION
## Summary
- `client-go`'s `apierrors` helpers (`IsForbidden`, `IsBadRequest`, `IsMethodNotSupported`, `IsInternalError`, ...) key off a Status object's `reason` field, not its `code`. The generic `statusObj` never set `reason`, so any controller or operator replayed against the mock mis-handles these errors — directly relevant to the writable-overlay and KWOK workflows, whose whole point is running real controllers against a capture.
- Adds `statusReasonForCode`, mapping the status codes this server actually returns to their `metav1.StatusReason` string, and sets it on `statusObj` when known.
- Deliberately **excludes 404**: a plain `writeStatus`/`statusObj` 404 is used for a resource genuinely unknown to the capture (wrong group/resource entirely — not in discovery or the index), and must not carry `reason: "NotFound"`, or `apierrors.IsNotFound()` would treat a capture-config problem as an ordinary missing object (#177). A real not-found for a known resource already goes through the dedicated `notFoundStatus`, which sets `reason` itself. An existing test (`TestHandler_NotFound_ItemPath_UnknownResourceKeepsGenericMessage`) already pins this distinction and caught the first version of this change getting it wrong.

Closes #255

## Test plan
- [x] `make fmt` (no diff)
- [x] `go build ./...` / `go vet ./...`
- [x] `go mod tidy` (no diff)
- [x] `go test ./...`
- [x] New test round-trips `statusObj` through JSON into a real `metav1.Status` wrapped in `apierrors.StatusError` and asserts the matching `apierrors.Is*` helper recognizes it — the same shape client-go builds from a response body
- [ ] Conformance CI (`.github/workflows/conformance.yml`) will re-validate this doesn't introduce a new mock↔upstream divergence