### PR TITLE
test(archive): cover the metadata a real v0.5.x archive carries

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -109,29 +109,50 @@ makes a similar promise for config files. The golden fixtures in
 against what an old release actually wrote:
 
 ```sh
-# 1. Get the old binary.
+# 1. Get the old binary. (Swap darwin_arm64 for your platform.)
 gh release download v0.5.1 --repo phenixblue/k8shark -p 'k8shark_*_darwin_arm64.tar.gz'
 mkdir -p /tmp/old && tar xzf k8shark_0.5.1_darwin_arm64.tar.gz -C /tmp/old
 
-# 2. Capture with it against a live cluster.
+# 2. Write a short capture config. The old release's own examples/k8shark.yaml
+#    runs for 10m over 11 resources; this is the same schema, just quicker.
+cat > /tmp/old-capture.yaml <<'YAML'
+duration: 20s
+output: /tmp/old-capture.kshrk
+resources:
+  - group: ""
+    version: v1
+    resource: pods
+    namespaces: ["*"]
+    interval: 5s
+  - group: ""
+    version: v1
+    resource: nodes
+    interval: 10s
+YAML
+
+# 3. Capture with the OLD binary against a live cluster.
 make kind-up
-KUBECONFIG=~/.kube/k8shark-dev.yaml /tmp/old/kshrk capture --config old.yaml
+KUBECONFIG=~/.kube/k8shark-dev.yaml /tmp/old/kshrk capture --config /tmp/old-capture.yaml
 
-# 3. Read it with the current build — every command, plus the mock server.
+# 4. Read that archive with the CURRENT build — every command, plus the mock
+#    server. A high API port keeps this from colliding with a real run.
 make build
-./kshrk inspect old.kshrk -o json
-./kshrk diagnose old.kshrk -o json
-./kshrk transitions old.kshrk -o json
-./kshrk open old.kshrk --api-port 18081 --kubeconfig-out /tmp/mock.yaml &
+./kshrk inspect      /tmp/old-capture.kshrk -o json
+./kshrk diagnose     /tmp/old-capture.kshrk -o json
+./kshrk transitions  /tmp/old-capture.kshrk -o json
+./kshrk query        /tmp/old-capture.kshrk '{.metadata.name}' -o json
+./kshrk open         /tmp/old-capture.kshrk --api-port 18081 --kubeconfig-out /tmp/mock.yaml &
 kubectl --kubeconfig /tmp/mock.yaml get pods -A
+kubectl --kubeconfig /tmp/mock.yaml get nodes
 
-# 4. And run the old release's shipped config through the current validator.
-git show v0.5.1:examples/k8shark.yaml > /tmp/v051.yaml
-./kshrk validate --config /tmp/v051.yaml
+# 5. Separately, run the old release's *shipped* config through the current
+#    validator — that's the config-schema half of the promise.
+git show v0.5.1:examples/k8shark.yaml > /tmp/v051-shipped.yaml
+./kshrk validate --config /tmp/v051-shipped.yaml
 ```
 
-Use a high API port (`18081`) rather than the default so a test run can't
-collide with a real one.
+Expect `inspect -o json` to report `"archive_format_version": 1`, and every
+command in step 4 to exit 0.
 
 Worth knowing: a v0.5.1 capture of a *single* resource still lands at ~1 MB
 because discovery and OpenAPI paths are captured alongside it, so a real old

