### PR TITLE
feat(config): announce legacy key deprecations instead of migrating silently

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -81,6 +81,7 @@ func runCapture(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
+	warnDeprecatedConfigKeys(cmd.ErrOrStderr(), cfg)
 
 	if v, _ := cmd.Flags().GetString("out"); v != "" {
 		cfg.Output = v

--- a/cmd/deprecation.go
+++ b/cmd/deprecation.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/phenixblue/k8shark/internal/config"
+)
+
+// warnDeprecatedConfigKeys prints one line per legacy config key the load
+// rewrote, naming the replacement.
+//
+// docs/stability-policy.md defines deprecation as announce -> coexist -> remove.
+// The coexistence was implemented but the announcement only ever existed in
+// release notes, so a config using a legacy spelling validated completely clean
+// and its owner had no way to learn the spelling was on its way out — until a
+// later minor removed it (#324).
+//
+// Deliberately not a validation failure: warnings go to stderr so `-o json`
+// stdout stays machine-readable, and the exit code is untouched. Per the
+// exit-code contract only `diagnose --fail-on` and `diff` may exit 1, and a
+// deprecated-but-working key is not a failure.
+//
+// It fires only when a legacy key was actually present, so a config using
+// current spellings stays silent — #240 removed spurious validate warnings and
+// this must not reintroduce the habit of ignoring them.
+func warnDeprecatedConfigKeys(w io.Writer, cfg *config.Config) {
+	if cfg == nil || len(cfg.Deprecations) == 0 {
+		return
+	}
+	for _, d := range cfg.Deprecations {
+		if d.Ignored {
+			fmt.Fprintf(w, "⚠ config: %q is deprecated and was ignored because %q is also set; remove %q\n",
+				d.Key, d.Replacement, d.Key)
+			continue
+		}
+		fmt.Fprintf(w, "⚠ config: %q is deprecated; use %q\n", d.Key, d.Replacement)
+	}
+	fmt.Fprintf(w, "  the legacy spellings still work, but will be removed in a future minor release — see docs/stability-policy.md#deprecation-policy\n")
+}

--- a/cmd/deprecation_test.go
+++ b/cmd/deprecation_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/config"
+)
+
+func TestWarnDeprecatedConfigKeys(t *testing.T) {
+	t.Run("silent for a current config", func(t *testing.T) {
+		var buf bytes.Buffer
+		warnDeprecatedConfigKeys(&buf, &config.Config{})
+		if buf.Len() != 0 {
+			// #240 removed spurious validate warnings; reintroducing one that
+			// fires on a clean config would teach users to ignore the channel.
+			t.Errorf("wrote %q for a config with no deprecations", buf.String())
+		}
+	})
+
+	t.Run("nil config is safe", func(t *testing.T) {
+		var buf bytes.Buffer
+		warnDeprecatedConfigKeys(&buf, nil)
+		if buf.Len() != 0 {
+			t.Errorf("wrote %q for a nil config", buf.String())
+		}
+	})
+
+	t.Run("names the replacement", func(t *testing.T) {
+		var buf bytes.Buffer
+		warnDeprecatedConfigKeys(&buf, &config.Config{Deprecations: []config.Deprecation{
+			{Key: "auto_discover", Replacement: "autoDiscover"},
+			{Key: "ui.api_port", Replacement: "ui.apiPort"},
+		}})
+		out := buf.String()
+		for _, want := range []string{"auto_discover", "autoDiscover", "ui.api_port", "ui.apiPort"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("output missing %q:\n%s", want, out)
+			}
+		}
+		// The announcement is the point — a user has to learn it's going away.
+		if !strings.Contains(out, "removed in a future minor release") {
+			t.Errorf("output doesn't say the spelling will be removed:\n%s", out)
+		}
+		if !strings.Contains(out, "stability-policy") {
+			t.Errorf("output doesn't point at the policy:\n%s", out)
+		}
+		// One summary line, not one per key.
+		if n := strings.Count(out, "removed in a future minor release"); n != 1 {
+			t.Errorf("summary line repeated %d times, want 1:\n%s", n, out)
+		}
+	})
+
+	t.Run("says so when the legacy value was discarded", func(t *testing.T) {
+		var buf bytes.Buffer
+		warnDeprecatedConfigKeys(&buf, &config.Config{Deprecations: []config.Deprecation{
+			{Key: "ui.api_port", Replacement: "ui.apiPort", Ignored: true},
+		}})
+		out := buf.String()
+		if !strings.Contains(out, "ignored") {
+			t.Errorf("output doesn't say the legacy value was ignored:\n%s", out)
+		}
+	})
+}

