### PR TITLE
fix(k8sbin): use the ".." barrier shape CodeQL recognizes

### DIFF
--- a/internal/k8sbin/k8sbin.go
+++ b/internal/k8sbin/k8sbin.go
@@ -428,7 +428,7 @@ const maxExtractedBytes = 4 << 30 // 4 GiB
 
 // extractTarGz extracts a gzip-compressed tar archive into destDir, which is
 // created if needed. Entries are path-sanitized so nothing can escape
-// destDir ("Zip Slip"): an entry whose name contains a ".." path segment is
+// destDir ("Zip Slip"): an entry whose name contains ".." anywhere is
 // rejected with an error, absolute-path entries are skipped, and only
 // regular files and directories are extracted — symlinks and other special
 // entry types are skipped rather than followed, so a symlink entry can never
@@ -466,30 +466,41 @@ func extractTarGz(tarGzPath, destDir string) error {
 		// hostile ".."-laden or absolute name could otherwise write outside
 		// destDir ("Zip Slip").
 		//
-		// First barrier: reject outright any name containing a ".." path
-		// segment, before the name is used to build a path at all. This is
-		// deliberately stricter than "clean it and check the result still
-		// lands inside destDir" — a legitimate Kubernetes source/binary
-		// tarball never contains a ".." segment, so there is nothing to gain
-		// from normalizing one and everything to gain from refusing to reason
-		// about it. It's an error rather than a skip (matching the
-		// negative-size case below) so a malformed archive fails loudly
-		// instead of silently omitting a source file that the build would
-		// then fail on for a confusing, unrelated-looking reason.
+		// First barrier: reject outright any name containing "..", anywhere,
+		// before the name is used to build a path at all. It's an error rather
+		// than a skip (matching the negative-size case below) so a malformed
+		// archive fails loudly instead of silently omitting a source file that
+		// the build would then fail on for a confusing, unrelated-looking
+		// reason.
 		//
-		// Segments are split on both separators, not just the host's: tar
-		// names are forward-slash by the format's own convention regardless
-		// of the extracting host, so on Linux a "..\\..\\x" name must still
-		// be judged segment-wise by the backslash a Windows host would honor.
-		for _, seg := range strings.FieldsFunc(hdr.Name, func(r rune) bool { return r == '/' || r == '\\' }) {
-			if seg == ".." {
-				return fmt.Errorf("tar entry %q contains a %q path segment; rejecting as unsafe", hdr.Name, "..")
-			}
+		// This is deliberately blunt: it refuses "foo..bar" and a "...."
+		// directory too, not only a real ".." path segment. Two reasons.
+		//
+		// 1. It costs nothing on the only archive this function ever reads.
+		//    extractTarGz has exactly one caller — buildFromSource, on
+		//    dl.k8s.io's kubernetes-src.tar.gz, checksum-verified first — and
+		//    none of that tarball's 35,083 entries (checked against v1.36.1)
+		//    contain ".." anywhere in the name. Re-check that if this function
+		//    is ever pointed at a different archive.
+		// 2. It's the barrier shape a static analyzer actually recognizes.
+		//    CodeQL's go/zipslip query treats a strings.Contains(name, "..")
+		//    guard as a sanitizer (it's the fix in its own docs); it did not
+		//    recognize the segment-wise check this replaces, so alert #13
+		//    stayed open on a path that adversarial testing shows is not
+		//    reachable (see TestExtractTarGz_AdversarialEntriesNeverEscape,
+		//    which proves containment independently of this check).
+		//
+		// Substring rather than segment-wise also sidesteps the separator
+		// question entirely: tar names are forward-slash by the format's own
+		// convention regardless of the extracting host, so a "..\\..\\x" name
+		// needs no special handling to be caught here.
+		if strings.Contains(hdr.Name, "..") {
+			return fmt.Errorf("tar entry %q contains %q; rejecting as unsafe", hdr.Name, "..")
 		}
 
 		// Remaining barriers. The absolute-path checks below are load-bearing,
-		// not redundant: a name like "/etc/passwd" carries no ".." segment, so
-		// it passes the rejection above, reaches here, and is skipped by them.
+		// not redundant: a name like "/etc/passwd" contains no "..", so it
+		// passes the rejection above, reaches here, and is skipped by them.
 		// Only the ".."-containment checks alongside them (on cleanedName, and
 		// on filepath.Rel's result) are now redundant with that rejection;
 		// those are kept as defense in depth so a future change to it can't

--- a/internal/k8sbin/k8sbin_test.go
+++ b/internal/k8sbin/k8sbin_test.go
@@ -72,19 +72,26 @@ func TestExtractTarGz_PathTraversalRejected(t *testing.T) {
 	}{
 		{name: "go.mod", wantSafe: true},
 		{name: "cmd/kube-apiserver/main.go", wantSafe: true},
-		// Any ".." path segment is rejected with an error, not normalized —
-		// including "foo/../bar", which would clean to the harmless "bar".
-		// A real Kubernetes tarball never contains one, so refusing to reason
-		// about it at all is strictly safer than cleaning it (see
-		// extractTarGz's first-barrier comment).
+		// Any ".." is rejected with an error, not normalized — including
+		// "foo/../bar", which would clean to the harmless "bar". Refusing to
+		// reason about it at all is strictly safer (see extractTarGz's
+		// first-barrier comment).
 		{name: "..", wantErr: true},
 		{name: "../etc/passwd", wantErr: true},
 		{name: "../../etc/passwd", wantErr: true},
 		{name: "foo/../../bar", wantErr: true},
 		{name: "foo/../bar", wantErr: true},
-		{name: `..\..\etc\passwd`, wantErr: true}, // backslash segments too, on every host
-		// Absolute paths are skipped rather than erroring (they carry no
-		// ".." segment to reject).
+		{name: `..\..\etc\passwd`, wantErr: true}, // backslash names too, on every host
+		// The rejection is deliberately blunt — a substring match, not a path
+		// segment — so these are refused even though neither is a traversal.
+		// Pinned as intended, not incidental: none of kubernetes-src.tar.gz's
+		// 35,083 entries contain ".." anywhere, so nothing real is lost, and
+		// the blunt form is what CodeQL's go/zipslip query recognizes as a
+		// sanitizer (alert #13).
+		{name: "foo..bar", wantErr: true},
+		{name: "..../escaped.txt", wantErr: true},
+		// Absolute paths are skipped rather than erroring (they contain no
+		// ".." to reject).
 		{name: "/etc/passwd"},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Follow-up to #312, which did **not** close [code-scanning alert #13](https://github.com/phenixblue/k8shark/security/code-scanning/13) (`go/zipslip`, high).

## What happened

I misjudged this on #312. That PR's Go analysis returned `results_count: 0`, and I read it as strong evidence the alert would auto-close on merge. It didn't — PR analyses are scoped differently from branch analyses. The post-merge analysis of `main` at `778546b` still reports `results_count=1` with the same three flagged filesystem operations, and alert #13 is still `open`.

Root cause: CodeQL's `go/zipslip` query doesn't model #312's segment-wise `strings.FieldsFunc` check as a sanitizer. The guard it *does* recognize is a plain `strings.Contains(name, "..")` rejection — the fix given in its own docs.

## The change

Swap the segment-wise check for the substring one. That's blunter: it refuses `foo..bar` and a `....` directory too, not only a real `..` path segment. Safe here on **evidence, not assumption**:

| Check | Result |
|---|---|
| `extractTarGz` callers | exactly one — `buildFromSource`, on `dl.k8s.io`'s `kubernetes-src.tar.gz`, checksum-verified before extraction |
| entries containing `..` anywhere, real v1.36.1 tarball | **0 of 35,083** |
| real v1.36.1 tarball extracted through the new check | **succeeds** — 29,208 files, 5,871 dirs, `vendor/` present (which `buildFromSource` requires) |

Substring-based also removes the separator question entirely: tar names are forward-slash by the format's convention regardless of the extracting host, so `..\..\x` needs no special handling to be caught.

Two new test cases (`foo..bar`, `..../escaped.txt`) pin the over-broadness as **intended rather than incidental**, and the code comment records the empirical basis plus a note to re-check it if this function is ever pointed at a different archive.

## Not a live hole

Worth restating: the code was never exploitable. `TestExtractTarGz_AdversarialEntriesNeverEscape` proves containment independently of this guard, across symlink-then-write-through, hard-link, backslash, `....//`, drive-letter, and deep-traversal variants — and is teeth-verified (neutering the sanitization makes it fail on an overwritten canary). This PR is about making an existing guarantee legible to static analysis.

## Test plan
- [x] `make fmt` / `go build ./...` / `go vet ./...` / `go mod tidy` (no diff)
- [x] `go test ./...` — all pass; `go test -race ./internal/k8sbin/`
- [x] Extracted the real `kubernetes-src.tar.gz` v1.36.1 end-to-end through the new check (throwaway test, since committing a 40 MB fixture isn't worth it)
- [ ] **Whether this actually clears alert #13 can only be confirmed by CodeQL's re-analysis of `main` after merge** — I'm not going to claim it will, having called that wrong once already. If it still fires, the code is provably safe and dismissing as a false positive is the remaining option.