### PR TITLE
fix(release): cosign v3 dropped sign-blob's --output-signature/--certificate

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,16 +51,28 @@ changelog:
 sboms:
   - artifacts: archive
 
+# cosign v3 (installed by cosign-installer v4.x — see release.yml) removed
+# sign-blob's --output-signature/--output-certificate in favor of a single
+# --bundle file that carries both the signature and the certificate. Passing
+# the old flags is a hard error on v3 ("must specify --bundle with
+# --new-bundle-format"), not a warning, so this block must use --bundle.
+#
+# `signature:` is how goreleaser learns which file the signing command
+# produced so it gets uploaded with the release; pointing it at the bundle
+# (and dropping `certificate:`, which no longer has a separate output) keeps
+# exactly one signing artifact attached: checksums.txt.bundle.
+#
+# Verifying this shape is `cosign verify-blob --bundle checksums.txt.bundle
+# ... checksums.txt` — see docs/releases.md, which must stay in step with it.
 signs:
   - artifacts: checksum
     cmd: cosign
-    certificate: '${artifact}.pem'
+    signature: '${artifact}.bundle'
     output: true
     args:
       - sign-blob
       - --yes
-      - --output-signature=${signature}
-      - --output-certificate=${certificate}
+      - --bundle=${signature}
       - ${artifact}
 
 homebrew_casks:

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ kind-down: ## Delete the dev KinD clusters (k8shark-dev and k8shark-scale)
 clean: ## Remove build artifacts
 	rm -f $(BINARY) coverage.out coverage.html
 
-release-snapshot: ## Build a local release snapshot without publishing (no signing)
+release-snapshot: ## Build a local release snapshot without publishing (DOES sign: needs OIDC)
 	goreleaser release --snapshot --clean
 
 release-local: ## Dry-run release with SBOM + Homebrew output but no publish

--- a/docs/development.md
+++ b/docs/development.md
@@ -95,7 +95,7 @@ Run `make help` to print all targets:
   e2e             Build binary and run end-to-end tests (requires kind + kubectl)
   kind-up         Create a dev KinD cluster with test resources (use --reset to recreate)
   kind-down       Delete the dev KinD cluster (k8shark-dev)