--- a/docs/development.md
+++ b/docs/development.md
@@ -99,6 +99,47 @@ This is how the v1.30–v1.36 range in the
 [version window](stability-policy.md#supported-kubernetes--kubectl-version-window)
 was established; `make e2e` with no `NODE_IMAGE` uses kind's default.
 
+## Verifying backward compatibility against a real old release
+
+[docs/archive-format.md](archive-format.md#format-version--compatibility)
+promises the `1.x` line reads every version-1 archive for the life of the
+series, and [docs/stability-policy.md](stability-policy.md#config-file-schema)
+makes a similar promise for config files. The golden fixtures in
+`internal/archive/testdata/` pin the *format*; this is how to check the promise
+against what an old release actually wrote:
+
+```sh
+# 1. Get the old binary.
+gh release download v0.5.1 --repo phenixblue/k8shark -p 'k8shark_*_darwin_arm64.tar.gz'
+tar xzf k8shark_0.5.1_darwin_arm64.tar.gz -C /tmp/old
+
+# 2. Capture with it against a live cluster.
+make kind-up
+KUBECONFIG=~/.kube/k8shark-dev.yaml /tmp/old/kshrk capture --config old.yaml
+
+# 3. Read it with the current build — every command, plus the mock server.
+make build
+./kshrk inspect old.kshrk -o json
+./kshrk diagnose old.kshrk -o json
+./kshrk transitions old.kshrk -o json
+./kshrk open old.kshrk --api-port 18081 --kubeconfig-out /tmp/mock.yaml &
+kubectl --kubeconfig /tmp/mock.yaml get pods -A
+
+# 4. And run the old release's shipped config through the current validator.
+git show v0.5.1:examples/k8shark.yaml > /tmp/v051.yaml
+./kshrk validate --config /tmp/v051.yaml
+```
+
+Use a high API port (`18081`) rather than the default so a test run can't
+collide with a real one.
+
+Worth knowing: a v0.5.1 capture of a *single* resource still lands at ~1 MB
+because discovery and OpenAPI paths are captured alongside it, so a real old
+archive is too heavy to check in as a fixture. `TestReadMetadata_RealV051Shape`
+in `internal/archive/format_test.go` instead encodes the metadata key set and
+value shapes observed from a real v0.5.1 capture, which is the part the golden
+fixture leaves uncovered.
+
 ## Make targets reference
 
 Run `make help` to print all targets:

--- a/docs/development.md
+++ b/docs/development.md
@@ -111,7 +111,7 @@ against what an old release actually wrote:
 ```sh
 # 1. Get the old binary.
 gh release download v0.5.1 --repo phenixblue/k8shark -p 'k8shark_*_darwin_arm64.tar.gz'
-tar xzf k8shark_0.5.1_darwin_arm64.tar.gz -C /tmp/old
+mkdir -p /tmp/old && tar xzf k8shark_0.5.1_darwin_arm64.tar.gz -C /tmp/old
 
 # 2. Capture with it against a live cluster.
 make kind-up

--- a/docs/development.md
+++ b/docs/development.md
@@ -142,8 +142,11 @@ make build
 ./kshrk transitions  /tmp/old-capture.kshrk -o json
 ./kshrk query        /tmp/old-capture.kshrk '{.metadata.name}' -o json
 ./kshrk open         /tmp/old-capture.kshrk --api-port 18081 --kubeconfig-out /tmp/mock.yaml &
+mock_pid=$!
+until [ -s /tmp/mock.yaml ]; do sleep 1; done
 kubectl --kubeconfig /tmp/mock.yaml get pods -A
 kubectl --kubeconfig /tmp/mock.yaml get nodes
+kill "$mock_pid"                       # don't leave a server bound to 18081
 
 # 5. Separately, run the old release's *shipped* config through the current
 #    validator — that's the config-schema half of the promise.

--- a/internal/archive/format_test.go
+++ b/internal/archive/format_test.go
@@ -356,3 +356,110 @@ func TestGoldenV2(t *testing.T) {
 		t.Fatalf("record JSON invalid: %v", err)
 	}
 }
+
+// TestReadMetadata_RealV051Shape covers the metadata payload a real v0.5.x
+// archive actually carries, which the golden-v1 fixture does not.
+//
+// golden-v1.kshrk is deliberately minimal — sampleArchive writes exactly three
+// metadata keys (format_version, capture_id, record_count) — so it pins the v1
+// *envelope* but exercises none of the fields a real capture fills in. A
+// capture taken with the released v0.5.1 binary against a live cluster writes
+// ten:
+//
+//	capture_id captured_at captured_until deduplicated_count format_version
+//	intervals kubernetes_version record_count server_address uncompressed_bytes
+//
+// The seven the golden omits are the ones with teeth: captured_at and
+// captured_until drive every time-window path (--from/--to, --at, replay
+// positioning), and intervals is a []string that a bad decode would silently
+// drop. docs/archive-format.md promises the 1.x line reads all version-1
+// archives for the life of the series, so those fields have to survive a read,
+// not just parse.
+//
+// The key set and value shapes here were read off an archive produced by the
+// real v0.5.1 release, not invented.
+func TestReadMetadata_RealV051Shape(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "v051-shape.kshrk")
+
+	sw, err := NewStreamWriter(path)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	capturedAt := time.Date(2026, 7, 31, 4, 30, 0, 0, time.UTC)
+	capturedUntil := capturedAt.Add(20 * time.Second)
+	rec := &format.Record{
+		ID: "rec-1", CapturedAt: capturedAt, APIPath: "/api/v1/nodes",
+		HTTPMethod: "GET", ResponseCode: 200,
+		ResponseBody: []byte(`{"apiVersion":"v1","kind":"NodeList","items":[]}`),
+	}
+	if _, err := sw.WriteRecord(rec); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+	// A bare map, not format.CaptureMetadata, so this stays pinned to the v1
+	// on-disk spelling even if the struct's tags are refactored later.
+	meta := map[string]any{
+		"format_version":     1,
+		"capture_id":         "8e04a3c4-f361-426a-9f3a-da1e261f7c5d",
+		"captured_at":        capturedAt.Format(time.RFC3339Nano),
+		"captured_until":     capturedUntil.Format(time.RFC3339Nano),
+		"kubernetes_version": "v1.36.1",
+		"server_address":     "https://127.0.0.1:57897",
+		"record_count":       135,
+		"deduplicated_count": 12,
+		"intervals":          []string{"4s"},
+		"uncompressed_bytes": 980157,
+	}
+	idx := map[string]any{
+		"/api/v1/nodes": map[string]any{
+			"api_path": "/api/v1/nodes", "seqs": []int{0},
+		},
+	}
+	if err := sw.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	ar, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer ar.Close()
+
+	got, err := ar.ReadMetadata()
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+
+	if got.FormatVersion != 1 {
+		t.Errorf("FormatVersion = %d, want 1", got.FormatVersion)
+	}
+	if got.CaptureID != "8e04a3c4-f361-426a-9f3a-da1e261f7c5d" {
+		t.Errorf("CaptureID = %q", got.CaptureID)
+	}
+	// The seven fields golden-v1 never exercises.
+	if !got.CapturedAt.Equal(capturedAt) {
+		t.Errorf("CapturedAt = %v, want %v", got.CapturedAt, capturedAt)
+	}
+	if !got.CapturedUntil.Equal(capturedUntil) {
+		t.Errorf("CapturedUntil = %v, want %v", got.CapturedUntil, capturedUntil)
+	}
+	if got.KubernetesVersion != "v1.36.1" {
+		t.Errorf("KubernetesVersion = %q, want v1.36.1", got.KubernetesVersion)
+	}
+	if got.ServerAddress != "https://127.0.0.1:57897" {
+		t.Errorf("ServerAddress = %q", got.ServerAddress)
+	}
+	if got.DeduplicatedCount != 12 {
+		t.Errorf("DeduplicatedCount = %d, want 12", got.DeduplicatedCount)
+	}
+	if len(got.Intervals) != 1 || got.Intervals[0] != "4s" {
+		t.Errorf("Intervals = %v, want [4s]", got.Intervals)
+	}
+	if got.UncompressedBytes != 980157 {
+		t.Errorf("UncompressedBytes = %d, want 980157", got.UncompressedBytes)
+	}
+	// Fields that postdate v0.5.1 must read as their zero value, not error.
+	if got.WatchEnabled || got.Encrypted || got.Redacted || got.AutoDiscovered {
+		t.Errorf("post-v0.5.1 flags should be false on a v0.5.1 archive: watch=%v enc=%v redacted=%v auto=%v",
+			got.WatchEnabled, got.Encrypted, got.Redacted, got.AutoDiscovered)
+	}
+}

--- a/internal/archive/format_test.go
+++ b/internal/archive/format_test.go
@@ -385,6 +385,10 @@ func TestReadMetadata_RealV051Shape(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStreamWriter: %v", err)
 	}
+	// Abort is a no-op once Finish has closed the writer, so this only fires on
+	// an early t.Fatalf below — where it releases the file handle that would
+	// otherwise block t.TempDir cleanup on Windows.
+	defer func() { _ = sw.Abort() }()
 	capturedAt := time.Date(2026, 7, 31, 4, 30, 0, 0, time.UTC)
 	capturedUntil := capturedAt.Add(20 * time.Second)
 	rec := &format.Record{
@@ -434,6 +438,9 @@ func TestReadMetadata_RealV051Shape(t *testing.T) {
 	}
 	if got.CaptureID != "8e04a3c4-f361-426a-9f3a-da1e261f7c5d" {
 		t.Errorf("CaptureID = %q", got.CaptureID)
+	}
+	if got.RecordCount != 135 {
+		t.Errorf("RecordCount = %d, want 135", got.RecordCount)
 	}
 	// The seven fields golden-v1 never exercises.
 	if !got.CapturedAt.Equal(capturedAt) {

--- a/internal/archive/format_test.go
+++ b/internal/archive/format_test.go
@@ -391,13 +391,21 @@ func TestReadMetadata_RealV051Shape(t *testing.T) {
 	defer func() { _ = sw.Abort() }()
 	capturedAt := time.Date(2026, 7, 31, 4, 30, 0, 0, time.UTC)
 	capturedUntil := capturedAt.Add(20 * time.Second)
-	rec := &format.Record{
-		ID: "rec-1", CapturedAt: capturedAt, APIPath: "/api/v1/nodes",
-		HTTPMethod: "GET", ResponseCode: 200,
-		ResponseBody: []byte(`{"apiVersion":"v1","kind":"NodeList","items":[]}`),
-	}
-	if _, err := sw.WriteRecord(rec); err != nil {
-		t.Fatalf("WriteRecord: %v", err)
+	// Two records at two seqs, so record_count, deduplicated_count and the
+	// index's seqs all agree with what was actually written. The real v0.5.1
+	// capture these values came from had 135 and 12; scaled down here, because
+	// an archive whose metadata contradicts its contents would break this test
+	// the day a reader starts cross-checking them — for a reason having nothing
+	// to do with metadata decoding.
+	for i, id := range []string{"rec-1", "rec-2"} {
+		rec := &format.Record{
+			ID: id, CapturedAt: capturedAt.Add(time.Duration(i) * 4 * time.Second),
+			APIPath: "/api/v1/nodes", HTTPMethod: "GET", ResponseCode: 200,
+			ResponseBody: []byte(`{"apiVersion":"v1","kind":"NodeList","items":[]}`),
+		}
+		if _, err := sw.WriteRecord(rec); err != nil {
+			t.Fatalf("WriteRecord(%s): %v", id, err)
+		}
 	}
 	// A bare map, not format.CaptureMetadata, so this stays pinned to the v1
 	// on-disk spelling even if the struct's tags are refactored later.
@@ -408,14 +416,14 @@ func TestReadMetadata_RealV051Shape(t *testing.T) {
 		"captured_until":     capturedUntil.Format(time.RFC3339Nano),
 		"kubernetes_version": "v1.36.1",
 		"server_address":     "https://127.0.0.1:57897",
-		"record_count":       135,
-		"deduplicated_count": 12,
+		"record_count":       2,
+		"deduplicated_count": 1,
 		"intervals":          []string{"4s"},
-		"uncompressed_bytes": 980157,
+		"uncompressed_bytes": 4096,
 	}
 	idx := map[string]any{
 		"/api/v1/nodes": map[string]any{
-			"api_path": "/api/v1/nodes", "seqs": []int{0},
+			"api_path": "/api/v1/nodes", "seqs": []int{0, 1},
 		},
 	}
 	if err := sw.Finish(meta, idx, nil); err != nil {
@@ -439,8 +447,8 @@ func TestReadMetadata_RealV051Shape(t *testing.T) {
 	if got.CaptureID != "8e04a3c4-f361-426a-9f3a-da1e261f7c5d" {
 		t.Errorf("CaptureID = %q", got.CaptureID)
 	}
-	if got.RecordCount != 135 {
-		t.Errorf("RecordCount = %d, want 135", got.RecordCount)
+	if got.RecordCount != 2 {
+		t.Errorf("RecordCount = %d, want 2", got.RecordCount)
 	}
 	// The seven fields golden-v1 never exercises.
 	if !got.CapturedAt.Equal(capturedAt) {
@@ -455,14 +463,14 @@ func TestReadMetadata_RealV051Shape(t *testing.T) {
 	if got.ServerAddress != "https://127.0.0.1:57897" {
 		t.Errorf("ServerAddress = %q", got.ServerAddress)
 	}
-	if got.DeduplicatedCount != 12 {
-		t.Errorf("DeduplicatedCount = %d, want 12", got.DeduplicatedCount)
+	if got.DeduplicatedCount != 1 {
+		t.Errorf("DeduplicatedCount = %d, want 1", got.DeduplicatedCount)
 	}
 	if len(got.Intervals) != 1 || got.Intervals[0] != "4s" {
 		t.Errorf("Intervals = %v, want [4s]", got.Intervals)
 	}
-	if got.UncompressedBytes != 980157 {
-		t.Errorf("UncompressedBytes = %d, want 980157", got.UncompressedBytes)
+	if got.UncompressedBytes != 4096 {
+		t.Errorf("UncompressedBytes = %d, want 4096", got.UncompressedBytes)
 	}
 	// Fields that postdate v0.5.1 must read as their zero value, not error.
 	if got.WatchEnabled || got.Encrypted || got.Redacted || got.AutoDiscovered {


### PR DESCRIPTION
Verifying the **v0.5.x → v1.0 upgrade path** (a pre-v1.0 item) turned up a hole
in the backward-compat fixture.

## The gap

`golden-v1.kshrk` pins the version-1 *envelope*, but `sampleArchive` writes
exactly three metadata keys. A capture taken with the **released v0.5.1 binary**
against a live cluster writes ten:

| | keys |
|---|---|
| `golden-v1.kshrk` | `capture_id` `format_version` `record_count` |
| real v0.5.1 capture | the above **+** `captured_at` `captured_until` `deduplicated_count` `intervals` `kubernetes_version` `server_address` `uncompressed_bytes` |

The seven it omits are the ones with teeth: `captured_at`/`captured_until` drive
every time-window path (`--from`/`--to`, `--at`, replay positioning), and
`intervals` is a `[]string` that a bad decode would silently drop to nil.

**Demonstrated, not assumed** — renaming a json tag the golden never exercises:

```
# json:"intervals" -> json:"intervals_renamed"
TestGoldenV1                    ok      <-- passes
TestReadMetadata_RealV051Shape  FAIL    Intervals = [], want [4s]

# json:"captured_until" -> json:"captured_until_renamed"
TestGoldenV1                    ok      <-- passes
TestReadMetadata_RealV051Shape  FAIL    CapturedUntil = 0001-01-01 …, want 2026-07-31 04:30:20
```

## The fix

`TestReadMetadata_RealV051Shape` encodes the key set and value shapes **read off
an actual v0.5.1 capture, not invented**, and asserts every field survives a
read — plus that fields postdating v0.5.1 come back as zero values rather than
erroring. It writes a bare `map[string]any` rather than
`format.CaptureMetadata`, so it stays pinned to the v1 on-disk spelling even if
the struct's tags are refactored later.

`golden-v1.kshrk` is untouched — it's SHA-pinned as a byte-stable fixture, and
changing it would defeat its purpose.

**No new binary fixture.** A v0.5.1 capture of a *single* resource still lands
at ~1 MB, because discovery and OpenAPI paths are captured alongside it. Not
worth the repo weight when the uncovered risk is the metadata payload.

## Upgrade path: verified end to end

Against a genuine v0.5.1 capture — 296 records, produced by the released binary
against a KinD cluster, `format_version: 1`:

**All 10 read paths succeed**, reporting `archive_format_version: 1`: `inspect`,
`inspect -o json`, `diagnose`, `diagnose -o json`, `query` (jsonpath and
`--text`), `transitions`, `transitions -o json`, `diff`, `redact`.

**The mock server serves it to real kubectl** — `get nodes`, `get pods -A` (34),
`get deployments -A` (16), `api-resources`, `version`, and a full
`get pod -o yaml`.

**Configs pass the current validator**: v0.5.1's shipped `examples/k8shark.yaml`
and `docs/demo/demo-capture.yaml` both validate, including the legacy snake_case
`ui.api_port` alias when uncommented.

(`v0.5.1:examples/kwok-stages.yaml` does *not* validate — correctly. It's a KWOK
Stage manifest consumed by the `kwok` binary, not a kshrk capture config. My
first pass at testing it was a category error.)

## One thing to decide separately

The legacy snake_case aliases are accepted **silently** — `applyLegacyKeyAliases`
renames them in place and `validate` prints a clean `✓ Config valid`. The
deprecation policy's step 1 is "announce", but there's no in-tool signal, so a
user on `api_port` has no way to learn they should migrate before a future minor
removes it. Not fixed here (it's a behavior change to `validate` output, out of
scope for a test PR) — worth its own issue if you want the warning.

`docs/development.md` gains the repeatable procedure for checking this against
any old release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)