### PR TITLE
test(release): smoke-test published artifacts on all six platforms

### DIFF
--- a/.github/workflows/artifact-smoke.yml
+++ b/.github/workflows/artifact-smoke.yml
@@ -69,7 +69,12 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          EXPLICIT: ${{ inputs.tag || github.event.release.tag_name }}
+          # github.event.inputs.* rather than inputs.*: the latter is documented as
+          # a workflow_dispatch/workflow_call context. It does resolve to empty on
+          # other events in practice (verified on a pull_request run), but the
+          # release path is both the one that matters here and the least
+          # exercised, so don't lean on undocumented behavior for it.
+          EXPLICIT: ${{ github.event.inputs.tag || github.event.release.tag_name }}
         run: |
           set -euo pipefail
           tag="$EXPLICIT"
@@ -117,7 +122,10 @@ jobs:
           # the contract (#320 landed after v1.0.0-rc.3) — so the PR run proves
           # the harness works end-to-end on all six platforms, and the shape
           # assertions are enforced where the version is known to have them.
-          EXPECT_CONTRACT: ${{ (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.expect_contract)) && '1' || '0' }}
+          # Compared to the string 'true' on purpose: github.event.inputs values
+          # are strings, so a bare truthiness check would read the literal
+          # "false" as true — every non-empty string is truthy here.
+          EXPECT_CONTRACT: ${{ (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.expect_contract == 'true')) && '1' || '0' }}
         run: |
           set -euo pipefail
           bin=bin/kshrk

--- a/.github/workflows/artifact-smoke.yml
+++ b/.github/workflows/artifact-smoke.yml
@@ -48,7 +48,14 @@ jobs:
           - runner: macos-latest
             goos: darwin
             goarch: arm64
-          - runner: macos-13
+          # macos-15-intel, not macos-13: the macOS 13 image was retired in
+          # December 2025, and a job targeting a retired label doesn't fail —
+          # it queues forever waiting for a runner that will never come.
+          # macos-15-intel is GitHub's last x86_64 macOS image and goes away
+          # when macOS 15 retires (Fall 2027). After that, run the amd64 binary
+          # on an arm64 runner under Rosetta: verified locally that an Apple
+          # Silicon mac executes the shipped darwin/amd64 binary fine.
+          - runner: macos-15-intel
             goos: darwin
             goarch: amd64
           - runner: windows-latest
@@ -58,6 +65,8 @@ jobs:
             goos: windows
             goarch: arm64
     runs-on: ${{ matrix.runner }}
+    # Each leg is 6-24s in practice; this only bounds a hang.
+    timeout-minutes: 15
     steps:
       - name: Checkout
         # Needed for scripts/artifact-smoke.sh and the examples/*.kshrk fixtures