-  release-snapshot  Build a local release snapshot without publishing (no signing)
+  release-snapshot  Build a local release snapshot without publishing (DOES sign: needs OIDC)
   release-local   Dry-run release with SBOM + Homebrew output but no publish
   clean           Remove build artifacts
   help            Print available targets

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -40,7 +40,7 @@ Only the latest minor receives patch releases; see the stability policy's
 1. **Tests** — runs `go test ./...` against the tagged commit. The release is blocked if tests fail.
 2. **GoReleaser** — builds cross-platform binaries, packages archives, generates a checksum file, and publishes the GitHub Release.
 3. **SBOM** — [Syft](https://github.com/anchore/syft) generates a Software Bill of Materials for each archive artifact.
-4. **Signing** — the `checksums.txt` file is signed with [cosign](https://github.com/sigstore/cosign) using keyless OIDC signing (no long-lived keys). The signature and certificate are attached to the release.
+4. **Signing** — the `checksums.txt` file is signed with [cosign](https://github.com/sigstore/cosign) using keyless OIDC signing (no long-lived keys). The signature and certificate are attached to the release together, as a single `checksums.txt.bundle`.
 5. **Attestation** — GitHub's `attest-build-provenance` action attaches a build provenance attestation to each release archive (`.tar.gz`/`.zip`).
 6. **Homebrew tap** — GoReleaser pushes an updated cask to `phenixblue/homebrew-tap`, so `brew upgrade --cask k8shark` picks up the new version automatically.
 
@@ -71,16 +71,21 @@ The cosign signing uses GitHub's OIDC token — no additional secret is needed.
 
 ```sh
 # Download the release artifacts
-gh release download v1.0.0-rc.1 --repo phenixblue/k8shark
+gh release download v1.0.0-rc.3 --repo phenixblue/k8shark
 
 # Verify the cosign signature
 cosign verify-blob \
-  --certificate checksums.txt.pem \
-  --signature checksums.txt.sig \
+  --bundle checksums.txt.bundle \
   --certificate-identity-regexp 'https://github.com/phenixblue/k8shark/.github/workflows/release.yml' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   checksums.txt
 ```
+
+The signature and certificate live together in a single `checksums.txt.bundle`
+(cosign's "new bundle format"). Releases signed before `v1.0.0-rc.3` instead
+carry a separate `checksums.txt.sig` and `checksums.txt.pem`; verify those
+with `--signature checksums.txt.sig --certificate checksums.txt.pem` in place
+of `--bundle`. Requires cosign v3+ (`--bundle` verification).
 
 ### Verify a binary checksum
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -76,10 +76,21 @@ gh release download v1.0.0-rc.3 --repo phenixblue/k8shark
 # Verify the cosign signature
 cosign verify-blob \
   --bundle checksums.txt.bundle \
-  --certificate-identity-regexp 'https://github.com/phenixblue/k8shark/.github/workflows/release.yml' \
+  --certificate-identity-regexp '^https://github\.com/phenixblue/k8shark/\.github/workflows/release\.yml@refs/tags/v.+$' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   checksums.txt
 ```
+
+**The identity regexp is anchored on purpose — don't loosen it.**
+`--certificate-identity-regexp` is an unanchored search, so a bare
+`https://github.com/phenixblue/k8shark/.github/workflows/release.yml` would
+also match any identity that merely *contains* that string (say
+`.../evil/x/.github/workflows/release.yml@refs/tags/v9?u=<the real one>`),
+which defeats the point of checking it. `^`/`$` plus escaped dots plus the
+required `@refs/tags/v…` suffix pins it to this repo's release workflow run
+from a version tag. The signing identity looks like
+`https://github.com/phenixblue/k8shark/.github/workflows/release.yml@refs/tags/v1.0.0-rc.2`
+(read off that release's own certificate).
 
 The signature and certificate live together in a single `checksums.txt.bundle`
 (cosign's newer bundle format), which is what `--bundle` above reads. Releases
@@ -112,14 +123,25 @@ gh attestation verify k8shark_<version>_linux_amd64.tar.gz \
 You can build a release locally without publishing using `make`:
 
 ```sh
-# Snapshot build (no signing, no publish)
+# Full pipeline including signing, but no publish.
+# Signing is keyless, so this needs an OIDC identity: expect the cosign step
+# to prompt for a browser login, or to fail if you're headless.
 make release-snapshot
 
-# Dry-run with SBOM + Homebrew output but no signing or publishing
+# Dry-run with SBOM + Homebrew output, skipping BOTH signing and publishing.
+# This is the one to use for a quick local check.
 make release-local
 ```
 
 Both commands place output in `./dist/`. Requires `goreleaser` in your PATH (`go install github.com/goreleaser/goreleaser/v2@latest`).
+
+**Run one of these before pushing a release tag.** A tag is effectively
+un-publishable once pushed, and the CI dry-run
+([release-check.yml](../.github/workflows/release-check.yml)) skips the signing
+step — it has no OIDC token — so signing is otherwise first exercised by the
+real release. That gap is exactly how a cosign v3 incompatibility survived
+until a tag was about to be cut: `release-snapshot` reproduces it locally,
+`release-local` does not.
 
 ## CI pipeline (non-release)
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -82,10 +82,17 @@ cosign verify-blob \
 ```
 
 The signature and certificate live together in a single `checksums.txt.bundle`
-(cosign's "new bundle format"). Releases signed before `v1.0.0-rc.3` instead
-carry a separate `checksums.txt.sig` and `checksums.txt.pem`; verify those
-with `--signature checksums.txt.sig --certificate checksums.txt.pem` in place
-of `--bundle`. Requires cosign v3+ (`--bundle` verification).
+(cosign's newer bundle format), which is what `--bundle` above reads. Releases
+are signed by the cosign version pinned in `release.yml` — v3.x, via
+`cosign-installer` v4.x — so verifying with a v3.x cosign is the tested
+combination.
+
+Releases before `v1.0.0-rc.3` instead carry separate `checksums.txt.sig` and
+`checksums.txt.pem`. Verify those by swapping `--bundle` for `--signature
+checksums.txt.sig --certificate checksums.txt.pem`. Those two flags are
+deprecated in cosign v3 but still functional (it prints a warning), so a
+single v3 cosign verifies both the old and new layouts — you don't need an
+older cosign for older releases.
 
 ### Verify a binary checksum
 


### PR DESCRIPTION
**This would have broken the `v1.0.0-rc.3` release.** Found by running `make release-snapshot` before pushing the tag, rather than after.

```
Error: must specify --bundle with --new-bundle-format
⨯ release failed  message=could not sign artifact cmd=cosign artifact=checksums.txt
```

## Cause

#300 bumped `sigstore/cosign-installer` 3.9.1 → 4.1.2. That action defaults to **cosign v3.0.6** (confirmed by reading the pinned commit's `action.yml`). cosign v3 removed `sign-blob`'s `--output-signature` / `--output-certificate` in favor of a single `--bundle` carrying both — and passing the old flags is a **hard error, not a warning**:

| args | cosign v3.1.2 result |
|---|---|
| `--output-signature=… --output-certificate=…` (current config) | rejected at parse time — `must specify --bundle with --new-bundle-format` |
| `--bundle=…` (this PR) | accepted; proceeds to the OIDC step |

`v1.0.0-rc.2` was tagged *before* #300 merged, so it signed with cosign v2 and succeeded. **rc.3 would have been the first release to run against v3.**

## Why CI didn't catch it

`release-check.yml` — added in #225 for precisely this class of bug — runs the snapshot with `--skip=sign,publish`, because keyless signing needs an OIDC token it doesn't request. So **the signing step is only ever exercised by a real tagged release.**

I've deliberately *not* changed that here: granting `id-token: write` to the dry-run job would make it emit real Sigstore transparency-log entries on every release-config PR. That's a reasonable thing to do (plenty of projects do), but it's a call worth making deliberately rather than smuggling into a bugfix. Flagging it as a follow-up.

Also fixed en route: `make release-snapshot`'s help text claimed *"no signing"*, but the target **does** sign — that wrong comment is a good part of why this went unnoticed locally. `release-local` is the one that skips signing.

## Changes

- **`.goreleaser.yaml`** — sign with `--bundle=${signature}`; point `signature:` at `${artifact}.bundle` so goreleaser uploads it; drop `certificate:`, which no longer has a separate output. One signing artifact now: `checksums.txt.bundle`.
- **`docs/releases.md`** — verify with `--bundle checksums.txt.bundle`, plus a note that releases before rc.3 carry separate `.sig`/`.pem` and how to verify *those*, so older releases stay verifiable from these docs.
- **`Makefile`** — correct the `release-snapshot` help text.

## Test plan
- [x] `goreleaser check` passes
- [x] Full `--skip=sign,publish` dry-run succeeds: 6 archives, 6 SBOMs, checksums, both Homebrew casks
- [x] Rendered `dist/config.yaml` confirms `--bundle=${signature}` resolves to `checksums.txt.bundle`
- [x] cosign v3.1.2 accepts the new arg list and rejects the old one at parse time
- [x] `make fmt` / `go build ./...` / `go vet ./...` / `go test ./...`
- [ ] End-to-end signing can only be confirmed by the real release job — that's the gap above. The next tag is the proof.