### PR TITLE
docs: drop the pinned e2e assertion count from the verified-range claim

### DIFF
--- a/docs/stability-policy.md
+++ b/docs/stability-policy.md
@@ -196,9 +196,10 @@ even considered.
     suite (capture, redaction, encryption round-trip, replay, writable
     overlay, `kubectl` round-trip) plus the mock-vs-live conformance
     differential, run against v1.30.3 / v1.32.3 / v1.34.3 / v1.36.1. All
-    four passed 113/113 e2e assertions with zero new conformance
-    divergences. Reproducing the claim takes both harnesses — the e2e suite
-    and the conformance differential are what the two halves of it rest on:
+    four passed every e2e assertion with zero failures and zero new
+    conformance divergences. Reproducing the claim takes both harnesses —
+    the e2e suite and the conformance differential are what its two halves
+    rest on:
 
     ```sh
     make build


### PR DESCRIPTION
Follow-up to #317, which merged before I noticed this.

`docs/stability-policy.md` says the version-matrix runs passed **113/113
e2e assertions**. That was accurate when those runs happened, but #317's
`jq` preflight check emits a `pass` of its own, so the reproduction
command the same paragraph documents now reports **114**:

```
==> Checking prerequisites
  [OK]   jq found at /usr/bin/jq
...
All 114 E2E assertions passed!
```

(From #317's own green e2e run — so the doc shipped already inconsistent
with the harness it points at.)

Beyond this specific drift, pinning an exact count in a policy document
that gets read for the life of the `1.x` line is a maintenance trap:
every future assertion added to the suite invalidates it again, and
nothing in CI catches it. The substance of the evidence is that the full
suite passed with zero failures across all four Kubernetes versions,
which is what it now says.

The version list (v1.30.3 / v1.32.3 / v1.34.3 / v1.36.1) and the
zero-new-conformance-divergences claim are unchanged — those are the
parts that actually carry the v1.30–v1.36 range.

Docs-only; no code or script changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)