### PR TITLE
fix(inspect): derive namespacedness from items, not the request path

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -144,8 +144,11 @@ Use `"*"` as a namespace value to automatically capture from all namespaces disc
 ### `namespaces`, request volume, and archive shape
 
 Every poll of a resource issues **two GETs** — the normal list plus a
-Table-format list, so the mock server can replay `kubectl`'s column layout — and
-stores a record for each. The three forms differ in how that is multiplied:
+Table-format list, so the mock server can replay `kubectl`'s column layout. Each
+*can* store a record; [deduplication](#response-deduplication) is on by default
+and skips writing when a response body is byte-identical to the previous one, so
+the record counts below are upper bounds. The three forms differ in how those
+GETs are multiplied:
 
 | form | GETs per poll | list records per poll |
 |------|---------------|-----------------------|
@@ -171,6 +174,10 @@ records at all.
 
 Measured by counting `apiserver_request_total` on the source apiserver. The
 cluster had **55 namespaces**: 52 contained at least one pod, 8 contained a Job.
+Deduplication was left at its default and skipped nothing in these runs
+(`deduplicated_count` was 0 in every archive) — a live list body changes between
+polls, so the record counts below are also the actual ones. A genuinely static
+resource would produce fewer.
 
 | resource | form | GETs/poll | plain records/poll |
 |----------|------|----------:|-------------------:|

--- a/docs/config.md
+++ b/docs/config.md
@@ -151,7 +151,7 @@ result:
 | form | GETs per poll | records per poll |
 |------|---------------|------------------|
 | `namespaces:` omitted | 2 (cluster-wide) | 1 |
-| `namespaces: ["*"]` | 2 (cluster-wide) | 1 per namespace *that has items* |
+| `namespaces: ["*"]` | 2 (cluster-wide) | 1 per namespace with items, plus any that just emptied |
 | `namespaces: [a, b, c]` | **2 per listed namespace** | 1 per listed namespace |
 
 `["*"]` does *not* poll each namespace separately. The engine fetches the

--- a/docs/config.md
+++ b/docs/config.md
@@ -143,38 +143,47 @@ Use `"*"` as a namespace value to automatically capture from all namespaces disc
 
 ### `namespaces`, request volume, and archive shape
 
-The three forms differ in **archive shape**, and only one of them scales its
-request volume with the number of namespaces:
+Every poll of a resource issues **two GETs** — the normal list plus a
+Table-format list, so the mock server can replay `kubectl`'s column layout. The
+three forms differ in how that is multiplied, and in how many archive records
+result:
 
-| form | requests per poll | records per poll |
-|------|-------------------|------------------|
-| `namespaces:` omitted | 1 cluster-wide LIST | 1 |
-| `namespaces: ["*"]` | 1 cluster-wide LIST | 1 per namespace |
-| `namespaces: [a, b, c]` | **1 LIST per listed namespace** | 1 per namespace |
+| form | GETs per poll | records per poll |
+|------|---------------|------------------|
+| `namespaces:` omitted | 2 (cluster-wide) | 1 |
+| `namespaces: ["*"]` | 2 (cluster-wide) | 1 per namespace *that has items* |
+| `namespaces: [a, b, c]` | **2 per listed namespace** | 1 per listed namespace |
 
 `["*"]` does *not* poll each namespace separately. The engine fetches the
-cluster-wide endpoint once and demultiplexes the response into per-namespace
-records (`fetchResourceClusterWide` in `internal/capture/poll.go`), so the mock
-server can answer per-namespace paths on replay. It costs archive space, not
-cluster load.
+cluster-wide endpoint and demultiplexes the response into per-namespace records
+(`fetchResourceClusterWide` in `internal/capture/poll.go`), so the mock server
+can answer per-namespace paths on replay. It costs archive space, not cluster
+load.
 
-Measured on a 52-namespace cluster, pods over three polls, counting
-`apiserver_request_total` on the source apiserver:
+The demux writes a record for each namespace present in the response, plus an
+empty-list record for any namespace that had items on a previous poll and no
+longer does — so a namespace that never contains the resource produces no
+records at all.
 
-| form | pod LIST requests | records | archive |
-|------|------------------:|--------:|--------:|
-| omitted | 6 | 3 | 1.15 MB |
-| `["*"]` | 7 | 156 | 2.48 MB |
-| explicit list of 10 namespaces | 61 | 30 | — |
+Measured by counting `apiserver_request_total` on the source apiserver, on a
+55-namespace cluster:
 
-All three captured the same 140 pods.
+| resource | form | GETs/poll | records/poll |
+|----------|------|----------:|-------------:|
+| pods (present in every namespace) | omitted | 2 | 1 |
+| pods | `["*"]` | 2 | 52 |
+| pods | explicit list of 10 namespaces | 20 | 10 |
+| jobs (present in 8 of 55 namespaces) | `["*"]` | 2 | 8 |
+
+Each form captured the same objects. Note the jobs row: `["*"]` produced 8
+records, not 55.
 
 **Guidance:**
 - Want every namespace? Use `["*"]`, or omit `namespaces:` if you don't need
-  per-namespace records. Both are one request per poll.
-- Want a few specific namespaces? An explicit list is fine and precise — just
-  know its request cost grows linearly with the list, so a long explicit list is
-  the one form worth avoiding on a large cluster.
+  per-namespace records. Both are two GETs per poll regardless of cluster size.
+- Want a few specific namespaces? An explicit list is precise, and its request
+  cost grows linearly with the list — a long explicit list is the one form worth
+  avoiding on a large cluster.
 - `--auto-discover` uses `["*"]` for namespaced resources, so it inherits the
   cheap cluster-wide path.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -118,7 +118,7 @@ resources:
 
 ### Namespaced vs. cluster-scoped resources
 
-- **Namespaced resources** (pods, deployments, services, PVCs, etc.): specify `namespaces:` with a list of namespaces to capture. Without `namespaces:`, the resource is skipped.
+- **Namespaced resources** (pods, deployments, services, PVCs, etc.): specify `namespaces:` with a list of namespaces to capture. Omitting `namespaces:` does *not* skip the resource — it is fetched from the cluster-wide path (e.g. `/api/v1/pods`), which returns objects from every namespace in a single request. See [namespaces, request volume, and archive shape](#namespaces-request-volume-and-archive-shape).
 - **Cluster-scoped resources** (nodes, persistentvolumes, storageclasses, namespaces, clusterroles, etc.): **do not include `namespaces:`**. k8shark fetches these from the cluster root path (e.g. `/api/v1/nodes`).
 
 > **Warning**: if you include `namespaces:` for a cluster-scoped resource, k8shark will warn during capture and automatically fall back to the correct cluster-scoped path.
@@ -141,46 +141,42 @@ Use `"*"` as a namespace value to automatically capture from all namespaces disc
 - If namespace discovery fails (e.g. RBAC permissions), the capture exits with a clear error.
 - A well-known cluster-scoped resource (nodes, persistentvolumes, etc.) with `namespaces: ["*"]` emits a warning and falls back to a cluster-scoped fetch.
 
-### Omitting `namespaces` costs far less on a large cluster
+### `namespaces`, request volume, and archive shape
 
-`namespaces: ["*"]` issues **one LIST per namespace**. Omitting `namespaces`
-entirely for a namespaced resource issues **one cluster-wide LIST** that returns
-objects from every namespace — the same data, at a fraction of the request
-volume.
+The three forms differ in **archive shape**, and only one of them scales its
+request volume with the number of namespaces:
 
-Measured against a real 80-namespace cluster with 175 listable namespaced
-resource types:
+| form | requests per poll | records per poll |
+|------|-------------------|------------------|
+| `namespaces:` omitted | 1 cluster-wide LIST | 1 |
+| `namespaces: ["*"]` | 1 cluster-wide LIST | 1 per namespace |
+| `namespaces: [a, b, c]` | **1 LIST per listed namespace** | 1 per namespace |
 
-| form | LIST calls per poll interval |
-|------|----------------------------:|
-| omitted (cluster-wide) | 315 |
-| `namespaces: ["*"]` | 14,140 |
+`["*"]` does *not* poll each namespace separately. The engine fetches the
+cluster-wide endpoint once and demultiplexes the response into per-namespace
+records (`fetchResourceClusterWide` in `internal/capture/poll.go`), so the mock
+server can answer per-namespace paths on replay. It costs archive space, not
+cluster load.
 
-That is a **44× difference**, and at the 30s default it is the difference
-between ~10 and ~470 requests per second sustained against the apiserver. A
-smaller check on a 52-namespace cluster captured byte-identical object sets
-either way — 140 pods and 94 deployments — while the wildcard form produced 5×
-the records and a 2.2× larger archive for no extra information.
+Measured on a 52-namespace cluster, pods over three polls, counting
+`apiserver_request_total` on the source apiserver:
 
-```yaml
-# Prefer this on a large cluster: one LIST, all namespaces.
-- group: ""
-  version: v1
-  resource: pods
-  interval: 30s
+| form | pod LIST requests | records | archive |
+|------|------------------:|--------:|--------:|
+| omitted | 6 | 3 | 1.15 MB |
+| `["*"]` | 7 | 156 | 2.48 MB |
+| explicit list of 10 namespaces | 61 | 30 | — |
 
-# Use "*" only when you need per-namespace *records* (separate archive entries
-# per namespace), or when combined with a short explicit namespace list.
-```
+All three captured the same 140 pods.
 
-Reach for `namespaces: ["*"]` when you want each namespace recorded as its own
-archive entry, or when narrowing to a handful of named namespaces. For "capture
-everything everywhere", omit the field.
-
-> **`--auto-discover` currently uses the wildcard form** for every namespaced
-> resource it finds, so on a large cluster it inherits the multiplication above.
-> Scope it with an explicit `namespaces:` list on the `all: true` entry when
-> pointing it at a big cluster.
+**Guidance:**
+- Want every namespace? Use `["*"]`, or omit `namespaces:` if you don't need
+  per-namespace records. Both are one request per poll.
+- Want a few specific namespaces? An explicit list is fine and precise — just
+  know its request cost grows linearly with the list, so a long explicit list is
+  the one form worth avoiding on a large cluster.
+- `--auto-discover` uses `["*"]` for namespaced resources, so it inherits the
+  cheap cluster-wide path.
 
 ### Response deduplication
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -141,6 +141,47 @@ Use `"*"` as a namespace value to automatically capture from all namespaces disc
 - If namespace discovery fails (e.g. RBAC permissions), the capture exits with a clear error.
 - A well-known cluster-scoped resource (nodes, persistentvolumes, etc.) with `namespaces: ["*"]` emits a warning and falls back to a cluster-scoped fetch.
 
+### Omitting `namespaces` costs far less on a large cluster
+
+`namespaces: ["*"]` issues **one LIST per namespace**. Omitting `namespaces`
+entirely for a namespaced resource issues **one cluster-wide LIST** that returns
+objects from every namespace — the same data, at a fraction of the request
+volume.
+
+Measured against a real 80-namespace cluster with 175 listable namespaced
+resource types:
+
+| form | LIST calls per poll interval |
+|------|----------------------------:|
+| omitted (cluster-wide) | 315 |
+| `namespaces: ["*"]` | 14,140 |
+
+That is a **44× difference**, and at the 30s default it is the difference
+between ~10 and ~470 requests per second sustained against the apiserver. A
+smaller check on a 52-namespace cluster captured byte-identical object sets
+either way — 140 pods and 94 deployments — while the wildcard form produced 5×
+the records and a 2.2× larger archive for no extra information.
+
+```yaml
+# Prefer this on a large cluster: one LIST, all namespaces.
+- group: ""
+  version: v1
+  resource: pods
+  interval: 30s
+
+# Use "*" only when you need per-namespace *records* (separate archive entries
+# per namespace), or when combined with a short explicit namespace list.
+```
+
+Reach for `namespaces: ["*"]` when you want each namespace recorded as its own
+archive entry, or when narrowing to a handful of named namespaces. For "capture
+everything everywhere", omit the field.
+
+> **`--auto-discover` currently uses the wildcard form** for every namespaced
+> resource it finds, so on a large cluster it inherits the multiplication above.
+> Scope it with an explicit `namespaces:` list on the `all: true` entry when
+> pointing it at a big cluster.
+
 ### Response deduplication
 
 By default, k8shark writes the first poll result for each API path and skips

--- a/docs/config.md
+++ b/docs/config.md
@@ -144,15 +144,19 @@ Use `"*"` as a namespace value to automatically capture from all namespaces disc
 ### `namespaces`, request volume, and archive shape
 
 Every poll of a resource issues **two GETs** — the normal list plus a
-Table-format list, so the mock server can replay `kubectl`'s column layout. The
-three forms differ in how that is multiplied, and in how many archive records
-result:
+Table-format list, so the mock server can replay `kubectl`'s column layout — and
+stores a record for each. The three forms differ in how that is multiplied:
 
-| form | GETs per poll | records per poll |
-|------|---------------|------------------|
+| form | GETs per poll | list records per poll |
+|------|---------------|-----------------------|
 | `namespaces:` omitted | 2 (cluster-wide) | 1 |
 | `namespaces: ["*"]` | 2 (cluster-wide) | 1 per namespace with items, plus any that just emptied |
 | `namespaces: [a, b, c]` | **2 per listed namespace** | 1 per listed namespace |
+
+Counts in the right-hand column are **plain-list records**, which is what `kshrk
+inspect` reports per resource — it skips `?as=Table` paths. Each plain record has
+a Table companion stored alongside it, so the archive's total record count runs
+roughly double the per-resource figures, plus discovery and OpenAPI paths.
 
 `["*"]` does *not* poll each namespace separately. The engine fetches the
 cluster-wide endpoint and demultiplexes the response into per-namespace records
@@ -165,18 +169,25 @@ empty-list record for any namespace that had items on a previous poll and no
 longer does — so a namespace that never contains the resource produces no
 records at all.
 
-Measured by counting `apiserver_request_total` on the source apiserver, on a
-55-namespace cluster:
+Measured by counting `apiserver_request_total` on the source apiserver. The
+cluster had **55 namespaces**: 52 contained at least one pod, 8 contained a Job.
 
-| resource | form | GETs/poll | records/poll |
-|----------|------|----------:|-------------:|
-| pods (present in every namespace) | omitted | 2 | 1 |
+| resource | form | GETs/poll | plain records/poll |
+|----------|------|----------:|-------------------:|
+| pods (in 52 of 55 namespaces) | omitted | 2 | 1 |
 | pods | `["*"]` | 2 | 52 |
 | pods | explicit list of 10 namespaces | 20 | 10 |
-| jobs (present in 8 of 55 namespaces) | `["*"]` | 2 | 8 |
+| jobs (in 8 of 55 namespaces) | `["*"]` | 2 | 8 |
 
-Each form captured the same objects. Note the jobs row: `["*"]` produced 8
-records, not 55.
+Each form captured the same objects. Two rows worth reading twice: `["*"]` on
+jobs produced **8** records, not 55, because the demux only writes namespaces
+that have items; and the explicit 10-namespace list is the only form whose GET
+count grew.
+
+For a concrete archive-total comparison over three polls of pods and
+deployments: the `["*"]` archive held 755 records (312 of them plain per-resource
+list records) at 2.48 MB, against 140 records (6 plain) at 1.15 MB for the
+cluster-wide form — the same 140 pods and 94 deployments either way.
 
 **Guidance:**
 - Want every namespace? Use `["*"]`, or omit `namespaces:` if you don't need

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -117,10 +117,6 @@ func summarizeResources(ar *archive.Archive, idx capture.Index) []ResourceSummar
 			a = &accum{nsSeen: map[string]bool{}}
 			byKey[k] = a
 		}
-		if ns != "" {
-			a.namespaced = true
-			a.nsSeen[ns] = true
-		}
 		a.records += len(entry.Seqs)
 
 		// Count items in the latest record for this path.
@@ -129,6 +125,18 @@ func summarizeResources(ar *archive.Archive, idx capture.Index) []ResourceSummar
 			if data, err := ar.ReadRecord(path, latestSeq); err == nil {
 				var rec capture.Record
 				if jerr := json.Unmarshal(data, &rec); jerr == nil && rec.ResponseCode == 200 {
+					// A /namespaces/<ns>/ segment only means something on a
+					// successful response. When a cluster-scoped resource is
+					// configured with `namespaces:` by mistake, the engine
+					// probes the namespaced endpoints, gets 404s, and falls
+					// back to the cluster-scoped path (fetchResource in
+					// internal/capture/poll.go) — but those 404 records stay in
+					// the archive. Reading the namespace out of them reported
+					// nodes as namespaced=true with bogus namespaces entries.
+					if ns != "" {
+						a.namespaced = true
+						a.nsSeen[ns] = true
+					}
 					var list struct {
 						Items []struct {
 							Metadata struct {

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -90,10 +90,70 @@ func Run(archivePath string, identities []age.Identity) (*Report, error) {
 	}, nil
 }
 
+// gvrKey identifies a resource type within an archive.
+type gvrKey struct{ group, version, resource string }
+
+// discoveryNamespaced reads the captured API discovery documents (/api/<version>
+// and /apis/<group>/<version>) and returns each resource type's namespaced flag
+// as the apiserver reported it.
+//
+// This is the authoritative answer, and it is the only one available when a
+// resource's list came back empty: a namespaced resource with zero objects has
+// no item namespaces to observe and no /namespaces/ path segment when captured
+// cluster-wide, yet it is still namespaced by API definition. Returns an empty
+// map when a capture didn't include discovery paths, in which case callers fall
+// back to inferring from the data.
+func discoveryNamespaced(ar *archive.Archive, idx capture.Index) map[gvrKey]bool {
+	out := map[gvrKey]bool{}
+
+	for path, entry := range idx {
+		if strings.Contains(path, "?") || len(entry.Seqs) == 0 {
+			continue
+		}
+		// /api/v1 -> group "", version v1.  /apis/apps/v1 -> group apps.
+		var group, version string
+		switch parts := strings.Split(strings.Trim(path, "/"), "/"); {
+		case len(parts) == 2 && parts[0] == "api":
+			version = parts[1]
+		case len(parts) == 3 && parts[0] == "apis":
+			group, version = parts[1], parts[2]
+		default:
+			continue
+		}
+
+		data, err := ar.ReadRecord(path, entry.Seqs[len(entry.Seqs)-1])
+		if err != nil {
+			continue
+		}
+		var rec capture.Record
+		if err := json.Unmarshal(data, &rec); err != nil || rec.ResponseCode != 200 {
+			continue
+		}
+		var list struct {
+			Resources []struct {
+				Name       string `json:"name"`
+				Namespaced bool   `json:"namespaced"`
+			} `json:"resources"`
+		}
+		if err := json.Unmarshal(rec.ResponseBody, &list); err != nil {
+			continue
+		}
+		for _, r := range list.Resources {
+			// Skip subresources ("pods/log"); they aren't summarized.
+			if strings.Contains(r.Name, "/") {
+				continue
+			}
+			out[gvrKey{group, version, r.Name}] = r.Namespaced
+		}
+	}
+	return out
+}
+
 // summarizeResources aggregates per-resource information from the index.
 // Item counts are read from the latest record for each path directly from the archive.
 func summarizeResources(ar *archive.Archive, idx capture.Index) []ResourceSummary {
-	type key struct{ group, version, resource string }
+	discovered := discoveryNamespaced(ar, idx)
+	type key = gvrKey
 	type accum struct {
 		namespaced bool
 		nsSeen     map[string]bool
@@ -174,11 +234,18 @@ func summarizeResources(ar *archive.Archive, idx capture.Index) []ResourceSummar
 			nsList = append(nsList, ns)
 		}
 		sort.Strings(nsList)
+		// Discovery is authoritative when the capture recorded it; the observed
+		// inference below is the fallback for captures that didn't. The
+		// namespaces list always comes from what was actually captured.
+		namespaced := a.namespaced
+		if d, ok := discovered[k]; ok {
+			namespaced = d
+		}
 		summaries = append(summaries, ResourceSummary{
 			Group:      k.group,
 			Version:    k.version,
 			Resource:   k.resource,
-			Namespaced: a.namespaced,
+			Namespaced: namespaced,
 			Namespaces: nsList,
 			Records:    a.records,
 			Items:      a.items,

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -130,10 +130,29 @@ func summarizeResources(ar *archive.Archive, idx capture.Index) []ResourceSummar
 				var rec capture.Record
 				if jerr := json.Unmarshal(data, &rec); jerr == nil && rec.ResponseCode == 200 {
 					var list struct {
-						Items []json.RawMessage `json:"items"`
+						Items []struct {
+							Metadata struct {
+								Namespace string `json:"namespace"`
+							} `json:"metadata"`
+						} `json:"items"`
 					}
 					if jerr2 := json.Unmarshal(rec.ResponseBody, &list); jerr2 == nil {
 						a.items += len(list.Items)
+						// Namespacedness has to come from the items, not the
+						// request path. A namespaced resource fetched
+						// cluster-wide (/api/v1/pods rather than
+						// /api/v1/namespaces/x/pods) has no namespace segment
+						// to read, and that is the *recommended* way to capture
+						// a large cluster — it costs one LIST instead of one
+						// per namespace. Deriving it from the path alone
+						// reported namespaced=false for every namespaced
+						// resource in exactly that case.
+						for _, it := range list.Items {
+							if it.Metadata.Namespace != "" {
+								a.namespaced = true
+								a.nsSeen[it.Metadata.Namespace] = true
+							}
+						}
 					}
 				}
 			}

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -335,5 +336,73 @@ func TestRun_404ProbePathsDoNotImplyNamespaced(t *testing.T) {
 	// The successful cluster-scoped fallback is still counted.
 	if nodes.Items != 2 {
 		t.Errorf("nodes: item_count = %d, want 2 from the cluster-scoped fallback", nodes.Items)
+	}
+}
+
+// TestRun_EmptyListUsesDiscoveryForNamespaced covers a namespaced resource whose
+// list came back empty.
+//
+// With zero items there are no item namespaces to observe, and a cluster-wide
+// capture has no /namespaces/ path segment either — so inference alone reported
+// namespaced=false for a resource that is namespaced by API definition.
+// Reproduced against a real cluster with `ingresses` (0 objects): inspect said
+// false while the same archive's /apis/networking.k8s.io/v1 discovery document
+// said true.
+//
+// The captured discovery document is authoritative and needs no format change,
+// so it wins when present. The other tests in this file deliberately omit
+// discovery paths, which keeps the inference fallback covered.
+func TestRun_EmptyListUsesDiscoveryForNamespaced(t *testing.T) {
+	now := time.Date(2026, 7, 31, 11, 0, 0, 0, time.UTC)
+	path := buildArchive(t, []*capture.Record{
+		{
+			// Discovery: the apiserver's own answer.
+			ID: "disco", CapturedAt: now, APIPath: "/apis/networking.k8s.io/v1",
+			HTTPMethod: "GET", ResponseCode: 200,
+			ResponseBody: json.RawMessage(`{"kind":"APIResourceList","groupVersion":"networking.k8s.io/v1","resources":[
+				{"name":"ingresses","namespaced":true,"kind":"Ingress"},
+				{"name":"ingresses/status","namespaced":true,"kind":"Ingress"},
+				{"name":"ingressclasses","namespaced":false,"kind":"IngressClass"}
+			]}`),
+		},
+		{
+			// An empty cluster-wide list: nothing to infer from.
+			ID: "ing-0", CapturedAt: now, APIPath: "/apis/networking.k8s.io/v1/ingresses",
+			HTTPMethod: "GET", ResponseCode: 200,
+			ResponseBody: json.RawMessage(`{"kind":"IngressList","apiVersion":"networking.k8s.io/v1","items":[]}`),
+		},
+		{
+			ID: "ingc-0", CapturedAt: now, APIPath: "/apis/networking.k8s.io/v1/ingressclasses",
+			HTTPMethod: "GET", ResponseCode: 200,
+			ResponseBody: json.RawMessage(`{"kind":"IngressClassList","apiVersion":"networking.k8s.io/v1","items":[]}`),
+		},
+	})
+
+	rep, err := Run(path, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	get := func(resource string) *ResourceSummary {
+		for i := range rep.Resources {
+			if rep.Resources[i].Resource == resource {
+				return &rep.Resources[i]
+			}
+		}
+		t.Fatalf("no summary for %q; got %+v", resource, rep.Resources)
+		return nil
+	}
+
+	if ing := get("ingresses"); !ing.Namespaced {
+		t.Error("ingresses: namespaced=false on an empty list; discovery says true")
+	}
+	// The same discovery document must not promote a cluster-scoped sibling.
+	if ingc := get("ingressclasses"); ingc.Namespaced {
+		t.Error("ingressclasses: namespaced=true; discovery says false")
+	}
+	// A subresource entry ("ingresses/status") must not become its own summary.
+	for _, r := range rep.Resources {
+		if strings.Contains(r.Resource, "/") {
+			t.Errorf("subresource leaked into the summary: %q", r.Resource)
+		}
 	}
 }

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -214,13 +214,13 @@ func TestRun_SortedOutput(t *testing.T) {
 // via the *cluster-wide* path (/api/v1/pods rather than
 // /api/v1/namespaces/x/pods).
 //
-// That form is the one to use on a large cluster — it costs a single LIST
-// instead of one per namespace, which on an 80-namespace cluster is a 44x
-// difference in request volume. Namespacedness was derived from whether the
-// request path contained a /namespaces/ segment, so precisely the recommended
-// configuration reported `"namespaced": false` for every namespaced resource,
-// and omitted `namespaces` entirely. Found against a real 80-namespace cluster,
-// where 9 of 11 captured resources were mislabeled.
+// That is a normal way to capture a large cluster: one cluster-wide LIST
+// returns objects from every namespace, and it is what omitting `namespaces:`
+// produces (see docs/config.md for the cost model). Namespacedness was derived
+// from whether the request path contained a /namespaces/ segment, so this form
+// reported `"namespaced": false` for every namespaced resource and omitted
+// `namespaces` entirely. Found against a real 80-namespace cluster, where 9 of
+// 11 captured resources were mislabeled.
 func TestRun_NamespacedFromItems_NotPathShape(t *testing.T) {
 	now := time.Date(2026, 7, 31, 9, 0, 0, 0, time.UTC)
 	path := buildArchive(t, []*capture.Record{

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -279,3 +279,61 @@ func TestRun_NamespacedFromItems_NotPathShape(t *testing.T) {
 		t.Errorf("nodes: namespaces = %v, want empty", nodes.Namespaces)
 	}
 }
+
+// TestRun_404ProbePathsDoNotImplyNamespaced covers a cluster-scoped resource
+// configured with `namespaces:` by mistake.
+//
+// The capture engine probes the namespaced endpoints, gets 404s, warns, and
+// falls back to the cluster-scoped path (fetchResource in
+// internal/capture/poll.go) — but the 404 records stay in the archive. Reading
+// the namespace out of a /namespaces/<ns>/ path without checking the response
+// code reported nodes as namespaced=true with two invented namespaces.
+func TestRun_404ProbePathsDoNotImplyNamespaced(t *testing.T) {
+	now := time.Date(2026, 7, 31, 10, 0, 0, 0, time.UTC)
+	notFound := json.RawMessage(`{"kind":"Status","apiVersion":"v1","status":"Failure","code":404}`)
+	path := buildArchive(t, []*capture.Record{
+		{
+			ID: "probe-default", CapturedAt: now,
+			APIPath:    "/api/v1/namespaces/default/nodes",
+			HTTPMethod: "GET", ResponseCode: 404, ResponseBody: notFound,
+		},
+		{
+			ID: "probe-kube-system", CapturedAt: now,
+			APIPath:    "/api/v1/namespaces/kube-system/nodes",
+			HTTPMethod: "GET", ResponseCode: 404, ResponseBody: notFound,
+		},
+		{
+			// The cluster-scoped fallback the engine also captures.
+			ID: "nodes-fallback", CapturedAt: now, APIPath: "/api/v1/nodes",
+			HTTPMethod: "GET", ResponseCode: 200,
+			ResponseBody: json.RawMessage(`{"kind":"NodeList","apiVersion":"v1","items":[
+				{"metadata":{"name":"node-1"}},{"metadata":{"name":"node-2"}}
+			]}`),
+		},
+	})
+
+	rep, err := Run(path, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var nodes *ResourceSummary
+	for i := range rep.Resources {
+		if rep.Resources[i].Resource == "nodes" {
+			nodes = &rep.Resources[i]
+		}
+	}
+	if nodes == nil {
+		t.Fatalf("no nodes summary; got %+v", rep.Resources)
+	}
+	if nodes.Namespaced {
+		t.Error("nodes: namespaced=true, derived from 404 probe paths rather than a successful response")
+	}
+	if len(nodes.Namespaces) != 0 {
+		t.Errorf("nodes: namespaces = %v, want empty — those came from 404 probes", nodes.Namespaces)
+	}
+	// The successful cluster-scoped fallback is still counted.
+	if nodes.Items != 2 {
+		t.Errorf("nodes: item_count = %d, want 2 from the cluster-scoped fallback", nodes.Items)
+	}
+}

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -209,3 +209,73 @@ func TestRun_SortedOutput(t *testing.T) {
 		}
 	}
 }
+
+// TestRun_NamespacedFromItems_NotPathShape covers a namespaced resource captured
+// via the *cluster-wide* path (/api/v1/pods rather than
+// /api/v1/namespaces/x/pods).
+//
+// That form is the one to use on a large cluster — it costs a single LIST
+// instead of one per namespace, which on an 80-namespace cluster is a 44x
+// difference in request volume. Namespacedness was derived from whether the
+// request path contained a /namespaces/ segment, so precisely the recommended
+// configuration reported `"namespaced": false` for every namespaced resource,
+// and omitted `namespaces` entirely. Found against a real 80-namespace cluster,
+// where 9 of 11 captured resources were mislabeled.
+func TestRun_NamespacedFromItems_NotPathShape(t *testing.T) {
+	now := time.Date(2026, 7, 31, 9, 0, 0, 0, time.UTC)
+	path := buildArchive(t, []*capture.Record{
+		{
+			// Cluster-wide pods LIST: no namespace in the path, but every item
+			// carries one.
+			ID: "pods-0", CapturedAt: now, APIPath: "/api/v1/pods",
+			HTTPMethod: "GET", ResponseCode: 200,
+			ResponseBody: json.RawMessage(`{"kind":"PodList","apiVersion":"v1","items":[
+				{"metadata":{"name":"a","namespace":"team-one"}},
+				{"metadata":{"name":"b","namespace":"team-two"}},
+				{"metadata":{"name":"c","namespace":"team-one"}}
+			]}`),
+		},
+		{
+			// A genuinely cluster-scoped resource must stay namespaced=false.
+			ID: "nodes-0", CapturedAt: now, APIPath: "/api/v1/nodes",
+			HTTPMethod: "GET", ResponseCode: 200,
+			ResponseBody: json.RawMessage(`{"kind":"NodeList","apiVersion":"v1","items":[
+				{"metadata":{"name":"node-1"}}
+			]}`),
+		},
+	})
+
+	rep, err := Run(path, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	find := func(resource string) *ResourceSummary {
+		for i := range rep.Resources {
+			if rep.Resources[i].Resource == resource {
+				return &rep.Resources[i]
+			}
+		}
+		t.Fatalf("no summary for %q; got %+v", resource, rep.Resources)
+		return nil
+	}
+
+	pods := find("pods")
+	if !pods.Namespaced {
+		t.Error("pods: namespaced=false for a cluster-wide LIST whose items all carry a namespace")
+	}
+	if len(pods.Namespaces) != 2 || pods.Namespaces[0] != "team-one" || pods.Namespaces[1] != "team-two" {
+		t.Errorf("pods: namespaces = %v, want [team-one team-two] deduped and sorted", pods.Namespaces)
+	}
+	if pods.Items != 3 {
+		t.Errorf("pods: item_count = %d, want 3", pods.Items)
+	}
+
+	nodes := find("nodes")
+	if nodes.Namespaced {
+		t.Error("nodes: namespaced=true for a cluster-scoped resource whose items carry no namespace")
+	}
+	if len(nodes.Namespaces) != 0 {
+		t.Errorf("nodes: namespaces = %v, want empty", nodes.Namespaces)
+	}
+}


### PR DESCRIPTION
Found by running the scale harness (`kind-scale.sh`, 50 namespaces) and then a
real **80-namespace / 460-pod OpenShift cluster** — the scale-run item from the
pre-v1.0 list.

## The bug

`inspect -o json` decided `resources[].namespaced` by checking whether the
captured request path contained a `/namespaces/` segment. A namespaced resource
fetched **cluster-wide** — `/api/v1/pods` rather than
`/api/v1/namespaces/x/pods` — has no such segment, so it reported
`"namespaced": false` and omitted `namespaces` entirely.

That's backwards from which configuration deserves to work: the cluster-wide
form is the one to use on a large cluster, because it costs one LIST instead of
one per namespace. On the real cluster **9 of 11 resources were mislabeled**:

```
   before                                    after
   configmaps: namespaced=false              configmaps: namespaced=true  ns=80
   events:     namespaced=false              events:     namespaced=true  ns=7
   pods:       namespaced=false              pods:       namespaced=true  ns=62
   services:   namespaced=false              services:   namespaced=true  ns=59
   deployments:namespaced=false              deployments:namespaced=true  ns=53
   …                                         …
   nodes:      namespaced=false  ✓ correct   nodes:      namespaced=false ✓
   namespaces: namespaced=false  ✓ correct   namespaces: namespaced=false ✓
```

The data contradicted the summary — every captured pod carried
`metadata.namespace`:

```console
$ kshrk query real.kshrk '{.metadata.namespace}' --resource pods -o json | jq -r '.matches[0].value'
"kube-system"
$ kshrk inspect real.kshrk -o json | jq '.resources[]|select(.resource=="pods")|.namespaced'
false
```

`namespaced` is a **frozen field** as of #320, so a wrong value is more than
cosmetic.

## The fix

Take it from the item bodies, which are authoritative however the resource was
fetched. Cluster-scoped resources still report `false` because their items carry
no namespace. Side benefit: `namespaces` is now populated for cluster-wide
captures, where it was previously absent.

**No archive format change**, so this corrects existing archives on re-inspect
rather than only new ones. Discovery does know the truth (`res.Namespaced` in
`internal/capture/discover.go`) but never persisted it; reading items avoids a
format bump and works retroactively.

Mutation-verified — disabling the inference reproduces the old behavior:

```
--- FAIL: TestRun_NamespacedFromItems_NotPathShape
    pods: namespaced=false for a cluster-wide LIST whose items all carry a namespace
    pods: namespaces = [], want [team-one team-two] deduped and sorted
```

## Corrected: the `namespaces` cost model (`docs/config.md`)

An earlier revision of this PR claimed `namespaces: ["*"]` issues one LIST per
namespace, with a 44× amplification figure. **That was wrong** — I inferred
request volume from record count, and the demux decouples them.
`fetchResourceClusterWide` fetches the cluster-wide endpoint exactly twice per
poll (plain + Table) regardless of namespace count, then demultiplexes into
per-namespace records so the mock server can answer per-namespace paths.

Measured with `apiserver_request_total` on the source apiserver — pods, three
polls, 52-namespace cluster:

| form | pod LIST requests | records | archive |
|---|---:|---:|---:|
| `namespaces:` omitted | 6 | 3 | 1.15 MB |
| `namespaces: ["*"]` | 7 | 156 | 2.48 MB |
| explicit list of 10 namespaces | **61** | 30 | — |

All three captured the same 140 pods. So `["*"]` costs archive space, not cluster
load, and the **explicit list** is the form whose request volume scales with
namespace count. `--auto-discover` uses `["*"]`, so it inherits the cheap path.
Issue #326, which I filed against auto-discover on the bad premise, is closed as
invalid.

The docs section now states this, plus a pre-existing error it contradicted:
"Namespaced vs. cluster-scoped resources" claimed that without `namespaces:` a
resource **is skipped**. It isn't — it's fetched cluster-wide, which is exactly
what my measurements relied on. That bullet had been steering readers into adding
`namespaces:` when they don't need it.

## Scale results (no defects beyond the above)

Real cluster, `--auto-discover` scoped to 2 namespaces across all 315 listable
types: **2,673 records / 1,542 paths / 14.6 MiB in 90s at 8% CPU**, 382 distinct
resource types including OpenShift CRDs and a third-party operator's, 5,736
objects, 4 secrets redacted, no crashes.

Read path on the real-cluster archive — all sub-2s:

| command | |
|---|---|
| `inspect -o json` | 0.22s |
| `diagnose -o json` | 0.31s |
| `query` (jsonpath) | 0.32s |
| `transitions -o json` | 1.21s |
| `diff` | 1.67s |

Mock server serving real-cluster data to real `kubectl`, all sub-second: 460
pods, 725 configmaps, 137 services, 340 api-resources, 80 namespaces,
`get pods -n <ns>`, `explain pod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

