### PR TITLE
fix(json): settle the -o json contract before v1.0 freezes it

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -68,7 +68,7 @@ func printInspectTable(cmd *cobra.Command, r *inspect.Report, wide bool) {
 	out := cmd.OutOrStdout()
 	duration := r.CapturedUntil.Sub(r.CapturedAt).Truncate(time.Second)
 
-	fmt.Fprintf(out, "Format:       v%d\n", r.FormatVersion)
+	fmt.Fprintf(out, "Format:       v%d\n", r.ArchiveFormatVersion)
 	fmt.Fprintf(out, "Capture ID:   %s\n", r.CaptureID)
 	fmt.Fprintf(out, "Captured:     %s → %s  (%s)\n",
 		r.CapturedAt.UTC().Format(time.RFC3339),

--- a/cmd/transitions.go
+++ b/cmd/transitions.go
@@ -99,7 +99,7 @@ func runTransitions(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	ts, err := transitions.LoadTransitions(args[0], opts, identities)
+	rep, err := transitions.LoadReport(args[0], opts, identities)
 	if err != nil {
 		return err
 	}
@@ -108,9 +108,9 @@ func runTransitions(cmd *cobra.Command, args []string) error {
 	case "json":
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
-		return enc.Encode(ts)
+		return enc.Encode(rep)
 	default:
-		return printTransitionTable(cmd, ts, showDiff)
+		return printTransitionTable(cmd, rep.Transitions, showDiff)
 	}
 }
 

--- a/docs/stability-policy.md
+++ b/docs/stability-policy.md
@@ -129,11 +129,16 @@ are per-command and independent: `diagnose`'s `schema_version` moving to 2
 says nothing about `query`'s.
 
 Collection fields are always arrays, never `null` — an empty result is `[]`,
-so `jq '.findings[]'` and friends work without a guard. Fields that are always
-knowable (`schema_version`, `capture_id`) are always emitted rather than
-dropped when empty, so the top-level key set is the same on every run;
-genuinely conditional fields (`diagnose`'s `at`, set only with `--at`) are the
-exception and are documented as such.
+so `jq '.findings[]'` and friends work without a guard.
+
+Each command's top-level key set is the same on every run: a field a command
+carries is emitted even when empty, rather than dropped. The key sets differ
+*between* commands, though — only `inspect`, `diagnose`, and `transitions`
+carry a `capture_id`. `query` doesn't, and `diff` deliberately doesn't, since
+it compares two archives and a single capture ID wouldn't identify either.
+
+The one deliberately conditional field is `diagnose`'s `at`, present only when
+`--at` was passed.
 
 #### Embedded Kubernetes objects are passthrough, not covered
 

--- a/docs/stability-policy.md
+++ b/docs/stability-policy.md
@@ -129,7 +129,11 @@ are per-command and independent: `diagnose`'s `schema_version` moving to 2
 says nothing about `query`'s.
 
 Collection fields are always arrays, never `null` — an empty result is `[]`,
-so `jq '.findings[]'` and friends work without a guard.
+so `jq '.findings[]'` and friends work without a guard. Fields that are always
+knowable (`schema_version`, `capture_id`) are always emitted rather than
+dropped when empty, so the top-level key set is the same on every run;
+genuinely conditional fields (`diagnose`'s `at`, set only with `--at`) are the
+exception and are documented as such.
 
 #### Embedded Kubernetes objects are passthrough, not covered
 

--- a/docs/stability-policy.md
+++ b/docs/stability-policy.md
@@ -38,8 +38,9 @@ series"). That page is the authority; this policy just points to it.
 
 ### CLI surface
 
-Every subcommand name, flag name and spelling, and flag semantics documented in
-[docs/usage.md](usage.md) are stable for the `1.x` line:
+Every subcommand name, flag name and spelling, and flag semantics listed in
+[docs/cli-reference.md](cli-reference.md) are stable for the `1.x` line, with
+the exceptions called out [below](#flags-explicitly-not-covered):
 
 | Command | Purpose |
 |---------|---------|
@@ -63,9 +64,27 @@ going through [deprecation](#deprecation-policy) first. Flags may gain new
 optional values or new sibling flags in a minor release; a required flag never
 becomes optional-with-different-default (or vice versa) without a major bump.
 
-`docs/usage.md` is the single source of truth for the current flag list —
-this policy intentionally doesn't duplicate it, to avoid the two drifting
-out of sync.
+[docs/cli-reference.md](cli-reference.md) is the single source of truth for
+the current flag list — this policy intentionally doesn't duplicate it, to
+avoid the two drifting out of sync. That page is **generated from the Cobra
+command definitions and drift-checked in CI**, so it can't fall behind the
+binary; `docs/usage.md` is a narrative guide that covers the common paths and
+deliberately doesn't enumerate every flag.
+
+#### Flags explicitly not covered
+
+The replay-orchestration and writable-overlay flags are **exempt** — their
+names and semantics may change in any release, including a patch:
+
+`--with-kwok`, `--with-controller-manager`, `--schedule-pods`, `--writable`,
+`--start-paused`, `--loop`, `--speed`
+
+These drive the newest and least-exercised parts of the mock server (KWOK and
+kube-controller-manager orchestration, the writable overlay, replay timing),
+where the shape of the feature is still likely to move. Everything else in
+`docs/cli-reference.md` is covered. Promoting one of these to covered is a
+minor-version change (widening coverage); the reverse would not be, which is
+why the exemption is being written down now rather than assumed.
 
 ### Exit codes
 
@@ -102,6 +121,39 @@ rule as the archive format:
   fields they don't recognize.
 - Removing a field, renaming a field, or changing a field's type/meaning is
   a major-version change.
+
+Every one of the five emits a JSON **object** at the top level (never a bare
+array) carrying its own `schema_version`, so the envelope can always gain
+fields and a consumer can always tell what shape it's parsing. The versions
+are per-command and independent: `diagnose`'s `schema_version` moving to 2
+says nothing about `query`'s.
+
+Collection fields are always arrays, never `null` — an empty result is `[]`,
+so `jq '.findings[]'` and friends work without a guard.
+
+#### Embedded Kubernetes objects are passthrough, not covered
+
+`diff` and `transitions` embed whole captured Kubernetes objects under
+`before` / `after`, and `query`'s `matches[].value` returns whatever the
+JSONPath expression selected. **Those payloads are passthrough of what the
+cluster returned; their field names and types belong to the Kubernetes API,
+not to k8shark**, and they vary with the captured cluster's version. The
+add-only rule above cannot sensibly apply to them and does not:
+
+- **Covered**: the wrapper each one sits in — `changes[].{path, group,
+  version, resource, namespace, before, after}` for `diff`,
+  `transitions[].{time, event_type, api_path, group, version, resource,
+  namespace, name, before, after}` for `transitions`, and
+  `matches[].{path, group, version, resource, namespace, name, value}` for
+  `query`.
+- **Not covered**: anything *inside* `before`, `after`, or `value`.
+
+`matches[].value` in particular is **polymorphic by design** — it is
+whatever JSON type the selected field holds, so `{.spec.replicas}` yields a
+number, `{.metadata.name}` a string, `{.metadata.labels}` an object, and
+`{.spec.containers}` an array. Consumers must type-switch on it rather than
+assume a type. This is not something a future release will "fix": the field
+mirrors the queried document.
 
 Table/text output (the human-facing default, no `-o` flag) is explicitly
 **not** covered — column layout, spacing, and wording can change in any

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -741,6 +741,37 @@ kshrk transitions capture.kshrk --resource replicasets --name api-5c59c454f5 --d
 | `--to` | capture end | End of the time window: RFC3339 or relative duration like `-1m` |
 | `--diff` | false | Show field-level changes for `MODIFIED` events |
 
+### JSON output schema
+
+`-o json` emits an object carrying `schema_version` and the event list. The
+wrapper fields are a stable contract; `before`/`after` hold the captured
+Kubernetes objects verbatim, so their contents follow the cluster's API rather
+than k8shark's own compatibility promise (see
+[docs/stability-policy.md](stability-policy.md#embedded-kubernetes-objects-are-passthrough-not-covered)).
+
+```json
+{
+  "schema_version": 1,
+  "capture_id": "550e8400-…",
+  "transitions": [
+    {
+      "time": "2026-04-09T10:03:12Z",
+      "event_type": "MODIFIED",
+      "api_path": "/apis/apps/v1/namespaces/prod/replicasets",
+      "group": "apps",
+      "version": "v1",
+      "resource": "replicasets",
+      "namespace": "prod",
+      "name": "api-5c59c454f5",
+      "before": { "…": "the prior object body" },
+      "after":  { "…": "the new object body" }
+    }
+  ]
+}
+```
+
+`transitions` is always an array — an empty result is `[]`, not `null`.
+
 ### Where events come from
 
 Each captured API path uses one of two detection modes, and a single `transitions` run can mix both across different resources in the same archive:

--- a/internal/diagnose/engine.go
+++ b/internal/diagnose/engine.go
@@ -46,7 +46,11 @@ func Run(store *store.CaptureStore, opts Options) Report {
 	if min == "" {
 		min = SeverityInfo
 	}
-	filtered := fs[:0:0]
+	// make, not fs[:0:0] — when no rule fired, fs is nil and nil[:0:0] stays
+	// nil, which marshals to `"findings": null` and breaks the most natural
+	// consumer pattern (`jq '.findings[]'` errors on null). Findings is
+	// documented as an array, so it has to be one even when empty.
+	filtered := make([]Finding, 0, len(fs))
 	for _, f := range fs {
 		if !SeverityAtLeast(f.Severity, min) {
 			continue

--- a/internal/diagnose/finding.go
+++ b/internal/diagnose/finding.go
@@ -54,11 +54,14 @@ type Finding struct {
 
 // Report is the top-level diagnose output.
 type Report struct {
-	SchemaVersion int       `json:"schema_version"`
-	CaptureID     string    `json:"capture_id,omitempty"`
-	At            string    `json:"at,omitempty"`
-	Summary       Summary   `json:"summary"`
-	Findings      []Finding `json:"findings"`
+	SchemaVersion int `json:"schema_version"`
+	// Not omitempty: a capture always has an ID, so dropping the key would
+	// make the frozen top-level key set non-deterministic. (At stays
+	// omitempty — it's only set when --at was passed.)
+	CaptureID string    `json:"capture_id"`
+	At        string    `json:"at,omitempty"`
+	Summary   Summary   `json:"summary"`
+	Findings  []Finding `json:"findings"`
 }
 
 // Summary counts findings by severity.

--- a/internal/diagnose/json_contract_test.go
+++ b/internal/diagnose/json_contract_test.go
@@ -7,47 +7,15 @@ import (
 
 // The `-o json` output is a stable, scriptable interface as of v1.0 (see
 // docs/stability-policy.md): adding a top-level key is a minor change,
-// renaming or removing one is a major change. These tests pin the key set so
-// an accidental tag rename fails here rather than silently breaking consumers.
-
-func TestReport_JSONContract_TopLevelKeys(t *testing.T) {
-	// Populated, not zero-value: a zero Report marshals "findings": null and
-	// "schema_version": 0 and would still satisfy key-presence checks.
-	b, err := json.Marshal(Report{
-		SchemaVersion: SchemaVersion,
-		CaptureID:     "550e8400-e29b-41d4-a716-446655440000",
-		Findings:      make([]Finding, 0),
-	})
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	var got map[string]json.RawMessage
-	if err := json.Unmarshal(b, &got); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	// `at` stays omitempty — it's only set when --at was passed — so it is
-	// deliberately not in the always-present set.
-	for _, k := range []string{"schema_version", "capture_id", "summary", "findings"} {
-		if _, ok := got[k]; !ok {
-			t.Errorf("missing frozen top-level key %q; got %s", k, b)
-		}
-	}
-	var probe struct {
-		SchemaVersion int `json:"schema_version"`
-	}
-	if err := json.Unmarshal(b, &probe); err != nil {
-		t.Fatalf("unmarshal probe: %v", err)
-	}
-	if probe.SchemaVersion != SchemaVersion {
-		t.Errorf("schema_version = %d, want %d", probe.SchemaVersion, SchemaVersion)
-	}
-}
-
-// TestRun_EmptyFindings_MarshalsAsArray guards the null-vs-[] footgun: a
-// capture with nothing wrong must still emit `"findings": []`, because the
-// most natural consumer pattern (`jq '.findings[]'`) errors on null.
-func TestRun_EmptyFindings_MarshalsAsArray(t *testing.T) {
-	// A store with one healthy pod list — no rule should fire.
+// renaming or removing one is a major change.
+//
+// This pins the key set against what Run actually returns rather than a
+// hand-built Report — a literal with Findings pre-initialized would keep
+// passing even if Run regressed to a nil slice, which is the `jq '.findings[]'`
+// footgun the contract exists to prevent. A clean capture is used so the empty
+// case (the one that regressed) is the one under test.
+func TestRun_JSONContract_CleanCapture(t *testing.T) {
+	// One healthy, empty pod list — no rule should fire.
 	cs := buildDiagStore(t, map[string]string{
 		"/api/v1/pods": `{"kind":"PodList","apiVersion":"v1","items":[]}`,
 	})
@@ -65,13 +33,55 @@ func TestRun_EmptyFindings_MarshalsAsArray(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	var probe struct {
-		Findings *[]Finding `json:"findings"`
-	}
-	if err := json.Unmarshal(b, &probe); err != nil {
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(b, &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if probe.Findings == nil {
+	// `at` stays omitempty — it's only set when --at was passed — so it is
+	// deliberately not in the always-present set.
+	for _, k := range []string{"schema_version", "capture_id", "summary", "findings"} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("missing frozen top-level key %q; got %s", k, b)
+		}
+	}
+
+	var fields struct {
+		SchemaVersion int        `json:"schema_version"`
+		CaptureID     string     `json:"capture_id"`
+		Findings      *[]Finding `json:"findings"`
+	}
+	if err := json.Unmarshal(b, &fields); err != nil {
+		t.Fatalf("unmarshal fields: %v", err)
+	}
+	if fields.SchemaVersion != SchemaVersion {
+		t.Errorf("schema_version = %d, want %d", fields.SchemaVersion, SchemaVersion)
+	}
+	if fields.CaptureID == "" {
+		t.Error("capture_id is empty; Run must populate it from store metadata")
+	}
+	if fields.Findings == nil {
 		t.Errorf("findings marshaled as null, want []; output was %s", b)
+	}
+}
+
+// TestRun_At_IsOmittedWhenUnset pins the one deliberately conditional field:
+// `at` appears only when Options.At was set, unlike capture_id which is always
+// emitted. Documented in docs/stability-policy.md.
+func TestRun_At_IsOmittedWhenUnset(t *testing.T) {
+	cs := buildDiagStore(t, map[string]string{
+		"/api/v1/pods": `{"kind":"PodList","apiVersion":"v1","items":[]}`,
+	})
+	defer cs.Close()
+
+	b, err := json.Marshal(Run(cs, Options{}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := got["at"]; ok {
+		t.Errorf("at present without --at; it should be omitempty. got %s", b)
 	}
 }

--- a/internal/diagnose/json_contract_test.go
+++ b/internal/diagnose/json_contract_test.go
@@ -13,7 +13,11 @@ import (
 func TestReport_JSONContract_TopLevelKeys(t *testing.T) {
 	// Populated, not zero-value: a zero Report marshals "findings": null and
 	// "schema_version": 0 and would still satisfy key-presence checks.
-	b, err := json.Marshal(Report{SchemaVersion: SchemaVersion, Findings: make([]Finding, 0)})
+	b, err := json.Marshal(Report{
+		SchemaVersion: SchemaVersion,
+		CaptureID:     "550e8400-e29b-41d4-a716-446655440000",
+		Findings:      make([]Finding, 0),
+	})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -21,8 +25,9 @@ func TestReport_JSONContract_TopLevelKeys(t *testing.T) {
 	if err := json.Unmarshal(b, &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	// capture_id and at are omitempty, so they're absent on a zero Report.
-	for _, k := range []string{"schema_version", "summary", "findings"} {
+	// `at` stays omitempty — it's only set when --at was passed — so it is
+	// deliberately not in the always-present set.
+	for _, k := range []string{"schema_version", "capture_id", "summary", "findings"} {
 		if _, ok := got[k]; !ok {
 			t.Errorf("missing frozen top-level key %q; got %s", k, b)
 		}

--- a/internal/diagnose/json_contract_test.go
+++ b/internal/diagnose/json_contract_test.go
@@ -1,0 +1,61 @@
+package diagnose
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The `-o json` output is a stable, scriptable interface as of v1.0 (see
+// docs/stability-policy.md): adding a top-level key is a minor change,
+// renaming or removing one is a major change. These tests pin the key set so
+// an accidental tag rename fails here rather than silently breaking consumers.
+
+func TestReport_JSONContract_TopLevelKeys(t *testing.T) {
+	b, err := json.Marshal(Report{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// capture_id and at are omitempty, so they're absent on a zero Report.
+	for _, k := range []string{"schema_version", "summary", "findings"} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("missing frozen top-level key %q; got %s", k, b)
+		}
+	}
+}
+
+// TestRun_EmptyFindings_MarshalsAsArray guards the null-vs-[] footgun: a
+// capture with nothing wrong must still emit `"findings": []`, because the
+// most natural consumer pattern (`jq '.findings[]'`) errors on null.
+func TestRun_EmptyFindings_MarshalsAsArray(t *testing.T) {
+	// A store with one healthy pod list — no rule should fire.
+	cs := buildDiagStore(t, map[string]string{
+		"/api/v1/pods": `{"kind":"PodList","apiVersion":"v1","items":[]}`,
+	})
+	defer cs.Close()
+
+	rep := Run(cs, Options{})
+	if len(rep.Findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(rep.Findings))
+	}
+	if rep.Findings == nil {
+		t.Error("Findings is nil; it must be an empty slice so JSON is [] not null")
+	}
+
+	b, err := json.Marshal(rep)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var probe struct {
+		Findings *[]Finding `json:"findings"`
+	}
+	if err := json.Unmarshal(b, &probe); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if probe.Findings == nil {
+		t.Errorf("findings marshaled as null, want []; output was %s", b)
+	}
+}

--- a/internal/diagnose/json_contract_test.go
+++ b/internal/diagnose/json_contract_test.go
@@ -11,7 +11,9 @@ import (
 // an accidental tag rename fails here rather than silently breaking consumers.
 
 func TestReport_JSONContract_TopLevelKeys(t *testing.T) {
-	b, err := json.Marshal(Report{})
+	// Populated, not zero-value: a zero Report marshals "findings": null and
+	// "schema_version": 0 and would still satisfy key-presence checks.
+	b, err := json.Marshal(Report{SchemaVersion: SchemaVersion, Findings: make([]Finding, 0)})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -24,6 +26,15 @@ func TestReport_JSONContract_TopLevelKeys(t *testing.T) {
 		if _, ok := got[k]; !ok {
 			t.Errorf("missing frozen top-level key %q; got %s", k, b)
 		}
+	}
+	var probe struct {
+		SchemaVersion int `json:"schema_version"`
+	}
+	if err := json.Unmarshal(b, &probe); err != nil {
+		t.Fatalf("unmarshal probe: %v", err)
+	}
+	if probe.SchemaVersion != SchemaVersion {
+		t.Errorf("schema_version = %d, want %d", probe.SchemaVersion, SchemaVersion)
 	}
 }
 

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -33,8 +33,16 @@ type Options struct {
 	Identities []age.Identity
 }
 
+// SchemaVersion is the version of the `kshrk diff -o json` output shape.
+// Bumped only on a breaking change to Result/Change's own fields — not for
+// changes to the passthrough Kubernetes objects under Change.Before /
+// Change.After, whose field names belong to the cluster's API, not to k8shark
+// (see docs/stability-policy.md).
+const SchemaVersion = 1
+
 type Result struct {
-	Changes []Change `json:"changes"`
+	SchemaVersion int      `json:"schema_version"`
+	Changes       []Change `json:"changes"`
 }
 
 type Change struct {
@@ -93,7 +101,7 @@ func Run(opts Options) (*Result, error) {
 		})
 	}
 
-	return &Result{Changes: changes}, nil
+	return &Result{SchemaVersion: SchemaVersion, Changes: changes}, nil
 }
 
 func RenderText(result *Result, color bool) (string, error) {

--- a/internal/diff/json_contract_test.go
+++ b/internal/diff/json_contract_test.go
@@ -3,13 +3,46 @@ package diff
 import (
 	"encoding/json"
 	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/capture"
 )
 
 // See docs/stability-policy.md: `-o json` is a frozen interface as of v1.0.
-func TestResult_JSONContract(t *testing.T) {
-	// Populated, not zero-value: a zero Result marshals "changes": null and
-	// "schema_version": 0 and would still satisfy key-presence checks.
-	b, err := json.Marshal(&Result{SchemaVersion: SchemaVersion, Changes: make([]Change, 0)})
+//
+// This marshals what Run actually returns rather than a hand-built Result. A
+// literal with Changes pre-initialized would keep passing even if Run
+// regressed to a nil slice or stopped populating SchemaVersion, which is
+// exactly what the contract needs guarded.
+func TestRun_JSONContract_NoDifferences(t *testing.T) {
+	at := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	body := `{"kind":"PodList","items":[{"metadata":{"name":"nginx"}}]}`
+
+	// Identical content on both sides, so there are legitimately no changes
+	// and the nil-vs-[] distinction is what's under test.
+	before := buildArchive(t, map[string][]capture.Record{
+		"/api/v1/namespaces/default/pods": {
+			newRecord("rec-1", "/api/v1/namespaces/default/pods", at, body),
+		},
+	})
+	after := buildArchive(t, map[string][]capture.Record{
+		"/api/v1/namespaces/default/pods": {
+			newRecord("rec-2", "/api/v1/namespaces/default/pods", at.Add(5*time.Minute), body),
+		},
+	})
+
+	result, err := Run(Options{BeforeArchive: before, AfterArchive: after})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result.Changes) != 0 {
+		t.Fatalf("expected no changes between identical bodies, got %d", len(result.Changes))
+	}
+	if result.Changes == nil {
+		t.Error("Changes is nil; it must be an empty slice so JSON is [] not null")
+	}
+
+	b, err := json.Marshal(result)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -22,31 +55,19 @@ func TestResult_JSONContract(t *testing.T) {
 			t.Errorf("missing frozen top-level key %q; got %s", k, b)
 		}
 	}
-	var probe struct {
-		SchemaVersion int `json:"schema_version"`
-	}
-	if err := json.Unmarshal(b, &probe); err != nil {
-		t.Fatalf("unmarshal probe: %v", err)
-	}
-	if probe.SchemaVersion != SchemaVersion {
-		t.Errorf("schema_version = %d, want %d", probe.SchemaVersion, SchemaVersion)
-	}
-}
 
-// Run must emit `"changes": []`, never null, so `jq '.changes[]'` works on a
-// no-differences result.
-func TestResult_EmptyChangesMarshalsAsArray(t *testing.T) {
-	b, err := json.Marshal(&Result{Changes: make([]Change, 0)})
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
+	var fields struct {
+		SchemaVersion int       `json:"schema_version"`
+		Changes       *[]Change `json:"changes"`
 	}
-	var probe struct {
-		Changes *[]Change `json:"changes"`
+	if err := json.Unmarshal(b, &fields); err != nil {
+		t.Fatalf("unmarshal fields: %v", err)
 	}
-	if err := json.Unmarshal(b, &probe); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	if fields.SchemaVersion != SchemaVersion {
+		t.Errorf("schema_version = %d, want %d", fields.SchemaVersion, SchemaVersion)
 	}
-	if probe.Changes == nil {
+	// Empty must be [] so `jq '.changes[]'` works.
+	if fields.Changes == nil {
 		t.Errorf("changes marshaled as null, want []; got %s", b)
 	}
 }

--- a/internal/diff/json_contract_test.go
+++ b/internal/diff/json_contract_test.go
@@ -7,7 +7,9 @@ import (
 
 // See docs/stability-policy.md: `-o json` is a frozen interface as of v1.0.
 func TestResult_JSONContract(t *testing.T) {
-	b, err := json.Marshal(&Result{})
+	// Populated, not zero-value: a zero Result marshals "changes": null and
+	// "schema_version": 0 and would still satisfy key-presence checks.
+	b, err := json.Marshal(&Result{SchemaVersion: SchemaVersion, Changes: make([]Change, 0)})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -17,8 +19,17 @@ func TestResult_JSONContract(t *testing.T) {
 	}
 	for _, k := range []string{"schema_version", "changes"} {
 		if _, ok := got[k]; !ok {
-			t.Errorf("missing frozen top-level key %q", k)
+			t.Errorf("missing frozen top-level key %q; got %s", k, b)
 		}
+	}
+	var probe struct {
+		SchemaVersion int `json:"schema_version"`
+	}
+	if err := json.Unmarshal(b, &probe); err != nil {
+		t.Fatalf("unmarshal probe: %v", err)
+	}
+	if probe.SchemaVersion != SchemaVersion {
+		t.Errorf("schema_version = %d, want %d", probe.SchemaVersion, SchemaVersion)
 	}
 }
 

--- a/internal/diff/json_contract_test.go
+++ b/internal/diff/json_contract_test.go
@@ -1,0 +1,41 @@
+package diff
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// See docs/stability-policy.md: `-o json` is a frozen interface as of v1.0.
+func TestResult_JSONContract(t *testing.T) {
+	b, err := json.Marshal(&Result{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"schema_version", "changes"} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("missing frozen top-level key %q", k)
+		}
+	}
+}
+
+// Run must emit `"changes": []`, never null, so `jq '.changes[]'` works on a
+// no-differences result.
+func TestResult_EmptyChangesMarshalsAsArray(t *testing.T) {
+	b, err := json.Marshal(&Result{Changes: make([]Change, 0)})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var probe struct {
+		Changes *[]Change `json:"changes"`
+	}
+	if err := json.Unmarshal(b, &probe); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if probe.Changes == nil {
+		t.Errorf("changes marshaled as null, want []; got %s", b)
+	}
+}

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -13,18 +13,26 @@ import (
 	"github.com/phenixblue/k8shark/internal/k8spath"
 )
 
+// SchemaVersion is the version of the `kshrk inspect -o json` output shape.
+// Distinct from Report.ArchiveFormatVersion, which reports the version of the
+// .kshrk archive being inspected — the two evolve independently.
+const SchemaVersion = 1
+
 // Report summarizes the contents of a capture archive.
 type Report struct {
-	FormatVersion     int               `json:"format_version"`
-	CaptureID         string            `json:"capture_id"`
-	CapturedAt        time.Time         `json:"captured_at"`
-	CapturedUntil     time.Time         `json:"captured_until"`
-	KubernetesVersion string            `json:"kubernetes_version"`
-	ServerAddress     string            `json:"server_address"`
-	RecordCount       int               `json:"record_count"`
-	ArchivePath       string            `json:"archive_path"`
-	ArchiveSize       int64             `json:"archive_size_bytes"`
-	Resources         []ResourceSummary `json:"resources"`
+	SchemaVersion int `json:"schema_version"`
+	// ArchiveFormatVersion is the .kshrk format version of the inspected
+	// archive (capture.CurrentFormatVersion), not the version of this output.
+	ArchiveFormatVersion int               `json:"archive_format_version"`
+	CaptureID            string            `json:"capture_id"`
+	CapturedAt           time.Time         `json:"captured_at"`
+	CapturedUntil        time.Time         `json:"captured_until"`
+	KubernetesVersion    string            `json:"kubernetes_version"`
+	ServerAddress        string            `json:"server_address"`
+	RecordCount          int               `json:"record_count"`
+	ArchivePath          string            `json:"archive_path"`
+	ArchiveSize          int64             `json:"archive_size_bytes"`
+	Resources            []ResourceSummary `json:"resources"`
 }
 
 // ResourceSummary describes a single captured resource type.
@@ -67,7 +75,9 @@ func Run(archivePath string, identities []age.Identity) (*Report, error) {
 	}
 
 	return &Report{
-		FormatVersion:     formatVersion,
+		SchemaVersion:        SchemaVersion,
+		ArchiveFormatVersion: formatVersion,
+
 		CaptureID:         meta.CaptureID,
 		CapturedAt:        meta.CapturedAt,
 		CapturedUntil:     meta.CapturedUntil,

--- a/internal/inspect/json_contract_test.go
+++ b/internal/inspect/json_contract_test.go
@@ -1,0 +1,36 @@
+package inspect
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The `-o json` output is a stable, scriptable interface as of v1.0 (see
+// docs/stability-policy.md). This pins the top-level key set so an accidental
+// tag rename fails here rather than silently breaking consumers.
+func TestReport_JSONContract_TopLevelKeys(t *testing.T) {
+	b, err := json.Marshal(Report{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{
+		"schema_version", "archive_format_version", "capture_id", "captured_at",
+		"captured_until", "kubernetes_version", "server_address", "record_count",
+		"archive_path", "archive_size_bytes", "resources",
+	} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("missing frozen top-level key %q", k)
+		}
+	}
+	// format_version was renamed to archive_format_version before v1.0 to
+	// disambiguate it from schema_version (the output's own version). It must
+	// not come back — two keys meaning different versions is the confusion the
+	// rename removed.
+	if _, ok := got["format_version"]; ok {
+		t.Error("format_version reappeared; it was renamed to archive_format_version")
+	}
+}

--- a/internal/inspect/json_contract_test.go
+++ b/internal/inspect/json_contract_test.go
@@ -3,13 +3,33 @@ package inspect
 import (
 	"encoding/json"
 	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/capture"
 )
 
 // The `-o json` output is a stable, scriptable interface as of v1.0 (see
-// docs/stability-policy.md). This pins the top-level key set so an accidental
-// tag rename fails here rather than silently breaking consumers.
-func TestReport_JSONContract_TopLevelKeys(t *testing.T) {
-	b, err := json.Marshal(Report{})
+// docs/stability-policy.md). This marshals what Run actually returns rather
+// than a zero-value Report: a zero value would emit `"resources": null` and
+// `"schema_version": 0` and still pass the key-presence checks, which would
+// make the test useless as a guard.
+func TestRun_JSONContract(t *testing.T) {
+	now := time.Date(2026, 4, 9, 8, 0, 0, 0, time.UTC)
+	path := buildArchive(t, []*capture.Record{{
+		ID:           "pods-0",
+		CapturedAt:   now,
+		APIPath:      "/api/v1/pods",
+		HTTPMethod:   "GET",
+		ResponseCode: 200,
+		ResponseBody: json.RawMessage(`{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"a"}}]}`),
+	}})
+
+	rep, err := Run(path, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	b, err := json.Marshal(rep)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -23,7 +43,7 @@ func TestReport_JSONContract_TopLevelKeys(t *testing.T) {
 		"archive_path", "archive_size_bytes", "resources",
 	} {
 		if _, ok := got[k]; !ok {
-			t.Errorf("missing frozen top-level key %q", k)
+			t.Errorf("missing frozen top-level key %q; got %s", k, b)
 		}
 	}
 	// format_version was renamed to archive_format_version before v1.0 to
@@ -32,5 +52,65 @@ func TestReport_JSONContract_TopLevelKeys(t *testing.T) {
 	// rename removed.
 	if _, ok := got["format_version"]; ok {
 		t.Error("format_version reappeared; it was renamed to archive_format_version")
+	}
+
+	var probe struct {
+		SchemaVersion        int                `json:"schema_version"`
+		ArchiveFormatVersion int                `json:"archive_format_version"`
+		Resources            *[]json.RawMessage `json:"resources"`
+	}
+	if err := json.Unmarshal(b, &probe); err != nil {
+		t.Fatalf("unmarshal probe: %v", err)
+	}
+	if probe.SchemaVersion != SchemaVersion {
+		t.Errorf("schema_version = %d, want %d", probe.SchemaVersion, SchemaVersion)
+	}
+	if probe.ArchiveFormatVersion == 0 {
+		t.Error("archive_format_version = 0; pre-versioning archives are normalized to 1")
+	}
+	if probe.Resources == nil {
+		t.Errorf("resources marshaled as null, want an array; got %s", b)
+	}
+}
+
+// TestRun_NoResources_MarshalsAsArray covers the same jq '.resources[]' footgun
+// guarded elsewhere: an archive whose only records aren't resource lists yields
+// zero resource summaries, and that must still be [] rather than null.
+func TestRun_NoResources_MarshalsAsArray(t *testing.T) {
+	now := time.Date(2026, 4, 9, 8, 0, 0, 0, time.UTC)
+	// A discovery path — summarizeResources skips anything that doesn't parse
+	// as group/version/resource, so this produces an empty summary list.
+	path := buildArchive(t, []*capture.Record{{
+		ID:           "disco-0",
+		CapturedAt:   now,
+		APIPath:      "/api",
+		HTTPMethod:   "GET",
+		ResponseCode: 200,
+		ResponseBody: json.RawMessage(`{"kind":"APIVersions","versions":["v1"]}`),
+	}})
+
+	rep, err := Run(path, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(rep.Resources) != 0 {
+		t.Fatalf("expected no resource summaries, got %d", len(rep.Resources))
+	}
+	if rep.Resources == nil {
+		t.Error("Resources is nil; it must be an empty slice so JSON is [] not null")
+	}
+
+	b, err := json.Marshal(rep)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var probe struct {
+		Resources *[]ResourceSummary `json:"resources"`
+	}
+	if err := json.Unmarshal(b, &probe); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if probe.Resources == nil {
+		t.Errorf("resources marshaled as null, want []; got %s", b)
 	}
 }

--- a/internal/inspect/version_test.go
+++ b/internal/inspect/version_test.go
@@ -17,8 +17,8 @@ func TestRun_ReportsFormatVersion_LegacyNormalizedToOne(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if report.FormatVersion != 1 {
-		t.Errorf("FormatVersion = %d, want 1", report.FormatVersion)
+	if report.ArchiveFormatVersion != 1 {
+		t.Errorf("ArchiveFormatVersion = %d, want 1", report.ArchiveFormatVersion)
 	}
 }
 

--- a/internal/query/json_contract_test.go
+++ b/internal/query/json_contract_test.go
@@ -8,50 +8,89 @@ import (
 // See docs/stability-policy.md: `-o json` is a frozen interface as of v1.0.
 // query has two match shapes — JSONPath mode (Result) and --text/--regex mode
 // (TextResult) — and both are frozen independently.
-func TestResult_JSONContract(t *testing.T) {
-	b, err := json.Marshal(&Result{})
+//
+// These marshal what the real constructors return rather than a hand-built
+// literal, so a regression to a nil slice in Run/SearchText fails here. A
+// zero-value struct would marshal `"matches": null` and pass regardless,
+// which defeats the point.
+
+func TestRun_JSONContract_NoMatches(t *testing.T) {
+	cs := buildQueryStore(t, map[string]string{
+		"/api/v1/pods": `{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"a"}}]}`,
+	})
+
+	// A path no captured object has, so the result is legitimately empty.
+	res, err := Run(cs, Options{Expression: "{.spec.thisFieldDoesNotExist}"})
 	if err != nil {
-		t.Fatalf("marshal: %v", err)
+		t.Fatalf("Run: %v", err)
 	}
-	var got map[string]json.RawMessage
-	if err := json.Unmarshal(b, &got); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	if len(res.Matches) != 0 {
+		t.Fatalf("expected no matches, got %d", len(res.Matches))
 	}
-	for _, k := range []string{"schema_version", "matches"} {
-		if _, ok := got[k]; !ok {
-			t.Errorf("Result: missing frozen top-level key %q", k)
-		}
-	}
+	assertMatchesContract(t, res, "Result")
 }
 
-func TestTextResult_JSONContract(t *testing.T) {
-	b, err := json.Marshal(&TextResult{})
+func TestSearchText_JSONContract_NoMatches(t *testing.T) {
+	cs := buildQueryStore(t, map[string]string{
+		"/api/v1/pods": `{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"a"}}]}`,
+	})
+
+	res, err := SearchText(cs, TextOptions{Pattern: "zzz-no-such-substring-anywhere"})
 	if err != nil {
-		t.Fatalf("marshal: %v", err)
+		t.Fatalf("SearchText: %v", err)
 	}
+	if len(res.Matches) != 0 {
+		t.Fatalf("expected no matches, got %d", len(res.Matches))
+	}
+	assertMatchesContract(t, res, "TextResult")
+}
+
+// assertMatchesContract checks the frozen top-level keys, that schema_version
+// is really populated (not a zero value that happens to marshal), and that an
+// empty matches list is [] rather than null so `jq '.matches[]'` works.
+func assertMatchesContract(t *testing.T, v any, label string) {
+	t.Helper()
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("%s: marshal: %v", label, err)
+	}
+
 	var got map[string]json.RawMessage
 	if err := json.Unmarshal(b, &got); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+		t.Fatalf("%s: unmarshal: %v", label, err)
 	}
 	for _, k := range []string{"schema_version", "matches"} {
 		if _, ok := got[k]; !ok {
-			t.Errorf("TextResult: missing frozen top-level key %q", k)
+			t.Errorf("%s: missing frozen top-level key %q; got %s", label, k, b)
 		}
+	}
+
+	var probe struct {
+		SchemaVersion int                `json:"schema_version"`
+		Matches       *[]json.RawMessage `json:"matches"`
+	}
+	if err := json.Unmarshal(b, &probe); err != nil {
+		t.Fatalf("%s: unmarshal probe: %v", label, err)
+	}
+	if probe.SchemaVersion != SchemaVersion {
+		t.Errorf("%s: schema_version = %d, want %d", label, probe.SchemaVersion, SchemaVersion)
+	}
+	if probe.Matches == nil {
+		t.Errorf("%s: matches marshaled as null, want []; got %s", label, b)
 	}
 }
 
 // Both modes carry group as omitempty, so it's absent for core-group resources
-// and present otherwise — identical behavior, not a per-mode difference.
+// and present otherwise — identical behavior, not a per-mode difference. (An
+// earlier freeze-review pass mistook the omitempty behavior for one mode
+// lacking the field; this pins that they agree.)
 func TestBothModes_GroupIsOmitEmpty(t *testing.T) {
-	jp, err := json.Marshal(Match{Name: "x"})
-	if err != nil {
-		t.Fatalf("marshal Match: %v", err)
-	}
-	tx, err := json.Marshal(TextMatch{Name: "x"})
-	if err != nil {
-		t.Fatalf("marshal TextMatch: %v", err)
-	}
-	for name, b := range map[string][]byte{"Match": jp, "TextMatch": tx} {
+	for name, v := range map[string]any{"Match": Match{Name: "x"}, "TextMatch": TextMatch{Name: "x"}} {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", name, err)
+		}
 		var m map[string]json.RawMessage
 		if err := json.Unmarshal(b, &m); err != nil {
 			t.Fatalf("unmarshal %s: %v", name, err)

--- a/internal/query/json_contract_test.go
+++ b/internal/query/json_contract_test.go
@@ -1,0 +1,76 @@
+package query
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// See docs/stability-policy.md: `-o json` is a frozen interface as of v1.0.
+// query has two match shapes — JSONPath mode (Result) and --text/--regex mode
+// (TextResult) — and both are frozen independently.
+func TestResult_JSONContract(t *testing.T) {
+	b, err := json.Marshal(&Result{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"schema_version", "matches"} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("Result: missing frozen top-level key %q", k)
+		}
+	}
+}
+
+func TestTextResult_JSONContract(t *testing.T) {
+	b, err := json.Marshal(&TextResult{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"schema_version", "matches"} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("TextResult: missing frozen top-level key %q", k)
+		}
+	}
+}
+
+// Both modes carry group as omitempty, so it's absent for core-group resources
+// and present otherwise — identical behavior, not a per-mode difference.
+func TestBothModes_GroupIsOmitEmpty(t *testing.T) {
+	jp, err := json.Marshal(Match{Name: "x"})
+	if err != nil {
+		t.Fatalf("marshal Match: %v", err)
+	}
+	tx, err := json.Marshal(TextMatch{Name: "x"})
+	if err != nil {
+		t.Fatalf("marshal TextMatch: %v", err)
+	}
+	for name, b := range map[string][]byte{"Match": jp, "TextMatch": tx} {
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(b, &m); err != nil {
+			t.Fatalf("unmarshal %s: %v", name, err)
+		}
+		if _, ok := m["group"]; ok {
+			t.Errorf("%s: group present on an empty group; expected omitempty to drop it", name)
+		}
+	}
+	for name, v := range map[string]any{"Match": Match{Group: "apps"}, "TextMatch": TextMatch{Group: "apps"}} {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", name, err)
+		}
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(b, &m); err != nil {
+			t.Fatalf("unmarshal %s: %v", name, err)
+		}
+		if _, ok := m["group"]; !ok {
+			t.Errorf("%s: group missing when non-empty", name)
+		}
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -39,9 +39,14 @@ type Match struct {
 	Value     json.RawMessage `json:"value"`
 }
 
+// SchemaVersion is the version of the `kshrk query -o json` output shape,
+// shared by Result (JSONPath mode) and TextResult (--text/--regex mode).
+const SchemaVersion = 1
+
 // Result is the full set of matches for one query.
 type Result struct {
-	Matches []Match `json:"matches"`
+	SchemaVersion int     `json:"schema_version"`
+	Matches       []Match `json:"matches"`
 }
 
 // Run evaluates opts.Expression against every captured object in store at
@@ -116,7 +121,7 @@ func Run(store *store.CaptureStore, opts Options) (*Result, error) {
 			}
 		}
 	}
-	return &Result{Matches: matches}, nil
+	return &Result{SchemaVersion: SchemaVersion, Matches: matches}, nil
 }
 
 // extractItems returns the objects to query in body: a list's items, or the

--- a/internal/query/text.go
+++ b/internal/query/text.go
@@ -59,7 +59,8 @@ type TextMatch struct {
 
 // TextResult is the full set of matches for one full-text search.
 type TextResult struct {
-	Matches []TextMatch `json:"matches"`
+	SchemaVersion int         `json:"schema_version"`
+	Matches       []TextMatch `json:"matches"`
 }
 
 // SearchText finds opts.Pattern across every captured object body and pod
@@ -126,7 +127,7 @@ func SearchText(store *store.CaptureStore, opts TextOptions) (*TextResult, error
 			})
 		}
 	}
-	return &TextResult{Matches: matches}, nil
+	return &TextResult{SchemaVersion: SchemaVersion, Matches: matches}, nil
 }
 
 func searchLogPath(store *store.CaptureStore, path string, at time.Time, find finder, opts TextOptions) ([]TextMatch, bool) {

--- a/internal/transitions/json_contract_test.go
+++ b/internal/transitions/json_contract_test.go
@@ -1,0 +1,44 @@
+package transitions
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestReport_IsObjectNotArray guards the shape change made before v1.0:
+// `transitions -o json` used to emit a bare top-level array, which had nowhere
+// to grow — no schema_version, no summary, no paging — without a breaking
+// change. The envelope is the extension point, so it must stay an object.
+func TestReport_IsObjectNotArray(t *testing.T) {
+	b, err := json.Marshal(&Report{SchemaVersion: SchemaVersion, Transitions: make([]Transition, 0)})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var probe any
+	if err := json.Unmarshal(b, &probe); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := probe.(map[string]any); !ok {
+		t.Fatalf("top level is %T, want a JSON object; got %s", probe, b)
+	}
+
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"schema_version", "transitions"} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("missing frozen top-level key %q", k)
+		}
+	}
+	// Empty must be [] so `jq '.transitions[]'` works.
+	var arr struct {
+		Transitions *[]Transition `json:"transitions"`
+	}
+	if err := json.Unmarshal(b, &arr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if arr.Transitions == nil {
+		t.Errorf("transitions marshaled as null, want []; got %s", b)
+	}
+}

--- a/internal/transitions/json_contract_test.go
+++ b/internal/transitions/json_contract_test.go
@@ -5,19 +5,37 @@ import (
 	"testing"
 )
 
-// TestReport_IsObjectNotArray guards the shape change made before v1.0:
+// TestLoadReport_IsObjectNotArray guards the shape change made before v1.0:
 // `transitions -o json` used to emit a bare top-level array, which had nowhere
 // to grow — no schema_version, no summary, no paging — without a breaking
 // change. The envelope is the extension point, so it must stay an object.
-func TestReport_IsObjectNotArray(t *testing.T) {
-	b, err := json.Marshal(&Report{
-		SchemaVersion: SchemaVersion,
-		CaptureID:     "550e8400-e29b-41d4-a716-446655440000",
-		Transitions:   make([]Transition, 0),
-	})
+//
+// This marshals what LoadReport actually returns, not a hand-built Report: a
+// literal with Transitions pre-initialized would keep passing even if
+// LoadReport regressed to a nil slice, reintroducing the `jq '.transitions[]'`
+// null footgun the contract exists to prevent.
+func TestLoadReport_IsObjectNotArray(t *testing.T) {
+	// Two identical snapshots — no state change, so the event list is
+	// legitimately empty and the nil-vs-[] distinction is what's under test.
+	body := `{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"a","uid":"u1"}}]}`
+	path := buildPollArchive(t, "/api/v1/pods", []string{body, body})
+
+	rep, err := LoadReport(path, FilterOpts{}, nil)
+	if err != nil {
+		t.Fatalf("LoadReport: %v", err)
+	}
+	if len(rep.Transitions) != 0 {
+		t.Fatalf("expected no transitions between identical snapshots, got %d", len(rep.Transitions))
+	}
+	if rep.Transitions == nil {
+		t.Error("Transitions is nil; it must be an empty slice so JSON is [] not null")
+	}
+
+	b, err := json.Marshal(rep)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
+
 	var probe any
 	if err := json.Unmarshal(b, &probe); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -32,17 +50,44 @@ func TestReport_IsObjectNotArray(t *testing.T) {
 	}
 	for _, k := range []string{"schema_version", "capture_id", "transitions"} {
 		if _, ok := got[k]; !ok {
-			t.Errorf("missing frozen top-level key %q", k)
+			t.Errorf("missing frozen top-level key %q; got %s", k, b)
 		}
 	}
+
+	var fields struct {
+		SchemaVersion int           `json:"schema_version"`
+		CaptureID     string        `json:"capture_id"`
+		Transitions   *[]Transition `json:"transitions"`
+	}
+	if err := json.Unmarshal(b, &fields); err != nil {
+		t.Fatalf("unmarshal fields: %v", err)
+	}
+	if fields.SchemaVersion != SchemaVersion {
+		t.Errorf("schema_version = %d, want %d", fields.SchemaVersion, SchemaVersion)
+	}
+	if fields.CaptureID == "" {
+		t.Error("capture_id is empty; LoadReport must populate it from archive metadata")
+	}
 	// Empty must be [] so `jq '.transitions[]'` works.
-	var arr struct {
-		Transitions *[]Transition `json:"transitions"`
-	}
-	if err := json.Unmarshal(b, &arr); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if arr.Transitions == nil {
+	if fields.Transitions == nil {
 		t.Errorf("transitions marshaled as null, want []; got %s", b)
+	}
+}
+
+// TestLoadTransitions_EmptyIsNonNil pins the same guarantee on the
+// envelope-free entry point, since it returns rep.Transitions directly.
+func TestLoadTransitions_EmptyIsNonNil(t *testing.T) {
+	body := `{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"a","uid":"u1"}}]}`
+	path := buildPollArchive(t, "/api/v1/pods", []string{body, body})
+
+	ts, err := LoadTransitions(path, FilterOpts{}, nil)
+	if err != nil {
+		t.Fatalf("LoadTransitions: %v", err)
+	}
+	if len(ts) != 0 {
+		t.Fatalf("expected no transitions, got %d", len(ts))
+	}
+	if ts == nil {
+		t.Error("LoadTransitions returned nil; callers marshaling it directly would emit null")
 	}
 }

--- a/internal/transitions/json_contract_test.go
+++ b/internal/transitions/json_contract_test.go
@@ -10,7 +10,11 @@ import (
 // to grow — no schema_version, no summary, no paging — without a breaking
 // change. The envelope is the extension point, so it must stay an object.
 func TestReport_IsObjectNotArray(t *testing.T) {
-	b, err := json.Marshal(&Report{SchemaVersion: SchemaVersion, Transitions: make([]Transition, 0)})
+	b, err := json.Marshal(&Report{
+		SchemaVersion: SchemaVersion,
+		CaptureID:     "550e8400-e29b-41d4-a716-446655440000",
+		Transitions:   make([]Transition, 0),
+	})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -26,7 +30,7 @@ func TestReport_IsObjectNotArray(t *testing.T) {
 	if err := json.Unmarshal(b, &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	for _, k := range []string{"schema_version", "transitions"} {
+	for _, k := range []string{"schema_version", "capture_id", "transitions"} {
 		if _, ok := got[k]; !ok {
 			t.Errorf("missing frozen top-level key %q", k)
 		}

--- a/internal/transitions/transitions.go
+++ b/internal/transitions/transitions.go
@@ -41,9 +41,12 @@ const SchemaVersion = 1
 // bare top-level array couldn't. Transitions is always a non-nil slice, so
 // consumers can iterate it unconditionally even on an empty result.
 type Report struct {
-	SchemaVersion int          `json:"schema_version"`
-	CaptureID     string       `json:"capture_id,omitempty"`
-	Transitions   []Transition `json:"transitions"`
+	SchemaVersion int `json:"schema_version"`
+	// CaptureID is not omitempty on purpose: metadata.json always carries a
+	// capture_id, so dropping the key on an empty value would make the frozen
+	// top-level key set non-deterministic for no benefit.
+	CaptureID   string       `json:"capture_id"`
+	Transitions []Transition `json:"transitions"`
 }
 
 // FilterOpts narrows which transitions are returned by LoadTransitions.
@@ -134,8 +137,12 @@ func LoadReport(archivePath string, opts FilterOpts, identities []age.Identity) 
 }
 
 // LoadTransitions is LoadReport without the output envelope: just the matching
-// transitions, sorted by time. Callers that render their own output (replay,
-// the table renderer, tests) want this; only `-o json` needs the envelope.
+// transitions, sorted by time, for callers that don't need the JSON wrapper.
+//
+// It delegates to LoadReport rather than duplicating the scan, so it does the
+// same work — it's a convenience, not a cheaper path. cmd/transitions.go
+// deliberately calls LoadReport for both output modes and passes
+// rep.Transitions to the table renderer, keeping one load path.
 func LoadTransitions(archivePath string, opts FilterOpts, identities []age.Identity) ([]Transition, error) {
 	rep, err := LoadReport(archivePath, opts, identities)
 	if err != nil {

--- a/internal/transitions/transitions.go
+++ b/internal/transitions/transitions.go
@@ -28,6 +28,24 @@ type Transition struct {
 	After     json.RawMessage `json:"after,omitempty"`  // new body  (ADDED,   MODIFIED)
 }
 
+// SchemaVersion is the version of the `kshrk transitions -o json` output
+// shape. Bumped only on a breaking change to Report's own fields — not for
+// changes to the passthrough Kubernetes objects under Transition.Before /
+// Transition.After, whose field names belong to the cluster's API, not to
+// k8shark (see docs/stability-policy.md).
+const SchemaVersion = 1
+
+// Report is the top-level `kshrk transitions -o json` output.
+//
+// The envelope exists so the output can gain fields in a minor release; a
+// bare top-level array couldn't. Transitions is always a non-nil slice, so
+// consumers can iterate it unconditionally even on an empty result.
+type Report struct {
+	SchemaVersion int          `json:"schema_version"`
+	CaptureID     string       `json:"capture_id,omitempty"`
+	Transitions   []Transition `json:"transitions"`
+}
+
 // FilterOpts narrows which transitions are returned by LoadTransitions.
 type FilterOpts struct {
 	Resource  string    // substring match against the resource name (e.g. "pods")
@@ -37,8 +55,9 @@ type FilterOpts struct {
 	Until     time.Time // inclusive upper bound on event time (zero = unbounded)
 }
 
-// LoadTransitions opens archivePath, discovers all state-change events that
-// match opts, and returns them sorted by time.
+// LoadReport opens archivePath, discovers all state-change events that match
+// opts, and returns them sorted by time, wrapped in the Report envelope that
+// `kshrk transitions -o json` emits.
 //
 // Detection modes:
 //   - Watch-enabled paths: events are read directly from watch-index.json
@@ -48,12 +67,17 @@ type FilterOpts struct {
 //
 // identities decrypts an encrypted archive; it is ignored for plaintext
 // archives, so callers may pass nil.
-func LoadTransitions(archivePath string, opts FilterOpts, identities []age.Identity) ([]Transition, error) {
+func LoadReport(archivePath string, opts FilterOpts, identities []age.Identity) (*Report, error) {
 	ar, err := archive.OpenWithIdentities(archivePath, identities)
 	if err != nil {
 		return nil, fmt.Errorf("opening archive: %w", err)
 	}
 	defer ar.Close()
+
+	meta, err := ar.ReadMetadata()
+	if err != nil {
+		return nil, fmt.Errorf("reading metadata: %w", err)
+	}
 
 	idx, err := ar.ReadIndex()
 	if err != nil {
@@ -68,7 +92,7 @@ func LoadTransitions(archivePath string, opts FilterOpts, identities []age.Ident
 		return nil, fmt.Errorf("reading watch index: %w", err)
 	}
 
-	var all []Transition
+	all := make([]Transition, 0)
 
 	for apiPath, entry := range idx {
 		// Skip Table-format query parameters.
@@ -102,7 +126,22 @@ func LoadTransitions(archivePath string, opts FilterOpts, identities []age.Ident
 		return all[i].Time.Before(all[j].Time)
 	})
 
-	return all, nil
+	return &Report{
+		SchemaVersion: SchemaVersion,
+		CaptureID:     meta.CaptureID,
+		Transitions:   all,
+	}, nil
+}
+
+// LoadTransitions is LoadReport without the output envelope: just the matching
+// transitions, sorted by time. Callers that render their own output (replay,
+// the table renderer, tests) want this; only `-o json` needs the envelope.
+func LoadTransitions(archivePath string, opts FilterOpts, identities []age.Identity) ([]Transition, error) {
+	rep, err := LoadReport(archivePath, opts, identities)
+	if err != nil {
+		return nil, err
+	}
+	return rep.Transitions, nil
 }
 
 // InferPollTransitions synthesizes ADDED/MODIFIED/DELETED transitions for a


### PR DESCRIPTION
Resolves the code and policy items from the freeze review in #318. Everything
here becomes a **major-version change** once `v1.0.0` ships, so this is the
last cheap window.

## ⚠️ Breaking for scripts written against `v1.0.0-rc.3`

Pre-1.0, so allowed — but worth calling out in the release notes.

**`transitions -o json` now emits an object, not a bare array:**

```console
# before (rc.3)                    # after
[                                  {
  { "event_type": "MODIFIED", …}     "schema_version": 1,
]                                   "capture_id": "550e8400-…",
                                    "transitions": [
                                      { "event_type": "MODIFIED", … }
                                    ]
                                  }
```

A bare array had nowhere to grow — no `schema_version`, no summary, no paging —
without a breaking change. The envelope is the entire point, and it's the one
thing that couldn't be added later.

**`inspect -o json`: `format_version` → `archive_format_version`.** It reports
the version of the *archive being inspected*, which sat confusingly beside
`diagnose`'s `schema_version` (the version of the *output*). The archive's own
on-disk `metadata.json` key is untouched — this is only the inspect output tag.

## Fix

**`diagnose -o json` emitted `"findings": null` on a clean capture.** The cause
was `filtered := fs[:0:0]` — when no rule fires, `fs` is nil and `nil[:0:0]`
stays nil. The most natural consumer pattern broke:

```console
$ kshrk diagnose examples/basic-workloads/capture.kshrk -o json | jq -r '.findings[].rule_id'
jq: error (at <stdin>:10): Cannot iterate over null (null)   # before
                                                             # after: exits 0
```

`jq '.findings | length'` returned `0` either way, which is why it hid.

## Addition

`schema_version` on all five structured outputs, per-command and independently
versioned. Minor-compatible, so not strictly required now — done here for
consistency while the surface is open.

## Policy

**Embedded Kubernetes objects are now explicitly passthrough.** `diff` and
`transitions` inline whole captured objects under `before`/`after`, and
`query.matches[].value` returns whatever JSONPath selected. Those field names
belong to the cluster's API and move with its version, so the policy's
"renaming a field is a major-version change" could not apply to them — it was
promising something k8shark cannot deliver. Now: **wrapper covered, payload
passthrough.**

`matches[].value` is documented as polymorphic by design, verified across four
expression kinds:

| expression | `.value` type |
|---|---|
| `{.spec.replicas}` | number |
| `{.metadata.name}` | string |
| `{.spec.template.spec.containers}` | array |
| `{.metadata.labels}` | object |

**Flag authority moves to the generated reference.** `docs/cli-reference.md`
(generated from Cobra, drift-checked in CI) replaces `docs/usage.md`, which is
a narrative guide that deliberately doesn't enumerate every flag. The gap
between them was exactly two flags (`--no-descriptions`, `--wide`).

Since nothing outside the web UI is marked experimental anywhere, pointing at
the complete list would freeze all 47 flags with no escape hatch — so the
replay-orchestration and writable-overlay flags are explicitly exempted:
`--with-kwok`, `--with-controller-manager`, `--schedule-pods`, `--writable`,
`--start-paused`, `--loop`, `--speed`. Those drive the newest, least-exercised
parts of the mock server. Widening coverage later is a minor change; narrowing
it would not be, which is why the exemption is written down now rather than
assumed.

## Tests

`json_contract_test.go` in each of the five packages pins the frozen top-level
key set, that collections marshal as `[]` not `null`, and that `transitions`'
top level is an object.

**None of these shapes had any JSON-level coverage before** — every existing
test asserted Go field names, so both the tag rename and the envelope change
passed a fully green suite. Confirmed the new tests are real guards by
mutation:

```
# nil-slice bug reintroduced
--- FAIL: TestRun_EmptyFindings_MarshalsAsArray
    findings marshaled as null, want []

# rename reverted
--- FAIL: TestReport_JSONContract_TopLevelKeys
    missing frozen top-level key "archive_format_version"
    format_version reappeared; it was renamed to archive_format_version
```

## One item from #318 was a false positive

`group` missing from `query --text` output. It is present in **both** modes
with identical `omitempty` behavior — omitted whenever the group is empty
(core-group resources). My earlier report sampled an `apps` resource in
JSONPath mode and a core one in text mode, so it read as a per-mode
difference. No code change; pinned by a test so it can't drift apart later.

## Verification

`gofmt`, `go mod tidy`, `go vet`, `go test -race ./...`, and `golangci-lint`
v1.64.8 (CI's pin) all clean. `docs/cli-reference.md` regenerates with no
drift — no flags changed. Confirmed nothing else consumes the changed shapes:
no script, no `internal/ui` code path, no example README, no conformance
baseline.

Refs #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)