### PR TITLE
fix(k8sbin): reject any ".." path segment in tar entries outright

### DIFF
--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -487,10 +487,13 @@ func extractTarGz(tarGzPath, destDir string) error {
 			}
 		}
 
-		// Remaining barriers, kept as defense in depth: with no ".." segment
-		// reaching here, none of the checks below should ever fire, but they
-		// independently re-verify containment so a future change to the
-		// rejection above can't silently reopen the traversal. filepath.Rel
+		// Remaining barriers. The absolute-path checks below are load-bearing,
+		// not redundant: a name like "/etc/passwd" carries no ".." segment, so
+		// it passes the rejection above, reaches here, and is skipped by them.
+		// Only the ".."-containment checks alongside them (on cleanedName, and
+		// on filepath.Rel's result) are now redundant with that rejection;
+		// those are kept as defense in depth so a future change to it can't
+		// silently reopen the traversal. filepath.Rel independently
 		// re-verifies containment on the joined result before target is ever
 		// used in a filesystem operation.
 		//

--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -428,9 +428,11 @@ const maxExtractedBytes = 4 << 30 // 4 GiB
 
 // extractTarGz extracts a gzip-compressed tar archive into destDir, which is
 // created if needed. Entries are path-sanitized so nothing can escape
-// destDir (no "..", no absolute paths), and only regular files and
-// directories are extracted — symlinks and other special entry types are
-// skipped rather than followed.
+// destDir ("Zip Slip"): an entry whose name contains a ".." path segment is
+// rejected with an error, absolute-path entries are skipped, and only
+// regular files and directories are extracted — symlinks and other special
+// entry types are skipped rather than followed, so a symlink entry can never
+// be used as an indirect escape for a later entry written "through" it.
 func extractTarGz(tarGzPath, destDir string) error {
 	f, err := os.Open(tarGzPath)
 	if err != nil {
@@ -462,16 +464,35 @@ func extractTarGz(tarGzPath, destDir string) error {
 
 		// hdr.Name comes from the archive and must never be trusted directly: a
 		// hostile ".."-laden or absolute name could otherwise write outside
-		// destDir ("Zip Slip"). filepath.Clean first normalizes harmless
-		// internal ".." segments that still resolve inside destDir (e.g.
-		// "foo/../bar" becomes "bar" — see TestExtractTarGz_PathTraversalRejected),
-		// but any name that still escapes destDir after cleaning (a leading
-		// "..", an absolute path) is rejected outright here — not remapped
-		// into destDir — so an escaping entry never silently lands somewhere
-		// surprising inside destDir instead of failing. filepath.Rel
-		// re-verifies containment on the joined result as a second,
-		// independent check before target is ever used in a filesystem
-		// operation below.
+		// destDir ("Zip Slip").
+		//
+		// First barrier: reject outright any name containing a ".." path
+		// segment, before the name is used to build a path at all. This is
+		// deliberately stricter than "clean it and check the result still
+		// lands inside destDir" — a legitimate Kubernetes source/binary
+		// tarball never contains a ".." segment, so there is nothing to gain
+		// from normalizing one and everything to gain from refusing to reason
+		// about it. It's an error rather than a skip (matching the
+		// negative-size case below) so a malformed archive fails loudly
+		// instead of silently omitting a source file that the build would
+		// then fail on for a confusing, unrelated-looking reason.
+		//
+		// Segments are split on both separators, not just the host's: tar
+		// names are forward-slash by the format's own convention regardless
+		// of the extracting host, so on Linux a "..\\..\\x" name must still
+		// be judged segment-wise by the backslash a Windows host would honor.
+		for _, seg := range strings.FieldsFunc(hdr.Name, func(r rune) bool { return r == '/' || r == '\\' }) {
+			if seg == ".." {
+				return fmt.Errorf("tar entry %q contains a %q path segment; rejecting as unsafe", hdr.Name, "..")
+			}
+		}
+
+		// Remaining barriers, kept as defense in depth: with no ".." segment
+		// reaching here, none of the checks below should ever fire, but they
+		// independently re-verify containment so a future change to the
+		// rejection above can't silently reopen the traversal. filepath.Rel
+		// re-verifies containment on the joined result before target is ever
+		// used in a filesystem operation.
 		//
 		// path.IsAbs(hdr.Name) is checked in addition to
 		// filepath.IsAbs(cleanedName), on the raw tar name rather than the

--- a/internal/k8sbin/k8sbin_test.go
+++ b/internal/k8sbin/k8sbin_test.go
@@ -157,10 +157,21 @@ func TestExtractTarGz_PathTraversalRejected(t *testing.T) {
 
 // TestExtractTarGz_AdversarialEntriesNeverEscape is the belt-and-suspenders
 // counterpart to TestExtractTarGz_PathTraversalRejected: rather than
-// asserting a specific accept/reject decision per name, it plants a canary
-// file as a *sibling* of destDir and proves that — whatever extractTarGz
-// decides to do — no entry ever writes outside destDir. It covers the Zip
-// Slip variants that defeat a naive ".." substring check:
+// asserting a specific accept/reject decision per name, it checks an
+// invariant — whatever extractTarGz decides to do with an entry, nothing
+// lands outside destDir.
+//
+// Scope of that check, stated precisely: it plants a canary file as a direct
+// *sibling* of destDir and asserts the canary is never modified, then walks
+// the enclosing temp root and asserts no marker content appears anywhere
+// outside destDir. That covers where a traversal escaping destDir actually
+// goes (its parent tree, which every case here targets), but it is not a
+// filesystem-wide assertion: a write to an unrelated absolute path outside
+// the temp root would not be detected here. The absolute-path cases below
+// are therefore about "does it stay contained", with the accept/reject
+// contract for them pinned by TestExtractTarGz_PathTraversalRejected.
+//
+// It covers the Zip Slip variants that defeat a naive ".." substring check:
 //
 //   - a symlink entry followed by a file written "through" it (the classic
 //     two-entry indirect escape; extractTarGz skips symlinks, so the second

--- a/internal/k8sbin/k8sbin_test.go
+++ b/internal/k8sbin/k8sbin_test.go
@@ -127,7 +127,10 @@ func TestExtractTarGz_PathTraversalRejected(t *testing.T) {
 			// ".."s still lands under.
 			foundInside, foundOutside := false, false
 			_ = filepath.Walk(tmp, func(p string, info os.FileInfo, err error) error {
-				if err != nil || info.IsDir() {
+				// Regular files only — see the same note in
+				// TestExtractTarGz_AdversarialEntriesNeverEscape: os.ReadFile
+				// would follow a symlink out of the temp tree.
+				if err != nil || info == nil || !info.Mode().IsRegular() {
 					return nil
 				}
 				b, rerr := os.ReadFile(p)
@@ -227,8 +230,15 @@ func TestExtractTarGz_AdversarialEntriesNeverEscape(t *testing.T) {
 					}
 				}
 			}
-			tw.Close()
-			gz.Close()
+			// Fail fast on flush/close errors so the bytes handed to
+			// extractTarGz below are known-good — a silently truncated
+			// archive would make this test pass for the wrong reason.
+			if err := tw.Close(); err != nil {
+				t.Fatalf("closing tar writer: %v", err)
+			}
+			if err := gz.Close(); err != nil {
+				t.Fatalf("closing gzip writer: %v", err)
+			}
 
 			root := t.TempDir()
 			tarPath := filepath.Join(root, "archive.tar.gz")
@@ -252,7 +262,11 @@ func TestExtractTarGz_AdversarialEntriesNeverEscape(t *testing.T) {
 				t.Errorf("canary outside destDir was overwritten with %q", string(b))
 			}
 			_ = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
-				if err != nil || info == nil || info.IsDir() || p == tarPath {
+				// Regular files only, not just "not a directory": if a
+				// regression ever made extractTarGz create a symlink,
+				// os.ReadFile would follow it and could report marker content
+				// read from entirely outside this temp tree.
+				if err != nil || info == nil || !info.Mode().IsRegular() || p == tarPath {
 					return nil
 				}
 				b, rerr := os.ReadFile(p)

--- a/internal/k8sbin/k8sbin_test.go
+++ b/internal/k8sbin/k8sbin_test.go
@@ -68,15 +68,24 @@ func TestExtractTarGz_PathTraversalRejected(t *testing.T) {
 	cases := []struct {
 		name     string
 		wantSafe bool
+		wantErr  bool
 	}{
-		{"go.mod", true},
-		{"cmd/kube-apiserver/main.go", true},
-		{"..", false},
-		{"../etc/passwd", false},
-		{"../../etc/passwd", false},
-		{"foo/../../bar", false},
-		{"/etc/passwd", false},
-		{"foo/../bar", true}, // cleans to "bar", still inside destDir
+		{name: "go.mod", wantSafe: true},
+		{name: "cmd/kube-apiserver/main.go", wantSafe: true},
+		// Any ".." path segment is rejected with an error, not normalized —
+		// including "foo/../bar", which would clean to the harmless "bar".
+		// A real Kubernetes tarball never contains one, so refusing to reason
+		// about it at all is strictly safer than cleaning it (see
+		// extractTarGz's first-barrier comment).
+		{name: "..", wantErr: true},
+		{name: "../etc/passwd", wantErr: true},
+		{name: "../../etc/passwd", wantErr: true},
+		{name: "foo/../../bar", wantErr: true},
+		{name: "foo/../bar", wantErr: true},
+		{name: `..\..\etc\passwd`, wantErr: true}, // backslash segments too, on every host
+		// Absolute paths are skipped rather than erroring (they carry no
+		// ".." segment to reject).
+		{name: "/etc/passwd"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -99,7 +108,15 @@ func TestExtractTarGz_PathTraversalRejected(t *testing.T) {
 				t.Fatal(err)
 			}
 			destDir := filepath.Join(tmp, "out")
-			if err := extractTarGz(tarPath, destDir); err != nil {
+			err := extractTarGz(tarPath, destDir)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("extractTarGz(%q) = nil, want an error", tc.name)
+				}
+				if !strings.Contains(err.Error(), "..") {
+					t.Errorf("error = %q, want it to name the %q segment", err.Error(), "..")
+				}
+			} else if err != nil {
 				t.Fatalf("extractTarGz: %v", err)
 			}
 
@@ -131,6 +148,127 @@ func TestExtractTarGz_PathTraversalRejected(t *testing.T) {
 			if foundInside != tc.wantSafe {
 				t.Errorf("entry %q extracted inside destDir = %v, want %v", tc.name, foundInside, tc.wantSafe)
 			}
+		})
+	}
+}
+
+// TestExtractTarGz_AdversarialEntriesNeverEscape is the belt-and-suspenders
+// counterpart to TestExtractTarGz_PathTraversalRejected: rather than
+// asserting a specific accept/reject decision per name, it plants a canary
+// file as a *sibling* of destDir and proves that — whatever extractTarGz
+// decides to do — no entry ever writes outside destDir. It covers the Zip
+// Slip variants that defeat a naive ".." substring check:
+//
+//   - a symlink entry followed by a file written "through" it (the classic
+//     two-entry indirect escape; extractTarGz skips symlinks, so the second
+//     entry lands in a real directory inside destDir)
+//   - a hard-link entry pointing outside destDir
+//   - backslash separators, which only the extracting host may honor
+//   - "....//" and "C:\", which look traversal-ish but aren't on a POSIX host
+//
+// This is the test that would catch a regression in the ".." rejection being
+// weakened or reordered, since it checks the invariant rather than the
+// mechanism (CodeQL alert #13).
+func TestExtractTarGz_AdversarialEntriesNeverEscape(t *testing.T) {
+	const marker = "ESCAPE-MARKER"
+	type entry struct {
+		name     string
+		typeflag byte
+		linkname string
+	}
+	cases := []struct {
+		desc    string
+		entries []entry
+	}{
+		// The direct escape vector, included here so this test fails loudly
+		// (not just the accept/reject table above) if the ".." rejection is
+		// ever removed.
+		{"plain parent traversal", []entry{{name: "../escaped.txt"}}},
+		{"backslash traversal", []entry{{name: `..\..\escaped.txt`}}},
+		{"dot-dot-dot-dot slash slash", []entry{{name: `....//escaped.txt`}}},
+		{"double-slash absolute", []entry{{name: "//etc/escaped.txt"}}},
+		{"windows drive letter", []entry{{name: `C:\escaped.txt`}}},
+		{"symlink to parent, then write through it", []entry{
+			{name: "link", typeflag: tar.TypeSymlink, linkname: ".."},
+			{name: "link/escaped.txt"},
+		}},
+		{"symlink to absolute dir, then write through it", []entry{
+			{name: "link", typeflag: tar.TypeSymlink, linkname: os.TempDir()},
+			{name: "link/escaped.txt"},
+		}},
+		{"hard link pointing outside", []entry{
+			{name: "hl", typeflag: tar.TypeLink, linkname: "../../escaped.txt"},
+		}},
+		{"deep traversal", []entry{{name: "a/b/c/../../../../../escaped.txt"}}},
+		{"trailing dotdot directory", []entry{{name: "sub/..", typeflag: tar.TypeDir}}},
+		{"leading ./..", []entry{{name: "./../escaped.txt"}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			var buf bytes.Buffer
+			gz := gzip.NewWriter(&buf)
+			tw := tar.NewWriter(gz)
+			for _, e := range tc.entries {
+				tf := e.typeflag
+				if tf == 0 {
+					tf = tar.TypeReg
+				}
+				h := &tar.Header{Name: e.name, Mode: 0o644, Typeflag: tf, Linkname: e.linkname}
+				if tf == tar.TypeReg {
+					h.Size = int64(len(marker))
+				}
+				if err := tw.WriteHeader(h); err != nil {
+					t.Fatal(err)
+				}
+				if tf == tar.TypeReg {
+					if _, err := tw.Write([]byte(marker)); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			tw.Close()
+			gz.Close()
+
+			root := t.TempDir()
+			tarPath := filepath.Join(root, "archive.tar.gz")
+			if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			// The canary sits directly alongside destDir, so a single "../"
+			// escape from inside destDir lands exactly on it.
+			canary := filepath.Join(root, "escaped.txt")
+			if err := os.WriteFile(canary, []byte("ORIGINAL"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			destDir := filepath.Join(root, "out")
+
+			// Either outcome is acceptable here (reject with an error, or
+			// extract somewhere safely inside destDir) — what must never
+			// happen is a write landing outside destDir.
+			_ = extractTarGz(tarPath, destDir)
+
+			if b, err := os.ReadFile(canary); err == nil && string(b) != "ORIGINAL" {
+				t.Errorf("canary outside destDir was overwritten with %q", string(b))
+			}
+			_ = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+				if err != nil || info == nil || info.IsDir() || p == tarPath {
+					return nil
+				}
+				b, rerr := os.ReadFile(p)
+				if rerr != nil || !strings.Contains(string(b), marker) {
+					return nil
+				}
+				// Compare against destDir with a separator boundary: a file
+				// legitimately *inside* destDir can itself be named
+				// "..\..\x" or "....", whose Rel result starts with the
+				// characters ".." without being an escape.
+				rel, rerr := filepath.Rel(destDir, p)
+				if rerr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+					t.Errorf("entry content landed outside destDir at %s", p)
+				}
+				return nil
+			})
 		})
 	}
 }


### PR DESCRIPTION
Resolves the [go/zipslip code-scanning alert #13](https://github.com/phenixblue/k8shark/security/code-scanning/13) (high severity) on `internal/k8sbin/k8sbin.go`'s `extractTarGz`.

## Was the alert valid?

**Not exploitable as written** — but worth fixing anyway, and I've tightened the contract rather than dismissing it.

I probed the existing sanitization with 11 adversarial archives covering the Zip Slip variants that defeat naive checks:

| Variant | Result |
|---|---|
| `../escaped.txt`, `../../etc/passwd`, `a/b/c/../../../../../x` | rejected |
| symlink → `..` then a file written *through* it (classic two-entry indirect escape) | symlink skipped; file landed safely inside `destDir` |
| symlink → absolute dir, then write through it | same |
| hard link → `../../escaped.txt` | skipped |
| `..\..\escaped.txt` (backslash separators) | contained on POSIX; rejected on Windows |
| `....//escaped.txt`, `//etc/x`, `C:\x` | contained (these only *look* traversal-ish) |

Nothing escaped `destDir`. The code already rejected escaping names and skipped symlinks rather than following them. CodeQL doesn't model the `filepath.Rel`-based containment check as a sanitizer, so it can't see that.

*(Worth noting: my first probe reported two false escapes because it used `strings.HasPrefix(rel, "..")` without a separator boundary — a file legitimately inside `destDir` can itself be named `..\..\x` or `....`. That's precisely the bug class the production code avoids by checking `".."+string(filepath.Separator)`.)*

## What changed

- **New first barrier:** reject outright any entry whose name contains a `..` path segment, before the name is used to build a path at all. Split on both separators, since tar names are forward-slash by the format's convention regardless of the extracting host.
- **Error, not skip** — matching the existing negative-size case — so a malformed archive fails loudly instead of silently omitting a source file that the subsequent `go build` would then fail on for an unrelated-looking reason.
- **Pre-existing guards kept** as defense in depth, so a future change to the new rejection can't silently reopen the traversal.

### One deliberate behavior change

`foo/../bar` previously cleaned to `bar` and extracted; it's now rejected. Refusing to reason about a `..` segment at all is strictly safer, and the entry can't occur in the archives this function actually reads — `dl.k8s.io` release tarballs, checksum-verified before extraction (`downloadAndVerifyToFile`), reached only from `buildFromSource`. The existing test case's expectation is flipped accordingly.

## Test plan
- [x] `TestExtractTarGz_PathTraversalRejected` extended with a `wantErr` dimension + a backslash case
- [x] New `TestExtractTarGz_AdversarialEntriesNeverEscape`: plants a canary as a *sibling* of `destDir` and asserts the **invariant** (nothing ever writes outside `destDir`) rather than any per-name decision — so it catches a regression in the mechanism, not just the current rules
- [x] **Verified the new test has teeth**: neutering all three sanitization layers makes it fail on the overwritten canary, then restored
- [x] `make fmt` / `go build ./...` / `go vet ./...` / `go mod tidy` (no diff)
- [x] `go test ./...` and `go test -race ./internal/k8sbin/`
- [ ] CodeQL re-analysis on this PR should clear alert #13; if the query still doesn't recognize the barrier, I'll dismiss it with this analysis as the justification