--- a/cmd/redact.go
+++ b/cmd/redact.go
@@ -105,6 +105,7 @@ func runRedact(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("loading config: %w", err)
 		}
+		warnDeprecatedConfigKeys(cmd.ErrOrStderr(), cfg)
 		if cfg.Redaction.RedactSecrets {
 			doRedactSecrets = true
 		}

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -68,6 +68,7 @@ func runUI(cmd *cobra.Command, args []string) error {
 	// Fall back to config-file ui.port / ui.apiPort when the flags were left at
 	// their default; an explicitly-passed flag always wins.
 	if cfg, err := config.Load(viper.ConfigFileUsed()); err == nil && cfg != nil {
+		warnDeprecatedConfigKeys(cmd.ErrOrStderr(), cfg)
 		if !cmd.Flags().Changed("ui-port") && cfg.UI.Port != "" {
 			uiPort = cfg.UI.Port
 		}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -31,6 +31,7 @@ warnings (e.g. a very short interval) are printed but exit zero.`,
 		if err != nil {
 			return err
 		}
+		warnDeprecatedConfigKeys(cmd.ErrOrStderr(), cfg)
 		if err := cfg.Validate(); err != nil {
 			return err
 		}

--- a/docs/config.md
+++ b/docs/config.md
@@ -14,6 +14,21 @@ form. `kshrk validate` rejects any other unrecognized key by name — a typo
 like `previouslogs` (wrong case, not a legacy alias) fails validation
 instead of being silently ignored.
 
+Loading a config that uses a legacy spelling now prints a warning naming the
+replacement, on stderr, without changing the exit code:
+
+```console
+$ kshrk validate --config old.yaml
+⚠ config: "auto_discover" is deprecated; use "autoDiscover"
+⚠ config: "ui.api_port" is deprecated; use "ui.apiPort"
+  the legacy spellings still work, but will be removed in a future minor release — see docs/stability-policy.md#deprecation-policy
+✓ Config valid (11 resource(s), all namespaces, duration 10m0s)
+```
+
+`capture`, `redact`, and `ui` warn too, so you don't have to run `validate` to
+find out. Setting both spellings warns that the legacy one is being ignored —
+that key has no effect on the run.
+
 ## Top-level fields
 
 | Field | Type | Default | Description |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -123,6 +124,10 @@ type Config struct {
 	DurationRaw string `mapstructure:"duration"`
 	// Duration is parsed from DurationRaw.
 	Duration time.Duration `mapstructure:"-"`
+
+	// Deprecations lists legacy config keys found while loading, populated by
+	// Load. Not a config key itself.
+	Deprecations []Deprecation `mapstructure:"-"`
 	// Output is the path to write the resulting .kshrk file.
 	Output string `mapstructure:"output"`
 	// Kubeconfig is the path to the kubeconfig to use. Empty = default resolution.
@@ -174,7 +179,7 @@ func Load(configFile string) (*Config, error) {
 		if err := yaml.Unmarshal(data, &raw); err != nil {
 			return nil, fmt.Errorf("parsing config file %q: %w", configFile, err)
 		}
-		applyLegacyKeyAliases(raw)
+		cfg.Deprecations = applyLegacyKeyAliases(raw)
 
 		// Decode twice from the same alias-normalized map: once strictly, so
 		// a typo'd or misspelled key (e.g. "previouslogs" instead of
@@ -236,6 +241,26 @@ func Load(configFile string) (*Config, error) {
 // nested section) to its current, camelCase replacement. Both spellings are
 // accepted for one minor release (#220); a future release will drop the
 // legacy spelling.
+// Deprecation records a legacy config key that was found and rewritten, so a
+// command can tell the user rather than migrating silently.
+//
+// docs/stability-policy.md defines deprecation as announce -> coexist -> remove.
+// Coexistence was implemented; the announcement only ever existed in release
+// notes, so a config using a legacy spelling validated completely clean and its
+// owner had no way to learn the spelling was on its way out — until a later
+// minor removed it (#324).
+type Deprecation struct {
+	// Key is the legacy spelling as written in the file (a dot-path for a
+	// nested key, e.g. "ui.api_port").
+	Key string
+	// Replacement is the canonical spelling to migrate to.
+	Replacement string
+	// Ignored is true when the canonical key was *also* set, so the legacy
+	// value was discarded rather than used. Worth saying out loud: the file
+	// contains a setting that has no effect.
+	Ignored bool
+}
+
 var legacyConfigKeyAliases = map[string]string{
 	"auto_discover":                "autoDiscover",
 	"auto_discover_exclude_groups": "autoDiscoverExcludeGroups",
@@ -250,7 +275,8 @@ var legacyConfigKeyAliases = map[string]string{
 // lowercased — see strictDecode's doc comment for why that matters). Keys
 // are dot-paths (e.g. "ui.api_port"); only one level of nesting is
 // supported, which is all legacyConfigKeyAliases currently needs.
-func applyLegacyKeyAliases(raw map[string]any) {
+func applyLegacyKeyAliases(raw map[string]any) []Deprecation {
+	var found []Deprecation
 	for legacyPath, canonicalPath := range legacyConfigKeyAliases {
 		m, legacy := resolveParent(raw, legacyPath)
 		if m == nil {
@@ -261,11 +287,21 @@ func applyLegacyKeyAliases(raw map[string]any) {
 			continue
 		}
 		cm, canonical := ensureParent(raw, canonicalPath)
-		if _, exists := cm[canonical]; !exists {
+		_, canonicalSet := cm[canonical]
+		if !canonicalSet {
 			cm[canonical] = v
 		}
 		delete(m, legacy)
+		found = append(found, Deprecation{
+			Key:         legacyPath,
+			Replacement: canonicalPath,
+			Ignored:     canonicalSet,
+		})
 	}
+	// Map iteration order is random; sort so the warnings a user sees are
+	// stable across runs.
+	sort.Slice(found, func(i, j int) bool { return found[i].Key < found[j].Key })
+	return found
 }
 
 // resolveParent walks a dot-path (e.g. "ui.apiPort") from raw and returns

--- a/internal/config/deprecation_test.go
+++ b/internal/config/deprecation_test.go
@@ -1,0 +1,152 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// docs/stability-policy.md defines deprecation as announce -> coexist -> remove.
+// Coexistence worked, but the announcement lived only in release notes, so a
+// config using a legacy spelling validated clean and its owner never learned the
+// spelling was going away (#324). Load now reports what it rewrote.
+
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "k8shark.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return path
+}
+
+func TestLoad_ReportsLegacyKeys(t *testing.T) {
+	path := writeConfig(t, `
+duration: 1m
+auto_discover: true
+ui:
+  api_port: "8081"
+resources:
+  - group: ""
+    version: v1
+    resource: pods
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// The rewrite itself must still work — this is a warning, not a rejection.
+	if !cfg.AutoDiscover {
+		t.Error("autoDiscover not applied from the legacy spelling")
+	}
+	if cfg.UI.APIPort != "8081" {
+		t.Errorf("ui.apiPort = %q, want 8081 from the legacy spelling", cfg.UI.APIPort)
+	}
+
+	if len(cfg.Deprecations) != 2 {
+		t.Fatalf("Deprecations = %+v, want 2 entries", cfg.Deprecations)
+	}
+	// Sorted, so the output is stable across runs despite map iteration order.
+	if cfg.Deprecations[0].Key != "auto_discover" || cfg.Deprecations[0].Replacement != "autoDiscover" {
+		t.Errorf("[0] = %+v", cfg.Deprecations[0])
+	}
+	if cfg.Deprecations[1].Key != "ui.api_port" || cfg.Deprecations[1].Replacement != "ui.apiPort" {
+		t.Errorf("[1] = %+v", cfg.Deprecations[1])
+	}
+	for _, d := range cfg.Deprecations {
+		if d.Ignored {
+			t.Errorf("%s marked Ignored, but no canonical key was set", d.Key)
+		}
+	}
+}
+
+// Deprecations is assigned before mapstructure.Decode runs over the same map.
+// The `mapstructure:"-"` tag has to keep the decode from clobbering it.
+func TestLoad_DeprecationsSurviveDecode(t *testing.T) {
+	path := writeConfig(t, `
+duration: 1m
+auto_discover: true
+resources:
+  - group: ""
+    version: v1
+    resource: pods
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Deprecations) == 0 {
+		t.Fatal("Deprecations was cleared by the mapstructure decode")
+	}
+}
+
+// When both spellings are present the canonical one wins and the legacy value is
+// discarded — a setting in the file that has no effect, which is worth saying.
+func TestLoad_BothSpellingsMarksLegacyIgnored(t *testing.T) {
+	path := writeConfig(t, `
+duration: 1m
+ui:
+  api_port: "9999"
+  apiPort: "8081"
+resources:
+  - group: ""
+    version: v1
+    resource: pods
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.UI.APIPort != "8081" {
+		t.Errorf("ui.apiPort = %q, want the canonical 8081 to win", cfg.UI.APIPort)
+	}
+	if len(cfg.Deprecations) != 1 {
+		t.Fatalf("Deprecations = %+v, want 1", cfg.Deprecations)
+	}
+	if !cfg.Deprecations[0].Ignored {
+		t.Error("legacy key not marked Ignored even though the canonical key was also set")
+	}
+}
+
+// A config using only canonical spellings must report nothing. #240 removed
+// spurious validate warnings; this warning must never fire on a current config.
+func TestLoad_CanonicalConfigReportsNothing(t *testing.T) {
+	path := writeConfig(t, `
+duration: 1m
+autoDiscover: true
+ui:
+  apiPort: "8081"
+resources:
+  - group: ""
+    version: v1
+    resource: pods
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Deprecations) != 0 {
+		t.Errorf("Deprecations = %+v, want none for an all-canonical config", cfg.Deprecations)
+	}
+}
+
+// The shipped examples must not trip the warning, or every user sees it on day
+// one and learns to ignore it.
+func TestLoad_ShippedExamplesHaveNoDeprecations(t *testing.T) {
+	for _, path := range []string{
+		"../../examples/k8shark.yaml",
+		"../../docs/demo/demo-capture.yaml",
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Skipf("%s not present: %v", path, err)
+		}
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load(%s): %v", path, err)
+		}
+		if len(cfg.Deprecations) != 0 {
+			t.Errorf("%s reports deprecations %+v; a shipped example must use canonical spellings", path, cfg.Deprecations)
+		}
+	}
+}


### PR DESCRIPTION
Closes #324.

## The gap

`docs/stability-policy.md` defines deprecation as **announce → coexist →
remove**. Coexistence was implemented — `applyLegacyKeyAliases` rewrites
`auto_discover`, `auto_discover_exclude_groups` and `ui.api_port` to their
canonical spellings — but it did so **in place with no diagnostic**, and the
announcement existed only in release notes.

So a config using a legacy spelling validated completely clean:

```console
$ kshrk validate --config old.yaml
✓ Config valid (11 resource(s), all namespaces, duration 10m0s)
```

The owner had no way to learn the spelling was going away, until a later minor
removed it. The coexistence window passed invisibly to exactly the people it
existed for.

## Now

```console
$ kshrk validate --config old.yaml
⚠ config: "auto_discover" is deprecated; use "autoDiscover"
⚠ config: "ui.api_port" is deprecated; use "ui.apiPort"
  the legacy spellings still work, but will be removed in a future minor release — see docs/stability-policy.md#deprecation-policy
✓ Config valid (1 resource(s), 0 namespace(s), duration 10s)
```

Setting both spellings gets a distinct message, because that line in the file has
no effect:

```console
⚠ config: "ui.api_port" is deprecated and was ignored because "ui.apiPort" is also set; remove "ui.api_port"
```

## Design points

- **stderr**, so `-o json` stdout stays machine-readable. Verified stdout alone
  is byte-unchanged.
- **Exit code untouched.** Per the exit-code contract only `diagnose --fail-on`
  and `diff` may exit `1`, and a deprecated-but-working key isn't a failure.
- **All four config-loading commands warn** — `validate`, `capture`, `redact`,
  `ui` — not just `validate`, since most users never run it. Confirmed on
  `capture` against a live cluster.
- **`Deprecations` is `mapstructure:"-"`**, matching the existing pattern for
  engine-set fields (`WildcardNamespaces`, `AutoDiscovered`), so no call-site
  signatures change. It's assigned *before* `mapstructure.Decode` runs over the
  same map, so there's an explicit test that the decode doesn't clobber it rather
  than trusting the tag.
- Sorted output, since map iteration order would otherwise reorder the warnings
  between runs.

## Not reintroducing #240

#240 removed spurious `validate` warnings, so the bar was that this must never
fire on a current config. It fires only when a legacy key was actually present
and rewritten, and a test asserts the shipped `examples/k8shark.yaml` and
`docs/demo/demo-capture.yaml` report nothing — so a new user never sees it and
doesn't learn to tune the channel out.

| config | output |
|---|---|
| legacy spellings | 2 warnings + summary, exit 0 |
| current spellings | **silent** |
| both spellings | 1 "ignored" warning, exit 0 |
| shipped examples | **silent** (asserted by test) |

## Tests

`internal/config/deprecation_test.go` — reporting, the rewrite still applying,
sorted/stable order, the `mapstructure:"-"` survival, the both-spellings case, an
all-canonical config reporting nothing, and the shipped examples being clean.

`cmd/deprecation_test.go` — silent on a clean config, nil-safe, names both
spellings, states the removal, points at the policy, and emits the summary line
exactly once rather than per key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)