### PR TITLE
chore(conformance): drop the fixed 404 not-found divergence from the baseline

### DIFF
--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -71,8 +71,12 @@ Currently accepted divergences (all in `internal/server/handler.go`):
 
 | Key | What | Why it's accepted (for now) |
 |-----|------|------------------------------|
-| `errors::404 not-found Status object` | The 404 body omits `reason: "NotFound"` and `details`. | Cosmetic-ish; `code: 404` is present. Candidate fix. |
 | `errors::404 for unknown group/version` | Unknown `/apis/<g>/<v>` returns `200` + empty `APIResourceList` instead of `404`. | The router synthesizes a list for any group path. Candidate fix. |
 | `version::/version keys` | `/version` omits newer keys (`emulationMajor` etc.) and hard-codes `major`/`minor`. | `/version` is a stub; `gitVersion` is correct. Version-dependent. |
+
+The not-found Status object divergence (404 body missing `reason: "NotFound"`
+and `details`) was fixed in #177 for a real, captured resource type —
+`notFoundStatus` in `internal/server/handler.go` sets both — and no longer
+appears in the baseline.
 
 Removing an entry here (by fixing the underlying behavior) tightens the gate.

--- a/scripts/conformance-baseline.json
+++ b/scripts/conformance-baseline.json
@@ -2,7 +2,6 @@
   "_comment": "Accepted mock<->upstream divergences (issue #136). Each key is 'category::name' from conformance_diff.py. Entries here are reported but do NOT fail the run; the gate fires only on NEW divergences. See docs/conformance.md for the rationale behind each. Regenerate with WRITE_BASELINE=1.",
   "accepted": [
     "errors::404 for unknown group/version",
-    "errors::404 not-found Status object",
     "version::/version keys"
   ]
 }


### PR DESCRIPTION
## Summary
- `errors::404 not-found Status object` was accepted in `scripts/conformance-baseline.json` for a 404 body missing `reason: "NotFound"` and `details` — but that was fixed in #177 for a real, captured resource type: `notFoundStatus` in `internal/server/handler.go` already sets both. The baseline was never regenerated, so the conformance gate stayed looser than the code deserves (a regression here wouldn't fail the job).
- Removes the stale entry and updates `docs/conformance.md`'s rationale table to match.
- The two remaining entries (unknown group/version returning `200` instead of `404`, and `/version`'s stubbed keys) are unrelated, still-genuine divergences called out as optional follow-ups in #256 — left as-is.

Closes #256

## Test plan
- [x] `scripts/conformance-baseline.json` is valid JSON
- [x] `make fmt` / `go build ./...` / `go vet ./...` / `go mod tidy` (no diff)
- [x] `go test ./...`
- [ ] Couldn't run `scripts/conformance.sh` locally (no Docker/KinD in this environment) — the `conformance` CI workflow will confirm `errors::404 not-found Status object` now reports PASS and no longer needs the baseline entry