--- a/.github/workflows/artifact-smoke.yml
+++ b/.github/workflows/artifact-smoke.yml
@@ -1,0 +1,126 @@
+name: artifact-smoke
+
+# Runs the bytes users actually download, on the platform they download them
+# for. The CI test matrix builds from source and runs `go test`; it never
+# executes a release artifact, so a packaging or cross-compilation defect
+# present only in the shipped binary would not be caught there.
+#
+# Triggers on a published release (so every tag is covered automatically), and
+# on demand against any existing tag via workflow_dispatch.
+
+on:
+  release:
+    types: [published]
+  # Mirrors release-check.yml (#315): exercise a change to this workflow or the
+  # smoke script in the PR that makes it, rather than discovering it broke at
+  # the next tag. Falls back to the latest published release as the subject.
+  pull_request:
+    paths:
+      - ".github/workflows/artifact-smoke.yml"
+      - "scripts/artifact-smoke.sh"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to smoke-test (e.g. v1.0.0)'
+        required: true
+        type: string
+      expect_contract:
+        description: 'Assert the v1.0 -o json shapes (off for releases before #320, e.g. v1.0.0-rc.3)'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            goos: linux
+            goarch: amd64
+          - runner: ubuntu-24.04-arm
+            goos: linux
+            goarch: arm64
+          - runner: macos-latest
+            goos: darwin
+            goarch: arm64
+          - runner: macos-13
+            goos: darwin
+            goarch: amd64
+          - runner: windows-latest
+            goos: windows
+            goarch: amd64
+          - runner: windows-11-arm
+            goos: windows
+            goarch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        # Needed for scripts/artifact-smoke.sh and the examples/*.kshrk fixtures
+        # the smoke test reads.
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Resolve the tag
+        id: tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPLICIT: ${{ inputs.tag || github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          tag="$EXPLICIT"
+          if [ -z "$tag" ]; then
+            # pull_request: no release payload, so test the latest release.
+            tag=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 1 --json tagName --jq '.[0].tagName')
+            echo "no tag given; using the latest release: $tag"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Download and verify the artifact
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          ext=tar.gz
+          if [ "${{ matrix.goos }}" = "windows" ]; then ext=zip; fi
+          # Release assets carry the version without the leading v.
+          asset="k8shark_${TAG#v}_${{ matrix.goos }}_${{ matrix.goarch }}.${ext}"
+          echo "asset: $asset"
+
+          mkdir -p dl && cd dl
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" -p "$asset" -p checksums.txt
+
+          # Verify the checksum before trusting the bytes. --ignore-missing so
+          # the single-asset download doesn't fail on the other entries.
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum --check --ignore-missing checksums.txt
+          else
+            shasum -a 256 --check --ignore-missing checksums.txt
+          fi
+
+          mkdir -p ../bin
+          if [ "$ext" = "zip" ]; then unzip -oq "$asset" -d ../bin; else tar xzf "$asset" -C ../bin; fi
+          ls -l ../bin
+
+      - name: Smoke-test the binary
+        shell: bash
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          # On a real release, enforce the frozen -o json shapes. On a PR the
+          # subject is whichever release happens to be latest, which may predate
+          # the contract (#320 landed after v1.0.0-rc.3) — so the PR run proves
+          # the harness works end-to-end on all six platforms, and the shape
+          # assertions are enforced where the version is known to have them.
+          EXPECT_CONTRACT: ${{ (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.expect_contract)) && '1' || '0' }}
+        run: |
+          set -euo pipefail
+          bin=bin/kshrk
+          if [ "${{ matrix.goos }}" = "windows" ]; then bin=bin/kshrk.exe; fi
+          chmod +x "$bin" || true
+          sh scripts/artifact-smoke.sh "$bin" "${TAG#v}" .

--- a/docs/development.md
+++ b/docs/development.md
@@ -123,11 +123,13 @@ release older than `v1.0.0` (the shapes were settled in #320, after
 `v1.0.0-rc.3`).
 
 The script is POSIX `sh`, not bash, so the same file runs on Alpine's busybox
