### PR TITLE
fix(release): declare the license on the prerelease cask too

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -110,6 +110,7 @@ homebrew_casks:
   - name: k8shark@rc
     homepage: https://github.com/phenixblue/k8shark
     description: Kubernetes cluster state capture and mock API replay tool (prerelease channel)
+    license: Apache-2.0
     skip_upload: '{{ if .Prerelease }}false{{ else }}true{{ end }}'
     binaries:
       - kshrk


### PR DESCRIPTION
Minor consistency fix found while auditing the Homebrew install path ahead of
`v1.0.0`.

The two `homebrew_casks` entries in `.goreleaser.yaml` describe the same binary,
but only the stable one declares a license:

| field | `k8shark` | `k8shark@rc` |
|---|---|---|
| `description` | … | … *(prerelease channel)* |
| `license` | `Apache-2.0` | **missing** |
| `skip_upload` | `auto` | `{{ if .Prerelease }}…` |

So the published `Casks/k8shark@rc.rb` carries no license field while the stable
cask will. Nothing enforces this — `goreleaser check` passes either way — it's
just an inconsistency between two channels shipping identical bits under
Apache-2.0.

`goreleaser check` re-validated after the change.

## Context

This is the cosmetic half of the Homebrew audit. The substantive finding is
phenixblue/homebrew-tap#2: the tap still holds a root-level `k8shark.rb`
**formula** pinned at v0.5.1, and because a formula wins the bare token, `brew
install phenixblue/tap/k8shark` (the documented command minus `--cask`) would
have silently installed v0.5.1 even after `v1.0.0` shipped. GoReleaser only
writes `Casks/`, so the release would not have cleaned it up.

Also worth knowing from that audit: `brew install --cask phenixblue/tap/k8shark`
— the README's primary install command — **fails today**, because no prerelease
creates the stable cask (`skip_upload: auto`) and the last stable release
predates the formula-to-cask migration in #224. `v1.0.0` will be the first
release to create it. The pipeline itself is proven: rc.3 pushed
`Casks/k8shark@rc.rb` to the tap successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)