### PR TITLE
test(capture): give the preflight room in DiscoveryCancelledByDuration

### DIFF
--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -924,16 +924,31 @@ func TestExpandWildcard_DiscoveryFailure(t *testing.T) {
 }
 
 func TestExpandWildcard_DiscoveryCancelledByDuration(t *testing.T) {
+	// The run duration has to comfortably exceed the preflight round-trip
+	// (GET /version) while still expiring during namespace discovery. At 50ms it
+	// did not: on a loaded Windows runner the TLS handshake plus round-trip to
+	// the local test server outran the budget, so the *preflight* failed with
+	// "context deadline exceeded" and the test saw a different error than the
+	// cancellation hint it asserts. This is a 10x margin, and costs nothing in
+	// wall time because the discovery handler returns the moment the deadline
+	// fires rather than sleeping a fixed span.
+	const runDuration = 500 * time.Millisecond
+
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v1/namespaces":
-			// Block until the run context is cancelled, rather than sleeping a
+			// Block until the run context is canceled, rather than sleeping a
 			// fixed span and hoping the deadline lands inside it. The handler
 			// then returns exactly when the deadline fires, so the test's
 			// runtime is the configured duration and not a hardcoded sleep.
+			//
+			// The second arm bounds the handler if cancellation never arrives,
+			// so a regression surfaces as this test failing rather than the
+			// whole package hanging. It's a multiple of runDuration so a broken
+			// run fails in a couple of seconds instead of a flat ten.
 			select {
 			case <-r.Context().Done():
-			case <-time.After(10 * time.Second): // safety net; never reached
+			case <-time.After(4 * runDuration):
 			}
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprint(w, `{"kind":"NamespaceList","items":[]}`)
@@ -948,17 +963,9 @@ func TestExpandWildcard_DiscoveryCancelledByDuration(t *testing.T) {
 	defer srv.Close()
 
 	outDir := t.TempDir()
-	// The run duration has to comfortably exceed the preflight round-trip
-	// (GET /version) while still expiring during namespace discovery. At 50ms it
-	// did not: on a loaded Windows runner the TLS handshake plus round-trip to
-	// the local test server outran the budget, so the *preflight* failed with
-	// "context deadline exceeded" and the test saw a different error than the
-	// cancellation hint it asserts. 500ms is a 10x margin, and costs nothing in
-	// wall time because the discovery handler returns the moment the deadline
-	// fires rather than sleeping a fixed span.
 	cfg := &config.Config{
-		DurationRaw: "500ms",
-		Duration:    500 * time.Millisecond,
+		DurationRaw: runDuration.String(),
+		Duration:    runDuration,
 		Output:      filepath.Join(outDir, "capture.kshrk"),
 		Resources: []config.Resource{
 			{Version: "v1", Resource: "pods", Namespaces: []string{"*"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},

--- a/internal/capture/engine_test.go
+++ b/internal/capture/engine_test.go
@@ -927,8 +927,14 @@ func TestExpandWildcard_DiscoveryCancelledByDuration(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v1/namespaces":
-			// Ensure the run context times out before this response is returned.
-			time.Sleep(100 * time.Millisecond)
+			// Block until the run context is cancelled, rather than sleeping a
+			// fixed span and hoping the deadline lands inside it. The handler
+			// then returns exactly when the deadline fires, so the test's
+			// runtime is the configured duration and not a hardcoded sleep.
+			select {
+			case <-r.Context().Done():
+			case <-time.After(10 * time.Second): // safety net; never reached
+			}
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprint(w, `{"kind":"NamespaceList","items":[]}`)
 		case "/version":
@@ -942,9 +948,17 @@ func TestExpandWildcard_DiscoveryCancelledByDuration(t *testing.T) {
 	defer srv.Close()
 
 	outDir := t.TempDir()
+	// The run duration has to comfortably exceed the preflight round-trip
+	// (GET /version) while still expiring during namespace discovery. At 50ms it
+	// did not: on a loaded Windows runner the TLS handshake plus round-trip to
+	// the local test server outran the budget, so the *preflight* failed with
+	// "context deadline exceeded" and the test saw a different error than the
+	// cancellation hint it asserts. 500ms is a 10x margin, and costs nothing in
+	// wall time because the discovery handler returns the moment the deadline
+	// fires rather than sleeping a fixed span.
 	cfg := &config.Config{
-		DurationRaw: "50ms",
-		Duration:    50 * time.Millisecond,
+		DurationRaw: "500ms",
+		Duration:    500 * time.Millisecond,
 		Output:      filepath.Join(outDir, "capture.kshrk"),
 		Resources: []config.Resource{
 			{Version: "v1", Resource: "pods", Namespaces: []string{"*"}, IntervalRaw: "200ms", Interval: 200 * time.Millisecond},


### PR DESCRIPTION
Caught by the pre-tag pass: **CI is currently failing on `main`** at `87e3f3a`,
`windows-latest` only.

```
engine_test.go:960: expected cancellation hint in error, got: capture preflight
failed (kubeconfig=default, server=…): Get "…/version": context deadline exceeded
```

## The race

`TestExpandWildcard_DiscoveryCancelledByDuration` asserts that cancelling
*namespace discovery* by the run duration yields a `"request canceled before
completion"` hint. It set the duration to **50ms**, which means the preflight
`GET /version` had to finish inside 50ms for discovery to be reached at all.

On a loaded Windows runner, the TLS handshake plus round-trip to the local
`httptest` server outruns that. The preflight fails first, with a different error
from a different code path, and the assertion sees it.

## The fix

- Duration **50ms → 500ms**, a 10× margin over the preflight round-trip.
- The discovery handler now blocks on `r.Context().Done()` instead of sleeping a
  fixed 100ms, so it returns exactly when the deadline fires.

The second change is what makes the first free: the test's wall time is the
configured duration rather than a hardcoded sleep, so widening the budget doesn't
slow the suite.

## Proven, not assumed

Injecting a 120ms preflight delay — what a loaded runner amounts to — reproduces
CI's exact message under the old budget and passes under the new one:

```
old (50ms):   FAIL … got: capture preflight failed … context deadline exceeded
new (500ms):  ok
```

Also 20 consecutive runs clean, and the package passes under `-race`.

## Note

This is the second timing-flake of the same shape as #327: a test waiting on one
condition while asserting on another that depends on it. Both were invisible
locally and only appeared on contended CI runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)