### PR TITLE
test(capture): wait for the events TestWatchResource_Reconnects asserts

### DIFF
--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -37,6 +37,21 @@ func (s *sliceSink) WriteRecord(rec *Record) (int, error) {
 	s.pathSeq[rec.APIPath] = seq + 1
 	return seq, nil
 }
+
+// eventTypes returns the set of watch event types recorded so far. Safe to call
+// while a watch goroutine is still writing, unlike reading s.records directly.
+func (s *sliceSink) eventTypes() map[string]bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	seen := make(map[string]bool)
+	for _, rec := range s.records {
+		if rec.EventType != "" {
+			seen[rec.EventType] = true
+		}
+	}
+	return seen
+}
+
 func (s *sliceSink) Finish(_, _, _ any) error { return nil }
 func (s *sliceSink) RecordCount() int {
 	s.mu.Lock()
@@ -2368,9 +2383,15 @@ func TestWatchResource_Reconnects(t *testing.T) {
 		eng.watchResource(ctx, res)
 	}()
 
+	// Wait for what is actually asserted below, not just for the second
+	// connection to exist. MODIFIED is delivered *by* that second connection, so
+	// breaking out the moment watchConn hits 2 lets the cancel land before the
+	// event has been read and recorded — which is how this test flaked on loaded
+	// CI runners while passing locally (#327).
 	deadline := time.Now().Add(2500 * time.Millisecond)
 	for time.Now().Before(deadline) {
-		if atomic.LoadInt32(&watchConn) >= 2 {
+		seen := ss.eventTypes()
+		if atomic.LoadInt32(&watchConn) >= 2 && seen["ADDED"] && seen["MODIFIED"] {
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
@@ -2382,12 +2403,7 @@ func TestWatchResource_Reconnects(t *testing.T) {
 		t.Fatalf("expected watch reconnect (>=2 watch connections), got %d", watchConn)
 	}
 
-	seen := map[string]bool{}
-	for _, rec := range ss.records {
-		if rec.EventType != "" {
-			seen[rec.EventType] = true
-		}
-	}
+	seen := ss.eventTypes()
 	if !seen["ADDED"] || !seen["MODIFIED"] {
 		t.Fatalf("expected ADDED and MODIFIED watch events across reconnects, got %v", seen)
 	}


### PR DESCRIPTION
Closes #327.

## The race

The test waited for the reconnect *count*, then cancelled immediately — but
asserted on event *delivery*:

```go
for time.Now().Before(deadline) {
    if atomic.LoadInt32(&watchConn) >= 2 { break }   // 2nd connection exists
    time.Sleep(20 * time.Millisecond)
}
cancel()                                            // cancel straight away
...
if !seen["ADDED"] || !seen["MODIFIED"] {             // but assert delivery
```

`MODIFIED` is delivered *by* that second connection. Breaking out the moment
`watchConn` hits 2 lets the cancel land before the event has been read and
recorded. The reconnect count was standing in for "the second stream produced its
event", and it isn't that.

It now polls for the reconnect count **and** both event types, with the same 2.5s
deadline as the failure bound — so the wait matches the assertion.

Polling `ss.records` while the watch goroutine is still writing needs the mutex
(the old read was only safe because it came after `<-done`), so this adds a
guarded `sliceSink.eventTypes()` accessor used for both the poll and the final
assertion.

## Mechanism proven, not assumed

I couldn't reproduce the flake locally — 60 runs at `-race -cpu=1` all passed with
the *old* condition. So rather than ship a plausible story, I injected the delay a
loaded runner supplies: 300ms between the second connection being accepted and its
event body being written.

```
old condition:  --- FAIL: TestWatchResource_Reconnects (0.81s)
                    expected ADDED and MODIFIED watch events across reconnects, got map[ADDED:true]
new condition:  ok
```

That's CI's exact failure message. And the timings line up — CI's failure took
**0.51s** against a 2500ms deadline, so it had likewise broken out of the loop
early rather than timing out.

## Verified

- 60 runs at `-count=60 -race -cpu=1` — pass
- Full `internal/capture` suite under `-race` — pass
- `golangci-lint`, `gofmt` — clean

## Why it mattered

This failed on `main` at `527a35b` as well as on an unrelated docs PR, so it was
costing signal in the watch path — core capture functionality, adjacent to where
#210's index/seq race lived. A test that goes red for reasons unrelated to the
change under review trains people to re-run without looking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)