### PR TITLE
test(cmd): add table tests for resolveRedaction

### DIFF
--- a/cmd/capture_test.go
+++ b/cmd/capture_test.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// newResolveRedactionCmd builds a bare *cobra.Command carrying exactly the
+// three flags resolveRedaction reads, mirroring captureCmd's registration
+// (cmd/capture.go's init) without sharing captureCmd's global flag state
+// across test cases.
+func newResolveRedactionCmd(t *testing.T, redactSecrets bool, allowSecret, redactField []string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("redact-secrets", false, "")
+	cmd.Flags().StringArray("allow-secret", nil, "")
+	cmd.Flags().StringArray("redact-field", nil, "")
+	if redactSecrets {
+		if err := cmd.Flags().Set("redact-secrets", "true"); err != nil {
+			t.Fatalf("setting redact-secrets: %v", err)
+		}
+	}
+	for _, a := range allowSecret {
+		if err := cmd.Flags().Set("allow-secret", a); err != nil {
+			t.Fatalf("setting allow-secret=%q: %v", a, err)
+		}
+	}
+	for _, f := range redactField {
+		if err := cmd.Flags().Set("redact-field", f); err != nil {
+			t.Fatalf("setting redact-field=%q: %v", f, err)
+		}
+	}
+	return cmd
+}
+
+func TestResolveRedaction(t *testing.T) {
+	cases := []struct {
+		name              string
+		flagRedactSecrets bool
+		flagAllowSecret   []string
+		flagRedactField   []string
+		cfgRedaction      config.RedactionConfig
+		wantDoRedact      bool
+		wantAllowList     map[string]bool
+		wantFieldRules    []config.RedactionRule
+	}{
+		{
+			name:          "neither flag nor config set",
+			wantDoRedact:  false,
+			wantAllowList: map[string]bool{},
+		},
+		{
+			name:              "flag alone enables redaction",
+			flagRedactSecrets: true,
+			wantDoRedact:      true,
+			wantAllowList:     map[string]bool{},
+		},
+		{
+			name:          "config alone enables redaction",
+			cfgRedaction:  config.RedactionConfig{RedactSecrets: true},
+			wantDoRedact:  true,
+			wantAllowList: map[string]bool{},
+		},
+		{
+			// Documents the asymmetry called out in #253: cfg.RedactSecrets
+			// can only turn redaction ON, never off. An explicit
+			// --redact-secrets=false against a config that enables it does
+			// nothing — this is the fail-safe direction (you can't
+			// accidentally disable redaction the config owner intended),
+			// so it's asserted here as intentional, not a bug.
+			name:              "config wins over an explicit flag=false (fail-safe direction)",
+			flagRedactSecrets: false,
+			cfgRedaction:      config.RedactionConfig{RedactSecrets: true},
+			wantDoRedact:      true,
+			wantAllowList:     map[string]bool{},
+		},
+		{
+			name:            "allowlist from flag only",
+			flagAllowSecret: []string{"default/a", "default/b"},
+			wantDoRedact:    false,
+			wantAllowList:   map[string]bool{"default/a": true, "default/b": true},
+		},
+		{
+			name:          "allowlist from config only",
+			cfgRedaction:  config.RedactionConfig{AllowSecrets: []string{"kube-system/c"}},
+			wantDoRedact:  false,
+			wantAllowList: map[string]bool{"kube-system/c": true},
+		},
+		{
+			name:            "allowlist merges flag and config",
+			flagAllowSecret: []string{"default/a"},
+			cfgRedaction:    config.RedactionConfig{AllowSecrets: []string{"kube-system/c"}},
+			wantDoRedact:    false,
+			wantAllowList:   map[string]bool{"default/a": true, "kube-system/c": true},
+		},
+		{
+			name: "field rules from config only",
+			cfgRedaction: config.RedactionConfig{
+				Rules: []config.RedactionRule{{FieldPath: "data.token", Kind: "Secret", Replacement: "REDACTED"}},
+			},
+			wantDoRedact:  false,
+			wantAllowList: map[string]bool{},
+			wantFieldRules: []config.RedactionRule{
+				{FieldPath: "data.token", Kind: "Secret", Replacement: "REDACTED"},
+			},
+		},
+		{
+			name:            "field rules from --redact-field flag only",
+			flagRedactField: []string{"data.api-key:ConfigMap:REDACTED"},
+			wantDoRedact:    false,
+			wantAllowList:   map[string]bool{},
+			wantFieldRules: []config.RedactionRule{
+				{FieldPath: "data.api-key", Kind: "ConfigMap", Replacement: "REDACTED"},
+			},
+		},
+		{
+			name:            "field rules from --redact-field flag with valueType",
+			flagRedactField: []string{"spec.replicas:Deployment:0:integer"},
+			wantDoRedact:    false,
+			wantAllowList:   map[string]bool{},
+			wantFieldRules: []config.RedactionRule{
+				{FieldPath: "spec.replicas", Kind: "Deployment", Replacement: "0", ValueType: "integer"},
+			},
+		},
+		{
+			name:            "field rules from config and flag both — config rules first, then flag rules",
+			flagRedactField: []string{"data.api-key:ConfigMap:REDACTED"},
+			cfgRedaction: config.RedactionConfig{
+				Rules: []config.RedactionRule{{FieldPath: "data.token", Kind: "Secret", Replacement: "REDACTED"}},
+			},
+			wantDoRedact:  false,
+			wantAllowList: map[string]bool{},
+			wantFieldRules: []config.RedactionRule{
+				{FieldPath: "data.token", Kind: "Secret", Replacement: "REDACTED"},
+				{FieldPath: "data.api-key", Kind: "ConfigMap", Replacement: "REDACTED"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newResolveRedactionCmd(t, tc.flagRedactSecrets, tc.flagAllowSecret, tc.flagRedactField)
+			cfg := &config.Config{Redaction: tc.cfgRedaction}
+
+			doRedact, allowList, fieldRules, err := resolveRedaction(cmd, cfg)
+			if err != nil {
+				t.Fatalf("resolveRedaction: unexpected error: %v", err)
+			}
+			if doRedact != tc.wantDoRedact {
+				t.Errorf("doRedactSecrets = %v, want %v", doRedact, tc.wantDoRedact)
+			}
+			if !reflect.DeepEqual(allowList, tc.wantAllowList) {
+				t.Errorf("allowList = %v, want %v", allowList, tc.wantAllowList)
+			}
+			if len(fieldRules) == 0 && len(tc.wantFieldRules) == 0 {
+				return // both nil/empty; reflect.DeepEqual(nil, []T{}) is false, so skip
+			}
+			if !reflect.DeepEqual(fieldRules, tc.wantFieldRules) {
+				t.Errorf("fieldRules = %+v, want %+v", fieldRules, tc.wantFieldRules)
+			}
+		})
+	}
+}
+
+// TestResolveRedaction_MalformedRedactFieldErrors guards the case #253 calls
+// out: a malformed --redact-field must return an error naming the flag, not
+// silently drop the rule and continue.
+func TestResolveRedaction_MalformedRedactFieldErrors(t *testing.T) {
+	cmd := newResolveRedactionCmd(t, false, nil, []string{"not-enough-parts"})
+	cfg := &config.Config{}
+
+	doRedact, allowList, fieldRules, err := resolveRedaction(cmd, cfg)
+	if err == nil {
+		t.Fatal("expected an error for a malformed --redact-field value")
+	}
+	if !strings.Contains(err.Error(), "--redact-field") {
+		t.Errorf("error = %q, want it to name --redact-field", err.Error())
+	}
+	if doRedact || allowList != nil || fieldRules != nil {
+		t.Errorf("expected zero-valued returns alongside the error, got doRedact=%v allowList=%v fieldRules=%v",
+			doRedact, allowList, fieldRules)
+	}
+}

--- a/cmd/capture_test.go
+++ b/cmd/capture_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -9,18 +10,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func boolPtr(b bool) *bool { return &b }
+
 // newResolveRedactionCmd builds a bare *cobra.Command carrying exactly the
 // three flags resolveRedaction reads, mirroring captureCmd's registration
 // (cmd/capture.go's init) without sharing captureCmd's global flag state
-// across test cases.
-func newResolveRedactionCmd(t *testing.T, redactSecrets bool, allowSecret, redactField []string) *cobra.Command {
+// across test cases. redactSecrets is tri-state: nil leaves the flag unset
+// (its zero-value default), so a test case can distinguish "the user never
+// passed --redact-secrets" from "the user explicitly passed
+// --redact-secrets=false" — resolveRedaction's cfg.RedactSecrets precedence
+// could in principle behave differently for the two.
+func newResolveRedactionCmd(t *testing.T, redactSecrets *bool, allowSecret, redactField []string) *cobra.Command {
 	t.Helper()
 	cmd := &cobra.Command{}
 	cmd.Flags().Bool("redact-secrets", false, "")
 	cmd.Flags().StringArray("allow-secret", nil, "")
 	cmd.Flags().StringArray("redact-field", nil, "")
-	if redactSecrets {
-		if err := cmd.Flags().Set("redact-secrets", "true"); err != nil {
+	if redactSecrets != nil {
+		if err := cmd.Flags().Set("redact-secrets", strconv.FormatBool(*redactSecrets)); err != nil {
 			t.Fatalf("setting redact-secrets: %v", err)
 		}
 	}
@@ -40,7 +47,7 @@ func newResolveRedactionCmd(t *testing.T, redactSecrets bool, allowSecret, redac
 func TestResolveRedaction(t *testing.T) {
 	cases := []struct {
 		name              string
-		flagRedactSecrets bool
+		flagRedactSecrets *bool // nil = flag not passed at all
 		flagAllowSecret   []string
 		flagRedactField   []string
 		cfgRedaction      config.RedactionConfig
@@ -55,7 +62,7 @@ func TestResolveRedaction(t *testing.T) {
 		},
 		{
 			name:              "flag alone enables redaction",
-			flagRedactSecrets: true,
+			flagRedactSecrets: boolPtr(true),
 			wantDoRedact:      true,
 			wantAllowList:     map[string]bool{},
 		},
@@ -68,12 +75,14 @@ func TestResolveRedaction(t *testing.T) {
 		{
 			// Documents the asymmetry called out in #253: cfg.RedactSecrets
 			// can only turn redaction ON, never off. An explicit
-			// --redact-secrets=false against a config that enables it does
-			// nothing — this is the fail-safe direction (you can't
-			// accidentally disable redaction the config owner intended),
-			// so it's asserted here as intentional, not a bug.
+			// --redact-secrets=false (not just the flag's unset default —
+			// this case really does call Flags().Set("redact-secrets",
+			// "false")) against a config that enables it does nothing —
+			// this is the fail-safe direction (you can't accidentally
+			// disable redaction the config owner intended), so it's
+			// asserted here as intentional, not a bug.
 			name:              "config wins over an explicit flag=false (fail-safe direction)",
-			flagRedactSecrets: false,
+			flagRedactSecrets: boolPtr(false),
 			cfgRedaction:      config.RedactionConfig{RedactSecrets: true},
 			wantDoRedact:      true,
 			wantAllowList:     map[string]bool{},
@@ -170,7 +179,7 @@ func TestResolveRedaction(t *testing.T) {
 // out: a malformed --redact-field must return an error naming the flag, not
 // silently drop the rule and continue.
 func TestResolveRedaction_MalformedRedactFieldErrors(t *testing.T) {
-	cmd := newResolveRedactionCmd(t, false, nil, []string{"not-enough-parts"})
+	cmd := newResolveRedactionCmd(t, nil, nil, []string{"not-enough-parts"})
 	cfg := &config.Config{}
 
 	doRedact, allowList, fieldRules, err := resolveRedaction(cmd, cfg)


### PR DESCRIPTION
## Summary
- `cmd/capture.go`'s `resolveRedaction` is the function deciding whether secrets get written to the archive in plaintext — merging `--redact-secrets`, `--allow-secret`, and `--redact-field` with the config file's `redaction` block — and had 0% coverage; there was no `cmd/capture_test.go` at all.
- `scripts/e2e.sh` phases 6/8b–8e are thorough on redaction *behavior*, but E2E is a coarse net: a **precedence** bug (a config `allowSecrets` entry unexpectedly widening the allowlist, or a `--redact-field` parse failure being swallowed) is exactly what a table test catches and a smoke test doesn't.
- Table-driven over `{flag set/unset} x {config set/unset} x {allowlist from flag/config/both} x {field rules from flag/config/both}`, plus a case pinning the malformed `--redact-field` error path (must return an error naming the flag, not silently drop the rule).
- Also pins the undocumented asymmetry called out in #253: `cfg.Redaction.RedactSecrets` can only turn redaction **on**, never off — an explicit `--redact-secrets=false` against a config that enables it does nothing. Asserted here as intentional (the fail-safe direction), not a bug.

Closes #253

## Test plan
- [x] `make fmt` (no diff)
- [x] `go build ./...` / `go vet ./...`
- [x] `go mod tidy` (no diff)
- [x] `go test ./...`
- [x] `resolveRedaction` coverage: 0% → 100%