### PR TITLE
ci(release-check): sign for real, so a cosign break fails here not at a tag

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -37,13 +37,32 @@ on:
 permissions:
   contents: read
   # Required for cosign's keyless signing to obtain an OIDC token. This job
-  # publishes nothing — contents stays read-only.
+  # publishes nothing — contents stays read-only. See CAN_SIGN below: signing
+  # is gated so PR-authored code from a fork never mints a token bearing this
+  # repository's identity.
   id-token: write
 
 jobs:
   goreleaser-dry-run:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      # Sign only on pushes to main and on same-repo PRs — never on a fork PR.
+      # Two reasons, and the gate is worth having even if only one holds:
+      #
+      #   1. Privilege. id-token: write on a pull_request-triggered workflow is
+      #      a permission grant evaluated against PR-authored code. Fork PRs
+      #      are not expected to be able to mint an OIDC token carrying this
+      #      repo's identity, but gating explicitly means the guarantee doesn't
+      #      rest on that being true (or staying true).
+      #   2. It would fail anyway. Without a usable token the cosign step
+      #      errors, so an external contributor touching .goreleaser.yaml would
+      #      get a red check they cannot fix.
+      #
+      # Fork PRs still run the whole build and every artifact assertion — only
+      # the signing step and its bundle verification are skipped. Same
+      # same-repo test conformance.yml uses to gate its PR-comment step.
+      CAN_SIGN: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -62,6 +81,7 @@ jobs:
       # the whole value of signing here is validating the exact cosign version
       # the real release will use.
       - name: Setup Cosign
+        if: env.CAN_SIGN == 'true'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Install GoReleaser
@@ -75,10 +95,17 @@ jobs:
         run: goreleaser check
 
       - name: goreleaser snapshot dry-run
-        # Only publish is skipped — signing runs for real, so a cosign/config
+        # Signing runs for real when CAN_SIGN, so a cosign/config
         # incompatibility fails here rather than at a release tag. See the
         # header comment.
-        run: goreleaser release --snapshot --clean --skip=publish
+        run: |
+          set -euo pipefail
+          if [ "$CAN_SIGN" = "true" ]; then
+            goreleaser release --snapshot --clean --skip=publish
+          else
+            echo "::notice title=signing not exercised::fork PR — running unsigned (no OIDC token available to a fork). Build and artifact checks still run; the signing path is validated on push to main."
+            goreleaser release --snapshot --clean --skip=sign,publish
+          fi
         env:
           HOMEBREW_TAP_OWNER: phenixblue
           HOMEBREW_TAP_NAME: homebrew-tap
@@ -94,6 +121,7 @@ jobs:
       # back — would slip past a pass/fail-only check. So assert the exact
       # filename docs/releases.md tells users to fetch, then round-trip it.
       - name: Verify the signature bundle round-trips
+        if: env.CAN_SIGN == 'true'
         run: |
           set -euo pipefail
           if [ ! -f dist/checksums.txt.bundle ]; then

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,10 +1,26 @@
 name: release-check
 
 # Exercises the actual release pipeline (goreleaser check + a full snapshot
-# build) on every change that could break it, instead of only ever finding out
-# when a real tag is pushed (#225). This is exactly how #223 (cosign
-# certificate never emitted) and #224 (goreleaser check failing on deprecated
-# brews:) went undetected for as long as they did.
+# build + real signing) on every change that could break it, instead of only
+# ever finding out when a real tag is pushed (#225). This is exactly how #223
+# (cosign certificate never emitted) and #224 (goreleaser check failing on
+# deprecated brews:) went undetected for as long as they did.
+#
+# This job used to run with --skip=sign, which left the signing step exercised
+# only by a real tagged release — and that gap is precisely how #314 happened:
+# a Dependabot bump of cosign-installer (#300) moved cosign v2 -> v3, whose
+# sign-blob dropped --output-signature/--output-certificate, and nothing
+# noticed until a v1.0.0-rc.3 tag was about to be cut. So it now signs for
+# real, with cosign pinned to the SAME commit release.yml uses (keep those two
+# pins in lockstep — pinning a different version here would validate the wrong
+# binary and defeat the point).
+#
+# Two consequences worth knowing about:
+#   - It needs id-token: write to get an OIDC token for keyless signing.
+#   - Signing is real, so each run writes an entry to Sigstore's public
+#     transparency log. Those entries carry this workflow's identity
+#     (.../release-check.yml@<ref>), never release.yml's, so a dry-run
+#     signature can't be mistaken for a released artifact's.
 on:
   pull_request:
     paths:
