### PR TITLE
docs: Homebrew installs ARE Gatekeeper-blocked on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ export KUBECONFIG=~/.kube/k8shark-<id>.yaml   # <id> is printed by the command a
 kubectl get pods -A
 ```
 
+> **macOS:** the binaries aren't Apple-notarized yet ([#316](https://github.com/phenixblue/k8shark/issues/316)),
+> and Homebrew quarantines cask installs, so the first run is blocked by Gatekeeper.
+> Approve it once in System Settings → Privacy & Security, or run
+> `xattr -d com.apple.quarantine "$(brew --prefix)/bin/kshrk"`. See
+> [docs/usage.md](docs/usage.md#macos-first-run-is-blocked-by-gatekeeper).
+
 No cluster on hand? Skip straight to [Examples](#examples) below — five pre-recorded
 captures you can replay immediately, no live cluster required.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -45,6 +45,26 @@ generation in favor of casks, and `@` in a Ruby class name is invalid regardless
 (`k8shark@rc` could only ever be a cask, which uses a `cask "name" do` string, not
 a class name) — hence `--cask` on both.
 
+#### macOS: first run is blocked by Gatekeeper
+
+The macOS binaries are not yet code-signed with an Apple Developer ID
+([#316](https://github.com/phenixblue/k8shark/issues/316)), and Homebrew applies
+`com.apple.quarantine` to everything it installs from a cask. The combination
+means the first run is refused with *"cannot be opened because the developer
+cannot be verified"*.
+
+Either approve it once in **System Settings → Privacy & Security**, or clear the
+attribute:
+
+```sh
+xattr -d com.apple.quarantine "$(brew --prefix)/bin/kshrk"
+```
+
+This affects the Homebrew install specifically. `go install` and building from
+source produce a local binary that is never quarantined, and neither is a
+tarball fetched with `gh release download` or `curl` — only a browser download
+or a Homebrew cask carries the attribute.
+
 ### go install
 
 ```sh


### PR DESCRIPTION
Correcting a claim I made when we deferred #316.

## What I got wrong

I said Homebrew "strips quarantine from cask `binary` artifacts", and concluded
that **no documented install path** was affected by the missing notarization.
That's backwards. Homebrew *applies* `com.apple.quarantine` to cask installs as a
security measure, and it's applied by `Cask::Quarantine` in Homebrew itself — a
cask author can't opt out.

Confirmed against the real v1.0.0 install:

```console
$ xattr "$(brew --caskroom)/k8shark/1.0.0/kshrk"
com.apple.provenance
com.apple.quarantine

$ spctl -a -vvv …/kshrk
…/kshrk: rejected
```

So the **primary** documented install path — the one the README leads with — is
precisely the one that hits *"cannot be opened because the developer cannot be
verified"*. Reported from a real v1.0.0 install, not hypothetical.

## What this adds

A note in the README quick start and a section in `docs/usage.md`, both giving
the workaround.

The suggested fix is `xattr -d com.apple.quarantine "$(brew --prefix)/bin/kshrk"`,
verified to clear the attribute and let the binary run. **`--no-quarantine` is
deliberately not suggested** — it no longer exists in Homebrew 6.x: absent from
`brew install --help`, absent from the Homebrew source, and `brew reinstall`
rejects it outright (`Error: invalid option: --no-quarantine`).

The unaffected paths named in the note were each checked rather than assumed:
`go install` and from-source builds are never quarantined, and a tarball fetched
with `gh release download` carries only `com.apple.provenance`.

## Bearing on #316

This doesn't change the decision to defer notarization, but it changes how that
deferral reads: it's a documented rough edge on the main install path, not
something almost nobody hits. I've corrected the exposure analysis on the issue
too.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)