### PR TITLE
fix(server): project as=PartialObjectMetadata; move controller logs aside

### DIFF
--- a/cmd/controllermanager.go
+++ b/cmd/controllermanager.go
@@ -10,6 +10,21 @@ import (
 	"github.com/phenixblue/k8shark/internal/k8sbin"
 )
 
+// garbagecollector is deliberately NOT in this list. It is the one controller
+// whose job is fundamentally incompatible with replaying a *partial* capture: it
+// deletes objects whose owners no longer exist, and in a capture that recorded
+// some resource types and not others, plenty of owners legitimately don't exist.
+// Enabled against a real 80-namespace capture it removed most of the replayed
+// state within a minute — namespaces 80 -> 30, pods 460 -> 148 — and the
+// daemonset controller then started failing on namespaces the GC had eaten.
+//
+// It previously appeared to be harmless only because it was broken: the mock
+// ignored as=PartialObjectMetadata, so the GC could not decode its
+// ownerReference lookups and never got as far as deleting anything (#329).
+// Honoring that negotiation is still correct on its own merits — any
+// metadata-only client needs it — but it turned a silently broken controller
+// into a destructive one, so the controller itself has to go.
+//
 // controllerManagerControllers is the curated set of kube-controller-manager
 // controllers --with-controller-manager enables: pure API-object reconcilers
 // that only need the writable overlay's CRUD+watch surface, not a real