@@ -20,6 +36,9 @@ on:
 
 permissions:
   contents: read
+  # Required for cosign's keyless signing to obtain an OIDC token. This job
+  # publishes nothing — contents stays read-only.
+  id-token: write
 
 jobs:
   goreleaser-dry-run:
@@ -39,6 +58,12 @@ jobs:
       - name: Setup Syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
+      # Must stay pinned to the same commit as release.yml's Setup Cosign step:
+      # the whole value of signing here is validating the exact cosign version
+      # the real release will use.
+      - name: Setup Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
@@ -50,9 +75,10 @@ jobs:
         run: goreleaser check
 
       - name: goreleaser snapshot dry-run
-        # Same skip set as `make release-local`: no signing (no OIDC token
-        # available outside the real release job) and no publish.
-        run: goreleaser release --snapshot --clean --skip=sign,publish
+        # Only publish is skipped — signing runs for real, so a cosign/config
+        # incompatibility fails here rather than at a release tag. See the
+        # header comment.
+        run: goreleaser release --snapshot --clean --skip=publish
         env:
           HOMEBREW_TAP_OWNER: phenixblue
           HOMEBREW_TAP_NAME: homebrew-tap
@@ -60,6 +86,31 @@ jobs:
           # even with --skip=publish, so this needs a non-empty value — never
           # dereferenced over the network since publish is skipped.
           HOMEBREW_TAP_GITHUB_TOKEN: unused-dry-run-token
+
+      # "goreleaser didn't error" is a weaker claim than "the signature exists
+      # under the name we publish and actually verifies". #314 was a hard
+      # failure, but a subtler regression — goreleaser's `signature:` template
+      # renaming the output, or cosign emitting a format verify-blob can't read
+      # back — would slip past a pass/fail-only check. So assert the exact
+      # filename docs/releases.md tells users to fetch, then round-trip it.
+      - name: Verify the signature bundle round-trips
+        run: |
+          set -euo pipefail
+          if [ ! -f dist/checksums.txt.bundle ]; then
+            echo "::error::dist/checksums.txt.bundle missing — signing produced no bundle, or goreleaser's signs[].signature no longer matches the name docs/releases.md documents"
+            ls -la dist/ || true
+            exit 1
+          fi
+          # Identity is this workflow (not release.yml), anchored for the same
+          # reason docs/releases.md anchors its own: the flag is an unanchored
+          # search, so a bare URL would also match any identity merely
+          # containing it.
+          cosign verify-blob \
+            --bundle dist/checksums.txt.bundle \
+            --certificate-identity-regexp '^https://github\.com/phenixblue/k8shark/\.github/workflows/release-check\.yml@.+$' \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+            dist/checksums.txt
+          echo "signature bundle verified"
 
       - name: Verify expected artifact set
         run: |

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -144,10 +144,12 @@ either release workflow. It didn't always: it used to skip signing, and that
 gap is exactly how a cosign v3 incompatibility survived until a `v1.0.0-rc.3`
 tag was about to be cut.
 
-Because that job only triggers on release-config paths, a change elsewhere
-that somehow affects packaging still won't be signed-tested until the tag.
-`make release-snapshot` reproduces the full signing path locally if you want
-belt-and-braces before a release; `make release-local` does not.
+Two caveats keep the local check useful. That job only triggers on
+release-config paths, so a change elsewhere that somehow affects packaging
+still isn't signed-tested until the tag; and it skips signing on pull requests
+from forks, which can't obtain an OIDC token. `make release-snapshot`
+reproduces the full signing path locally for extra assurance before a release;
+`make release-local` does not.
 
 ## CI pipeline (non-release)
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -135,13 +135,19 @@ make release-local
 
 Both commands place output in `./dist/`. Requires `goreleaser` in your PATH (`go install github.com/goreleaser/goreleaser/v2@latest`).
 