-`ash` and in Windows Git Bash. Testing a linux binary locally on macOS:
+`ash` and in Windows Git Bash. Testing a linux binary locally on macOS, using
+the `linux_amd64` artifact extracted above — **`--platform` must match the
+artifact's `GOARCH`**, or the container can't execute it:
 
 ```sh
-docker run --rm --platform linux/arm64 \
-  -v "$PWD/kshrk:/kshrk:ro" -v "$PWD:/work:ro" alpine:3 \
+docker run --rm --platform linux/amd64 \
+  -v /tmp/ks/kshrk:/kshrk:ro -v "$PWD:/work:ro" alpine:3 \
   /bin/sh /work/scripts/artifact-smoke.sh /kshrk 1.0.0 /work
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -99,6 +99,46 @@ This is how the v1.30–v1.36 range in the
 [version window](stability-policy.md#supported-kubernetes--kubectl-version-window)
 was established; `make e2e` with no `NODE_IMAGE` uses kind's default.
 
+## Release-artifact smoke test
+
+`make e2e`, `make test`, and the CI matrix all build from source. Nothing among
+them executes a **published release artifact**, so a packaging or
+cross-compilation defect present only in the shipped binary would go unnoticed
+until a user hit it.
+
+[`scripts/artifact-smoke.sh`](../scripts/artifact-smoke.sh) closes that: point it
+at an extracted binary and it checks the binary runs, reports the expected
+version, reads a real `.kshrk` archive, honors the exit-code contract, and emits
+the frozen `-o json` shapes.
+
+```sh
+# Against a published release, by hand:
+gh release download v1.0.0 --repo phenixblue/k8shark -p 'k8shark_*_linux_amd64.tar.gz'
+mkdir -p /tmp/ks && tar xzf k8shark_1.0.0_linux_amd64.tar.gz -C /tmp/ks
+./scripts/artifact-smoke.sh /tmp/ks/kshrk 1.0.0 .
+```
+
+Set `EXPECT_CONTRACT=0` to skip the `-o json` shape assertions when testing a
+release older than `v1.0.0` (the shapes were settled in #320, after
+`v1.0.0-rc.3`).
+
+The script is POSIX `sh`, not bash, so the same file runs on Alpine's busybox
+`ash` and in Windows Git Bash. Testing a linux binary locally on macOS:
+
+```sh
+docker run --rm --platform linux/arm64 \
+  -v "$PWD/kshrk:/kshrk:ro" -v "$PWD:/work:ro" alpine:3 \
+  /bin/sh /work/scripts/artifact-smoke.sh /kshrk 1.0.0 /work
+```
+
+Running it under both `debian:stable-slim` and `alpine:3` is worth the extra
+minute: the binaries are built `CGO_ENABLED=0`, and musl is where a stray libc
+dependency would surface.
+
+[artifact-smoke.yml](../.github/workflows/artifact-smoke.yml) runs it
+automatically on every published release across all six shipped platforms
+(linux/darwin/windows × amd64/arm64), verifying each archive's checksum before
+executing it. It can also be dispatched manually against any existing tag.
 ## Verifying backward compatibility against a real old release
 
 [docs/archive-format.md](archive-format.md#format-version--compatibility)

--- a/scripts/artifact-smoke.sh
+++ b/scripts/artifact-smoke.sh
@@ -81,8 +81,11 @@ if [ "$EXPECT_CONTRACT" = "1" ]; then
   # findings must be [] not null, so `jq '.findings[]'` works on a clean capture.
   if d=$("$BIN" diagnose "$BASIC" -o json 2>&1); then
     case "$d" in
+      # Match the opening bracket, so a findings that turned into an object or
+      # a string fails instead of passing as "present and not null".
+      *'"findings": ['*|*'"findings":['*) ok "diagnose findings is an array" ;;
       *'"findings": null'*|*'"findings":null'*) bad "diagnose findings is null, want []" ;;
-      *'"findings"'*) ok "diagnose findings is an array" ;;
+      *'"findings"'*) bad "diagnose findings is present but is not an array" ;;
       *) bad "diagnose output has no findings key" ;;
     esac
   else

--- a/scripts/artifact-smoke.sh
+++ b/scripts/artifact-smoke.sh
@@ -28,7 +28,11 @@ FAIL=0
 ok()   { printf '  [OK]   %s\n' "$1"; PASS=$((PASS + 1)); }
 bad()  { printf '  [FAIL] %s\n' "$1"; FAIL=$((FAIL + 1)); }
 
-printf -- '--- %s/%s  kshrk=%s ---\n' "$(uname -s)" "$(uname -m)" "$BIN"
+# %s format rather than a literal leading "---": POSIX printf takes no options,
+# so `printf -- ...` relies on an unspecified extension to protect a format
+# beginning with a dash. Every shell tested handles it, but this script's whole
+# point is not depending on that.
+printf '%s\n' "--- $(uname -s)/$(uname -m)  kshrk=$BIN ---"
 
 # ── Portability: does the shipped binary run at all, everywhere? ──────────────
 # Catches the class of defect this script exists for: a dynamically-linked

--- a/scripts/artifact-smoke.sh
+++ b/scripts/artifact-smoke.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env sh
+# Smoke-test an *already-extracted* kshrk binary from a published release.
+#
+# This is the one check that runs the bytes users actually download, on the
+# platform they download them for. The CI test matrix builds from source and
+# runs `go test`; it never executes a release artifact, so a packaging or
+# cross-compilation defect that only shows up in the shipped binary would not
+# be caught there. Wired up in .github/workflows/artifact-smoke.yml.
+#
+# POSIX sh on purpose — it has to run on Alpine (busybox ash) as well as on
+# glibc distros and Windows Git Bash, so: no arrays, no [[ ]], no local.
+#
+# Usage:   ./scripts/artifact-smoke.sh <binary> <expected-version> [repo-root]
+# Env:     EXPECT_CONTRACT=0  skip the -o json shape assertions, for binaries
+#                             released before the v1.0 contract landed (#320).
+set -u
+
+BIN="${1:?usage: artifact-smoke.sh <binary> <expected-version> [repo-root]}"
+WANT_VERSION="${2:?expected version, e.g. 1.0.0}"
+ROOT="${3:-.}"
+EXPECT_CONTRACT="${EXPECT_CONTRACT:-1}"
+
+BASIC="$ROOT/examples/basic-workloads/capture.kshrk"
+ROLLING="$ROOT/examples/rolling-update/capture.kshrk"
+
+PASS=0
+FAIL=0
+ok()   { printf '  [OK]   %s\n' "$1"; PASS=$((PASS + 1)); }
+bad()  { printf '  [FAIL] %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+printf -- '--- %s/%s  kshrk=%s ---\n' "$(uname -s)" "$(uname -m)" "$BIN"
+
+# ── Portability: does the shipped binary run at all, everywhere? ──────────────
+# Catches the class of defect this script exists for: a dynamically-linked
+# binary that can't resolve libc on musl, a wrong-arch build, a corrupt
+# archive, or a stripped-away entry point.
+if out=$("$BIN" version 2>&1); then
+  ok "version runs: $out"
+else
+  bad "version failed: $out"
+  printf '  => cannot execute the binary; abandoning the rest\n'
+  exit 1
+fi
+
+case "$out" in
+  *"$WANT_VERSION"*) ok "version reports $WANT_VERSION" ;;
+  *) bad "version is '$out', want it to contain '$WANT_VERSION'" ;;
+esac
+
+if "$BIN" --help >/dev/null 2>&1; then ok "--help exits 0"; else bad "--help exited nonzero"; fi
+
+# ── Real work: read a zip+zstd archive off disk ───────────────────────────────
+# `version`/`--help` would pass on a binary whose archive layer was broken, so
+# actually decode a capture.
+if json=$("$BIN" inspect "$BASIC" -o json 2>&1); then
+  ok "inspect -o json read a real archive"
+  case "$json" in
+    *'"record_count"'*) ok "inspect output has record_count" ;;
+    *) bad "inspect output missing record_count" ;;
+  esac
+else
+  bad "inspect failed: $(printf '%s' "$json" | head -n 2)"
+fi
+
+# ── Exit-code contract (docs/stability-policy.md) ─────────────────────────────
+"$BIN" inspect "$ROOT/no-such-archive.kshrk" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 2 ]; then ok "missing archive exits 2"; else bad "missing archive exited $rc, want 2"; fi
+
+# ── Frozen -o json shapes (#320) ──────────────────────────────────────────────
+if [ "$EXPECT_CONTRACT" = "1" ]; then
+  case "$json" in
+    *'"schema_version"'*) ok "inspect has schema_version" ;;
+    *) bad "inspect missing schema_version" ;;
+  esac
+  case "$json" in
+    *'"archive_format_version"'*) ok "inspect has archive_format_version" ;;
+    *) bad "inspect missing archive_format_version (renamed from format_version in #320)" ;;
+  esac
+
+  # findings must be [] not null, so `jq '.findings[]'` works on a clean capture.
+  if d=$("$BIN" diagnose "$BASIC" -o json 2>&1); then
+    case "$d" in
+      *'"findings": null'*|*'"findings":null'*) bad "diagnose findings is null, want []" ;;
+      *'"findings"'*) ok "diagnose findings is an array" ;;
+      *) bad "diagnose output has no findings key" ;;
+    esac
+  else
+    bad "diagnose failed: $(printf '%s' "$d" | head -n 2)"
+  fi
+
+  # transitions must be an object envelope, not a bare array.
+  if t=$("$BIN" transitions "$ROLLING" -o json 2>&1); then
+    case "$t" in
+      \{*) ok "transitions emits an object envelope" ;;
+      \[*) bad "transitions emits a bare array; #320 wrapped it in an object" ;;
+      *) bad "transitions output is neither object nor array" ;;
+    esac
+  else
+    bad "transitions failed: $(printf '%s' "$t" | head -n 2)"
+  fi
+else
+  printf '  [skip] -o json shape checks (EXPECT_CONTRACT=0)\n'
+fi
+
+printf '  => passed=%s failed=%s\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes the gap I flagged after the freeze review: **nothing ever executes a
published release artifact.** `make e2e`, `make test`, and the CI matrix all
build from source, so a packaging or cross-compilation defect present only in
the shipped binary has nothing catching it. `v1.0.0-rc.3` was verified by hand
on darwin/arm64 only — five of the six shipped platforms were never run.

## What's added

[`scripts/artifact-smoke.sh`](scripts/artifact-smoke.sh) takes an extracted
binary and checks it runs, reports the expected version, **reads a real `.kshrk`
archive** (exercising the zip+zstd layer, which `version`/`--help` would not),
honors the exit-code contract, and emits the frozen `-o json` shapes. POSIX `sh`
rather than bash, so one file covers Alpine's busybox `ash` and Windows Git Bash.

[`artifact-smoke.yml`](.github/workflows/artifact-smoke.yml) runs it on every
published release across all six shipped platforms — linux/darwin/windows ×
amd64/arm64 — verifying each archive's checksum before executing it. Also
dispatchable against any existing tag.

It additionally runs on PRs touching either file, mirroring `release-check.yml`
(#315). A smoke test exercised only by a real tag has exactly the blind spot
that let the cosign v3 break reach a tag in #314. **This PR is therefore its own
first test run** — including the Windows execution I can't do locally.

## What I found running it against v1.0.0-rc.3

**Linux, both arches, both libc implementations — 24/24 pass:**

| | glibc (`debian:stable-slim`) | musl (`alpine:3`) |
|---|---|---|
| linux/amd64 | 6/6 | 6/6 |
| linux/arm64 | 6/6 | 6/6 |

Worth testing musl specifically: the builds are `CGO_ENABLED=0`, and musl is
where a stray libc dependency would surface. Both confirmed statically linked.

**Windows** — both zips are correct `PE32+` binaries for their architecture
(`x86-64` and `Aarch64`), containing `kshrk.exe` plus LICENSE/NOTICE/README, and
**zero entry names contain a backslash**, so the #226 path-separator bug class is
clean. Execution needs a runner, which this PR's own CI run provides.

**Checksums** — all four non-darwin archives verify against `checksums.txt`.

**Expected version-specific gaps:** rc.3 lacks `schema_version` and
`archive_format_version`, still emits `findings: null`, and still returns a bare
array from `transitions` — correct, since #320 landed after it. They fail
*identically* on all four linux combos, which is itself evidence of no platform
divergence. Hence `EXPECT_CONTRACT`, off for pre-#320 releases.

## Two things I verified rather than assumed

`[ cond ] && var=x` under `set -euo pipefail` is exempt from `set -e` mid-script
but becomes a step failure as the **last** command in a script:

```console
$ bash -c 'set -e; ext=a; [ x = y ] && ext=b; echo survived'   # exit 0
survived
$ bash -c 'set -e; ext=a; [ x = y ] && ext=b'                  # exit 1  <-- trap
```

Both of mine sat mid-script and would have worked, but a later edit appending a
line would silently break them, so they're explicit `if` blocks now.

The `ubuntu-24.04-arm` and `windows-11-arm` runner labels need a public repo —
confirmed `visibility=public`.

## Verified

`sh -n` clean; YAML parses with all six matrix legs; the script passes 10/10
against a post-#320 local build (so the contract assertions demonstrably fire
when the binary has them) and 6/6 with `EXPECT_CONTRACT=0` against rc.3. All
actions SHA-pinned per CLAUDE.md, reusing the `checkout` pin already in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)