@@ -21,7 +36,6 @@ var controllerManagerControllers = []string{
 	"namespace",
 	"serviceaccount",
 	"resourcequota",
-	"garbagecollector",
 	"daemonset",
 	"deployment",
 	"replicaset",

--- a/cmd/controllermanager.go
+++ b/cmd/controllermanager.go
@@ -63,7 +63,12 @@ var controllerLogFlagHelp = "destination for kube-controller-manager's own outpu
 // was one controller retrying — interleaved with replay's progress line. The
 // output is diagnostic, so the default is a file whose path is printed once;
 // silently discarding it would make a misbehaving controller impossible to
-// debug. "-" restores the old inline streaming.
+// debug.
+//
+// "-" streams inline again, but sends both the child's stdout and stderr to
+// *stderr* rather than restoring the previous stdout->stdout split: that keeps
+// kshrk's own stdout clean for anything parsing it. In practice nothing is lost,
+// because kube-controller-manager logs through klog, which writes to stderr.
 func resolveControllerLog(dest string) (w io.Writer, closeFn func(), shown string, err error) {
 	if dest == "-" {
 		return os.Stderr, func() {}, "stderr", nil

--- a/cmd/controllermanager.go
+++ b/cmd/controllermanager.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -42,6 +43,12 @@ var controllerManagerFlagHelp = "also run kube-controller-manager (downloaded/bu
 	"Kubernetes version) against the server, reconciling a curated set of controllers (" +
 	strings.Join(controllerManagerControllers, ", ") + ") — see docs/kwok.md (implies --writable)"
 
+// controllerLogFlagHelp is the --controller-log description, shared by `replay`
+// and `ui` for the same reason controllerManagerFlagHelp is.
+var controllerLogFlagHelp = "destination for kube-controller-manager's own output when " +
+	"--with-controller-manager is set: a file path, or \"-\" to stream it inline " +
+	"(default: a temp file whose path is printed at startup)"
+
 // startControllerManager locates or builds a kube-controller-manager binary
 // matching k8sVersion (see internal/k8sbin) and runs it against the mock
 // server's kubeconfig with the curated controller set, no leader election (a
@@ -49,7 +56,33 @@ var controllerManagerFlagHelp = "also run kube-controller-manager (downloaded/bu
 // real TokenReview/SubjectAccessReview API for it to call — it falls back to
 // always-allow, same as any other out-of-cluster test harness). It returns a
 // cleanup func that stops the subprocess.
-func startControllerManager(kubeconfigPath, k8sVersion string) (cleanup func(), err error) {
+// logDest resolves where kube-controller-manager's own output goes.
+//
+// It used to be wired straight to kshrk's stdout/stderr, which drowned
+// everything else: a one-minute replay produced 3,000 lines, 5 MB, of which 84%
+// was one controller retrying — interleaved with replay's progress line. The
+// output is diagnostic, so the default is a file whose path is printed once;
+// silently discarding it would make a misbehaving controller impossible to
+// debug. "-" restores the old inline streaming.
+func resolveControllerLog(dest string) (w io.Writer, closeFn func(), shown string, err error) {
+	if dest == "-" {
+		return os.Stderr, func() {}, "stderr", nil
+	}
+	if dest == "" {
+		f, ferr := os.CreateTemp("", "kshrk-controller-manager-*.log")
+		if ferr != nil {
+			return nil, nil, "", fmt.Errorf("creating controller log file: %w", ferr)
+		}
+		return f, func() { _ = f.Close() }, f.Name(), nil
+	}
+	f, ferr := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if ferr != nil {
+		return nil, nil, "", fmt.Errorf("opening controller log %q: %w", dest, ferr)
+	}
+	return f, func() { _ = f.Close() }, dest, nil
+}
+
+func startControllerManager(kubeconfigPath, k8sVersion, controllerLog string) (cleanup func(), err error) {
 	binPath, err := k8sbin.EnsureControllerManager(k8sVersion, func(msg string) {
 		fmt.Fprintf(os.Stderr, "--with-controller-manager: %s\n", msg)
 	})
@@ -63,18 +96,26 @@ func startControllerManager(kubeconfigPath, k8sVersion string) (cleanup func(), 
 		"--use-service-account-credentials=false",
 		"--controllers=" + strings.Join(controllerManagerControllers, ","),
 	}
+	logW, closeLog, logShown, err := resolveControllerLog(controllerLog)
+	if err != nil {
+		return nil, fmt.Errorf("--with-controller-manager: %w", err)
+	}
+
 	c := exec.Command(binPath, args...)
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
+	c.Stdout = logW
+	c.Stderr = logW
 	if err := c.Start(); err != nil {
+		closeLog()
 		return nil, fmt.Errorf("--with-controller-manager: starting kube-controller-manager: %w", err)
 	}
+	fmt.Fprintf(os.Stderr, "--with-controller-manager: controller output -> %s\n", logShown)
 
 	cleanup = func() {
 		if c.Process != nil {
 			_ = c.Process.Kill()
 		}
 		_ = c.Wait()
+		closeLog()
 	}
 	return cleanup, nil
 }

--- a/cmd/controllermanager_test.go
+++ b/cmd/controllermanager_test.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// kube-controller-manager's output used to go straight to kshrk's stdout/stderr,
+// where one retrying controller produced 5 MB in a minute and buried the replay
+// banner (#329). resolveControllerLog moves it aside without discarding it.
+func TestResolveControllerLog(t *testing.T) {
+	t.Run("dash streams inline", func(t *testing.T) {
+		w, closeFn, shown, err := resolveControllerLog("-")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer closeFn()
+		if w != os.Stderr {
+			t.Errorf("writer = %v, want os.Stderr", w)
+		}
+		if shown != "stderr" {
+			t.Errorf("shown = %q, want stderr", shown)
+		}
+	})
+
+	t.Run("explicit path is written and truncated", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "kcm.log")
+		if err := os.WriteFile(path, []byte("stale content from a previous run"), 0o600); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		w, closeFn, shown, err := resolveControllerLog(path)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if shown != path {
+			t.Errorf("shown = %q, want %q", shown, path)
+		}
+		if _, err := w.Write([]byte("fresh")); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		closeFn()
+
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if string(got) != "fresh" {
+			t.Errorf("file = %q, want %q — O_TRUNC should drop the previous run's log", got, "fresh")
+		}
+	})
+
+	t.Run("empty picks a temp file whose path is reported", func(t *testing.T) {
+		w, closeFn, shown, err := resolveControllerLog("")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if _, werr := w.Write([]byte("x")); werr != nil {
+			t.Fatalf("write: %v", werr)
+		}
+		closeFn()
+		defer os.Remove(shown)
+
+		// The path has to be reportable: a default that silently swallowed the
+		// output would make a misbehaving controller undebuggable.
+		if !strings.Contains(filepath.Base(shown), "kshrk-controller-manager-") {
+			t.Errorf("temp path = %q, want it to identify itself", shown)
+		}
+		if _, serr := os.Stat(shown); serr != nil {
+			t.Errorf("reported path does not exist: %v", serr)
+		}
+	})
+
+	t.Run("unwritable path is an error, not a silent fallback", func(t *testing.T) {
+		if _, _, _, err := resolveControllerLog(filepath.Join(t.TempDir(), "no-such-dir", "kcm.log")); err == nil {
+			t.Error("expected an error for an unwritable destination")
+		}
+	})
+}

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -53,6 +53,7 @@ func init() {
 	replayCmd.Flags().Bool("schedule-pods", true, "bind unscheduled pods to a node on create (the scheduler replay lacks); --writable only")
 	replayCmd.Flags().Bool("with-kwok", false, "also run a detected 'kwok' binary against the server to drive pod/node lifecycle (implies --writable)")
 	replayCmd.Flags().Bool("with-controller-manager", false, controllerManagerFlagHelp)
+	replayCmd.Flags().String("controller-log", "", controllerLogFlagHelp)
 }
 
 func runReplay(cmd *cobra.Command, args []string) error {
@@ -67,6 +68,7 @@ func runReplay(cmd *cobra.Command, args []string) error {
 	schedulePods, _ := cmd.Flags().GetBool("schedule-pods")
 	withKwok, _ := cmd.Flags().GetBool("with-kwok")
 	withControllerManager, _ := cmd.Flags().GetBool("with-controller-manager")
+	controllerLog, _ := cmd.Flags().GetString("controller-log")
 	verbose, _ := cmd.Root().PersistentFlags().GetBool("verbose")
 
 	if err := validateKwokFlags(withKwok, schedulePods); err != nil {
@@ -124,7 +126,7 @@ func runReplay(cmd *cobra.Command, args []string) error {
 
 	var controllerManagerCleanup func()
 	if withControllerManager {
-		controllerManagerCleanup, err = startControllerManager(srv.KubeconfigPath(), srv.KubernetesVersion())
+		controllerManagerCleanup, err = startControllerManager(srv.KubeconfigPath(), srv.KubernetesVersion(), controllerLog)
 		if err != nil {
 			if kwokCleanup != nil {
 				kwokCleanup()

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -54,6 +54,7 @@ func init() {
 	uiCmd.Flags().Bool("writable", false, "replay mode: accept client writes into an in-memory overlay")
 	uiCmd.Flags().Bool("with-kwok", false, "replay mode: also run a detected 'kwok' binary against the server to drive pod/node lifecycle (implies --writable)")
 	uiCmd.Flags().Bool("with-controller-manager", false, controllerManagerFlagHelp)
+	uiCmd.Flags().String("controller-log", "", controllerLogFlagHelp)
 }
 
 func runUI(cmd *cobra.Command, args []string) error {
@@ -85,6 +86,7 @@ func runUI(cmd *cobra.Command, args []string) error {
 	writable, _ := cmd.Flags().GetBool("writable")
 	withKwok, _ := cmd.Flags().GetBool("with-kwok")
 	withControllerManager, _ := cmd.Flags().GetBool("with-controller-manager")
+	controllerLog, _ := cmd.Flags().GetString("controller-log")
 	// --with-kwok and --with-controller-manager both drive the overlay from a
 	// live process, so either implies --writable (and replay mode).
 	if withKwok || withControllerManager {
@@ -143,7 +145,7 @@ func runUI(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if withControllerManager {
-		controllerManagerCleanup, err = startControllerManager(mockSrv.KubeconfigPath(), mockSrv.KubernetesVersion())
+		controllerManagerCleanup, err = startControllerManager(mockSrv.KubeconfigPath(), mockSrv.KubernetesVersion(), controllerLog)
 		if err != nil {
 			if kwokCleanup != nil {
 				kwokCleanup()

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -843,6 +843,7 @@ kshrk replay <capture.kshrk> [flags]
 
 ```
       --api-port string           port for the mock API server (0 = random available port) (default "0")
+      --controller-log string     destination for kube-controller-manager's own output when --with-controller-manager is set: a file path, or "-" to stream it inline (default: a temp file whose path is printed at startup)
       --from string               replay window start: RFC3339 or relative duration like -10m (default: capture start)
   -h, --help                      help for replay
       --kubeconfig-out string     where to write the generated kubeconfig (default: ~/.kube/k8shark-<id>.yaml)
@@ -972,6 +973,7 @@ kshrk ui <capture.kshrk> [flags]
 ```
       --api-port string           port for the mock API server (0 = random available port) (default "0")
       --at string                 pin UI data to a specific timestamp (RFC3339 or relative duration like -5m)
+      --controller-log string     destination for kube-controller-manager's own output when --with-controller-manager is set: a file path, or "-" to stream it inline (default: a temp file whose path is printed at startup)
       --from string               replay window start: RFC3339 or relative duration like -10m
   -h, --help                      help for ui
       --kubeconfig-out string     where to write the generated kubeconfig (default: ~/.kube/k8shark-<id>.yaml)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -854,7 +854,7 @@ kshrk replay <capture.kshrk> [flags]
       --to string                 replay window end: RFC3339 or relative duration like -1m (default: capture end)
       --ui                        also start the web dashboard as a replay transport (VCR)
       --ui-port string            port for the dashboard when --ui is set (0 = random) (default "0")
-      --with-controller-manager   also run kube-controller-manager (downloaded/built to match the capture's Kubernetes version) against the server, reconciling a curated set of controllers (namespace, serviceaccount, resourcequota, garbagecollector, daemonset, deployment, replicaset, statefulset, job, cronjob, endpoint, endpointslice, endpointslicemirroring, disruption) — see docs/kwok.md (implies --writable)
+      --with-controller-manager   also run kube-controller-manager (downloaded/built to match the capture's Kubernetes version) against the server, reconciling a curated set of controllers (namespace, serviceaccount, resourcequota, daemonset, deployment, replicaset, statefulset, job, cronjob, endpoint, endpointslice, endpointslicemirroring, disruption) — see docs/kwok.md (implies --writable)
       --with-kwok                 also run a detected 'kwok' binary against the server to drive pod/node lifecycle (implies --writable)
       --writable                  accept client writes into an in-memory overlay (closed-loop controller dev)
 ```
@@ -982,7 +982,7 @@ kshrk ui <capture.kshrk> [flags]
       --start-paused              replay mode: start paused (the UI defaults to this; pass --start-paused=false to auto-play)
       --to string                 replay window end: RFC3339 or relative duration like -1m
       --ui-port string            port for the local UI server (0 = random available port) (default "0")
-      --with-controller-manager   also run kube-controller-manager (downloaded/built to match the capture's Kubernetes version) against the server, reconciling a curated set of controllers (namespace, serviceaccount, resourcequota, garbagecollector, daemonset, deployment, replicaset, statefulset, job, cronjob, endpoint, endpointslice, endpointslicemirroring, disruption) — see docs/kwok.md (implies --writable)
+      --with-controller-manager   also run kube-controller-manager (downloaded/built to match the capture's Kubernetes version) against the server, reconciling a curated set of controllers (namespace, serviceaccount, resourcequota, daemonset, deployment, replicaset, statefulset, job, cronjob, endpoint, endpointslice, endpointslicemirroring, disruption) — see docs/kwok.md (implies --writable)
       --with-kwok                 replay mode: also run a detected 'kwok' binary against the server to drive pod/node lifecycle (implies --writable)
       --writable                  replay mode: accept client writes into an in-memory overlay
 ```

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -79,4 +79,14 @@ and `details`) was fixed in #177 for a real, captured resource type —
 `notFoundStatus` in `internal/server/handler.go` sets both — and no longer
 appears in the baseline.
 
+`Accept: …;as=PartialObjectMetadata;g=meta.k8s.io` was a divergence the
+differential never covered, because nothing in the read surface it compares
+requests a metadata-only projection — the mock returned the full object, which a
+client decoding strictly against `PartialObjectMetadata` rejects outright. That
+surfaced only when `replay --with-controller-manager` was run end to end and
+kube-controller-manager's garbagecollector, which walks `ownerReferences` with a
+metadata client, failed to sync any item and retried forever (#329). It is now
+projected in `internal/store/responses_codec.go`; a `Status` body is deliberately
+passed through unprojected so a 404 stays decodable as `Status`.
+
 Removing an entry here (by fixing the underlying behavior) tightens the gate.

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -123,10 +123,22 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// and for endpoints that never return a protobuf object and may be large or
 	// streamed (OpenAPI docs, pod logs), to avoid buffering them pointlessly.
 	watchParam := r.URL.Query().Get("watch")
-	if kstore.WantsProtobuf(r) && watchParam != "1" && watchParam != "true" && !kstore.IsNonProtobufPath(path) {
+	isWatch := watchParam == "1" || watchParam == "true"
+	if kstore.WantsProtobuf(r) && !isWatch && !kstore.IsNonProtobufPath(path) {
 		pw := kstore.NewProtobufResponseWriter(w)
 		defer pw.Flush()
 		w = pw
+	}
+
+	// Metadata-only projection (as=PartialObjectMetadata), used by
+	// kube-controller-manager's garbagecollector to walk ownerReferences (#329).
+	// Installed *after* the protobuf wrapper so its deferred Flush runs first
+	// (defers are LIFO): the body is projected to metadata, and protobuf
+	// encoding then sees the projected object rather than the full one.
+	if mv, ok := kstore.WantsPartialObjectMetadata(r); ok && !isWatch && !kstore.IsNonProtobufPath(path) {
+		mw := kstore.NewPartialMetadataResponseWriter(w, mv)
+		defer mw.Flush()
+		w = mw
 	}
 
 	// Replay transport controls live under a reserved prefix that can't collide

--- a/internal/store/partialmetadata_test.go
+++ b/internal/store/partialmetadata_test.go
@@ -1,0 +1,137 @@
+package store
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// kube-controller-manager's garbagecollector requests ownerReference targets
+// metadata-only. Returning the full object made it fail to decode and retry
+// forever (#329), so these pin both the negotiation and the projection.
+
+func TestWantsPartialObjectMetadata(t *testing.T) {
+	cases := []struct {
+		name, accept, wantVer string
+		want                  bool
+	}{
+		{"garbagecollector's header", "application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1", "v1", true},
+		{"v1beta1", "application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1beta1", "v1beta1", true},
+		{"protobuf first, json fallback", "application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1", "v1", true},
+		{"missing v defaults to v1", "application/json;as=PartialObjectMetadata;g=meta.k8s.io", "v1", true},
+		// as=Table uses the same parameter style and must not be mistaken for it.
+		{"Table", "application/json;as=Table;g=meta.k8s.io;v=v1", "", false},
+		{"wrong group", "application/json;as=PartialObjectMetadata;g=example.com;v=v1", "", false},
+		{"plain json", "application/json", "", false},
+		{"empty", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/api/v1/pods", nil)
+			if tc.accept != "" {
+				r.Header.Set("Accept", tc.accept)
+			}
+			gotVer, got := WantsPartialObjectMetadata(r)
+			if got != tc.want || gotVer != tc.wantVer {
+				t.Errorf("= (%q, %v), want (%q, %v)", gotVer, got, tc.wantVer, tc.want)
+			}
+		})
+	}
+}
+
+func TestProjectPartialMetadata_SingleObject(t *testing.T) {
+	body := []byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm","namespace":"ns","uid":"u1"},"data":{"secret-ish":"value"}}`)
+	got, ok := projectPartialMetadata(body, "v1")
+	if !ok {
+		t.Fatal("projection refused a plain object")
+	}
+	var out map[string]any
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out["kind"] != "PartialObjectMetadata" || out["apiVersion"] != "meta.k8s.io/v1" {
+		t.Errorf("kind/apiVersion = %v/%v", out["kind"], out["apiVersion"])
+	}
+	// The point of the projection: the payload is gone, the metadata isn't.
+	if _, leaked := out["data"]; leaked {
+		t.Error("data survived the metadata projection")
+	}
+	md, _ := out["metadata"].(map[string]any)
+	if md["name"] != "cm" || md["namespace"] != "ns" || md["uid"] != "u1" {
+		t.Errorf("metadata = %v", md)
+	}
+}
+
+func TestProjectPartialMetadata_List(t *testing.T) {
+	body := []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{"resourceVersion":"77"},"items":[
+		{"metadata":{"name":"a","namespace":"ns"},"spec":{"nodeName":"n1"}},
+		{"metadata":{"name":"b","namespace":"ns"},"spec":{"nodeName":"n2"}}
+	]}`)
+	got, ok := projectPartialMetadata(body, "v1")
+	if !ok {
+		t.Fatal("projection refused a list")
+	}
+	var out struct {
+		Kind       string `json:"kind"`
+		APIVersion string `json:"apiVersion"`
+		Metadata   struct {
+			ResourceVersion string `json:"resourceVersion"`
+		} `json:"metadata"`
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Kind != "PartialObjectMetadataList" || out.APIVersion != "meta.k8s.io/v1" {
+		t.Errorf("kind/apiVersion = %s/%s", out.Kind, out.APIVersion)
+	}
+	// The list's own resourceVersion must survive, or paging and watch bookmarks
+	// stop lining up.
+	if out.Metadata.ResourceVersion != "77" {
+		t.Errorf("list resourceVersion = %q, want 77", out.Metadata.ResourceVersion)
+	}
+	if len(out.Items) != 2 {
+		t.Fatalf("items = %d, want 2", len(out.Items))
+	}
+	for i, it := range out.Items {
+		if it["kind"] != "PartialObjectMetadata" {
+			t.Errorf("item %d kind = %v", i, it["kind"])
+		}
+		if _, leaked := it["spec"]; leaked {
+			t.Errorf("item %d kept its spec", i)
+		}
+	}
+}
+
+// A Status must pass through untouched: a client asking for metadata still needs
+// to decode a 404 as Status, not receive a projected object.
+func TestProjectPartialMetadata_PassesThroughStatusAndNonObjects(t *testing.T) {
+	for _, body := range []string{
+		`{"kind":"Status","apiVersion":"v1","status":"Failure","code":404,"reason":"NotFound"}`,
+		`{"paths":["/api","/apis"]}`, // no kind — discovery root
+		`not json at all`,
+		`{"kind":"ConfigMap","apiVersion":"v1"}`, // object with no metadata
+	} {
+		if _, ok := projectPartialMetadata([]byte(body), "v1"); ok {
+			t.Errorf("projected a body it should have passed through: %s", body)
+		}
+	}
+}
+
+// The writer must leave a non-JSON content type alone.
+func TestPartialMetadataResponseWriter_NonJSONPassesThrough(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := NewPartialMetadataResponseWriter(rec, "v1")
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+	w.Flush()
+	if got := rec.Body.String(); got != "ok" {
+		t.Errorf("body = %q, want ok", got)
+	}
+	if !strings.Contains(strings.Join(rec.Header().Values("Vary"), ","), "Accept") {
+		t.Error("Vary: Accept not set; a cache could reuse this across Accept headers")
+	}
+}

--- a/internal/store/partialmetadata_test.go
+++ b/internal/store/partialmetadata_test.go
@@ -191,6 +191,42 @@ func TestProjectPartialMetadata_EmptyList(t *testing.T) {
 	}
 }
 
+// A kind ending in "List" is not proof of an object list. The discovery
+// documents APIResourceList and APIGroupList end in "List" but carry
+// `resources`/`groups`, and projecting them emptied discovery outright: /api/v1
+// went from 38 resources to 0 and /apis from 93 groups to 0 for any client that
+// bootstrapped with a metadata Accept header.
+func TestProjectPartialMetadata_DiscoveryListsAreNotObjectLists(t *testing.T) {
+	for name, body := range map[string]string{
+		"APIResourceList": `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"v1","resources":[
+			{"name":"pods","namespaced":true,"kind":"Pod"},
+			{"name":"nodes","namespaced":false,"kind":"Node"}
+		]}`,
+		"APIGroupList": `{"kind":"APIGroupList","apiVersion":"v1","groups":[
+			{"name":"apps","versions":[{"groupVersion":"apps/v1","version":"v1"}]}
+		]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got, ok := projectPartialMetadata([]byte(body), "v1"); ok {
+				t.Errorf("projected a discovery document, discarding its payload; got %s", got)
+			}
+		})
+	}
+
+	// A genuine list with an items field still projects, including an empty one —
+	// the distinction is whether `items` is present, not whether it has entries.
+	for name, body := range map[string]string{
+		"populated": `{"kind":"PodList","apiVersion":"v1","items":[{"metadata":{"name":"a"}}]}`,
+		"empty":     `{"kind":"PodList","apiVersion":"v1","items":[]}`,
+	} {
+		t.Run("still projects/"+name, func(t *testing.T) {
+			if _, ok := projectPartialMetadata([]byte(body), "v1"); !ok {
+				t.Error("refused a genuine object list")
+			}
+		})
+	}
+}
+
 // Vary: Accept must appear once even when both negotiation wrappers stack, which
 // happens when a client prefers protobuf *and* asks for a metadata projection.
 func TestVaryAccept_NotDuplicatedWhenWritersStack(t *testing.T) {

--- a/internal/store/partialmetadata_test.go
+++ b/internal/store/partialmetadata_test.go
@@ -26,6 +26,15 @@ func TestWantsPartialObjectMetadata(t *testing.T) {
 		{"wrong group", "application/json;as=PartialObjectMetadata;g=example.com;v=v1", "", false},
 		{"plain json", "application/json", "", false},
 		{"empty", "", "", false},
+
+		// q-values, mirroring WantsProtobuf. Returning on the first syntactic
+		// match would project even where the client said not to.
+		{"metadata clause disabled with q=0", "application/json, application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1;q=0", "", false},
+		{"metadata outranked by a higher-q plain clause", "application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1;q=0.5, application/json;q=0.9", "", false},
+		{"metadata wins on higher q despite coming second", "application/json;q=0.5, application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1;q=0.9", "v1", true},
+		{"equal q keeps the earlier clause (plain first)", "application/json;q=0.8, application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1;q=0.8", "", false},
+		{"equal q keeps the earlier clause (metadata first)", "application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1;q=0.8, application/json;q=0.8", "v1", true},
+		{"unrelated media type does not outrank", "text/plain;q=1.0, application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1;q=0.5", "v1", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/store/partialmetadata_test.go
+++ b/internal/store/partialmetadata_test.go
@@ -120,6 +120,61 @@ func TestProjectPartialMetadata_PassesThroughStatusAndNonObjects(t *testing.T) {
 	}
 }
 
+// A list containing an item that can't be projected must pass through whole
+// rather than come back shorter. The garbagecollector is the main consumer of
+// this projection, and an item silently missing from its input can read as "the
+// owner is gone" — so a lossy projection is worse than none.
+func TestProjectPartialMetadata_ListRefusesRatherThanDropItems(t *testing.T) {
+	cases := map[string]string{
+		"item missing metadata": `{"kind":"PodList","apiVersion":"v1","items":[
+			{"metadata":{"name":"a","namespace":"ns"}},
+			{"spec":{"nodeName":"n2"}}
+		]}`,
+		"item is not an object": `{"kind":"PodList","apiVersion":"v1","items":[
+			{"metadata":{"name":"a","namespace":"ns"}},
+			"not-an-object"
+		]}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got, ok := projectPartialMetadata([]byte(body), "v1"); ok {
+				t.Errorf("projected a list with an unprojectable item instead of passing it through; got %s", got)
+			}
+		})
+	}
+
+	// Sanity: a fully projectable list of the same shape still projects.
+	good := `{"kind":"PodList","apiVersion":"v1","items":[
+		{"metadata":{"name":"a","namespace":"ns"}},
+		{"metadata":{"name":"b","namespace":"ns"}}
+	]}`
+	if _, ok := projectPartialMetadata([]byte(good), "v1"); !ok {
+		t.Error("refused a list whose items are all projectable")
+	}
+}
+
+// An empty list is projectable — there is nothing to drop, and returning
+// PartialObjectMetadataList with zero items is what a real apiserver does.
+func TestProjectPartialMetadata_EmptyList(t *testing.T) {
+	got, ok := projectPartialMetadata([]byte(`{"kind":"PodList","apiVersion":"v1","items":[]}`), "v1")
+	if !ok {
+		t.Fatal("refused an empty list")
+	}
+	var out struct {
+		Kind  string           `json:"kind"`
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Kind != "PartialObjectMetadataList" || len(out.Items) != 0 {
+		t.Errorf("kind=%s items=%d, want PartialObjectMetadataList with 0 items", out.Kind, len(out.Items))
+	}
+	if out.Items == nil {
+		t.Error("items is null; it must be [] so clients can iterate it")
+	}
+}
+
 // The writer must leave a non-JSON content type alone.
 func TestPartialMetadataResponseWriter_NonJSONPassesThrough(t *testing.T) {
 	rec := httptest.NewRecorder()

--- a/internal/store/partialmetadata_test.go
+++ b/internal/store/partialmetadata_test.go
@@ -35,6 +35,13 @@ func TestWantsPartialObjectMetadata(t *testing.T) {
 		{"equal q keeps the earlier clause (plain first)", "application/json;q=0.8, application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1;q=0.8", "", false},
 		{"equal q keeps the earlier clause (metadata first)", "application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1;q=0.8, application/json;q=0.8", "v1", true},
 		{"unrelated media type does not outrank", "text/plain;q=1.0, application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1;q=0.5", "v1", true},
+
+		// Only versions we can name are servable. Echoing an unknown v= into
+		// apiVersion would hand back `meta.k8s.io/<typo>` while claiming the
+		// request was honored.
+		{"unknown version loses negotiation", "application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v99", "", false},
+		{"typo'd version loses negotiation", "application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1beta", "", false},
+		{"unknown version does not shadow a good clause", "application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v99;q=0.9, application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1;q=0.5", "v1", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -181,6 +188,33 @@ func TestProjectPartialMetadata_EmptyList(t *testing.T) {
 	}
 	if out.Items == nil {
 		t.Error("items is null; it must be [] so clients can iterate it")
+	}
+}
+
+// Vary: Accept must appear once even when both negotiation wrappers stack, which
+// happens when a client prefers protobuf *and* asks for a metadata projection.
+func TestVaryAccept_NotDuplicatedWhenWritersStack(t *testing.T) {
+	rec := httptest.NewRecorder()
+	inner := NewProtobufResponseWriter(rec)
+	outer := NewPartialMetadataResponseWriter(inner, "v1")
+
+	outer.Header().Set("Content-Type", "application/json")
+	outer.WriteHeader(http.StatusOK)
+	_, _ = outer.Write([]byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm"},"data":{"k":"v"}}`))
+	// Same order as the handler's LIFO defers: projection, then protobuf.
+	outer.Flush()
+	inner.Flush()
+
+	var accepts int
+	for _, v := range rec.Header().Values("Vary") {
+		for _, field := range strings.Split(v, ",") {
+			if strings.EqualFold(strings.TrimSpace(field), "Accept") {
+				accepts++
+			}
+		}
+	}
+	if accepts != 1 {
+		t.Errorf("Vary lists Accept %d times, want exactly 1; got %v", accepts, rec.Header().Values("Vary"))
 	}
 }
 

--- a/internal/store/responses_codec.go
+++ b/internal/store/responses_codec.go
@@ -136,7 +136,7 @@ func (p *ProtobufResponseWriter) Flush() {
 
 	// The chosen representation depends on Accept, so caches/intermediaries must
 	// not reuse it across differing Accept headers.
-	p.Header().Add("Vary", "Accept")
+	addVaryAccept(p.Header())
 
 	ct := p.Header().Get("Content-Type")
 	if strings.HasPrefix(ct, "application/json") {
@@ -171,6 +171,27 @@ const (
 	partialMetadataListKind = "PartialObjectMetadataList"
 	metaGroup               = "meta.k8s.io"
 )
+
+// partialMetadataVersions are the meta.k8s.io versions this projection can
+// answer in. A clause naming anything else isn't a representation we can serve,
+// so it loses negotiation rather than being echoed into the response — emitting
+// `apiVersion: meta.k8s.io/<typo>` would hand the client a body it can't decode
+// while claiming we honored its request.
+var partialMetadataVersions = map[string]bool{"v1": true, "v1beta1": true}
+
+// addVaryAccept records that the representation depends on Accept, without
+// duplicating the header when response writers stack (the protobuf and metadata
+// wrappers can both wrap the same response).
+func addVaryAccept(h http.Header) {
+	for _, v := range h.Values("Vary") {
+		for _, field := range strings.Split(v, ",") {
+			if strings.EqualFold(strings.TrimSpace(field), "Accept") {
+				return
+			}
+		}
+	}
+	h.Add("Vary", "Accept")
+}
 
 // WantsPartialObjectMetadata reports whether the client's Accept header asks for
 // a metadata-only projection, and returns the meta.k8s.io version to answer in
@@ -211,14 +232,25 @@ func WantsPartialObjectMetadata(r *http.Request) (string, bool) {
 		if q <= 0 {
 			continue
 		}
+		version := params["v"]
+		if version == "" {
+			version = "v1"
+		}
 		isPartial := params["as"] == partialMetadataKind && params["g"] == metaGroup
+		if isPartial && !partialMetadataVersions[version] {
+			// A metadata projection in a version we can't produce isn't a
+			// representation we can serve, so it's skipped rather than allowed to
+			// win — otherwise a high-q clause naming an unknown version would
+			// consume the negotiation and shadow a lower-q clause we *can*
+			// answer. Same reason WantsProtobuf skips media types outright
+			// instead of ranking them.
+			continue
+		}
 		if q > bestQ { // strictly greater; equal q keeps the earlier clause
 			bestQ = q
 			bestIsPartial = isPartial
 			if isPartial {
-				if bestVersion = params["v"]; bestVersion == "" {
-					bestVersion = "v1"
-				}
+				bestVersion = version
 			} else {
 				bestVersion = ""
 			}
@@ -263,7 +295,7 @@ func (p *PartialMetadataResponseWriter) Flush() {
 
 	// The representation depends on Accept, so it must not be cached across
 	// differing Accept headers.
-	p.Header().Add("Vary", "Accept")
+	addVaryAccept(p.Header())
 
 	if strings.HasPrefix(p.Header().Get("Content-Type"), "application/json") {
 		if projected, ok := projectPartialMetadata(body, p.metaVersion); ok {

--- a/internal/store/responses_codec.go
+++ b/internal/store/responses_codec.go
@@ -315,9 +315,16 @@ func (p *PartialMetadataResponseWriter) Flush() {
 // the caller passes those through.
 func projectPartialMetadata(body []byte, metaVersion string) ([]byte, bool) {
 	var probe struct {
-		Kind     string            `json:"kind"`
-		Metadata json.RawMessage   `json:"metadata"`
-		Items    []json.RawMessage `json:"items"`
+		Kind     string          `json:"kind"`
+		Metadata json.RawMessage `json:"metadata"`
+		// Pointer so an absent `items` is distinguishable from `items: []`. A
+		// kind ending in "List" is not sufficient evidence of an object list:
+		// the discovery documents APIResourceList and APIGroupList also end in
+		// "List" but carry `resources`/`groups`. Projecting those produced an
+		// empty PartialObjectMetadataList and silently discarded discovery —
+		// /api/v1 went from 38 resources to 0, /apis from 93 groups to 0 — for
+		// any client that bootstrapped discovery with a metadata Accept header.
+		Items *[]json.RawMessage `json:"items"`
 	}
 	if err := json.Unmarshal(body, &probe); err != nil {
 		return nil, false
@@ -332,6 +339,10 @@ func projectPartialMetadata(body []byte, metaVersion string) ([]byte, bool) {
 	// List: project each item, preserving the list's own metadata
 	// (resourceVersion/continue) so watch bookmarks and paging still line up.
 	if strings.HasSuffix(probe.Kind, "List") {
+		if probe.Items == nil {
+			// "List" in the kind but no items field: not an object list.
+			return nil, false
+		}
 		out := map[string]any{
 			"kind":       partialMetadataListKind,
 			"apiVersion": apiVersion,
@@ -339,8 +350,8 @@ func projectPartialMetadata(body []byte, metaVersion string) ([]byte, bool) {
 		if len(probe.Metadata) > 0 {
 			out["metadata"] = probe.Metadata
 		}
-		items := make([]map[string]any, 0, len(probe.Items))
-		for _, raw := range probe.Items {
+		items := make([]map[string]any, 0, len(*probe.Items))
+		for _, raw := range *probe.Items {
 			var it struct {
 				Metadata json.RawMessage `json:"metadata"`
 			}

--- a/internal/store/responses_codec.go
+++ b/internal/store/responses_codec.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	"encoding/json"
 	"mime"
 	"net/http"
 	"strconv"
@@ -149,4 +150,164 @@ func (p *ProtobufResponseWriter) Flush() {
 	}
 	p.ResponseWriter.WriteHeader(status)
 	_, _ = p.ResponseWriter.Write(body)
+}
+
+// ── PartialObjectMetadata projection (issue #329) ────────────────────────────
+//
+// kube-controller-manager's garbagecollector walks ownerReferences using a
+// metadata-only client, requesting `as=PartialObjectMetadata`. Ignoring that
+// parameter and returning the full object doesn't merely waste bytes — the
+// client decodes strictly against the negotiated type and fails outright:
+//
+//	unable to decode returned object as PartialObjectMetadata:
+//	invalid character 'k' looking for beginning of value
+//
+// which left the GC unable to sync any item and retrying forever. Projecting the
+// body down to apiVersion/kind/metadata is what a real apiserver does for this
+// Accept parameter, and it's cheap: the metadata is already in the response.
+
+const (
+	partialMetadataKind     = "PartialObjectMetadata"
+	partialMetadataListKind = "PartialObjectMetadataList"
+	metaGroup               = "meta.k8s.io"
+)
+
+// WantsPartialObjectMetadata reports whether the client's Accept header asks for
+// a metadata-only projection, and returns the meta.k8s.io version to answer in
+// (v1 or v1beta1). Only `g=meta.k8s.io` counts: `as=Table` uses the same
+// parameter style and is handled separately.
+func WantsPartialObjectMetadata(r *http.Request) (string, bool) {
+	accept := r.Header.Get("Accept")
+	if accept == "" {
+		return "", false
+	}
+	for _, part := range strings.Split(accept, ",") {
+		_, params, err := mime.ParseMediaType(strings.TrimSpace(part))
+		if err != nil {
+			continue
+		}
+		if params["as"] != partialMetadataKind || params["g"] != metaGroup {
+			continue
+		}
+		v := params["v"]
+		if v == "" {
+			v = "v1"
+		}
+		return v, true
+	}
+	return "", false
+}
+
+// PartialMetadataResponseWriter buffers a response so a JSON object or list body
+// can be projected to PartialObjectMetadata(List) on flush.
+//
+// Anything that isn't a recognizable object or list — a Status from a 404, an
+// OpenAPI document, plain text — passes through untouched. That matters: error
+// responses must stay decodable as Status, or a client would see a decode
+// failure instead of the NotFound it was told to expect.
+type PartialMetadataResponseWriter struct {
+	http.ResponseWriter
+	metaVersion string
+	status      int
+	buf         bytes.Buffer
+}
+
+func NewPartialMetadataResponseWriter(w http.ResponseWriter, metaVersion string) *PartialMetadataResponseWriter {
+	return &PartialMetadataResponseWriter{ResponseWriter: w, metaVersion: metaVersion}
+}
+
+func (p *PartialMetadataResponseWriter) WriteHeader(code int) { p.status = code }
+
+func (p *PartialMetadataResponseWriter) Write(b []byte) (int, error) { return p.buf.Write(b) }
+
+// Flush writes the buffered response, projecting a JSON body to metadata-only
+// when it is a Kubernetes object or list; otherwise it passes through unchanged.
+func (p *PartialMetadataResponseWriter) Flush() {
+	status := p.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	body := p.buf.Bytes()
+
+	// The representation depends on Accept, so it must not be cached across
+	// differing Accept headers.
+	p.Header().Add("Vary", "Accept")
+
+	if strings.HasPrefix(p.Header().Get("Content-Type"), "application/json") {
+		if projected, ok := projectPartialMetadata(body, p.metaVersion); ok {
+			p.Header().Del("Content-Length") // length changed
+			p.ResponseWriter.WriteHeader(status)
+			_, _ = p.ResponseWriter.Write(projected)
+			return
+		}
+	}
+	p.ResponseWriter.WriteHeader(status)
+	_, _ = p.ResponseWriter.Write(body)
+}
+
+// projectPartialMetadata rewrites a Kubernetes object or list JSON body as
+// PartialObjectMetadata or PartialObjectMetadataList. It reports false for
+// anything it doesn't recognize — a Status, a non-object, malformed JSON — so
+// the caller passes those through.
+func projectPartialMetadata(body []byte, metaVersion string) ([]byte, bool) {
+	var probe struct {
+		Kind     string            `json:"kind"`
+		Metadata json.RawMessage   `json:"metadata"`
+		Items    []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return nil, false
+	}
+	// A Status is an error/result envelope, not an object to project. Leaving it
+	// alone keeps 404s decodable as Status.
+	if probe.Kind == "" || probe.Kind == "Status" {
+		return nil, false
+	}
+	apiVersion := metaGroup + "/" + metaVersion
+
+	// List: project each item, preserving the list's own metadata
+	// (resourceVersion/continue) so watch bookmarks and paging still line up.
+	if strings.HasSuffix(probe.Kind, "List") {
+		out := map[string]any{
+			"kind":       partialMetadataListKind,
+			"apiVersion": apiVersion,
+		}
+		if len(probe.Metadata) > 0 {
+			out["metadata"] = probe.Metadata
+		}
+		items := make([]map[string]any, 0, len(probe.Items))
+		for _, raw := range probe.Items {
+			var it struct {
+				Metadata json.RawMessage `json:"metadata"`
+			}
+			if err := json.Unmarshal(raw, &it); err != nil || len(it.Metadata) == 0 {
+				continue
+			}
+			items = append(items, map[string]any{
+				"kind":       partialMetadataKind,
+				"apiVersion": apiVersion,
+				"metadata":   it.Metadata,
+			})
+		}
+		out["items"] = items
+		encoded, err := json.Marshal(out)
+		if err != nil {
+			return nil, false
+		}
+		return encoded, true
+	}
+
+	// Single object.
+	if len(probe.Metadata) == 0 {
+		return nil, false
+	}
+	encoded, err := json.Marshal(map[string]any{
+		"kind":       partialMetadataKind,
+		"apiVersion": apiVersion,
+		"metadata":   probe.Metadata,
+	})
+	if err != nil {
+		return nil, false
+	}
+	return encoded, true
 }

--- a/internal/store/responses_codec.go
+++ b/internal/store/responses_codec.go
@@ -176,26 +176,58 @@ const (
 // a metadata-only projection, and returns the meta.k8s.io version to answer in
 // (v1 or v1beta1). Only `g=meta.k8s.io` counts: `as=Table` uses the same
 // parameter style and is handled separately.
+//
+// q-values are honored the same way WantsProtobuf honors them — highest q wins,
+// header order breaks ties, q=0 means "not acceptable". Returning on the first
+// syntactic match instead would project even when the client explicitly
+// de-prioritized or disabled that clause, e.g.
+// `application/json, application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1;q=0`.
 func WantsPartialObjectMetadata(r *http.Request) (string, bool) {
 	accept := r.Header.Get("Accept")
 	if accept == "" {
 		return "", false
 	}
+	bestQ := 0.0
+	bestVersion := ""
+	bestIsPartial := false
 	for _, part := range strings.Split(accept, ",") {
-		_, params, err := mime.ParseMediaType(strings.TrimSpace(part))
+		mt, params, err := mime.ParseMediaType(strings.TrimSpace(part))
 		if err != nil {
 			continue
 		}
-		if params["as"] != partialMetadataKind || params["g"] != metaGroup {
+		// Only clauses in a representation we can actually serve compete; an
+		// unrelated media type shouldn't outrank a metadata clause.
+		switch mt {
+		case ProtobufMediaType, "application/json", "application/*", "*/*":
+		default:
 			continue
 		}
-		v := params["v"]
-		if v == "" {
-			v = "v1"
+		q := 1.0
+		if qs, ok := params["q"]; ok {
+			if v, perr := strconv.ParseFloat(qs, 64); perr == nil {
+				q = v
+			}
 		}
-		return v, true
+		if q <= 0 {
+			continue
+		}
+		isPartial := params["as"] == partialMetadataKind && params["g"] == metaGroup
+		if q > bestQ { // strictly greater; equal q keeps the earlier clause
+			bestQ = q
+			bestIsPartial = isPartial
+			if isPartial {
+				if bestVersion = params["v"]; bestVersion == "" {
+					bestVersion = "v1"
+				}
+			} else {
+				bestVersion = ""
+			}
+		}
 	}
-	return "", false
+	if !bestIsPartial {
+		return "", false
+	}
+	return bestVersion, true
 }
 
 // PartialMetadataResponseWriter buffers a response so a JSON object or list body

--- a/internal/store/responses_codec.go
+++ b/internal/store/responses_codec.go
@@ -281,7 +281,14 @@ func projectPartialMetadata(body []byte, metaVersion string) ([]byte, bool) {
 				Metadata json.RawMessage `json:"metadata"`
 			}
 			if err := json.Unmarshal(raw, &it); err != nil || len(it.Metadata) == 0 {
-				continue
+				// Refuse the whole projection rather than emit a shorter list.
+				// Dropping an item would change the response's meaning, and the
+				// caller most likely to ask for this projection is the garbage
+				// collector — for which a silently missing item can read as "the
+				// owner is gone". Passing the original list through is the
+				// fail-safe: the client sees real data it can't project, not
+				// projected data that lies about what exists.
+				return nil, false
 			}
 			items = append(items, map[string]any{
 				"kind":       partialMetadataKind,


### PR DESCRIPTION
Closes #329 — both halves of the 1+3 approach.

## 1. Honor `as=PartialObjectMetadata`

kube-controller-manager's garbagecollector walks `ownerReferences` with a
metadata-only client. The mock ignored the `as=` parameter and returned the full
object — byte-identical to a request without the header — and the client, which
decodes strictly against the negotiated type, rejected it outright:

```
unable to decode returned object as PartialObjectMetadata:
invalid character 'k' looking for beginning of value
```

So the GC could not sync a single item, and retried forever.

Now projected in `internal/store/responses_codec.go` as a ResponseWriter wrapper
alongside the existing protobuf one. That covers captured reads, overlay reads,
lists and single objects **uniformly** — as opposed to `as=Table`, which is
patched per call site. It's installed *after* the protobuf wrapper so its deferred
Flush runs first (LIFO): the body is projected to metadata, and protobuf encoding
then sees the projected object rather than the full one.

```console
$ curl -H 'Accept: application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1' .../configmaps/stork-config
{"kind":"PartialObjectMetadata","apiVersion":"meta.k8s.io/v1","metadata":{...}}   # no `data`

$ curl -H '…as=PartialObjectMetadata…' .../nodes
{"kind":"PartialObjectMetadataList",...,"items":[{"kind":"PartialObjectMetadata",...}]}   # no `spec`

$ curl -H '…as=PartialObjectMetadata…' .../configmaps/no-such-cm
{"kind":"Status","code":404,"reason":"NotFound"}      # deliberately NOT projected

$ curl .../configmaps/stork-config                    # no header
{"kind":"ConfigMap",...,"data":{...}}                 # unchanged
```

Two details worth keeping: a `Status` passes through unprojected, so a 404 stays
decodable as `Status` instead of becoming an object the client can't interpret;
and a list's own `metadata` (resourceVersion/continue) is preserved, or paging and
watch bookmarks stop lining up.

## 3. Stop merging controller output into kshrk's stdout

It was wired straight to `os.Stdout`/`os.Stderr`, so one retrying controller
buried the replay banner. Now it goes to a file whose path is printed once;
`--controller-log <path>` chooses the destination, `--controller-log -` restores
inline streaming. A default that silently discarded the output would make a
misbehaving controller undebuggable — hence printing the path rather than just
dropping it.

## Measured, same replay of a real 80-namespace capture

| | before | after |
|---|---|---|
| garbagecollector error lines | 2,688 | **2** (both informational) |
| `PartialObjectMetadata` failures | 2,538 | **0** |
| kshrk's own output | 5.0 MB / 3,164 lines | **8.0 KB / 20 lines** |
| controller output | inline | temp file, 452 KB / 1,078 lines |

The GC now reaches `"All resource monitors have synced. Proceeding to collect
garbage"` — a state it could never previously reach. And the closed loop still
works: Deployment → ReplicaSet → Pods, with scaling propagating.

kshrk's output is readable again:

```
--with-controller-manager: using cached kube-controller-manager v1.31.14 (...)
--with-controller-manager: controller output -> /var/folders/.../kshrk-controller-manager-790283867.log
k8shark replay server running
  Address:    https://127.0.0.1:18086
  Window:     2026-07-31T17:23:33Z → 2026-07-31T17:24:24Z (52s)
```

## Tests

`internal/store/partialmetadata_test.go` — header negotiation (including that
`as=Table` uses the same parameter style and must not match, and that
protobuf-preferred Accept lists still resolve), single-object and list projection,
and that `Status`/non-objects/malformed JSON pass through.

`cmd/controllermanager_test.go` — `-` streams inline, an explicit path truncates a
previous run's log, the default reports a discoverable temp path, and an unwritable
destination errors rather than silently falling back.

## Why the conformance differential missed it

Nothing in the read surface it compares requests a metadata-only projection, so
this could only surface by running `--with-controller-manager` end to end — which
had no script or e2e coverage at all. `docs/conformance.md` now records that.

`docs/cli-reference.md` regenerated for the new flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Course correction: `garbagecollector` is removed from the curated set

Fixing the projection made the garbage collector *work*, and a working garbage
collector **destroys the replay**. Its job is deleting objects whose owners no
longer exist — and in a capture that recorded some resource types and not others,
plenty of owners legitimately don't exist. Measured against the same
80-namespace capture, within a minute:

| | early | after ~50s |
|---|---|---|
| namespaces | 80 | **30** |
| pods | 460 | **148** |

The daemonset controller then began failing on namespaces the GC had already
eaten — errors that were *absent* before this PR, because the GC used to be too
broken to delete anything. That's the tell: the controller looked harmless only
because it never got far enough to do damage.

This isn't a fidelity gap to close in the mock. A partial capture and a garbage
collector are fundamentally incompatible. #329 offered dropping the controller as
an *alternative* to honoring the negotiation; it turns out to be required
*alongside* it.

The projection stays on its own merits — a real conformance gap that any
metadata-only client hits — it just doesn't get to imply the GC is usable.

With the controller removed:

| | |
|---|---|
| namespaces | 80 → **80** |
| pods | 460 → **460** |
| daemon_controller errors | **0** |
| `PartialObjectMetadata` decode failures | **0** |
| kshrk's own output | **20 lines** |
| closed loop | Deployment → ReplicaSet 3/3 → 3 Pods |

Also from review: `WantsPartialObjectMetadata` ignored q-values, so a client
sending `…;as=PartialObjectMetadata;…;q=0` — explicitly refusing the projection —
received it anyway. It now negotiates the way `WantsProtobuf` beside it does:
highest q wins, header order breaks ties, `q=0` means not acceptable. Six q-value
cases added.
