### PR TITLE
Add Google Analytics (GA4) tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,14 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-9DW66SR1MF"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-9DW66SR1MF');
+</script>
 <title>k8shark — Like Wireshark, but for Kubernetes</title>
 <meta name="description" content="Capture a Kubernetes cluster's state to a portable archive and replay it through a mock API server — use kubectl against a customer's environment without live cluster access.">
 <meta property="og:title" content="k8shark — Like Wireshark, but for Kubernetes">


### PR DESCRIPTION
## Summary
- Adds the GA4 `gtag.js` snippet (measurement ID `G-9DW66SR1MF`) to the `<head>` of `index.html` for the k8shark.io landing page.

## Test plan
- [ ] Merge and verify the page still renders correctly on k8shark.io
- [ ] Confirm pageviews start showing up in the GA4 real-time report

🤖 Generated with [Claude Code](https://claude.com/claude-code)