-**Run one of these before pushing a release tag.** A tag is effectively
-un-publishable once pushed, and the CI dry-run
-([release-check.yml](../.github/workflows/release-check.yml)) skips the signing
-step — it has no OIDC token — so signing is otherwise first exercised by the
-real release. That gap is exactly how a cosign v3 incompatibility survived
-until a tag was about to be cut: `release-snapshot` reproduces it locally,
-`release-local` does not.
+Signing is also covered in CI:
+[release-check.yml](../.github/workflows/release-check.yml) runs the full
+snapshot with `--skip=publish` only — it signs for real (using the same pinned
+cosign as the release job) and verifies the resulting
+`checksums.txt.bundle` round-trips — on every change to `.goreleaser.yaml` or
+either release workflow. It didn't always: it used to skip signing, and that
+gap is exactly how a cosign v3 incompatibility survived until a `v1.0.0-rc.3`
+tag was about to be cut.
+
+Because that job only triggers on release-config paths, a change elsewhere
+that somehow affects packaging still won't be signed-tested until the tag.
+`make release-snapshot` reproduces the full signing path locally if you want
+belt-and-braces before a release; `make release-local` does not.
 
 ## CI pipeline (non-release)
 


### PR DESCRIPTION
Closes the gap that let #314 through. Option (a) from the discussion after `v1.0.0-rc.3`.

## The gap

`release-check.yml` — added in #225 to catch release-pipeline breakage — ran the snapshot with `--skip=sign`, so **signing was only ever exercised by a real tagged release.**

That's precisely how #314 happened: #300 bumped `cosign-installer` v3.9.1 → v4.1.2 (cosign v2 → **v3**), v3's `sign-blob` dropped `--output-signature`/`--output-certificate`, and nothing noticed until a `v1.0.0-rc.3` tag was about to be cut. It was only caught because the release snapshot got run by hand first.

Three separate problems in this release path (the cosign break, an unanchored identity regexp, and docs claiming "no signing") all lived in the least-exercised corner of CI. This makes that corner exercised.

## Changes

- **`id-token: write`** so cosign can obtain an OIDC token. `contents` stays `read-only` — this job still publishes nothing.
- **Install cosign, pinned to the same commit as `release.yml`**, with a comment to keep the two in lockstep. Pinning a *different* version here would validate the wrong binary and defeat the purpose. (Verified both files now carry an identical pin.)
- **`--skip=publish`** only; signing runs for real.
- **Assert the signature round-trips**, not merely that goreleaser exited 0:
  1. `dist/checksums.txt.bundle` exists under the exact name `docs/releases.md` tells users to fetch
  2. `cosign verify-blob --bundle …` succeeds against it

  #314 was a hard failure, but a subtler regression — `signs[].signature` renaming the output, or cosign emitting a format `verify-blob` can't read back — would sail past a pass/fail-only check. The identity regexp is anchored for the same reason the docs' one is.

## Trade-off (called out in the workflow header)

Signing is real, so **each run writes an entry to Sigstore's public transparency log.** Those entries carry *this* workflow's identity (`.../release-check.yml@<ref>`), never `release.yml`'s — so a dry-run signature can't be mistaken for a released artifact's. The job only triggers on `.goreleaser.yaml` / release-workflow paths, so this is low volume.

## Docs

`docs/releases.md` said this job skips signing — no longer true. Updated, while keeping the point that it only fires on release-config paths, so `make release-snapshot` remains the belt-and-braces local check before a tag.

## Test plan
- [x] YAML parses; step order and `permissions` verified
- [x] Confirmed the cosign pin is byte-identical between `release.yml` and `release-check.yml`
- [x] `go build ./...` / `go vet ./...` / `gofmt`
- [x] **This PR touches `.goreleaser.yaml`-adjacent paths, so `release-check` runs on it — the first real proof is this PR's own check going green with a verified bundle.** If it fails, the change is wrong and should not merge.