### PR TITLE
chore(pre-tag): refresh release-doc examples; note the inert cask license key

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -88,6 +88,11 @@ homebrew_casks:
   - name: k8shark
     homepage: https://github.com/phenixblue/k8shark
     description: Kubernetes cluster state capture and mock API replay tool
+    # license: is inert for casks — Homebrew has no cask license stanza (it's a
+    # formula concept), so GoReleaser accepts the key and drops it from the
+    # rendered file. Verified against `make release-local` output: neither
+    # generated cask contains it. Kept for documentation value and symmetry with
+    # the @rc entry; don't expect it in the tap.
     license: Apache-2.0
     skip_upload: auto
     binaries:

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -5,8 +5,8 @@
 Releases are cut by pushing a version tag to `main`. The tag triggers the [release workflow](../.github/workflows/release.yml) which runs [GoReleaser](https://goreleaser.com) to build and publish everything.
 
 ```sh
-git tag v1.0.0-rc.1
-git push origin v1.0.0-rc.1
+git tag v1.0.0
+git push origin v1.0.0
 ```
 
 Use [semantic versioning](https://semver.org): `vMAJOR.MINOR.PATCH`. Tags that contain a pre-release identifier (e.g. `v1.0.0-rc.1`) are automatically marked as pre-release on GitHub.
@@ -70,8 +70,8 @@ The cosign signing uses GitHub's OIDC token — no additional secret is needed.
 ### Verify the checksum signature
 
 ```sh
-# Download the release artifacts
-gh release download v1.0.0-rc.3 --repo phenixblue/k8shark
+# Download the release artifacts (substitute the tag you are verifying)
+gh release download v1.0.0 --repo phenixblue/k8shark
 
 # Verify the cosign signature
 cosign verify-blob \
@@ -89,7 +89,7 @@ also match any identity that merely *contains* that string (say
 which defeats the point of checking it. `^`/`$` plus escaped dots plus the
 required `@refs/tags/v…` suffix pins it to this repo's release workflow run
 from a version tag. The signing identity looks like
-`https://github.com/phenixblue/k8shark/.github/workflows/release.yml@refs/tags/v1.0.0-rc.2`
+`https://github.com/phenixblue/k8shark/.github/workflows/release.yml@refs/tags/v1.0.0`
 (read off that release's own certificate).
 
 The signature and certificate live together in a single `checksums.txt.bundle`

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -5,8 +5,9 @@
 Releases are cut by pushing a version tag to `main`. The tag triggers the [release workflow](../.github/workflows/release.yml) which runs [GoReleaser](https://goreleaser.com) to build and publish everything.
 
 ```sh
-git tag v1.0.0
-git push origin v1.0.0
+TAG=v1.0.0            # the release you are cutting
+git tag "$TAG"
+git push origin "$TAG"
 ```
 
 Use [semantic versioning](https://semver.org): `vMAJOR.MINOR.PATCH`. Tags that contain a pre-release identifier (e.g. `v1.0.0-rc.1`) are automatically marked as pre-release on GitHub.
@@ -70,8 +71,9 @@ The cosign signing uses GitHub's OIDC token — no additional secret is needed.
 ### Verify the checksum signature
 
 ```sh
-# Download the release artifacts (substitute the tag you are verifying)
-gh release download v1.0.0 --repo phenixblue/k8shark
+# Download the release artifacts
+TAG=v1.0.0            # the release you are verifying
+gh release download "$TAG" --repo phenixblue/k8shark
 
 # Verify the cosign signature
 cosign verify-blob \
@@ -89,8 +91,8 @@ also match any identity that merely *contains* that string (say
 which defeats the point of checking it. `^`/`$` plus escaped dots plus the
 required `@refs/tags/v…` suffix pins it to this repo's release workflow run
 from a version tag. The signing identity looks like
-`https://github.com/phenixblue/k8shark/.github/workflows/release.yml@refs/tags/v1.0.0`
-(read off that release's own certificate).
+`https://github.com/phenixblue/k8shark/.github/workflows/release.yml@refs/tags/vX.Y.Z`
+(read the real one off that release's own certificate).
 
 The signature and certificate live together in a single `checksums.txt.bundle`
 (cosign's newer bundle format), which is what `--bundle` above reads. Releases


### PR DESCRIPTION
Found during the pre-tag pass.

`docs/releases.md`'s **"Verifying a release"** section hardcoded:

```sh
gh release download v1.0.0-rc.3 --repo phenixblue/k8shark
```

Once `v1.0.0` ships, anyone following those instructions downloads and verifies
**rc.3** — not the release they actually have. The illustrative signing identity
named `rc.2` and the tag-pushing example showed `rc.1`, both written when
prereleases were the only thing to point at.

Three prerelease references are deliberately left: the note that a prerelease
identifier marks a GitHub prerelease, the pre-rc.3 `.sig`/`.pem` layout guidance,
and the account of the cosign v3 break. Those are historical or contextual, not
examples to copy.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)