### PR TITLE
test: add fuzz targets for the archive reader, redaction, and patch application

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,51 @@
+name: fuzz
+
+# Runs each fuzz target for a short, fixed duration on every PR/push touching
+# the fuzzed packages, catching regressions without the cost of a full
+# nightly/continuous fuzzing setup (issue #254). Any crasher gets its input
+# committed to testdata/fuzz/<target>/ (via `go test -fuzz` locally) and
+# replayed as a normal `go test` case from then on, alongside CI.
+
+on:
+  pull_request:
+    paths:
+      - 'internal/archive/**'
+      - 'internal/redact/**'
+      - 'internal/server/**'
+      - '.github/workflows/fuzz.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'internal/archive/**'
+      - 'internal/redact/**'
+      - 'internal/server/**'
+      - '.github/workflows/fuzz.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pkg: ./internal/archive
+            target: FuzzOpenArchive
+          - pkg: ./internal/redact
+            target: FuzzApplyRules
+          - pkg: ./internal/server
+            target: FuzzApplyPatch
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Fuzz ${{ matrix.target }}
+        run: go test ${{ matrix.pkg }} -run=${{ matrix.target }} -fuzz=${{ matrix.target }} -fuzztime=30s

--- a/internal/archive/fuzz_test.go
+++ b/internal/archive/fuzz_test.go
@@ -1,0 +1,43 @@
+package archive
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// FuzzOpenArchive guards the untrusted-input surface #254 calls out:
+// .kshrk files move between organizations, so Open must never panic or
+// allocate without bound on arbitrary bytes, only ever return an error.
+// Seeded with the golden archives (plain and passphrase-encrypted, across
+// both format versions) so the fuzzer starts from real zip/age structure
+// and mutates from there rather than starting from nothing.
+func FuzzOpenArchive(f *testing.F) {
+	for _, seed := range []string{
+		"testdata/golden-v1.kshrk",
+		"testdata/golden-v1-passphrase.kshrk",
+		"testdata/golden-v2.kshrk",
+		"testdata/golden-v2-passphrase.kshrk",
+	} {
+		data, err := os.ReadFile(seed)
+		if err != nil {
+			f.Fatalf("reading seed %s: %v", seed, err)
+		}
+		f.Add(data)
+	}
+	f.Add([]byte{})
+	f.Add([]byte("not a zip file"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		path := filepath.Join(t.TempDir(), "fuzz.kshrk")
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatalf("writing fuzz input: %v", err)
+		}
+		ar, err := Open(path)
+		if err != nil {
+			return // any error is a valid outcome for untrusted input
+		}
+		defer ar.Close()
+		_, _ = ar.ReadMetadata()
+	})
+}

--- a/internal/redact/fuzz_test.go
+++ b/internal/redact/fuzz_test.go
@@ -1,0 +1,41 @@
+package redact
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/config"
+)
+
+// FuzzApplyRules fuzzes tokenizePath (exercised internally by ApplyRules'
+// per-rule path resolution) together with ApplyRules' traversal itself. A
+// panic here aborts a redaction run mid-way, which for a redaction tool
+// means a partially-redacted archive that a user may believe is clean —
+// ApplyRules must only ever return an error, never panic, regardless of
+// path syntax or object shape.
+func FuzzApplyRules(f *testing.F) {
+	seeds := []struct {
+		objJSON, fieldPath, kind, replacement string
+	}{
+		{`{"kind":"Secret","data":{"password":"hunter2"}}`, "data.password", "Secret", "REDACTED"},
+		{`{"kind":"PodList","items":[{"kind":"Pod","spec":{"containers":[{"env":[{"name":"X","value":"secret"}]}]}}]}`,
+			"spec.containers[*].env[*].value", "Pod", "REDACTED"},
+		{`{"kind":"ConfigMap","data":{"a":{"b":{"c":"v"}}}}`, "**.c", "*", "REDACTED"},
+		{`{}`, "", "", ""},
+		{`{"a":1}`, "a[0]", "", "x"},
+		{`{"a":[1,2,3]}`, "a[-1]", "", "x"},
+		{`{"a":1}`, "**", "", "x"},
+	}
+	for _, s := range seeds {
+		f.Add(s.objJSON, s.fieldPath, s.kind, s.replacement)
+	}
+
+	f.Fuzz(func(t *testing.T, objJSON, fieldPath, kind, replacement string) {
+		var obj map[string]interface{}
+		if err := json.Unmarshal([]byte(objJSON), &obj); err != nil {
+			return // ApplyRules' contract is a decoded object; invalid JSON isn't its input
+		}
+		rule := config.RedactionRule{FieldPath: fieldPath, Kind: kind, Replacement: replacement}
+		_, _ = ApplyRules(obj, []config.RedactionRule{rule})
+	})
+}

--- a/internal/server/fuzz_test.go
+++ b/internal/server/fuzz_test.go
@@ -1,0 +1,35 @@
+package server
+
+import "testing"
+
+// FuzzApplyPatch fuzzes the write path's patch application — JSON Patch
+// (RFC 6902), strategic-merge, apply-patch+yaml, and plain JSON merge — all
+// four of which decode an untrusted client-supplied body. applyPatch must
+// only ever return an error on malformed input, never panic; a panic here
+// would take down the mock server on a single bad request.
+func FuzzApplyPatch(f *testing.F) {
+	seeds := []struct {
+		current, patch                        string
+		contentType, group, version, resource string
+	}{
+		{`{"kind":"Pod","spec":{"containers":[{"name":"a","image":"x"}]}}`,
+			`{"spec":{"containers":[{"name":"a","image":"y"}]}}`,
+			"application/strategic-merge-patch+json", "", "v1", "pods"},
+		{`{"a":1}`, `[{"op":"replace","path":"/a","value":2}]`,
+			"application/json-patch+json", "", "v1", "configmaps"},
+		{`{"a":1}`, "a: 2\n",
+			"application/apply-patch+yaml", "", "v1", "configmaps"},
+		{`{"a":1}`, `{"a":2}`,
+			"application/merge-patch+json", "", "v1", "configmaps"},
+		{`{"a":1}`, `{"a":2}`, "", "apps", "v1", "deployments"},
+		{``, ``, "application/json-patch+json", "", "v1", "pods"},
+		{`not json`, `not json either`, "application/strategic-merge-patch+json", "", "v1", "pods"},
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s.current), []byte(s.patch), s.contentType, s.group, s.version, s.resource)
+	}
+
+	f.Fuzz(func(t *testing.T, current, patch []byte, contentType, group, version, resource string) {
+		_, _ = applyPatch(current, patch, contentType, group, version, resource)
+	})
+}

--- a/internal/server/fuzz_test.go
+++ b/internal/server/fuzz_test.go
@@ -2,34 +2,53 @@ package server
 
 import "testing"
 
+// supportedPatchContentTypes are the Content-Types applyPatch is ever
+// actually called with in production — every call site gates on
+// supportedPatchType first (see writes.go's overlayPatch/overlayScaleWrite),
+// so a request with any other Content-Type never reaches applyPatch at all.
+var supportedPatchContentTypes = []string{
+	"application/json-patch+json",
+	"application/strategic-merge-patch+json",
+	"application/apply-patch+yaml",
+	"application/merge-patch+json",
+}
+
 // FuzzApplyPatch fuzzes the write path's patch application — JSON Patch
 // (RFC 6902), strategic-merge, apply-patch+yaml, and plain JSON merge — all
 // four of which decode an untrusted client-supplied body. applyPatch must
 // only ever return an error on malformed input, never panic; a panic here
 // would take down the mock server on a single bad request.
+//
+// contentType is constrained to supportedPatchContentTypes (optionally with
+// a "; charset=..." parameter, which patchMediaType strips) rather than
+// fuzzed as a free-form string, so the fuzzer explores current/patch/GVR
+// mutations within applyPatch's real contract instead of spending its budget
+// on Content-Type values production never reaches.
 func FuzzApplyPatch(f *testing.F) {
 	seeds := []struct {
-		current, patch                        string
-		contentType, group, version, resource string
+		current, patch           string
+		ctIndex                  uint8
+		ctParam                  bool
+		group, version, resource string
 	}{
 		{`{"kind":"Pod","spec":{"containers":[{"name":"a","image":"x"}]}}`,
-			`{"spec":{"containers":[{"name":"a","image":"y"}]}}`,
-			"application/strategic-merge-patch+json", "", "v1", "pods"},
-		{`{"a":1}`, `[{"op":"replace","path":"/a","value":2}]`,
-			"application/json-patch+json", "", "v1", "configmaps"},
-		{`{"a":1}`, "a: 2\n",
-			"application/apply-patch+yaml", "", "v1", "configmaps"},
-		{`{"a":1}`, `{"a":2}`,
-			"application/merge-patch+json", "", "v1", "configmaps"},
-		{`{"a":1}`, `{"a":2}`, "", "apps", "v1", "deployments"},
-		{``, ``, "application/json-patch+json", "", "v1", "pods"},
-		{`not json`, `not json either`, "application/strategic-merge-patch+json", "", "v1", "pods"},
+			`{"spec":{"containers":[{"name":"a","image":"y"}]}}`, 1, false, "", "v1", "pods"},
+		{`{"a":1}`, `[{"op":"replace","path":"/a","value":2}]`, 0, false, "", "v1", "configmaps"},
+		{`{"a":1}`, "a: 2\n", 2, true, "", "v1", "configmaps"},
+		{`{"a":1}`, `{"a":2}`, 3, false, "", "v1", "configmaps"},
+		{`{"a":1}`, `{"a":2}`, 0, true, "apps", "v1", "deployments"},
+		{``, ``, 0, false, "", "v1", "pods"},
+		{`not json`, `not json either`, 1, false, "", "v1", "pods"},
 	}
 	for _, s := range seeds {
-		f.Add([]byte(s.current), []byte(s.patch), s.contentType, s.group, s.version, s.resource)
+		f.Add([]byte(s.current), []byte(s.patch), s.ctIndex, s.ctParam, s.group, s.version, s.resource)
 	}
 
-	f.Fuzz(func(t *testing.T, current, patch []byte, contentType, group, version, resource string) {
+	f.Fuzz(func(t *testing.T, current, patch []byte, ctIndex uint8, ctParam bool, group, version, resource string) {
+		contentType := supportedPatchContentTypes[int(ctIndex)%len(supportedPatchContentTypes)]
+		if ctParam {
+			contentType += "; charset=utf-8"
+		}
 		_, _ = applyPatch(current, patch, contentType, group, version, resource)
 	})
 }


### PR DESCRIPTION
## Summary
No fuzzing existed anywhere in the repo — no `func Fuzz*`, no `testdata/fuzz/`, no property-based tests. Adds the three targets in value order from #254:

- **`FuzzOpenArchive`** (`internal/archive`) — the untrusted-input surface: `.kshrk` files move between organizations. Seeded with the golden archives (plain and passphrase-encrypted, both format versions). Asserts `Open` never panics on arbitrary bytes, only ever errors.
- **`FuzzApplyRules`** (`internal/redact`) — exercises `tokenizePath` (via `ApplyRules`' per-rule path resolution) and `ApplyRules`' traversal together. A panic here aborts a redaction run mid-way — for a redaction tool that means a partially-redacted archive a user may believe is clean.
- **`FuzzApplyPatch`** (`internal/server`) — the write path's four patch strategies (JSON Patch, strategic-merge, `apply-patch+yaml`, plain merge), all of which decode an untrusted client-supplied body. `applyPatch` is at 54.5% coverage with the JSON-patch and `apply-patch+yaml` branches uncovered.

Adds `.github/workflows/fuzz.yml`, running each target for 30s on PRs/pushes touching the fuzzed packages — a future crasher gets committed to `testdata/fuzz/<target>/` and gates CI from then on.

The "also worth covering as ordinary tests" list in #254 (truncated encrypted file, malformed JSON in a record, unicode/long resource names, zip-slip) is explicitly separate from this issue's acceptance criteria and isn't addressed here.

Closes #254

## Test plan
- [x] `make fmt` / `go build ./...` / `go vet ./...` / `go mod tidy` (no diff)
- [x] `go test ./...`
- [x] Ran each target locally for 25-30s (kind/Docker unavailable in this environment, so no corpus could be seeded from a live capture):
  - `FuzzOpenArchive`: completed, no crash
  - `FuzzApplyRules`: ~4M execs, no crash
  - `FuzzApplyPatch`: ~860k execs, no crash
- [ ] `.github/workflows/fuzz.yml` will run for real on this PR (it's scoped to trigger on changes under `internal/archive/**`, `internal/redact/**`, `internal/server/**`, and the workflow file itself)