### PR TITLE
fix: evaluate fieldSelectors per-kind on reads, watches and deletes

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     paths:
       - 'internal/server/**'
+      - 'internal/store/**'
       - 'internal/capture/**'
       - 'scripts/conformance*.sh'
       - 'scripts/conformance_diff.py'
@@ -20,6 +21,7 @@ on:
       - main
     paths:
       - 'internal/server/**'
+      - 'internal/store/**'
       - 'internal/capture/**'
       - 'scripts/conformance*'
       - '.github/workflows/conformance.yml'

--- a/.github/workflows/fieldselector-drift.yml
+++ b/.github/workflows/fieldselector-drift.yml
@@ -1,0 +1,53 @@
+name: fieldselector-drift
+
+# The mock apiserver hand-maintains Kubernetes' per-kind field-label tables
+# (internal/store/fieldselector.go), because upstream registers them in
+# k8s.io/kubernetes's internal API packages, which are not importable from
+# k8s.io/api or client-go — there is nothing to reflect over at build time.
+#
+# This job is one of three mechanisms that keep those tables honest:
+#
+#   1. this workflow — parses the upstream source at the Kubernetes minor pinned
+#      in go.mod and diffs it against scripts/fieldselector-snapshot.json;
+#   2. TestFieldSelectorTables_* in internal/store — asserts the Go tables match
+#      that snapshot, offline, on every `make test`;
+#   3. the conformance differential (.github/workflows/conformance.yml, section
+#      G) — compares actual behavior against a live KinD apiserver.
+#
+# (1) exists to cover what (3) cannot: a capture has no CertificateSigningRequest
+# to exercise, so spec.signerName would otherwise go unchecked. It needs network
+# access to raw.githubusercontent.com, so it runs on a schedule and on PRs that
+# touch the tables rather than on every push.
+#
+# A failure here is not necessarily a bug in k8shark — it means upstream changed
+# a field-label table. Read the diff, update internal/store/fieldselector.go to
+# match, then run `make fieldselector-drift-update` to refresh the snapshot.
+
+on:
+  pull_request:
+    paths:
+      - 'internal/store/fieldselector*.go'
+      - 'scripts/fieldselector_drift.py'
+      - 'scripts/fieldselector-snapshot.json'
+      - 'go.mod'
+      - '.github/workflows/fieldselector-drift.yml'
+  schedule:
+    # Weekly, Monday 06:00 UTC. Upstream field-label tables change rarely, so a
+    # weekly check is early enough to land a fix before the next k8s bump.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # python3 is preinstalled on ubuntu-latest and the script is stdlib-only,
+      # so no setup-python step or dependency install is needed.
+      - name: Check field-label tables against upstream
+        run: make fieldselector-drift

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,18 @@ Therefore:
   negative = corrupt (rejected), greater than `CurrentFormatVersion` = rejected
   with an "upgrade kshrk" error. Bump `CurrentFormatVersion` only on a breaking,
   structurally-incompatible change.
+- **Field selectors:** `internal/store/fieldselector.go` mirrors the
+  apiserver's *two independent* layers — `AddFieldLabelConversionFunc`
+  (which labels are accepted; unaccepted → 400) and `ToSelectableFields`
+  (which resolve to a value; absent → `""`). They are not the same list
+  (pods accept `status.podIPs` but never select on it), so don't collapse
+  them. The tables are hand-maintained because upstream registers them in
+  `k8s.io/kubernetes`'s internal API packages, unreachable from `k8s.io/api`
+  — three mechanisms detect drift (conformance differential, weekly
+  `make fieldselector-drift`, and `TestFieldSelectorTables_*` against
+  `scripts/fieldselector-snapshot.json`). Validation is shared by list,
+  watch and deletecollection, matching upstream (#339). See the "Field
+  selectors" section of `docs/conformance.md`.
 - **`internal/store`** holds `CaptureStore`/`LoadStore` (archive-backed
   reads, selectors, response content negotiation) — extracted from
   `internal/server` (#234) so `diagnose`/`query`/`diff` read an archive

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-race test-cover bench fmt lint lint-ci-install lint-ci docs e2e e2e-kwok kind-up kind-chaos kind-scale kind-down release-snapshot release-local clean help
+.PHONY: build test test-race test-cover bench fmt lint lint-ci-install lint-ci fieldselector-drift fieldselector-drift-update docs e2e e2e-kwok kind-up kind-chaos kind-scale kind-down release-snapshot release-local clean help
 
 BINARY  := kshrk
 VERSION ?= dev
@@ -33,6 +33,12 @@ lint-ci-install: ## Install the pinned golangci-lint version used in CI
 
 lint-ci: ## Run golangci-lint exactly like CI (requires lint-ci-install)
 	golangci-lint run
+
+fieldselector-drift: ## Check the field-label tables against upstream Kubernetes source (needs network)
+	python3 scripts/fieldselector_drift.py
+
+fieldselector-drift-update: ## Refresh scripts/fieldselector-snapshot.json from upstream
+	python3 scripts/fieldselector_drift.py --update
 
 docs: ## Regenerate docs/cli-reference.md from the live Cobra command tree
 	go run ./tools/gendocs

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -24,8 +24,8 @@ per [#136](https://github.com/phenixblue/k8shark/issues/136).
 In-scope surface: discovery (`/api`, `/apis`, `/api/v1`, `/apis/<g>/<v>`,
 per-resource `kind`/`namespaced`/`shortNames`/`verbs`/subresources), `/version`,
 OpenAPI v2/v3, resource LIST/GET envelopes and item structure, health
-(`/healthz`, `/readyz`, `/livez`), and error shapes (not-found, unknown
-group/version).
+(`/healthz`, `/readyz`, `/livez`), error shapes (not-found, unknown
+group/version), and `?fieldSelector=` queries (see below).
 
 Run it locally (needs `kind`, `kubectl`, `jq`, `python3`):
 
@@ -38,6 +38,50 @@ KEEP=1 ./scripts/conformance.sh     # leave cluster + mock running to poke at
 Set `CONFORMANCE_MD=/path/report.md` to also write a Markdown summary (the CI
 workflow uses this for the job summary and posts it as a sticky PR comment that
 is updated in place on each run).
+
+## Field selectors, and keeping their tables in sync
+
+`?fieldSelector=` is the one part of the read surface where fidelity depends on
+data the mock cannot derive from the capture. kubectl contributes nothing here —
+cli-runtime forwards the raw string and holds no per-kind table — so everything a
+client expects is owed by the server. The apiserver evaluates a selector in two
+independent layers:
+
+| Layer | Upstream source | What it decides |
+|-------|-----------------|-----------------|
+| Validation + aliasing | `AddFieldLabelConversionFunc` in `pkg/apis/<group>/<version>/conversion.go` | Which labels are accepted at all; unaccepted → **400**. Rewrites aliases (`spec.host` → `spec.nodeName`). |
+| Matching | `ToSelectableFields` in `pkg/registry/.../strategy.go` | Which labels resolve to a value; a label absent here reads as `""`. |
+
+The two lists genuinely differ, so `internal/store/fieldselector.go` keeps them
+separate. Pods accept `status.podIPs` but never select on it, so upstream accepts
+`status.podIPs=10.0.0.1` and then matches nothing. Collapsing the layers would
+either reject a key upstream accepts or match on one it ignores.
+
+Those tables are hand-maintained: upstream registers them in
+`k8s.io/kubernetes`'s *internal* API packages, which are not importable from
+`k8s.io/api` or `client-go`, so there is nothing to reflect over at build time.
+Three mechanisms keep them honest, each covering the others' blind spots:
+
+1. **The differential** (section G of `conformance_diff.py`) — probes real
+   `?fieldSelector=` queries against both servers and compares status code *and*
+   matched set. The live apiserver *is* the table, so an upstream change shows up
+   as a new divergence. Blind spot: it only exercises kinds and keys the capture
+   actually contains.
+2. **`scripts/fieldselector_drift.py`** — parses the upstream source at the
+   Kubernetes minor pinned in `go.mod` and diffs it against
+   `scripts/fieldselector-snapshot.json`. Covers the kinds the capture lacks (a
+   KinD capture has no CertificateSigningRequest). Runs weekly and on PRs that
+   touch the tables (`.github/workflows/fieldselector-drift.yml`); needs network.
+3. **`TestFieldSelectorTables_*`** in `internal/store` — asserts the Go tables
+   match that snapshot, offline, on every `make test`. Without it the snapshot
+   could track upstream perfectly while the Go code drifted from both.
+
+When (2) fails, upstream changed something. Read the diff, update
+`internal/store/fieldselector.go`, then refresh the snapshot:
+
+```sh
+make fieldselector-drift-update
+```
 
 ## Why not the CNCF conformance suite?
 

--- a/internal/server/fieldselector_test.go
+++ b/internal/server/fieldselector_test.go
@@ -152,9 +152,78 @@ func TestHandler_FieldSelector_TablePathFilters(t *testing.T) {
 	}
 }
 
+// TestHandler_LabelSelectorOnly_NoFieldSelector covers every request shape that
+// carries a labelSelector and no fieldSelector, which leaves the compiled
+// *kstore.FieldSelector nil all the way down. The methods called on it
+// (NeedsFullObject, Matches, Restricts) are nil-safe by design — a nil receiver
+// means "matches everything" — and these exercise the JSON list, stored Table
+// and watch paths to keep it that way.
+func TestHandler_LabelSelectorOnly_NoFieldSelector(t *testing.T) {
+	pods := []podSpec{
+		{name: "web-1", namespace: "demo", nodeName: "node-a", phase: "Running",
+			labels: map[string]string{"app": "web"}},
+		{name: "db-1", namespace: "demo", nodeName: "node-b", phase: "Running",
+			labels: map[string]string{"app": "db"}},
+	}
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/demo/pods":          listWithPods(pods),
+		"/api/v1/namespaces/demo/pods?as=Table": partialMetadataTable(pods),
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	t.Run("json list", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, fsPodsPath+"?labelSelector=app%3Dweb", nil)
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+		if rw.Code != 200 {
+			t.Fatalf("status %d (body: %s)", rw.Code, rw.Body.String())
+		}
+		if got := itemNames(t, rw.Body.Bytes()); !equalStrings(got, []string{"web-1"}) {
+			t.Errorf("got %v, want [web-1]", got)
+		}
+	})
+
+	t.Run("stored table", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, fsPodsPath+"?labelSelector=app%3Dweb", nil)
+		req.Header.Set("Accept", "application/json;as=Table;v=v1;g=meta.k8s.io")
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+		if rw.Code != 200 {
+			t.Fatalf("status %d (body: %s)", rw.Code, rw.Body.String())
+		}
+		if got := tableRowNames(t, rw.Body.Bytes()); !equalStrings(got, []string{"web-1"}) {
+			t.Errorf("rows %v, want [web-1]", got)
+		}
+	})
+
+	t.Run("watch", func(t *testing.T) {
+		names := watchInitialNames(t, h,
+			fsPodsPath+"?watch=true&timeoutSeconds=1&labelSelector=app%3Dweb")
+		if !equalStrings(names, []string{"web-1"}) {
+			t.Errorf("watch initial events = %v, want [web-1]", names)
+		}
+	})
+
+	t.Run("no selectors at all", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, fsPodsPath, nil)
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+		if rw.Code != 200 {
+			t.Fatalf("status %d (body: %s)", rw.Code, rw.Body.String())
+		}
+		if got := itemNames(t, rw.Body.Bytes()); !equalStrings(got, []string{"web-1", "db-1"}) {
+			t.Errorf("got %v, want both pods", got)
+		}
+	})
+}
+
 // partialMetadataTable builds a stored Table whose rows embed
 // PartialObjectMetadata, which is what a real apiserver serves for a Table
-// projection — spec and status are simply absent from the row objects.
+// projection. The row objects carry the *full* ObjectMeta — labels included, so
+// a labelSelector still filters rows directly — and nothing else: spec and
+// status are absent, which is why a selector on those has to be resolved
+// against the JSON list instead. Verified against a real capture; getting this
+// shape wrong in either direction makes the Table tests meaningless.
 func partialMetadataTable(pods []podSpec) []byte {
 	rows := make([]map[string]any, 0, len(pods))
 	for _, p := range pods {
@@ -163,7 +232,11 @@ func partialMetadataTable(pods []podSpec) []byte {
 			"object": map[string]any{
 				"apiVersion": "meta.k8s.io/v1",
 				"kind":       "PartialObjectMetadata",
-				"metadata":   map[string]any{"name": p.name, "namespace": p.namespace},
+				"metadata": map[string]any{
+					"name":      p.name,
+					"namespace": p.namespace,
+					"labels":    p.labels,
+				},
 			},
 		})
 	}

--- a/internal/server/fieldselector_test.go
+++ b/internal/server/fieldselector_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -296,6 +297,76 @@ func TestHandler_FieldSelector_StoredTableWithPartialMetadata(t *testing.T) {
 		if !equalStrings(got, tc.want) {
 			t.Errorf("[%s] rows %v, want %v", tc.query, got, tc.want)
 		}
+	}
+}
+
+// TestHandler_FieldSelector_StoredTableFallsBackOnBadItem checks the escape
+// hatch. When one list item's identity cannot be decoded there is no way to
+// correlate it with a Table row, so kstore.ListIdentities fails closed and the
+// handler must fall back to a computed Table — built from the already-filtered
+// JSON list — rather than serve a stored Table with rows silently dropped.
+func TestHandler_FieldSelector_StoredTableFallsBackOnBadItem(t *testing.T) {
+	good := []podSpec{
+		{name: "web-1", namespace: "demo", nodeName: "node-a", phase: "Running"},
+	}
+	// A list carrying one well-formed pod plus an item whose metadata.name is a
+	// number, which decodes into neither K8sObject nor the identity-only shape.
+	listBody, err := json.Marshal(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "PodList",
+		"metadata":   map[string]any{},
+		"items": []json.RawMessage{
+			json.RawMessage(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"web-1",` +
+				`"namespace":"demo"},"spec":{"nodeName":"node-a"},"status":{"phase":"Running"}}`),
+			json.RawMessage(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":7,"namespace":"demo"}}`),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/demo/pods":          listBody,
+		"/api/v1/namespaces/demo/pods?as=Table": partialMetadataTable(good),
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	req := httptest.NewRequest(http.MethodGet, fsPodsPath+"?fieldSelector=spec.nodeName=node-a", nil)
+	req.Header.Set("Accept", "application/json;as=Table;v=v1;g=meta.k8s.io")
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+	if rw.Code != 200 {
+		t.Fatalf("status %d (body: %s)", rw.Code, rw.Body.String())
+	}
+	// Decoded leniently: the computed Table carries a row for the malformed item
+	// too — its metadata.name is still the original number, so a strict
+	// string-typed decode would fail here. That the row survives at all is the
+	// point: the fallback trades captured column fidelity for not losing rows.
+	var table struct {
+		Kind string `json:"kind"`
+		Rows []struct {
+			Object struct {
+				Metadata map[string]any `json:"metadata"`
+			} `json:"object"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal(rw.Body.Bytes(), &table); err != nil {
+		t.Fatalf("decoding table: %v\nbody: %s", err, rw.Body.String())
+	}
+	if table.Kind != "Table" {
+		t.Fatalf("kind = %q, want Table", table.Kind)
+	}
+	var names []string
+	for _, r := range table.Rows {
+		names = append(names, fmt.Sprint(r.Object.Metadata["name"]))
+	}
+	found := false
+	for _, n := range names {
+		if n == "web-1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("rows %v: web-1 matches spec.nodeName=node-a and must not be dropped", names)
 	}
 }
 

--- a/internal/server/fieldselector_test.go
+++ b/internal/server/fieldselector_test.go
@@ -1,0 +1,352 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fieldSelectorTestStore holds two pods on different nodes, in different
+// phases — enough to tell "filtered correctly" apart from "matched everything".
+func fieldSelectorTestStore(t *testing.T) *handler {
+	t.Helper()
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/demo/pods": listWithPods([]podSpec{
+			{name: "web-1", namespace: "demo", nodeName: "node-a", phase: "Running"},
+			{name: "web-2", namespace: "demo", nodeName: "node-b", phase: "Failed"},
+		}),
+	})
+	return newHandler(store, time.Time{}, false)
+}
+
+const fsPodsPath = "/api/v1/namespaces/demo/pods"
+
+// TestHandler_FieldSelector_ReadPathFilters is the direct regression test for
+// #339: on the read path a supported non-metadata key must filter, and must not
+// degrade to matching every item.
+func TestHandler_FieldSelector_ReadPathFilters(t *testing.T) {
+	h := fieldSelectorTestStore(t)
+
+	cases := []struct {
+		query string
+		want  []string
+	}{
+		{"metadata.name=web-1", []string{"web-1"}},
+		{"spec.nodeName=node-a", []string{"web-1"}},
+		{"spec.nodeName=node-b", []string{"web-2"}},
+		// The case from the issue: a supported key with a value nothing
+		// matches used to return every pod.
+		{"spec.nodeName=does-not-exist", nil},
+		{"status.phase=Failed", []string{"web-2"}},
+		{"status.phase=Running", []string{"web-1"}},
+		{"status.phase=Pending", nil},
+		{"spec.nodeName=node-a,status.phase=Failed", nil},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, fsPodsPath+"?fieldSelector="+tc.query, nil)
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+		if rw.Code != 200 {
+			t.Errorf("[%s] status %d, want 200 (body: %s)", tc.query, rw.Code, rw.Body.String())
+			continue
+		}
+		got := itemNames(t, rw.Body.Bytes())
+		if !equalStrings(got, tc.want) {
+			t.Errorf("[%s] got %v, want %v", tc.query, got, tc.want)
+		}
+	}
+}
+
+// TestHandler_FieldSelector_RejectsUnsupportedKey checks the 400. A real
+// apiserver either supports a key or rejects it; it never over-matches.
+func TestHandler_FieldSelector_RejectsUnsupportedKey(t *testing.T) {
+	h := fieldSelectorTestStore(t)
+
+	cases := []struct {
+		query   string
+		wantMsg string
+	}{
+		{"spec.bogus=x", "field label not supported: spec.bogus"},
+		// Accepted for nodes, not for pods.
+		{"spec.unschedulable=true", "field label not supported: spec.unschedulable"},
+		// Valid for pods, but paired with an invalid one.
+		{"spec.nodeName=node-a,spec.bogus=x", "field label not supported: spec.bogus"},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, fsPodsPath+"?fieldSelector="+tc.query, nil)
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+		if rw.Code != http.StatusBadRequest {
+			t.Errorf("[%s] status %d, want 400 (body: %s)", tc.query, rw.Code, rw.Body.String())
+			continue
+		}
+		var status struct {
+			Kind    string `json:"kind"`
+			Status  string `json:"status"`
+			Message string `json:"message"`
+			Code    int    `json:"code"`
+		}
+		if err := json.Unmarshal(rw.Body.Bytes(), &status); err != nil {
+			t.Errorf("[%s] body is not a Status: %v", tc.query, err)
+			continue
+		}
+		if status.Kind != "Status" || status.Code != 400 {
+			t.Errorf("[%s] body = %+v, want a Status with code 400", tc.query, status)
+		}
+		if !strings.Contains(status.Message, tc.wantMsg) {
+			t.Errorf("[%s] message = %q, want it to contain %q", tc.query, status.Message, tc.wantMsg)
+		}
+	}
+}
+
+// TestHandler_FieldSelector_ItemGetIgnoresSelector checks we don't invent a 400
+// where upstream has none: a single-object GET takes GetOptions, which carries
+// no field selector, so the parameter is ignored rather than validated.
+func TestHandler_FieldSelector_ItemGetIgnoresSelector(t *testing.T) {
+	h := fieldSelectorTestStore(t)
+	req := httptest.NewRequest(http.MethodGet, fsPodsPath+"/web-1?fieldSelector=spec.bogus=x", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+	if rw.Code != 200 {
+		t.Errorf("item GET with a bogus fieldSelector: status %d, want 200 (body: %s)",
+			rw.Code, rw.Body.String())
+	}
+}
+
+// TestHandler_FieldSelector_TablePathFilters covers the Table projection, which
+// filters rows through a separate code path from the JSON list — `kubectl get`
+// without -o hits this one.
+func TestHandler_FieldSelector_TablePathFilters(t *testing.T) {
+	h := fieldSelectorTestStore(t)
+
+	for _, tc := range []struct {
+		query string
+		want  int
+	}{
+		{"spec.nodeName=node-a", 1},
+		{"spec.nodeName=does-not-exist", 0},
+	} {
+		req := httptest.NewRequest(http.MethodGet, fsPodsPath+"?fieldSelector="+tc.query, nil)
+		req.Header.Set("Accept", "application/json;as=Table;v=v1;g=meta.k8s.io")
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+		if rw.Code != 200 {
+			t.Fatalf("[%s] status %d (body: %s)", tc.query, rw.Code, rw.Body.String())
+		}
+		var table struct {
+			Kind string            `json:"kind"`
+			Rows []json.RawMessage `json:"rows"`
+		}
+		if err := json.Unmarshal(rw.Body.Bytes(), &table); err != nil {
+			t.Fatalf("[%s] decoding table: %v", tc.query, err)
+		}
+		if table.Kind != "Table" {
+			t.Fatalf("[%s] kind = %q, want Table", tc.query, table.Kind)
+		}
+		if len(table.Rows) != tc.want {
+			t.Errorf("[%s] %d rows, want %d", tc.query, len(table.Rows), tc.want)
+		}
+	}
+}
+
+// partialMetadataTable builds a stored Table whose rows embed
+// PartialObjectMetadata, which is what a real apiserver serves for a Table
+// projection — spec and status are simply absent from the row objects.
+func partialMetadataTable(pods []podSpec) []byte {
+	rows := make([]map[string]any, 0, len(pods))
+	for _, p := range pods {
+		rows = append(rows, map[string]any{
+			"cells": []any{p.name, "1/1", "Running", 0, "1d"},
+			"object": map[string]any{
+				"apiVersion": "meta.k8s.io/v1",
+				"kind":       "PartialObjectMetadata",
+				"metadata":   map[string]any{"name": p.name, "namespace": p.namespace},
+			},
+		})
+	}
+	body, _ := json.Marshal(map[string]any{
+		"apiVersion": "meta.k8s.io/v1",
+		"kind":       "Table",
+		"metadata":   map[string]any{"resourceVersion": "1"},
+		"columnDefinitions": []map[string]any{
+			{"name": "Name", "type": "string"},
+			{"name": "Ready", "type": "string"},
+			{"name": "Status", "type": "string"},
+			{"name": "Restarts", "type": "integer"},
+			{"name": "Age", "type": "date"},
+		},
+		"rows": rows,
+	})
+	return body
+}
+
+// TestHandler_FieldSelector_StoredTableWithPartialMetadata is the regression
+// test for the subtler half of the Table path. `kubectl get` without -o asks for
+// a Table, and a stored Table's rows carry metadata only — so evaluating
+// spec.nodeName against the row matches nothing regardless of its value, turning
+// the over-matching bug into an under-matching one. A real apiserver filters the
+// full objects and then projects, which is what the handler must reproduce.
+func TestHandler_FieldSelector_StoredTableWithPartialMetadata(t *testing.T) {
+	pods := []podSpec{
+		{name: "web-1", namespace: "demo", nodeName: "node-a", phase: "Running"},
+		{name: "web-2", namespace: "demo", nodeName: "node-b", phase: "Failed"},
+	}
+	store := buildTestStore(t, map[string][]byte{
+		"/api/v1/namespaces/demo/pods":          listWithPods(pods),
+		"/api/v1/namespaces/demo/pods?as=Table": partialMetadataTable(pods),
+	})
+	h := newHandler(store, time.Time{}, false)
+
+	for _, tc := range []struct {
+		query string
+		want  []string
+	}{
+		{"spec.nodeName=node-a", []string{"web-1"}},
+		{"spec.nodeName=node-b", []string{"web-2"}},
+		{"spec.nodeName=does-not-exist", nil},
+		{"status.phase=Failed", []string{"web-2"}},
+		// Metadata keys are present on the row objects, so they still filter
+		// through the ordinary row-matching path.
+		{"metadata.name=web-1", []string{"web-1"}},
+	} {
+		req := httptest.NewRequest(http.MethodGet, fsPodsPath+"?fieldSelector="+tc.query, nil)
+		req.Header.Set("Accept", "application/json;as=Table;v=v1;g=meta.k8s.io")
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+		if rw.Code != 200 {
+			t.Fatalf("[%s] status %d (body: %s)", tc.query, rw.Code, rw.Body.String())
+		}
+		got := tableRowNames(t, rw.Body.Bytes())
+		if !equalStrings(got, tc.want) {
+			t.Errorf("[%s] rows %v, want %v", tc.query, got, tc.want)
+		}
+	}
+}
+
+// tableRowNames extracts metadata.name from each row's embedded object.
+func tableRowNames(t *testing.T, body []byte) []string {
+	t.Helper()
+	var table struct {
+		Kind string `json:"kind"`
+		Rows []struct {
+			Object struct {
+				Metadata struct {
+					Name string `json:"name"`
+				} `json:"metadata"`
+			} `json:"object"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal(body, &table); err != nil {
+		t.Fatalf("decoding table: %v\nbody: %s", err, body)
+	}
+	if table.Kind != "Table" {
+		t.Fatalf("kind = %q, want Table", table.Kind)
+	}
+	var names []string
+	for _, r := range table.Rows {
+		names = append(names, r.Object.Metadata.Name)
+	}
+	return names
+}
+
+// TestHandler_FieldSelector_WatchFilters covers the watch path, which shares the
+// conversion with list upstream. An informer watching one node's pods must not
+// receive every pod.
+func TestHandler_FieldSelector_WatchFilters(t *testing.T) {
+	h := fieldSelectorTestStore(t)
+
+	names := watchInitialNames(t, h, fsPodsPath+"?watch=true&timeoutSeconds=1&fieldSelector=spec.nodeName=node-a")
+	if !equalStrings(names, []string{"web-1"}) {
+		t.Errorf("watch initial events = %v, want [web-1]", names)
+	}
+	names = watchInitialNames(t, h, fsPodsPath+"?watch=true&timeoutSeconds=1&fieldSelector=spec.nodeName=does-not-exist")
+	if len(names) != 0 {
+		t.Errorf("watch initial events = %v, want none", names)
+	}
+}
+
+// TestHandler_FieldSelector_WatchRejectsUnsupportedKey checks the watch path
+// returns the same 400 as the list path rather than streaming everything.
+func TestHandler_FieldSelector_WatchRejectsUnsupportedKey(t *testing.T) {
+	h := fieldSelectorTestStore(t)
+	req := httptest.NewRequest(http.MethodGet,
+		fsPodsPath+"?watch=true&timeoutSeconds=1&fieldSelector=spec.bogus=x", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+	if rw.Code != http.StatusBadRequest {
+		t.Errorf("watch with a bogus fieldSelector: status %d, want 400 (body: %s)",
+			rw.Code, rw.Body.String())
+	}
+	if !strings.Contains(rw.Body.String(), "field label not supported: spec.bogus") {
+		t.Errorf("watch 400 body = %s", rw.Body.String())
+	}
+}
+
+// TestOverlay_DeleteCollection_AcceptsPerKindFieldLabel is the write-path half
+// of #339. deletecollection used to 400 on spec.nodeName — a key a real
+// apiserver accepts for pods — so the two paths diverged from upstream in
+// opposite directions. It must now be accepted, and match by value.
+func TestOverlay_DeleteCollection_AcceptsPerKindFieldLabel(t *testing.T) {
+	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	clock, _ := newTestClock(t, from, from.Add(time.Minute), 1, false, false)
+	srv := newWritableServer(t, writableTestStore(t, from), clock) // captures pod-base
+
+	code, body := doReq(t, http.MethodDelete,
+		srv.URL+podsPath+"?fieldSelector=spec.nodeName%3Dnode-1", "", "")
+	if code != 200 {
+		t.Fatalf("deletecollection with spec.nodeName: status %d, want 200 (body: %s)", code, body)
+	}
+	// pod-base carries no spec.nodeName, so it reads as the empty string and
+	// does not match node-1 — accepted, and correctly matched nothing.
+	if code, _ := doReq(t, http.MethodGet, srv.URL+podsPath+"/pod-base", "", ""); code != 200 {
+		t.Errorf("pod-base should survive a non-matching fieldSelector: status %d", code)
+	}
+}
+
+// watchInitialNames collects the object names from a watch stream's initial
+// ADDED burst.
+func watchInitialNames(t *testing.T, h *handler, url string) []string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+	if rw.Code != 200 {
+		t.Fatalf("watch %s: status %d (body: %s)", url, rw.Code, rw.Body.String())
+	}
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(rw.Body.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var ev struct {
+			Type   string `json:"type"`
+			Object struct {
+				Metadata struct {
+					Name string `json:"name"`
+				} `json:"metadata"`
+			} `json:"object"`
+		}
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("decoding watch event %q: %v", line, err)
+		}
+		if ev.Type == "ADDED" {
+			names = append(names, ev.Object.Metadata.Name)
+		}
+	}
+	return names
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -445,7 +445,9 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 	//
 	// ok is false when a stored Table cannot be filtered faithfully, and the
 	// caller must fall back to a computed Table rather than serve rows the
-	// selector was never really applied to. That happens when the selector reads
+	// selector was never really applied to — either because the JSON list did
+	// not reconstruct, or because an item's identity would not decode, leaving
+	// no way to correlate it with a row. That happens when the selector reads
 	// spec or status: a stored Table's rows embed PartialObjectMetadata, so those
 	// fields simply are not there, and evaluating against the row would match
 	// nothing regardless of the value. A real apiserver filters full objects and

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -344,7 +344,7 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 				return
 			}
 			if clusterCode == 200 {
-				filtered, ferr := kstore.ApplySelectors(clusterBody, "", "metadata.namespace="+ns)
+				filtered, ferr := kstore.ApplySelectors(clusterBody, "", kstore.NamespaceScopeSelector(ns))
 				if ferr == nil {
 					body, code = filtered, 200
 				}
@@ -402,9 +402,27 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		}
 	}
 
-	// Apply label/field selectors if present.
+	// Apply label/field selectors if present. The field selector is validated
+	// against the kind's field-label contract before anything is filtered: an
+	// unsupported label is a 400 on a read exactly as on a deletecollection,
+	// which is what a real apiserver does (the conversion runs in the generic
+	// handler, shared by list, watch and delete). Silently ignoring it would
+	// serve every item as if the selector had matched everything.
+	//
+	// Skipped for an item-level GET, where ParseAPIPath yields no resource: a
+	// single-object GET takes GetOptions, which has no field selector, so
+	// upstream ignores the parameter rather than rejecting it.
 	labelSel := r.URL.Query().Get("labelSelector")
-	fieldSel := r.URL.Query().Get("fieldSelector")
+	selGroup, _, selResource, _ := kstore.ParseAPIPath(strings.TrimSuffix(path, "/"))
+	var fieldSel *kstore.FieldSelector
+	if selResource != "" {
+		var fsErr error
+		fieldSel, fsErr = kstore.ParseFieldSelector(selGroup, selResource, r.URL.Query().Get("fieldSelector"))
+		if fsErr != nil {
+			h.writeStatus(w, http.StatusBadRequest, fsErr.Error())
+			return
+		}
+	}
 	body, err = kstore.ApplySelectors(body, labelSel, fieldSel)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, statusObj(500, err.Error()))
@@ -424,14 +442,34 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 	// tableFiltered applies label/field selectors to a stored Table-format body,
 	// removing rows whose embedded object does not match. Returns tb unchanged
 	// when selectors are empty or if filtering fails (best-effort).
-	tableFiltered := func(tb []byte) []byte {
-		if labelSel == "" && fieldSel == "" {
-			return tb
+	//
+	// ok is false when a stored Table cannot be filtered faithfully, and the
+	// caller must fall back to a computed Table rather than serve rows the
+	// selector was never really applied to. That happens when the selector reads
+	// spec or status: a stored Table's rows embed PartialObjectMetadata, so those
+	// fields simply are not there, and evaluating against the row would match
+	// nothing regardless of the value. A real apiserver filters full objects and
+	// then projects to Table, so we intersect with the identities that survived
+	// on the JSON list — which was filtered with the full objects above (#339).
+	tableFiltered := func(tb []byte) ([]byte, bool) {
+		if labelSel == "" && fieldSel == nil {
+			return tb, true
+		}
+		if fieldSel.NeedsFullObject() {
+			allow, ok := kstore.ListIdentities(body)
+			if !ok {
+				return nil, false
+			}
+			out, ferr := kstore.FilterTableRowsToIdentities(tb, allow)
+			if ferr != nil {
+				return nil, false
+			}
+			return out, true
 		}
 		if out, ferr := kstore.FilterTableRows(tb, labelSel, fieldSel); ferr == nil {
-			return out
+			return out, true
 		}
-		return tb
+		return tb, true
 	}
 
 	// If kubectl requests Table format, try the captured Table response first
@@ -442,10 +480,13 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		// mode so the Table reflects overlay writes (built from the merged body
 		// below) rather than the captured-only stored Table.
 		if tb, tbCode, _ := h.store.Latest(path+"?as=Table", at); tbCode == 200 && h.overlay == nil {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(200)
-			_, _ = w.Write(tableFiltered(tb))
-			return
+			if out, ok := tableFiltered(tb); ok {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(200)
+				_, _ = w.Write(out)
+				return
+			}
+			// Fall through to the computed Table, built from the filtered list.
 		}
 		// Single-item GET: extract the matching row from the parent list's Table.
 		// Selectors on single-item GETs are resolved by name, not labels — no
@@ -465,10 +506,13 @@ func (h *handler) serveResource(w http.ResponseWriter, r *http.Request, path str
 		// Also bypassed in writable mode (see above).
 		if _, _, _, reqNS := kstore.ParseAPIPath(path); reqNS == "" && h.overlay == nil {
 			if tb, tbCode, _ := h.store.AggregateTableAcrossNamespaces(path, at); tbCode == 200 {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(200)
-				_, _ = w.Write(tableFiltered(tb))
-				return
+				if out, ok := tableFiltered(tb); ok {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(200)
+					_, _ = w.Write(out)
+					return
+				}
+				// Fall through to the computed Table, built from the filtered list.
 			}
 		}
 		// Compute a Table for objects not covered by a captured Table (writable
@@ -559,7 +603,7 @@ func (h *handler) trySingleItemGet(path string, at time.Time) ([]byte, int) {
 			clusterBody, clusterCode, cerr := h.store.ReconstructAt(clusterParent, at)
 			if cerr == nil && clusterCode == 200 {
 				// Filter to the requested namespace before doing the name lookup.
-				filtered, ferr := kstore.ApplySelectors(clusterBody, "", "metadata.namespace="+ns)
+				filtered, ferr := kstore.ApplySelectors(clusterBody, "", kstore.NamespaceScopeSelector(ns))
 				if ferr == nil {
 					body, code = filtered, 200
 				}
@@ -613,7 +657,16 @@ func (h *handler) trySingleItemGet(path string, at time.Time) ([]byte, int) {
 
 func (h *handler) handleWatch(w http.ResponseWriter, r *http.Request, path string, at time.Time) {
 	watchPath := strings.TrimSuffix(path, "/")
-	list, ok, err := h.resolveWatchList(watchPath, at, r.URL.Query().Get("labelSelector"), r.URL.Query().Get("fieldSelector"))
+	// Same per-kind field-label validation as the list path — a watch and a list
+	// share the conversion upstream, so an unsupported label is a 400 here too
+	// rather than a stream of everything (#339).
+	selGroup, _, selResource, _ := kstore.ParseAPIPath(watchPath)
+	fieldSel, fsErr := kstore.ParseFieldSelector(selGroup, selResource, r.URL.Query().Get("fieldSelector"))
+	if fsErr != nil {
+		h.writeStatus(w, http.StatusBadRequest, fsErr.Error())
+		return
+	}
+	list, ok, err := h.resolveWatchList(watchPath, at, r.URL.Query().Get("labelSelector"), fieldSel)
 	if err != nil {
 		h.writeStatus(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/server/teststore_test.go
+++ b/internal/server/teststore_test.go
@@ -79,6 +79,11 @@ type podSpec struct {
 	name      string
 	namespace string
 	labels    map[string]string
+	// nodeName and phase populate spec.nodeName and status.phase, the fields
+	// the per-kind pod field selectors read. Both are omitted from the built
+	// object when empty, so existing callers get the same body as before.
+	nodeName string
+	phase    string
 }
 
 // listWithPods builds a PodList body from pods, defaulting an empty namespace
@@ -91,7 +96,7 @@ func listWithPods(pods []podSpec) []byte {
 		if ns == "" {
 			ns = "default"
 		}
-		items = append(items, map[string]any{
+		item := map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Pod",
 			"metadata": map[string]any{
@@ -99,7 +104,14 @@ func listWithPods(pods []podSpec) []byte {
 				"namespace": ns,
 				"labels":    p.labels,
 			},
-		})
+		}
+		if p.nodeName != "" {
+			item["spec"] = map[string]any{"nodeName": p.nodeName}
+		}
+		if p.phase != "" {
+			item["status"] = map[string]any{"phase": p.phase}
+		}
+		items = append(items, item)
 	}
 	body, _ := json.Marshal(map[string]any{
 		"apiVersion": "v1",

--- a/internal/server/watch_replay.go
+++ b/internal/server/watch_replay.go
@@ -34,7 +34,7 @@ type watchList struct {
 // cluster-scoped namespace filtering, empty-list synthesis), then applies label
 // and field selectors. ok is false only when the resource can't be resolved at
 // all; err is non-nil only for internal reconstruction failures.
-func (h *handler) resolveWatchList(watchPath string, at time.Time, labelSelector, fieldSelector string) (watchList, bool, error) {
+func (h *handler) resolveWatchList(watchPath string, at time.Time, labelSelector string, fieldSel *kstore.FieldSelector) (watchList, bool, error) {
 	rawBody, code, err := h.store.ReconstructAt(watchPath, at)
 	if err != nil {
 		return watchList{}, false, err
@@ -64,7 +64,7 @@ func (h *handler) resolveWatchList(watchPath string, at time.Time, labelSelector
 			}
 			clusterBody, clusterCode, cerr := h.store.ReconstructAt(clusterPath, at)
 			if cerr == nil && clusterCode == 200 {
-				filtered, ferr := kstore.ApplySelectors(clusterBody, "", "metadata.namespace="+ns)
+				filtered, ferr := kstore.ApplySelectors(clusterBody, "", kstore.NamespaceScopeSelector(ns))
 				if ferr == nil {
 					rawBody, code = filtered, 200
 				}
@@ -103,7 +103,7 @@ func (h *handler) resolveWatchList(watchPath string, at time.Time, labelSelector
 		rawBody, overlaySkipRV = h.mergeOverlayList(watchPath, rawBody)
 	}
 
-	body, serr := kstore.ApplySelectors(rawBody, labelSelector, fieldSelector)
+	body, serr := kstore.ApplySelectors(rawBody, labelSelector, fieldSel)
 	if serr != nil {
 		// Best-effort: fall back to the unfiltered list rather than failing the
 		// whole watch on a selector/marshal error.
@@ -143,22 +143,23 @@ type replayEvent struct {
 }
 
 // matchesSelectors reports whether a single object satisfies the label and
-// field selectors. An empty selector matches everything; a malformed selector
-// or unparseable object is treated as a match (best-effort, never hides data).
-func matchesSelectors(raw json.RawMessage, labelSelector, fieldSelector string) bool {
-	if labelSelector == "" && fieldSelector == "" {
+// field selectors. An empty selector matches everything; a malformed label
+// selector or unparseable object is treated as a match (best-effort, never
+// hides data). fieldSel is already validated per-kind by the watch handler,
+// which 400s an unsupported label before streaming anything.
+func matchesSelectors(raw json.RawMessage, labelSelector string, fieldSel *kstore.FieldSelector) bool {
+	if labelSelector == "" && fieldSel == nil {
 		return true
 	}
 	labelReqs, err := kstore.ParseRequirements(labelSelector)
 	if err != nil {
 		return true
 	}
-	fieldReqs := kstore.ParseFieldSelector(fieldSelector)
 	var obj kstore.K8sObject
 	if err := json.Unmarshal(raw, &obj); err != nil {
 		return true
 	}
-	return kstore.MatchesLabels(&obj, labelReqs) && kstore.MatchesFields(&obj, fieldReqs)
+	return kstore.MatchesLabels(&obj, labelReqs) && fieldSel.Matches(raw, &obj)
 }
 
 // withKind stamps apiVersion/kind onto a watch event object when they're absent,
@@ -214,7 +215,16 @@ func (h *handler) streamReplayWatch(w http.ResponseWriter, r *http.Request, path
 	clock := h.clock
 	watchPath := strings.TrimSuffix(path, "/")
 	labelSel := r.URL.Query().Get("labelSelector")
-	fieldSel := r.URL.Query().Get("fieldSelector")
+	// Validate the field selector against the kind's field-label contract before
+	// streaming anything: upstream runs the same conversion for a watch as for a
+	// list, so an unsupported label is a 400 here too rather than a stream of
+	// every object (#339).
+	selGroup, _, selResource, _ := kstore.ParseAPIPath(watchPath)
+	fieldSel, fsErr := kstore.ParseFieldSelector(selGroup, selResource, r.URL.Query().Get("fieldSelector"))
+	if fsErr != nil {
+		h.writeStatus(w, http.StatusBadRequest, fsErr.Error())
+		return
+	}
 	// WatchList (client-go 1.32+): the initial-list burst must be terminated by
 	// a BOOKMARK carrying the k8s.io/initial-events-end annotation, or informers
 	// never complete their initial sync.
@@ -620,7 +630,7 @@ func sleepInterruptible(ctx context.Context, timer <-chan time.Time, d time.Dura
 // loops past `epoch` (passLooped) or is seeked past `seekGen` (passSeeked), or
 // the request is canceled/times out (passCanceled). Each emitted object carries
 // its own monotonic rv so clients can resume coherently.
-func (h *handler) replayPass(ctx context.Context, timer <-chan time.Time, clock *ReplayClock, timeline []replayEvent, minRV int64, epoch, seekGen int, labelSel, fieldSel string, emit func(string, json.RawMessage) bool) passResult {
+func (h *handler) replayPass(ctx context.Context, timer <-chan time.Time, clock *ReplayClock, timeline []replayEvent, minRV int64, epoch, seekGen int, labelSel string, fieldSel *kstore.FieldSelector, emit func(string, json.RawMessage) bool) passResult {
 	for _, ev := range timeline {
 		if ev.rv <= minRV {
 			continue

--- a/internal/server/writes.go
+++ b/internal/server/writes.go
@@ -427,13 +427,23 @@ func (h *handler) overlayDeleteCollection(w http.ResponseWriter, r *http.Request
 		writeJSON(w, http.StatusInternalServerError, statusObj(http.StatusInternalServerError, err.Error()))
 		return
 	}
-	// Unlike a read (kstore.ApplySelectors/kstore.FilterItems, deliberately best-effort — a
-	// malformed selector there just means "show more than intended"), a
-	// malformed or unsupported selector here would mean "delete more than
-	// intended" — kstore.FilterItemsStrict parses with apimachinery's real selector
-	// grammar and 400s on anything malformed, rather than silently matching
-	// everything.
-	msg, filtered := kstore.FilterItemsStrict(items, r.URL.Query().Get("labelSelector"), r.URL.Query().Get("fieldSelector"))
+	// Field-label validation is shared with the read path now (kstore.ParseFieldSelector
+	// applies the kind's real per-kind contract, so spec.nodeName is accepted for
+	// pods here just as it is on a list). What stays stricter on this path is
+	// label parsing and the refusal of a selector that parses to zero
+	// requirements: on a read that only means "show more than intended", but
+	// here it would mean "delete more than intended".
+	//
+	// Note that kubectl's `delete --field-selector` does not reach this handler
+	// at all — it lists first and then deletes by name — so the read path's
+	// validation is what actually protects that flow (#339).
+	fieldSelRaw := r.URL.Query().Get("fieldSelector")
+	fieldSel, fsErr := kstore.ParseFieldSelector(group, resource, fieldSelRaw)
+	if fsErr != nil {
+		h.writeStatus(w, http.StatusBadRequest, fsErr.Error())
+		return
+	}
+	msg, filtered := kstore.FilterItemsStrict(items, r.URL.Query().Get("labelSelector"), fieldSelRaw, fieldSel)
 	if msg != "" {
 		h.writeStatus(w, http.StatusBadRequest, msg)
 		return

--- a/internal/server/writes_test.go
+++ b/internal/server/writes_test.go
@@ -1964,12 +1964,13 @@ func TestOverlay_DeleteCollection_AggregateAcrossNamespacesFallback(t *testing.T
 }
 
 // TestOverlay_DeleteCollection_InvalidSelectorRejected verifies deletecollection
-// rejects a malformed or unsupported labelSelector/fieldSelector with 400
-// (kstore.FilterItemsStrict, backed by k8s.io/apimachinery's labels.Parse and
-// fields.ParseSelector) rather than the read path's best-effort leniency
-// (kstore.FilterItems/kstore.ApplySelectors) — which for a mutating deletecollection would
-// mean "delete more than the caller asked for," not just "display more than
-// intended."
+// rejects a malformed or unsupported labelSelector/fieldSelector with 400.
+// Field labels are validated per-kind by kstore.ParseFieldSelector (shared with
+// the read path, since upstream runs the same conversion for both); label
+// selectors and selectors that restrict nothing are rejected by
+// kstore.FilterItemsStrict, which is stricter than the read path's best-effort
+// leniency because for a mutating deletecollection "matches more than intended"
+// means "delete more than the caller asked for."
 func TestOverlay_DeleteCollection_InvalidSelectorRejected(t *testing.T) {
 	from := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
 
@@ -1977,7 +1978,12 @@ func TestOverlay_DeleteCollection_InvalidSelectorRejected(t *testing.T) {
 		name  string
 		query string
 	}{
-		{"unsupported fieldSelector key", "?fieldSelector=spec.nodeName%3Dnode-1"},
+		// A key no kind accepts. spec.nodeName is deliberately *not* here: a
+		// real apiserver accepts it for pods, and rejecting it was its own
+		// divergence (#339) — see the accepted-key assertion below.
+		{"unsupported fieldSelector key", "?fieldSelector=spec.bogus%3Dx"},
+		// Accepted for pods, but not for this kind.
+		{"field label from another kind", "?fieldSelector=spec.unschedulable%3Dtrue"},
 		// A bare "!" isn't a valid requirement (! must be followed by a key).
 		{"bare negation, no key", "?labelSelector=%21"},
 		// labels.Parse rejects a stray comma outright.

--- a/internal/store/fieldselector.go
+++ b/internal/store/fieldselector.go
@@ -339,15 +339,35 @@ func rulesFor(group, resource string) fieldLabelRules {
 	return metadataOnlyRules
 }
 
+// decodeMode says what Matches needs in order to evaluate the selector.
+type decodeMode uint8
+
+const (
+	// decodeFromObject: every requirement resolves from an already-decoded
+	// K8sObject — metadata.name/namespace, any spec.* or status.* path (both are
+	// map[string]any on the struct), and accepted-but-not-selectable labels,
+	// which resolve to "" whatever the source. No second unmarshal needed.
+	decodeFromObject decodeMode = iota
+	// decodeFromRaw: at least one requirement reads a field outside
+	// metadata/spec/status, so the whole object has to be decoded. Events
+	// (involvedObject.*/regarding.*/reason/type/source/reportingComponent) and
+	// Secrets (top-level type) are the kinds that land here.
+	decodeFromRaw
+)
+
 // FieldSelector is a parsed, per-kind-validated fieldSelector. A nil
 // *FieldSelector matches everything, so callers can pass one through unchecked.
 type FieldSelector struct {
 	sel   fields.Selector
 	rules fieldLabelRules
 	// metadataOnly is true when every requirement reads metadata.name or
-	// metadata.namespace, which lets Matches answer from the already-decoded
-	// K8sObject instead of unmarshaling the object a second time.
+	// metadata.namespace — i.e. when the selector can be evaluated against a
+	// PartialObjectMetadata, which is what a Table row carries. Distinct from
+	// mode: a spec.nodeName selector needs no second unmarshal (mode is
+	// decodeFromObject) but still cannot be answered from a Table row.
 	metadataOnly bool
+	// mode is how Matches gets at the values. See decodeMode.
+	mode decodeMode
 }
 
 // ParseFieldSelector parses and validates a client-supplied fieldSelector for
@@ -383,12 +403,21 @@ func ParseFieldSelector(group, resource, selector string) (*FieldSelector, error
 	if err != nil {
 		return nil, err
 	}
-	fs := &FieldSelector{sel: transformed, rules: rules, metadataOnly: true}
+	fs := &FieldSelector{sel: transformed, rules: rules, metadataOnly: true, mode: decodeFromObject}
 	for _, req := range transformed.Requirements() {
 		p, ok := rules.selectable[req.Field]
-		if !ok || (p.path != "metadata.name" && p.path != "metadata.namespace") {
+		if !ok {
+			// Accepted but never set by ToSelectableFields: resolves to "" from
+			// any source, so it needs no raw decode — but it is not a metadata
+			// field either, so a Table row cannot answer it.
 			fs.metadataOnly = false
-			break
+			continue
+		}
+		if p.path != "metadata.name" && p.path != "metadata.namespace" {
+			fs.metadataOnly = false
+		}
+		if !resolvableFromObject(p) {
+			fs.mode = decodeFromRaw
 		}
 	}
 	return fs, nil
@@ -440,7 +469,13 @@ func (fs *FieldSelector) Matches(raw json.RawMessage, obj *K8sObject) bool {
 	if fs == nil {
 		return true
 	}
-	if fs.metadataOnly && obj != nil {
+	// Prefer the caller's already-decoded object. K8sObject carries Spec and
+	// Status as map[string]any, so every metadata/spec/status path resolves from
+	// it — which is most selectors in practice, spec.nodeName and status.phase
+	// among them. Decoding the object a second time to reach the same values
+	// costs about half again the wall time and better than twice the allocations
+	// on a large list.
+	if fs.mode == decodeFromObject && obj != nil {
 		return fs.sel.Matches(fieldsAdapter{rules: fs.rules, obj: obj})
 	}
 	var m map[string]any
@@ -448,6 +483,21 @@ func (fs *FieldSelector) Matches(raw json.RawMessage, obj *K8sObject) bool {
 		return true
 	}
 	return fs.sel.Matches(fieldsAdapter{rules: fs.rules, m: m})
+}
+
+// resolvableFromObject reports whether a path can be read off a decoded
+// K8sObject rather than the whole object. Its fallback (only core Events'
+// "source") has to be reachable too, or the fallback would silently read empty.
+func resolvableFromObject(p selectablePath) bool {
+	if !pathUnderStruct(p.path) {
+		return false
+	}
+	return p.fallback == "" || pathUnderStruct(p.fallback)
+}
+
+func pathUnderStruct(path string) bool {
+	return path == "metadata.name" || path == "metadata.namespace" ||
+		strings.HasPrefix(path, "spec.") || strings.HasPrefix(path, "status.")
 }
 
 // fieldsAdapter exposes an object's selectable fields as fields.Fields, so
@@ -473,15 +523,6 @@ func (f fieldsAdapter) Get(label string) string {
 	if !ok {
 		return ""
 	}
-	if f.obj != nil {
-		switch p.path {
-		case "metadata.name":
-			return f.obj.Metadata.Name
-		case "metadata.namespace":
-			return f.obj.Metadata.Namespace
-		}
-		return ""
-	}
 	v := f.valueAt(p.path, p.kind)
 	if v == "" && p.fallback != "" {
 		v = f.valueAt(p.fallback, p.kind)
@@ -490,11 +531,37 @@ func (f fieldsAdapter) Get(label string) string {
 }
 
 func (f fieldsAdapter) valueAt(path string, kind valueKind) string {
-	v, ok := lookupPath(f.m, path)
+	var (
+		v  any
+		ok bool
+	)
+	if f.obj != nil {
+		v, ok = f.lookupInObject(path)
+	} else {
+		v, ok = lookupPath(f.m, path)
+	}
 	if !ok {
 		return zeroFieldValue(kind)
 	}
 	return stringifyFieldValue(v, kind)
+}
+
+// lookupInObject resolves a path against the decoded K8sObject. Only the paths
+// resolvableFromObject accepts reach here, so anything else is a programming
+// error rather than a missing field — it reports not-found, which reads as the
+// zero value, the same answer a genuinely absent field gives.
+func (f fieldsAdapter) lookupInObject(path string) (any, bool) {
+	switch {
+	case path == "metadata.name":
+		return f.obj.Metadata.Name, true
+	case path == "metadata.namespace":
+		return f.obj.Metadata.Namespace, true
+	case strings.HasPrefix(path, "spec."):
+		return lookupPath(f.obj.Spec, strings.TrimPrefix(path, "spec."))
+	case strings.HasPrefix(path, "status."):
+		return lookupPath(f.obj.Status, strings.TrimPrefix(path, "status."))
+	}
+	return nil, false
 }
 
 // lookupPath walks a dotted path through a decoded JSON object. None of

--- a/internal/store/fieldselector.go
+++ b/internal/store/fieldselector.go
@@ -72,7 +72,10 @@ type selectablePath struct {
 	path string
 	// fallback supplies the value when path resolves to the empty string.
 	// Mirrors core/v1 Events' "source", which upstream computes as
-	// event.Source.Component falling back to event.ReportingController.
+	// event.Source.Component falling back to event.ReportingController. Both
+	// fields are named differently on the wire than on the internal type, so
+	// the paths here are source.component and reportingComponent respectively —
+	// the same two fields, spelled as the v1 serialization spells them.
 	fallback string
 	kind     valueKind
 }
@@ -539,8 +542,13 @@ func stringifyFieldValue(v any, kind valueKind) string {
 		return strconv.FormatBool(t)
 	case float64:
 		// Counts arrive as float64 from encoding/json; upstream stringifies them
-		// with strconv.Itoa, so keep integral values integral.
-		if !math.IsInf(t, 0) && !math.IsNaN(t) && t == math.Trunc(t) {
+		// with strconv.Itoa, so keep integral values integral. The range check
+		// is load-bearing: converting an out-of-range float64 to int64 is
+		// undefined in Go, and archive content is not trusted to hold only
+		// plausible counts. math.MaxInt64 rounds up to 2^63 as a float64, so the
+		// bound is deliberately exclusive.
+		if !math.IsInf(t, 0) && !math.IsNaN(t) && t == math.Trunc(t) &&
+			t >= math.MinInt64 && t < math.MaxInt64 {
 			return strconv.FormatInt(int64(t), 10)
 		}
 		return strconv.FormatFloat(t, 'f', -1, 64)

--- a/internal/store/fieldselector.go
+++ b/internal/store/fieldselector.go
@@ -1,0 +1,553 @@
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/fields"
+)
+
+// Field selectors, as the apiserver actually implements them.
+//
+// kubectl contributes nothing here: cli-runtime's Builder.FieldSelectorParam
+// trims the string, rejects a conflict with --all, and forwards it as
+// ?fieldSelector=. It holds no per-kind table, so every guarantee a client
+// expects — the 400 on a bad key, the per-kind key set — is owed by the server,
+// which for a replay is us.
+//
+// The apiserver evaluates a selector in two *independent* layers, and this file
+// mirrors both:
+//
+//  1. Validation and aliasing — Scheme.ConvertFieldLabel(gvk, label, value),
+//     backed by the per-kind funcs registered with AddFieldLabelConversionFunc
+//     in k8s.io/kubernetes/pkg/apis/<group>/<version>/conversion.go. The
+//     generic endpoint handler runs every requirement through it via
+//     fields.Selector.Transform and turns a rejection into a 400 — identically
+//     for LIST, WATCH and DELETECOLLECTION. A kind with no registered func
+//     falls back to runtime.DefaultMetaV1FieldSelectorConversion, which accepts
+//     only metadata.name and metadata.namespace; that fallback is why a custom
+//     resource rejects everything else.
+//
+//  2. Matching — the registry strategy's ToSelectableFields
+//     (k8s.io/kubernetes/pkg/registry/.../strategy.go), which projects the
+//     object into a fields.Set the selector is then matched against.
+//
+// The two lists are not the same, so collapsing them into one table would be
+// wrong in both directions. Pods accept status.podIPs (layer 1) but
+// PodToSelectableFields never sets it (layer 2), so upstream accepts
+// status.podIPs=10.0.0.1 and then matches nothing, because fields.Set.Get
+// returns "" for a key that was never set. Meanwhile spec.host is accepted only
+// as a legacy alias, rewritten to spec.nodeName before matching. Keeping
+// acceptance and selectability separate reproduces both behaviors exactly.
+//
+// These tables are hand-maintained because there is nothing to reflect over:
+// the registrations live in k8s.io/kubernetes's internal API packages, which
+// are not reachable from k8s.io/api or client-go. Two mechanisms detect drift —
+// the conformance differential exercises fieldSelector queries against a live
+// apiserver, and scripts/fieldselector_drift.py diffs these tables against
+// upstream source. See docs/conformance.md.
+
+// valueKind says how to stringify a resolved JSON value and, more importantly,
+// what an *absent* key resolves to. ToSelectableFields always sets every
+// selectable key, so an unset bool reads "false" and an unset count reads "0" —
+// never "".
+type valueKind uint8
+
+const (
+	valueString valueKind = iota
+	valueBool
+	valueInt
+)
+
+// selectablePath locates one canonical label's value in the serialized object.
+type selectablePath struct {
+	// path is a dotted path into the object as served over the wire, which is
+	// not always the label: Job's status.successful reads status.succeeded, and
+	// an events.k8s.io/v1 Event carries regarding.* where the canonical label
+	// says involvedObject.*.
+	path string
+	// fallback supplies the value when path resolves to the empty string.
+	// Mirrors core/v1 Events' "source", which upstream computes as
+	// event.Source.Component falling back to event.ReportingController.
+	fallback string
+	kind     valueKind
+}
+
+// kindSpec transcribes one kind's two upstream lists. Deliberately verbose and
+// literal so a reviewer can diff it against the upstream files named above.
+type kindSpec struct {
+	// namespaced mirrors the generic.ObjectMetaFieldsSet(_, namespaced)
+	// argument in the kind's ToSelectableFields. Cluster-scoped kinds (Node,
+	// Namespace, CertificateSigningRequest) neither accept nor select
+	// metadata.namespace — `kubectl get nodes --field-selector
+	// metadata.namespace=x` is a 400 upstream, not an empty result.
+	namespaced bool
+	// accepted are the labels the conversion func takes unchanged, beyond the
+	// metadata keys implied by namespaced.
+	accepted []string
+	// aliases are labels the conversion func takes and rewrites, mapping the
+	// client's spelling to the canonical label: legacy (pods' spec.host) or
+	// version-specific (events.k8s.io/v1's regarding.*).
+	aliases map[string]string
+	// selectable maps a *canonical* label to where its value lives. A canonical
+	// label that is accepted but missing here resolves to "" — upstream's
+	// behavior for a key ToSelectableFields never sets.
+	selectable map[string]selectablePath
+	// rejectf overrides the 400 message for an unaccepted label. Upstream's
+	// text is per-kind and inconsistent; batch/v1 Job is the odd one out.
+	rejectf func(label string) string
+}
+
+// groupResource keys the table by API group and plural resource, since that is
+// what the request path yields. Upstream keys by GroupVersionKind, but the
+// group/resource mapping is stable and no kind's field-label contract varies
+// across the versions we serve — except Events, whose two API groups differ
+// enough that they get separate entries.
+type groupResource struct {
+	group    string
+	resource string
+}
+
+// fieldSelectorKinds transcribes upstream's per-kind field-label contracts.
+// Every entry is sourced from a pair of upstream files: the conversion func for
+// `accepted`/`aliases`, the registry strategy for `selectable`. A resource
+// absent here gets metadataOnlyRules, matching upstream's fallback for any kind
+// with no registered conversion func — including every custom resource and, as
+// it happens, everything in the apps group (apps/v1 registers none, so a
+// Deployment or ReplicaSet really does reject status.replicas).
+var fieldSelectorKinds = map[groupResource]kindSpec{
+	// pkg/apis/core/v1/conversion.go + pkg/registry/core/pod/strategy.go
+	{"", "pods"}: {
+		namespaced: true,
+		accepted: []string{
+			"spec.nodeName", "spec.restartPolicy", "spec.schedulerName",
+			"spec.serviceAccountName", "spec.hostNetwork", "status.phase",
+			"status.podIP", "status.podIPs", "status.nominatedNodeName",
+		},
+		aliases: map[string]string{"spec.host": "spec.nodeName"},
+		selectable: map[string]selectablePath{
+			"spec.nodeName":           {path: "spec.nodeName"},
+			"spec.restartPolicy":      {path: "spec.restartPolicy"},
+			"spec.schedulerName":      {path: "spec.schedulerName"},
+			"spec.serviceAccountName": {path: "spec.serviceAccountName"},
+			// Upstream reads Spec.SecurityContext.HostNetwork on the internal
+			// type; the v1 wire format carries it at spec.hostNetwork.
+			"spec.hostNetwork": {path: "spec.hostNetwork", kind: valueBool},
+			"status.phase":     {path: "status.phase"},
+			// Upstream reads Status.PodIPs[0].IP; the serialized object carries
+			// the equivalent scalar, which the apiserver keeps in sync.
+			"status.podIP":             {path: "status.podIP"},
+			"status.nominatedNodeName": {path: "status.nominatedNodeName"},
+			// status.podIPs is intentionally absent: accepted by the conversion
+			// func, never set by PodToSelectableFields.
+		},
+	},
+	// pkg/apis/core/v1/conversion.go + pkg/registry/core/node/strategy.go
+	{"", "nodes"}: {
+		accepted: []string{"spec.unschedulable"},
+		selectable: map[string]selectablePath{
+			"spec.unschedulable": {path: "spec.unschedulable", kind: valueBool},
+		},
+	},
+	// pkg/apis/core/v1/conversion.go + pkg/registry/core/namespace/strategy.go
+	{"", "namespaces"}: {
+		accepted: []string{"status.phase"},
+		selectable: map[string]selectablePath{
+			"status.phase": {path: "status.phase"},
+			// NamespaceToSelectableFields also sets a bare "name" key, kept
+			// upstream for backward compatibility. It is unreachable: the
+			// conversion func does not accept "name", so no request can select
+			// on it. Omitted deliberately.
+		},
+	},
+	// pkg/apis/core/v1/conversion.go + pkg/registry/core/secret/strategy.go
+	{"", "secrets"}: {
+		namespaced: true,
+		accepted:   []string{"type"},
+		selectable: map[string]selectablePath{"type": {path: "type"}},
+	},
+	// pkg/apis/core/v1/conversion.go + pkg/registry/core/service/strategy.go
+	{"", "services"}: {
+		namespaced: true,
+		accepted:   []string{"spec.clusterIP", "spec.type"},
+		selectable: map[string]selectablePath{
+			"spec.clusterIP": {path: "spec.clusterIP"},
+			"spec.type":      {path: "spec.type"},
+		},
+	},
+	// pkg/apis/core/v1/conversion.go
+	// + pkg/registry/core/replicationcontroller/strategy.go
+	{"", "replicationcontrollers"}: {
+		namespaced: true,
+		accepted:   []string{"status.replicas"},
+		selectable: map[string]selectablePath{
+			"status.replicas": {path: "status.replicas", kind: valueInt},
+		},
+	},
+	// pkg/apis/core/v1/conversion.go + pkg/registry/core/event/strategy.go
+	{"", "events"}: {
+		namespaced: true,
+		accepted: []string{
+			"involvedObject.kind", "involvedObject.namespace", "involvedObject.name",
+			"involvedObject.uid", "involvedObject.apiVersion",
+			"involvedObject.resourceVersion", "involvedObject.fieldPath",
+			"reason", "reportingComponent", "source", "type",
+		},
+		selectable: map[string]selectablePath{
+			"involvedObject.kind":            {path: "involvedObject.kind"},
+			"involvedObject.namespace":       {path: "involvedObject.namespace"},
+			"involvedObject.name":            {path: "involvedObject.name"},
+			"involvedObject.uid":             {path: "involvedObject.uid"},
+			"involvedObject.apiVersion":      {path: "involvedObject.apiVersion"},
+			"involvedObject.resourceVersion": {path: "involvedObject.resourceVersion"},
+			"involvedObject.fieldPath":       {path: "involvedObject.fieldPath"},
+			"reason":                         {path: "reason"},
+			"reportingComponent":             {path: "reportingComponent"},
+			"source":                         {path: "source.component", fallback: "reportingComponent"},
+			"type":                           {path: "type"},
+		},
+	},
+	// pkg/apis/events/v1/conversion.go + pkg/registry/core/event/strategy.go.
+	// events.k8s.io/v1 shares the core Event storage, so the canonical labels
+	// are the core ones — but the wire format uses regarding.* and
+	// reportingController, and the core spellings are *not* accepted here.
+	{"events.k8s.io", "events"}: {
+		namespaced: true,
+		accepted:   []string{"reason", "type"},
+		aliases: map[string]string{
+			"regarding.kind":            "involvedObject.kind",
+			"regarding.namespace":       "involvedObject.namespace",
+			"regarding.name":            "involvedObject.name",
+			"regarding.uid":             "involvedObject.uid",
+			"regarding.apiVersion":      "involvedObject.apiVersion",
+			"regarding.resourceVersion": "involvedObject.resourceVersion",
+			"regarding.fieldPath":       "involvedObject.fieldPath",
+			"reportingController":       "reportingComponent",
+		},
+		selectable: map[string]selectablePath{
+			"involvedObject.kind":            {path: "regarding.kind"},
+			"involvedObject.namespace":       {path: "regarding.namespace"},
+			"involvedObject.name":            {path: "regarding.name"},
+			"involvedObject.uid":             {path: "regarding.uid"},
+			"involvedObject.apiVersion":      {path: "regarding.apiVersion"},
+			"involvedObject.resourceVersion": {path: "regarding.resourceVersion"},
+			"involvedObject.fieldPath":       {path: "regarding.fieldPath"},
+			"reason":                         {path: "reason"},
+			"reportingComponent":             {path: "reportingController"},
+			"type":                           {path: "type"},
+		},
+	},
+	// pkg/apis/batch/v1/conversion.go + pkg/registry/batch/job/strategy.go
+	{"batch", "jobs"}: {
+		namespaced: true,
+		accepted:   []string{"status.successful"},
+		selectable: map[string]selectablePath{
+			// The label and the field differ: upstream reads Status.Succeeded.
+			"status.successful": {path: "status.succeeded", kind: valueInt},
+		},
+		rejectf: func(label string) string {
+			return fmt.Sprintf("field label %q not supported for Job", label)
+		},
+	},
+	// pkg/apis/certificates/v1/conversion.go
+	// + pkg/registry/certificates/certificates/strategy.go
+	{"certificates.k8s.io", "certificatesigningrequests"}: {
+		accepted: []string{"spec.signerName"},
+		selectable: map[string]selectablePath{
+			"spec.signerName": {path: "spec.signerName"},
+		},
+	},
+}
+
+// fieldLabelRules is a kindSpec compiled into lookup form.
+type fieldLabelRules struct {
+	accepted   map[string]string // client label -> canonical label
+	selectable map[string]selectablePath
+	rejectf    func(label string) string
+}
+
+// defaultRejectf is the message most upstream conversion funcs use.
+func defaultRejectf(label string) string {
+	return "field label not supported: " + label
+}
+
+// metadataOnlyRules mirrors runtime.DefaultMetaV1FieldSelectorConversion, the
+// fallback for any kind with no registered conversion func. Note the distinct
+// error text — upstream's generic path does not say "field label not
+// supported".
+var metadataOnlyRules = fieldLabelRules{
+	accepted: map[string]string{
+		"metadata.name":      "metadata.name",
+		"metadata.namespace": "metadata.namespace",
+	},
+	selectable: map[string]selectablePath{
+		"metadata.name":      {path: "metadata.name"},
+		"metadata.namespace": {path: "metadata.namespace"},
+	},
+	rejectf: func(label string) string {
+		return fmt.Sprintf("%q is not a known field selector: only %q, %q",
+			label, "metadata.name", "metadata.namespace")
+	},
+}
+
+var compiledFieldSelectorRules = compileFieldSelectorRules()
+
+func compileFieldSelectorRules() map[groupResource]fieldLabelRules {
+	out := make(map[groupResource]fieldLabelRules, len(fieldSelectorKinds))
+	for gr, spec := range fieldSelectorKinds {
+		r := fieldLabelRules{
+			accepted:   make(map[string]string, len(spec.accepted)+len(spec.aliases)+2),
+			selectable: make(map[string]selectablePath, len(spec.selectable)+2),
+			rejectf:    spec.rejectf,
+		}
+		if r.rejectf == nil {
+			r.rejectf = defaultRejectf
+		}
+		r.accepted["metadata.name"] = "metadata.name"
+		r.selectable["metadata.name"] = selectablePath{path: "metadata.name"}
+		if spec.namespaced {
+			r.accepted["metadata.namespace"] = "metadata.namespace"
+			r.selectable["metadata.namespace"] = selectablePath{path: "metadata.namespace"}
+		}
+		for _, label := range spec.accepted {
+			r.accepted[label] = label
+		}
+		for from, to := range spec.aliases {
+			r.accepted[from] = to
+		}
+		for label, p := range spec.selectable {
+			r.selectable[label] = p
+		}
+		out[gr] = r
+	}
+	return out
+}
+
+// rulesFor returns the field-label contract for a group/resource, falling back
+// to the metadata-only rules for anything not in the table.
+func rulesFor(group, resource string) fieldLabelRules {
+	if r, ok := compiledFieldSelectorRules[groupResource{group, resource}]; ok {
+		return r
+	}
+	return metadataOnlyRules
+}
+
+// FieldSelector is a parsed, per-kind-validated fieldSelector. A nil
+// *FieldSelector matches everything, so callers can pass one through unchecked.
+type FieldSelector struct {
+	sel   fields.Selector
+	rules fieldLabelRules
+	// metadataOnly is true when every requirement reads metadata.name or
+	// metadata.namespace, which lets Matches answer from the already-decoded
+	// K8sObject instead of unmarshaling the object a second time.
+	metadataOnly bool
+}
+
+// ParseFieldSelector parses and validates a client-supplied fieldSelector for
+// the given API group and plural resource, mirroring the apiserver: the real
+// selector grammar, then every requirement through the kind's field-label
+// conversion. A returned error is what the apiserver reports as a 400 — callers
+// on the read, watch and delete paths must all surface it as one, since
+// upstream rejects an unsupported label identically on all three.
+//
+// Returns (nil, nil) for an empty selector, meaning no restriction.
+func ParseFieldSelector(group, resource, selector string) (*FieldSelector, error) {
+	if selector == "" {
+		return nil, nil
+	}
+	sel, err := fields.ParseSelector(selector)
+	if err != nil {
+		return nil, fmt.Errorf("invalid fieldSelector: %w", err)
+	}
+	rules := rulesFor(group, resource)
+	// Transform is upstream's own mechanism (see listOpts in
+	// apiserver/pkg/endpoints/handlers/get.go): it rewrites aliases and
+	// propagates a rejection. Never return ("", "", nil) from this func —
+	// apimachinery reads an empty field+value as "replace this requirement with
+	// Everything", which would silently widen the selector to match-all, the
+	// exact bug this file fixes.
+	transformed, err := sel.Transform(func(label, value string) (string, string, error) {
+		canonical, ok := rules.accepted[label]
+		if !ok {
+			return "", "", errors.New(rules.rejectf(label))
+		}
+		return canonical, value, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	fs := &FieldSelector{sel: transformed, rules: rules, metadataOnly: true}
+	for _, req := range transformed.Requirements() {
+		p, ok := rules.selectable[req.Field]
+		if !ok || (p.path != "metadata.name" && p.path != "metadata.namespace") {
+			fs.metadataOnly = false
+			break
+		}
+	}
+	return fs, nil
+}
+
+// NamespaceScopeSelector restricts an aggregated cluster-wide list body to one
+// namespace. It skips per-kind validation on purpose: it is synthesized
+// internally to narrow a list the server itself widened, not parsed from a
+// client request, and metadata.namespace is not an accepted label for every
+// kind even where narrowing by it is meaningful.
+func NamespaceScopeSelector(namespace string) *FieldSelector {
+	return &FieldSelector{
+		sel:          fields.OneTermEqualSelector("metadata.namespace", namespace),
+		rules:        metadataOnlyRules,
+		metadataOnly: true,
+	}
+}
+
+// Restricts reports whether the selector actually narrows anything. A non-empty
+// selector string can parse to zero requirements (fields.ParseSelector accepts
+// a stray comma), which the write path treats as an error rather than as
+// "matches everything".
+func (fs *FieldSelector) Restricts() bool {
+	return fs != nil && !fs.sel.Empty()
+}
+
+// NeedsFullObject reports whether evaluating the selector requires more than an
+// object's metadata. A Table projection carries only PartialObjectMetadata, so a
+// caller filtering Table rows must fall back to identity matching against the
+// full objects when this is true.
+func (fs *FieldSelector) NeedsFullObject() bool {
+	return fs != nil && !fs.metadataOnly
+}
+
+// String returns the canonical selector text, after alias rewriting.
+func (fs *FieldSelector) String() string {
+	if fs == nil {
+		return ""
+	}
+	return fs.sel.String()
+}
+
+// Matches reports whether one object satisfies the selector. raw is the object
+// as served; obj is the same object already decoded, used for the common
+// metadata-only case to avoid a second unmarshal. An object that cannot be
+// decoded counts as a match, so a malformed item is never silently hidden
+// (matching FilterItems' convention).
+func (fs *FieldSelector) Matches(raw json.RawMessage, obj *K8sObject) bool {
+	if fs == nil {
+		return true
+	}
+	if fs.metadataOnly && obj != nil {
+		return fs.sel.Matches(fieldsAdapter{rules: fs.rules, obj: obj})
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return true
+	}
+	return fs.sel.Matches(fieldsAdapter{rules: fs.rules, m: m})
+}
+
+// fieldsAdapter exposes an object's selectable fields as fields.Fields, so
+// apimachinery's own selector can evaluate it. Exactly one of m and obj is set:
+// obj is the metadata-only fast path.
+type fieldsAdapter struct {
+	rules fieldLabelRules
+	m     map[string]any
+	obj   *K8sObject
+}
+
+// Has reports whether the label is one ToSelectableFields would have set.
+func (f fieldsAdapter) Has(label string) bool {
+	_, ok := f.rules.selectable[label]
+	return ok
+}
+
+// Get returns the label's value, or "" for a label the kind's
+// ToSelectableFields never sets — reproducing fields.Set.Get for a missing key,
+// which is why upstream's accepted-but-not-selectable labels match nothing.
+func (f fieldsAdapter) Get(label string) string {
+	p, ok := f.rules.selectable[label]
+	if !ok {
+		return ""
+	}
+	if f.obj != nil {
+		switch p.path {
+		case "metadata.name":
+			return f.obj.Metadata.Name
+		case "metadata.namespace":
+			return f.obj.Metadata.Namespace
+		}
+		return ""
+	}
+	v := f.valueAt(p.path, p.kind)
+	if v == "" && p.fallback != "" {
+		v = f.valueAt(p.fallback, p.kind)
+	}
+	return v
+}
+
+func (f fieldsAdapter) valueAt(path string, kind valueKind) string {
+	v, ok := lookupPath(f.m, path)
+	if !ok {
+		return zeroFieldValue(kind)
+	}
+	return stringifyFieldValue(v, kind)
+}
+
+// lookupPath walks a dotted path through a decoded JSON object. None of
+// upstream's selectable fields index into an array, so no array syntax is
+// supported.
+func lookupPath(m map[string]any, path string) (any, bool) {
+	cur := m
+	parts := strings.Split(path, ".")
+	for i, part := range parts {
+		v, ok := cur[part]
+		if !ok {
+			return nil, false
+		}
+		if i == len(parts)-1 {
+			return v, true
+		}
+		next, ok := v.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		cur = next
+	}
+	return nil, false
+}
+
+// zeroFieldValue is what an absent key reads as. ToSelectableFields always sets
+// every selectable key, so an unset bool is "false" and an unset count is "0";
+// only strings read as empty.
+func zeroFieldValue(kind valueKind) string {
+	switch kind {
+	case valueBool:
+		return "false"
+	case valueInt:
+		return "0"
+	default:
+		return ""
+	}
+}
+
+func stringifyFieldValue(v any, kind valueKind) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case bool:
+		return strconv.FormatBool(t)
+	case float64:
+		// Counts arrive as float64 from encoding/json; upstream stringifies them
+		// with strconv.Itoa, so keep integral values integral.
+		if !math.IsInf(t, 0) && !math.IsNaN(t) && t == math.Trunc(t) {
+			return strconv.FormatInt(int64(t), 10)
+		}
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	case nil:
+		return zeroFieldValue(kind)
+	default:
+		// A map or array is never a selectable value upstream.
+		return ""
+	}
+}

--- a/internal/store/fieldselector_bench_test.go
+++ b/internal/store/fieldselector_bench_test.go
@@ -1,0 +1,83 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+// These guard the decode-avoidance in FieldSelector.Matches. Every metadata,
+// spec and status path resolves from the K8sObject the caller already decoded;
+// only fields outside those (Events, Secrets' type) need the object unmarshaled a
+// second time. When that held for spec paths too, filtering a 1000-pod list on
+// spec.nodeName cost about half again the wall time and better than twice the
+// allocations of the same list filtered on metadata.namespace. The two should now
+// track each other closely — a gap reopening means the classification regressed.
+//
+// SpecPath and MetadataOnly are the comparison; EventRawPath measures the case
+// that genuinely cannot avoid the second decode.
+
+// benchPods builds a list of realistically sized pods. The saved decode scales
+// with the whole object, not with the fields the selector reads, so a toy object
+// would understate it.
+func benchPods(n int) []json.RawMessage {
+	out := make([]json.RawMessage, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, json.RawMessage(fmt.Sprintf(`{
+		  "apiVersion":"v1","kind":"Pod",
+		  "metadata":{"name":"web-%d","namespace":"demo","uid":"u-%d",
+		    "labels":{"app":"web","pod-template-hash":"5bff58cf7","tier":"frontend"},
+		    "annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"a\":1,\"b\":2,\"c\":3}"},
+		    "ownerReferences":[{"apiVersion":"apps/v1","kind":"ReplicaSet","name":"web","uid":"r-1"}]},
+		  "spec":{"nodeName":"node-a","restartPolicy":"Always","schedulerName":"default-scheduler",
+		    "serviceAccountName":"default","hostNetwork":false,
+		    "containers":[{"name":"web","image":"nginx:1.27","ports":[{"containerPort":80}],
+		      "resources":{"requests":{"cpu":"10m","memory":"16Mi"},"limits":{"memory":"64Mi"}},
+		      "volumeMounts":[{"name":"kube-api-access","mountPath":"/var/run/secrets/k8s.io"}]}],
+		    "volumes":[{"name":"kube-api-access","projected":{"sources":[{"serviceAccountToken":{"path":"token"}}]}}]},
+		  "status":{"phase":"Running","podIP":"10.244.0.%d","hostIP":"172.18.0.2",
+		    "conditions":[{"type":"Ready","status":"True"},{"type":"Initialized","status":"True"}],
+		    "containerStatuses":[{"name":"web","ready":true,"restartCount":0,"image":"nginx:1.27"}]}}`,
+			i, i, i%250)))
+	}
+	return out
+}
+
+func benchmarkFilterItems(b *testing.B, group, resource, selector string, items []json.RawMessage) {
+	b.Helper()
+	fs, err := ParseFieldSelector(group, resource, selector)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// FilterItems filters in place, so hand it a fresh slice each round.
+		in := make([]json.RawMessage, len(items))
+		copy(in, items)
+		FilterItems(in, "", fs)
+	}
+}
+
+func BenchmarkFilterItems_MetadataOnly(b *testing.B) {
+	benchmarkFilterItems(b, "", "pods", "metadata.namespace=demo", benchPods(1000))
+}
+
+func BenchmarkFilterItems_SpecPath(b *testing.B) {
+	benchmarkFilterItems(b, "", "pods", "spec.nodeName=node-a", benchPods(1000))
+}
+
+func BenchmarkFilterItems_StatusPath(b *testing.B) {
+	benchmarkFilterItems(b, "", "pods", "status.phase=Running", benchPods(1000))
+}
+
+func BenchmarkFilterItems_EventRawPath(b *testing.B) {
+	items := make([]json.RawMessage, 0, 1000)
+	for i := 0; i < 1000; i++ {
+		items = append(items, json.RawMessage(fmt.Sprintf(
+			`{"metadata":{"name":"e-%d","namespace":"demo"},`+
+				`"involvedObject":{"kind":"Pod","name":"web-%d","namespace":"demo"},`+
+				`"reason":"Scheduled","type":"Normal","source":{"component":"default-scheduler"},`+
+				`"message":"Successfully assigned demo/web-%d to node-a","count":1}`, i, i, i)))
+	}
+	benchmarkFilterItems(b, "", "events", "involvedObject.kind=Pod", items)
+}

--- a/internal/store/fieldselector_snapshot_test.go
+++ b/internal/store/fieldselector_snapshot_test.go
@@ -1,0 +1,289 @@
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// This test closes the loop between the hand-maintained tables in
+// fieldselector.go and upstream Kubernetes. There are three links in the chain:
+//
+//	upstream source  --(scripts/fieldselector_drift.py)-->  snapshot JSON
+//	snapshot JSON    --(this test)-->                       fieldSelectorKinds
+//
+// The script keeps the snapshot honest against upstream (it needs the network,
+// so it runs as its own CI job); this test keeps the Go tables honest against
+// the snapshot, offline and on every `make test`. Without it, the snapshot could
+// track upstream perfectly while the Go code quietly drifted from both.
+//
+// The conformance differential (scripts/conformance_diff.py, section G) is the
+// third mechanism, comparing actual behavior against a live apiserver.
+
+const snapshotPath = "../../scripts/fieldselector-snapshot.json"
+
+// upstreamSnapshot mirrors the JSON scripts/fieldselector_drift.py writes.
+type upstreamSnapshot struct {
+	KubernetesVersion string `json:"kubernetesVersion"`
+	// Accepted is file path -> Kind -> accepted field labels.
+	Accepted map[string]map[string][]string `json:"accepted"`
+	// Selectable is file path -> function name -> selectable field labels.
+	Selectable map[string]map[string][]string `json:"selectable"`
+}
+
+// snapshotAcceptedKey identifies one entry in the snapshot's accepted section.
+type snapshotAcceptedKey struct {
+	file string
+	kind string
+}
+
+// acceptedSources maps each upstream conversion func to the group/resource its
+// contract governs in our table.
+var acceptedSources = map[snapshotAcceptedKey]groupResource{
+	{"pkg/apis/core/v1/conversion.go", "Pod"}:                               {"", "pods"},
+	{"pkg/apis/core/v1/conversion.go", "Node"}:                              {"", "nodes"},
+	{"pkg/apis/core/v1/conversion.go", "Namespace"}:                         {"", "namespaces"},
+	{"pkg/apis/core/v1/conversion.go", "Secret"}:                            {"", "secrets"},
+	{"pkg/apis/core/v1/conversion.go", "Service"}:                           {"", "services"},
+	{"pkg/apis/core/v1/conversion.go", "ReplicationController"}:             {"", "replicationcontrollers"},
+	{"pkg/apis/core/v1/conversion.go", "Event"}:                             {"", "events"},
+	{"pkg/apis/events/v1/conversion.go", "Event"}:                           {"events.k8s.io", "events"},
+	{"pkg/apis/batch/v1/conversion.go", "Job"}:                              {"batch", "jobs"},
+	{"pkg/apis/certificates/v1/conversion.go", "CertificateSigningRequest"}: {"certificates.k8s.io", "certificatesigningrequests"},
+}
+
+// snapshotSelectableKey identifies one entry in the snapshot's selectable section.
+type snapshotSelectableKey struct {
+	file string
+	fn   string
+}
+
+// selectableSources maps each upstream ToSelectableFields to the group/resource
+// it projects in our table.
+var selectableSources = map[snapshotSelectableKey]groupResource{
+	{"pkg/registry/core/pod/strategy.go", "ToSelectableFields"}:                             {"", "pods"},
+	{"pkg/registry/core/node/strategy.go", "NodeToSelectableFields"}:                        {"", "nodes"},
+	{"pkg/registry/core/namespace/strategy.go", "NamespaceToSelectableFields"}:              {"", "namespaces"},
+	{"pkg/registry/core/secret/strategy.go", "SelectableFields"}:                            {"", "secrets"},
+	{"pkg/registry/core/service/strategy.go", "SelectableFields"}:                           {"", "services"},
+	{"pkg/registry/core/replicationcontroller/strategy.go", "ControllerToSelectableFields"}: {"", "replicationcontrollers"},
+	{"pkg/registry/core/event/strategy.go", "ToSelectableFields"}:                           {"", "events"},
+	{"pkg/registry/batch/job/strategy.go", "JobToSelectableFields"}:                         {"batch", "jobs"},
+	{"pkg/registry/certificates/certificates/strategy.go", "SelectableFields"}:              {"certificates.k8s.io", "certificatesigningrequests"},
+}
+
+// metadataLabels are supplied upstream by generic.ObjectMetaFieldsSet rather than
+// appearing in the fields.Set literal, so they are absent from the snapshot's
+// selectable lists and excluded when comparing.
+var metadataLabels = map[string]bool{
+	"metadata.name":      true,
+	"metadata.namespace": true,
+}
+
+// inertSelectableLabels are keys upstream's ToSelectableFields sets that no
+// conversion func accepts, making them unreachable through the API. We omit them
+// deliberately rather than implement a field no request can select on.
+var inertSelectableLabels = map[snapshotSelectableKey]map[string]bool{
+	// NamespaceToSelectableFields sets a bare "name" alongside metadata.name,
+	// kept upstream for backward compatibility and flagged there as a bug.
+	{"pkg/registry/core/namespace/strategy.go", "NamespaceToSelectableFields"}: {"name": true},
+}
+
+func loadUpstreamSnapshot(t *testing.T) upstreamSnapshot {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Clean(snapshotPath))
+	if err != nil {
+		t.Fatalf("reading %s: %v (regenerate with scripts/fieldselector_drift.py --update)",
+			snapshotPath, err)
+	}
+	var snap upstreamSnapshot
+	if err := json.Unmarshal(b, &snap); err != nil {
+		t.Fatalf("decoding %s: %v", snapshotPath, err)
+	}
+	return snap
+}
+
+// TestFieldSelectorTables_AcceptedMatchesUpstream asserts every label upstream's
+// conversion funcs accept is accepted here, and that we accept nothing extra.
+func TestFieldSelectorTables_AcceptedMatchesUpstream(t *testing.T) {
+	snap := loadUpstreamSnapshot(t)
+
+	for key, gr := range acceptedSources {
+		kinds, ok := snap.Accepted[key.file]
+		if !ok {
+			t.Errorf("snapshot has no accepted entry for %s", key.file)
+			continue
+		}
+		want, ok := kinds[key.kind]
+		if !ok {
+			t.Errorf("snapshot %s has no accepted labels for kind %s", key.file, key.kind)
+			continue
+		}
+		rules, ok := compiledFieldSelectorRules[gr]
+		if !ok {
+			t.Errorf("no field-selector rules for %+v (upstream %s/%s accepts %v)",
+				gr, key.file, key.kind, want)
+			continue
+		}
+		got := make([]string, 0, len(rules.accepted))
+		for label := range rules.accepted {
+			got = append(got, label)
+		}
+		sort.Strings(got)
+		sort.Strings(want)
+		if diff := labelSetDiff(want, got); diff != "" {
+			t.Errorf("accepted labels for %+v disagree with upstream %s/%s:\n%s",
+				gr, key.file, key.kind, diff)
+		}
+	}
+}
+
+// TestFieldSelectorTables_SelectableMatchesUpstream asserts our selectable set
+// matches ToSelectableFields, so an accepted-but-not-selectable label stays
+// accepted-but-not-selectable (pods' status.podIPs) and nothing we claim to
+// filter on is absent upstream.
+func TestFieldSelectorTables_SelectableMatchesUpstream(t *testing.T) {
+	snap := loadUpstreamSnapshot(t)
+
+	for key, gr := range selectableSources {
+		fns, ok := snap.Selectable[key.file]
+		if !ok {
+			t.Errorf("snapshot has no selectable entry for %s", key.file)
+			continue
+		}
+		upstreamLabels, ok := fns[key.fn]
+		if !ok {
+			t.Errorf("snapshot %s has no selectable labels for %s", key.file, key.fn)
+			continue
+		}
+		rules, ok := compiledFieldSelectorRules[gr]
+		if !ok {
+			t.Errorf("no field-selector rules for %+v", gr)
+			continue
+		}
+
+		want := make([]string, 0, len(upstreamLabels))
+		for _, label := range upstreamLabels {
+			if inertSelectableLabels[key][label] {
+				continue
+			}
+			want = append(want, label)
+		}
+		got := make([]string, 0, len(rules.selectable))
+		for label := range rules.selectable {
+			// Metadata labels come from ObjectMetaFieldsSet upstream, so they are
+			// not in the snapshot's list.
+			if metadataLabels[label] {
+				continue
+			}
+			got = append(got, label)
+		}
+		sort.Strings(want)
+		sort.Strings(got)
+		if diff := labelSetDiff(want, got); diff != "" {
+			t.Errorf("selectable labels for %+v disagree with upstream %s/%s:\n%s",
+				gr, key.file, key.fn, diff)
+		}
+	}
+}
+
+// TestFieldSelectorTables_EveryKindIsCovered guards against adding an entry to
+// fieldSelectorKinds without wiring it into the snapshot comparison, which would
+// leave it unchecked against upstream forever.
+func TestFieldSelectorTables_EveryKindIsCovered(t *testing.T) {
+	covered := map[groupResource]bool{}
+	for _, gr := range acceptedSources {
+		covered[gr] = true
+	}
+	for gr := range fieldSelectorKinds {
+		if !covered[gr] {
+			t.Errorf("fieldSelectorKinds has %+v with no acceptedSources entry: add one so "+
+				"the upstream snapshot comparison covers it", gr)
+		}
+	}
+	for _, gr := range selectableSources {
+		if _, ok := fieldSelectorKinds[gr]; !ok {
+			t.Errorf("selectableSources references %+v, which is not in fieldSelectorKinds", gr)
+		}
+	}
+}
+
+// TestFieldSelectorTables_SelectablePathsResolve checks every selectable path is
+// non-empty and, for a canonical label, that it is actually reachable — a typo
+// in a path would otherwise read as "field absent" and silently match nothing.
+func TestFieldSelectorTables_SelectablePathsResolve(t *testing.T) {
+	for gr, spec := range fieldSelectorKinds {
+		for label, p := range spec.selectable {
+			if p.path == "" {
+				t.Errorf("%+v: selectable %q has an empty path", gr, label)
+			}
+		}
+		// Every canonical label a selectable entry defines must be reachable:
+		// either accepted directly, an alias target, or a metadata key.
+		rules := compiledFieldSelectorRules[gr]
+		for label := range spec.selectable {
+			if metadataLabels[label] {
+				continue
+			}
+			reachable := false
+			for _, canonical := range rules.accepted {
+				if canonical == label {
+					reachable = true
+					break
+				}
+			}
+			if !reachable {
+				t.Errorf("%+v: selectable %q is not reachable — no accepted label maps to it",
+					gr, label)
+			}
+		}
+	}
+}
+
+// labelSetDiff returns a human-readable description of how two sorted label
+// sets differ, or "" when they match.
+func labelSetDiff(want, got []string) string {
+	inWant := map[string]bool{}
+	for _, w := range want {
+		inWant[w] = true
+	}
+	inGot := map[string]bool{}
+	for _, g := range got {
+		inGot[g] = true
+	}
+	var missing, extra []string
+	for _, w := range want {
+		if !inGot[w] {
+			missing = append(missing, w)
+		}
+	}
+	for _, g := range got {
+		if !inWant[g] {
+			extra = append(extra, g)
+		}
+	}
+	if len(missing) == 0 && len(extra) == 0 {
+		return ""
+	}
+	out := ""
+	if len(missing) > 0 {
+		out += "  missing (upstream has, we don't): " + join(missing) + "\n"
+	}
+	if len(extra) > 0 {
+		out += "  extra (we have, upstream doesn't): " + join(extra) + "\n"
+	}
+	return out
+}
+
+func join(s []string) string {
+	out := ""
+	for i, v := range s {
+		if i > 0 {
+			out += ", "
+		}
+		out += v
+	}
+	return out
+}

--- a/internal/store/fieldselector_test.go
+++ b/internal/store/fieldselector_test.go
@@ -1,0 +1,573 @@
+package store
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// mustFieldSelector parses a selector that is expected to be valid.
+func mustFieldSelector(t *testing.T, group, resource, sel string) *FieldSelector {
+	t.Helper()
+	fs, err := ParseFieldSelector(group, resource, sel)
+	if err != nil {
+		t.Fatalf("ParseFieldSelector(%q, %q, %q): unexpected error: %v", group, resource, sel, err)
+	}
+	return fs
+}
+
+// obj marshals a JSON object literal for use as a single list item.
+func obj(t *testing.T, v map[string]any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// pod builds a minimal pod carrying the fields the pod selectors read.
+func pod(t *testing.T, name, namespace, nodeName, phase string) json.RawMessage {
+	t.Helper()
+	return obj(t, map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": name, "namespace": namespace},
+		"spec":       map[string]any{"nodeName": nodeName},
+		"status":     map[string]any{"phase": phase},
+	})
+}
+
+// matchNames returns the names of the items the selector matches.
+func matchNames(t *testing.T, fs *FieldSelector, items []json.RawMessage) []string {
+	t.Helper()
+	var out []string
+	for _, raw := range items {
+		var o K8sObject
+		if err := json.Unmarshal(raw, &o); err != nil {
+			t.Fatalf("unmarshal item: %v", err)
+		}
+		if fs.Matches(raw, &o) {
+			out = append(out, o.Metadata.Name)
+		}
+	}
+	return out
+}
+
+// TestParseFieldSelector_RejectsUnsupportedLabel is the core of #339: a label
+// the kind does not accept must be an error the caller turns into a 400, not a
+// silently dropped requirement that widens the selector to match everything.
+func TestParseFieldSelector_RejectsUnsupportedLabel(t *testing.T) {
+	cases := []struct {
+		group, resource, sel string
+		wantMsg              string
+	}{
+		// A registered kind uses its conversion func's message.
+		{"", "pods", "spec.bogus=x", "field label not supported: spec.bogus"},
+		{"", "nodes", "status.phase=Running", "field label not supported: status.phase"},
+		// Cluster-scoped kinds do not accept metadata.namespace: upstream's Node
+		// conversion func lists only metadata.name and spec.unschedulable.
+		{"", "nodes", "metadata.namespace=default", "field label not supported: metadata.namespace"},
+		{"certificates.k8s.io", "certificatesigningrequests", "metadata.namespace=x",
+			"field label not supported: metadata.namespace"},
+		// batch/v1's Job conversion func has its own wording.
+		{"batch", "jobs", "spec.parallelism=2", `field label "spec.parallelism" not supported for Job`},
+		// An unregistered kind (every custom resource, and everything in the
+		// apps group, which registers no conversion func) falls back to
+		// runtime.DefaultMetaV1FieldSelectorConversion and its distinct message.
+		{"example.com", "widgets", "spec.size=large",
+			`"spec.size" is not a known field selector: only "metadata.name", "metadata.namespace"`},
+		{"apps", "deployments", "status.replicas=3",
+			`"status.replicas" is not a known field selector: only "metadata.name", "metadata.namespace"`},
+		// events.k8s.io/v1 accepts regarding.* — the core spelling is not valid
+		// against that group even though it is the canonical internal label.
+		{"events.k8s.io", "events", "involvedObject.name=web",
+			"field label not supported: involvedObject.name"},
+		{"events.k8s.io", "events", "source=kubelet", "field label not supported: source"},
+	}
+	for _, tc := range cases {
+		fs, err := ParseFieldSelector(tc.group, tc.resource, tc.sel)
+		if err == nil {
+			t.Errorf("ParseFieldSelector(%q, %q, %q) = %v, want error",
+				tc.group, tc.resource, tc.sel, fs)
+			continue
+		}
+		if err.Error() != tc.wantMsg {
+			t.Errorf("ParseFieldSelector(%q, %q, %q) error = %q, want %q",
+				tc.group, tc.resource, tc.sel, err.Error(), tc.wantMsg)
+		}
+	}
+}
+
+// TestParseFieldSelector_AcceptsPerKindLabels guards the other direction: keys a
+// real apiserver accepts must not be rejected. deletecollection used to 400 on
+// pods' spec.nodeName, which upstream accepts.
+func TestParseFieldSelector_AcceptsPerKindLabels(t *testing.T) {
+	cases := []struct{ group, resource, sel string }{
+		{"", "pods", "spec.nodeName=node-1"},
+		{"", "pods", "status.phase=Running"},
+		{"", "pods", "spec.restartPolicy=Always"},
+		{"", "pods", "spec.schedulerName=default-scheduler"},
+		{"", "pods", "spec.serviceAccountName=default"},
+		{"", "pods", "spec.hostNetwork=false"},
+		{"", "pods", "status.podIP=10.0.0.1"},
+		{"", "pods", "status.nominatedNodeName=node-2"},
+		{"", "pods", "metadata.name=web,metadata.namespace=default,spec.nodeName=node-1"},
+		{"", "nodes", "spec.unschedulable=true"},
+		{"", "nodes", "metadata.name=node-1"},
+		{"", "namespaces", "status.phase=Active"},
+		{"", "secrets", "type=kubernetes.io/service-account-token"},
+		{"", "services", "spec.clusterIP=10.96.0.1"},
+		{"", "services", "spec.type=ClusterIP"},
+		{"", "replicationcontrollers", "status.replicas=3"},
+		{"", "events", "involvedObject.name=web"},
+		{"", "events", "involvedObject.kind=Pod,reason=Scheduled,type=Normal"},
+		{"", "events", "source=kubelet"},
+		{"", "events", "reportingComponent=kubelet"},
+		{"events.k8s.io", "events", "regarding.name=web"},
+		{"events.k8s.io", "events", "reportingController=kubelet"},
+		{"batch", "jobs", "status.successful=1"},
+		{"certificates.k8s.io", "certificatesigningrequests", "spec.signerName=kubernetes.io/kubelet-serving"},
+		// The metadata keys stay valid for an unregistered kind.
+		{"example.com", "widgets", "metadata.name=w1"},
+		{"example.com", "widgets", "metadata.namespace=default"},
+	}
+	for _, tc := range cases {
+		if _, err := ParseFieldSelector(tc.group, tc.resource, tc.sel); err != nil {
+			t.Errorf("ParseFieldSelector(%q, %q, %q): unexpected error: %v",
+				tc.group, tc.resource, tc.sel, err)
+		}
+	}
+}
+
+// TestFieldSelector_FiltersOnNonMetadataKeys is the issue's reproduction: a
+// supported key with a non-matching value must filter, not match everything.
+func TestFieldSelector_FiltersOnNonMetadataKeys(t *testing.T) {
+	items := []json.RawMessage{
+		pod(t, "web-1", "demo", "node-a", "Running"),
+		pod(t, "web-2", "demo", "node-b", "Failed"),
+	}
+	cases := []struct {
+		sel  string
+		want []string
+	}{
+		{"spec.nodeName=does-not-exist", nil},
+		{"spec.nodeName=node-a", []string{"web-1"}},
+		{"spec.nodeName!=node-a", []string{"web-2"}},
+		{"status.phase=Failed", []string{"web-2"}},
+		{"status.phase=Running", []string{"web-1"}},
+		{"status.phase=Pending", nil},
+		// A legacy alias is rewritten to its canonical label before matching.
+		{"spec.host=node-a", []string{"web-1"}},
+		// Requirements combine with AND across keys.
+		{"spec.nodeName=node-a,status.phase=Running", []string{"web-1"}},
+		{"spec.nodeName=node-a,status.phase=Failed", nil},
+		{"metadata.namespace=demo,spec.nodeName=node-b", []string{"web-2"}},
+	}
+	for _, tc := range cases {
+		fs := mustFieldSelector(t, "", "pods", tc.sel)
+		got := matchNames(t, fs, items)
+		if !stringSliceEqual(got, tc.want) {
+			t.Errorf("[%q] matched %v, want %v", tc.sel, got, tc.want)
+		}
+	}
+}
+
+// TestFieldSelector_AcceptedButNotSelectable pins the upstream drift between the
+// two layers. Pods' conversion func accepts status.podIPs but
+// PodToSelectableFields never sets it, so upstream accepts the request and then
+// matches nothing — fields.Set.Get returns "" for a key that was never set.
+func TestFieldSelector_AcceptedButNotSelectable(t *testing.T) {
+	items := []json.RawMessage{
+		pod(t, "web-1", "demo", "node-a", "Running"),
+		pod(t, "web-2", "demo", "node-b", "Failed"),
+	}
+
+	fs := mustFieldSelector(t, "", "pods", "status.podIPs=10.0.0.1")
+	if got := matchNames(t, fs, items); got != nil {
+		t.Errorf("status.podIPs=10.0.0.1 matched %v, want no items", got)
+	}
+	// Matching the empty value matches everything, exactly as upstream does.
+	fs = mustFieldSelector(t, "", "pods", "status.podIPs=")
+	if got := matchNames(t, fs, items); !stringSliceEqual(got, []string{"web-1", "web-2"}) {
+		t.Errorf("status.podIPs= matched %v, want both items", got)
+	}
+}
+
+// TestFieldSelector_AbsentFieldDefaults checks that an unset field reads the way
+// ToSelectableFields would have written it: bools as "false", counts as "0",
+// strings as empty. A capture that never recorded the field is the common case.
+func TestFieldSelector_AbsentFieldDefaults(t *testing.T) {
+	bare := obj(t, map[string]any{"metadata": map[string]any{"name": "x"}})
+
+	cases := []struct {
+		group, resource, sel string
+		want                 bool
+	}{
+		// Pods: spec.hostNetwork is a bool, so absent reads "false".
+		{"", "pods", "spec.hostNetwork=false", true},
+		{"", "pods", "spec.hostNetwork=true", false},
+		// Nodes: same for spec.unschedulable.
+		{"", "nodes", "spec.unschedulable=false", true},
+		{"", "nodes", "spec.unschedulable=true", false},
+		// Counts read "0" when absent.
+		{"", "replicationcontrollers", "status.replicas=0", true},
+		{"", "replicationcontrollers", "status.replicas=3", false},
+		{"batch", "jobs", "status.successful=0", true},
+		// Strings read empty when absent, so a non-empty query cannot match.
+		{"", "pods", "spec.nodeName=node-a", false},
+		{"", "pods", "spec.nodeName=", true},
+	}
+	for _, tc := range cases {
+		fs := mustFieldSelector(t, tc.group, tc.resource, tc.sel)
+		if got := fs.Matches(bare, nil); got != tc.want {
+			t.Errorf("[%s %s %q] Matches = %v, want %v",
+				tc.group, tc.resource, tc.sel, got, tc.want)
+		}
+	}
+}
+
+// TestFieldSelector_ValueStringification covers the non-string wire types:
+// upstream stringifies bools with FormatBool and counts with Itoa, so a JSON
+// number must not come back as "3e+00".
+func TestFieldSelector_ValueStringification(t *testing.T) {
+	hostNet := obj(t, map[string]any{
+		"metadata": map[string]any{"name": "p"},
+		"spec":     map[string]any{"hostNetwork": true},
+	})
+	if fs := mustFieldSelector(t, "", "pods", "spec.hostNetwork=true"); !fs.Matches(hostNet, nil) {
+		t.Error("spec.hostNetwork=true should match a pod with hostNetwork: true")
+	}
+	if fs := mustFieldSelector(t, "", "pods", "spec.hostNetwork=false"); fs.Matches(hostNet, nil) {
+		t.Error("spec.hostNetwork=false should not match a pod with hostNetwork: true")
+	}
+
+	rc := obj(t, map[string]any{
+		"metadata": map[string]any{"name": "rc"},
+		"status":   map[string]any{"replicas": 3},
+	})
+	if fs := mustFieldSelector(t, "", "replicationcontrollers", "status.replicas=3"); !fs.Matches(rc, nil) {
+		t.Error("status.replicas=3 should match replicas: 3")
+	}
+
+	// Job's label and field differ: status.successful reads status.succeeded.
+	job := obj(t, map[string]any{
+		"metadata": map[string]any{"name": "j"},
+		"status":   map[string]any{"succeeded": 2},
+	})
+	if fs := mustFieldSelector(t, "batch", "jobs", "status.successful=2"); !fs.Matches(job, nil) {
+		t.Error("status.successful=2 should match status.succeeded: 2")
+	}
+}
+
+// TestFieldSelector_EventPaths covers the two Event API groups, whose wire
+// formats differ while sharing the same canonical labels, plus core Events'
+// "source", which upstream computes with a fallback.
+func TestFieldSelector_EventPaths(t *testing.T) {
+	coreEvent := obj(t, map[string]any{
+		"metadata":       map[string]any{"name": "e1", "namespace": "demo"},
+		"involvedObject": map[string]any{"kind": "Pod", "name": "web-1"},
+		"reason":         "Scheduled",
+		"type":           "Normal",
+		"source":         map[string]any{"component": "default-scheduler"},
+	})
+	for _, sel := range []string{
+		"involvedObject.kind=Pod",
+		"involvedObject.name=web-1",
+		"reason=Scheduled",
+		"type=Normal",
+		"source=default-scheduler",
+	} {
+		if fs := mustFieldSelector(t, "", "events", sel); !fs.Matches(coreEvent, nil) {
+			t.Errorf("core event: %q should match", sel)
+		}
+	}
+
+	// source falls back to reportingComponent when source.component is unset,
+	// mirroring upstream's ToSelectableFields.
+	fallbackEvent := obj(t, map[string]any{
+		"metadata":           map[string]any{"name": "e2"},
+		"reportingComponent": "kubelet",
+	})
+	if fs := mustFieldSelector(t, "", "events", "source=kubelet"); !fs.Matches(fallbackEvent, nil) {
+		t.Error("core event: source should fall back to reportingComponent")
+	}
+
+	// events.k8s.io/v1 carries regarding.* and reportingController on the wire,
+	// and its accepted labels are spelled that way too.
+	newEvent := obj(t, map[string]any{
+		"metadata":            map[string]any{"name": "e3", "namespace": "demo"},
+		"regarding":           map[string]any{"kind": "Pod", "name": "web-1"},
+		"reportingController": "kubelet",
+		"reason":              "Scheduled",
+	})
+	for _, sel := range []string{
+		"regarding.kind=Pod",
+		"regarding.name=web-1",
+		"reportingController=kubelet",
+		"reason=Scheduled",
+	} {
+		if fs := mustFieldSelector(t, "events.k8s.io", "events", sel); !fs.Matches(newEvent, nil) {
+			t.Errorf("events.k8s.io event: %q should match", sel)
+		}
+	}
+	if fs := mustFieldSelector(t, "events.k8s.io", "events", "regarding.name=other"); fs.Matches(newEvent, nil) {
+		t.Error("events.k8s.io event: regarding.name=other should not match")
+	}
+}
+
+// TestParseFieldSelector_MalformedGrammar checks we use apimachinery's real
+// grammar. Whitespace around the operator is *not* trimmed upstream — the label
+// becomes "metadata.name " and the conversion rejects it — so k8shark's old
+// hand-rolled trimming was itself a divergence.
+func TestParseFieldSelector_MalformedGrammar(t *testing.T) {
+	if _, err := ParseFieldSelector("", "pods", "metadata.name = nginx"); err == nil {
+		t.Error(`"metadata.name = nginx" should be rejected: upstream does not trim around the operator`)
+	}
+	if _, err := ParseFieldSelector("", "pods", "not-a-selector"); err == nil {
+		t.Error("a segment with no operator should be rejected")
+	}
+	// A stray comma parses to zero requirements upstream rather than erroring,
+	// so the read path accepts it as "no restriction".
+	fs, err := ParseFieldSelector("", "pods", ",")
+	if err != nil {
+		t.Fatalf("a stray comma should parse: %v", err)
+	}
+	if fs.Restricts() {
+		t.Error("a selector with zero requirements should not restrict")
+	}
+}
+
+func TestParseFieldSelector_Empty(t *testing.T) {
+	fs, err := ParseFieldSelector("", "pods", "")
+	if err != nil {
+		t.Fatalf("empty selector: %v", err)
+	}
+	if fs != nil {
+		t.Errorf("empty selector should parse to nil, got %v", fs)
+	}
+	// A nil selector matches everything, so callers can pass it through.
+	if !fs.Matches(pod(t, "web", "demo", "node-a", "Running"), nil) {
+		t.Error("a nil selector should match every object")
+	}
+	if fs.Restricts() {
+		t.Error("a nil selector should not restrict")
+	}
+}
+
+// TestFieldSelector_Aliases_Canonicalize checks the alias rewrite happens once,
+// at parse time, so String() reports the canonical form.
+func TestFieldSelector_Aliases_Canonicalize(t *testing.T) {
+	fs := mustFieldSelector(t, "", "pods", "spec.host=node-a")
+	if got := fs.String(); !strings.Contains(got, "spec.nodeName=node-a") {
+		t.Errorf("spec.host should canonicalize to spec.nodeName, got %q", got)
+	}
+}
+
+func TestNamespaceScopeSelector(t *testing.T) {
+	items := []json.RawMessage{
+		pod(t, "web-1", "demo", "node-a", "Running"),
+		pod(t, "web-2", "other", "node-b", "Running"),
+	}
+	fs := NamespaceScopeSelector("demo")
+	if got := matchNames(t, fs, items); !stringSliceEqual(got, []string{"web-1"}) {
+		t.Errorf("namespace scope matched %v, want [web-1]", got)
+	}
+}
+
+// TestFieldSelector_MatchesWithoutDecodedObject checks the raw-only path used
+// where no decoded K8sObject is at hand.
+func TestFieldSelector_MatchesWithoutDecodedObject(t *testing.T) {
+	p := pod(t, "web-1", "demo", "node-a", "Running")
+	if fs := mustFieldSelector(t, "", "pods", "metadata.name=web-1"); !fs.Matches(p, nil) {
+		t.Error("metadata-only selector should match with a nil decoded object")
+	}
+	if fs := mustFieldSelector(t, "", "pods", "metadata.name=other"); fs.Matches(p, nil) {
+		t.Error("metadata-only selector should not match a different name")
+	}
+}
+
+// TestFieldSelector_UndecodableObjectIsKept keeps the existing convention: an
+// item we cannot inspect is never silently hidden.
+func TestFieldSelector_UndecodableObjectIsKept(t *testing.T) {
+	fs := mustFieldSelector(t, "", "pods", "spec.nodeName=node-a")
+	if !fs.Matches(json.RawMessage(`not json`), nil) {
+		t.Error("an undecodable object should count as a match")
+	}
+}
+
+// TestApplySelectors_NonMetadataFieldFilter exercises the list path end to end,
+// which is what `kubectl get pods --field-selector spec.nodeName=…` hits.
+func TestApplySelectors_NonMetadataFieldFilter(t *testing.T) {
+	body, err := json.Marshal(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "PodList",
+		"metadata":   map[string]any{},
+		"items": []json.RawMessage{
+			pod(t, "web-1", "demo", "node-a", "Running"),
+			pod(t, "web-2", "demo", "node-b", "Running"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := ApplySelectors(body, "", mustFieldSelector(t, "", "pods", "spec.nodeName=node-a"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := itemNames(t, out); !stringSliceEqual(got, []string{"web-1"}) {
+		t.Errorf("got %v, want [web-1]", got)
+	}
+
+	out, err = ApplySelectors(body, "", mustFieldSelector(t, "", "pods", "spec.nodeName=does-not-exist"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := itemNames(t, out); len(got) != 0 {
+		t.Errorf("got %v, want no items", got)
+	}
+}
+
+// TestListIdentities covers the basis for filtering a Table whose rows carry
+// only metadata: ok must be false when there is no list to intersect with, so
+// the caller falls back instead of dropping every row.
+func TestListIdentities(t *testing.T) {
+	body, err := json.Marshal(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "PodList",
+		"items": []json.RawMessage{
+			pod(t, "web-1", "demo", "node-a", "Running"),
+			pod(t, "web-2", "other", "node-b", "Running"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids, ok := ListIdentities(body)
+	if !ok {
+		t.Fatal("ListIdentities on a list body: ok = false")
+	}
+	if !ids[ObjectIdentity{"demo", "web-1"}] || !ids[ObjectIdentity{"other", "web-2"}] {
+		t.Errorf("identities = %v, want both pods", ids)
+	}
+	if len(ids) != 2 {
+		t.Errorf("got %d identities, want 2", len(ids))
+	}
+
+	if _, ok := ListIdentities([]byte(`{"kind":"Pod"}`)); ok {
+		t.Error("a non-list body should report ok = false")
+	}
+	if _, ok := ListIdentities([]byte(`not json`)); ok {
+		t.Error("an undecodable body should report ok = false")
+	}
+}
+
+// TestFilterTableRowsToIdentities checks rows are kept by namespace/name, which
+// is all a PartialObjectMetadata row exposes.
+func TestFilterTableRowsToIdentities(t *testing.T) {
+	table, err := json.Marshal(map[string]any{
+		"apiVersion": "meta.k8s.io/v1",
+		"kind":       "Table",
+		"rows": []map[string]any{
+			{"cells": []any{"web-1"}, "object": map[string]any{
+				"kind":     "PartialObjectMetadata",
+				"metadata": map[string]any{"name": "web-1", "namespace": "demo"},
+			}},
+			{"cells": []any{"web-2"}, "object": map[string]any{
+				"kind":     "PartialObjectMetadata",
+				"metadata": map[string]any{"name": "web-2", "namespace": "demo"},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := FilterTableRowsToIdentities(table, map[ObjectIdentity]bool{
+		{"demo", "web-1"}: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Rows []struct {
+			Object struct {
+				Metadata struct {
+					Name string `json:"name"`
+				} `json:"metadata"`
+			} `json:"object"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Rows) != 1 || got.Rows[0].Object.Metadata.Name != "web-1" {
+		t.Errorf("kept %d rows (first %q), want just web-1",
+			len(got.Rows), got.Rows[0].Object.Metadata.Name)
+	}
+
+	// A body that isn't a Table comes back untouched.
+	plain := []byte(`{"kind":"PodList"}`)
+	out, err = FilterTableRowsToIdentities(plain, nil)
+	if err != nil || string(out) != string(plain) {
+		t.Errorf("non-Table body = %s, %v; want it unchanged", out, err)
+	}
+}
+
+// TestFieldSelector_NeedsFullObject drives the Table fallback decision.
+func TestFieldSelector_NeedsFullObject(t *testing.T) {
+	cases := []struct {
+		sel  string
+		want bool
+	}{
+		{"metadata.name=web-1", false},
+		{"metadata.namespace=demo", false},
+		{"metadata.name=web-1,metadata.namespace=demo", false},
+		{"spec.nodeName=node-a", true},
+		{"status.phase=Running", true},
+		{"metadata.name=web-1,spec.nodeName=node-a", true},
+		// Accepted but not selectable still needs the full object: it is not a
+		// metadata key, and resolving it to "" is what makes it match nothing.
+		{"status.podIPs=10.0.0.1", true},
+	}
+	for _, tc := range cases {
+		fs := mustFieldSelector(t, "", "pods", tc.sel)
+		if got := fs.NeedsFullObject(); got != tc.want {
+			t.Errorf("[%s] NeedsFullObject = %v, want %v", tc.sel, got, tc.want)
+		}
+	}
+	if (*FieldSelector)(nil).NeedsFullObject() {
+		t.Error("a nil selector should not need the full object")
+	}
+}
+
+// TestFilterItemsStrict_FieldSelector covers deletecollection's path: the
+// per-kind contract now applies (so pods' spec.nodeName is accepted, where it
+// used to be rejected), while a selector that restricts nothing is still
+// refused.
+func TestFilterItemsStrict_FieldSelector(t *testing.T) {
+	items := []json.RawMessage{
+		pod(t, "web-1", "demo", "node-a", "Running"),
+		pod(t, "web-2", "demo", "node-b", "Running"),
+	}
+
+	fs := mustFieldSelector(t, "", "pods", "spec.nodeName=node-a")
+	msg, filtered := FilterItemsStrict(items, "", "spec.nodeName=node-a", fs)
+	if msg != "" {
+		t.Fatalf("spec.nodeName should be accepted for pods, got %q", msg)
+	}
+	if got := len(filtered); got != 1 {
+		t.Errorf("filtered %d items, want 1", got)
+	}
+
+	// Zero requirements must not degrade to "delete everything".
+	commaOnly := mustFieldSelector(t, "", "pods", ",")
+	msg, filtered = FilterItemsStrict(items, "", ",", commaOnly)
+	if msg == "" {
+		t.Error("a selector that restricts nothing should be refused on the write path")
+	}
+	if filtered != nil {
+		t.Error("a refused selector should return no items")
+	}
+}

--- a/internal/store/fieldselector_test.go
+++ b/internal/store/fieldselector_test.go
@@ -515,6 +515,86 @@ func TestFilterTableRowsToIdentities(t *testing.T) {
 	}
 }
 
+// TestListIdentities_UndecodableItemIsKept guards the convention the rest of
+// this file follows: an item we cannot fully decode is never silently hidden.
+// K8sObject declares Labels as map[string]string, so an object with a
+// non-string label value fails to unmarshal against it — and since FilterItems
+// keeps such an item, dropping its identity here would make the Table path lose
+// a row the JSON list path kept.
+func TestListIdentities_UndecodableItemIsKept(t *testing.T) {
+	odd := json.RawMessage(
+		`{"metadata":{"name":"odd","namespace":"demo","labels":{"a":1}},"spec":{"nodeName":"node-a"}}`)
+
+	// Precondition: this really is undecodable as a K8sObject, so the test
+	// stays meaningful if that struct changes.
+	var probe K8sObject
+	if err := json.Unmarshal(odd, &probe); err == nil {
+		t.Skip("K8sObject now decodes non-string labels; pick another malformed shape")
+	}
+
+	body, err := json.Marshal(map[string]any{"items": []json.RawMessage{odd}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids, ok := ListIdentities(body)
+	if !ok {
+		t.Fatal("ListIdentities ok = false")
+	}
+	if !ids[ObjectIdentity{"demo", "odd"}] {
+		t.Errorf("identity dropped for an item FilterItems would keep: %v", ids)
+	}
+
+	// And the two paths agree: the row survives Table filtering too.
+	table, err := json.Marshal(map[string]any{
+		"kind": "Table",
+		"rows": []map[string]any{{"cells": []any{"odd"}, "object": json.RawMessage(odd)}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := FilterTableRowsToIdentities(table, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Rows []json.RawMessage `json:"rows"`
+	}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Rows) != 1 {
+		t.Errorf("kept %d rows, want 1 — the JSON list path keeps this item", len(got.Rows))
+	}
+}
+
+// TestFieldSelector_OutOfRangeNumber checks a count that cannot fit in an int64.
+// Converting an out-of-range float64 to int64 is undefined in Go, so without a
+// range check a wildly large value stringifies to something arbitrary — and
+// archive content is not trusted to hold only plausible counts.
+func TestFieldSelector_OutOfRangeNumber(t *testing.T) {
+	huge := obj(t, map[string]any{
+		"metadata": map[string]any{"name": "rc"},
+		"status":   map[string]any{"replicas": 1e30},
+	})
+	// Assert the exact rendering rather than "not some wrong value": the result
+	// of the undefined conversion is platform-specific (amd64 gives MinInt64,
+	// arm64 saturates to MaxInt64), so a negative assertion would pass
+	// vacuously on one of them.
+	fs := mustFieldSelector(t, "", "replicationcontrollers",
+		"status.replicas=1000000000000000000000000000000")
+	if !fs.Matches(huge, nil) {
+		t.Error("a replicas value of 1e30 should render as its full decimal expansion")
+	}
+	// Sanity: an in-range count still formats as an integer, not 3e+00.
+	normal := obj(t, map[string]any{
+		"metadata": map[string]any{"name": "rc"},
+		"status":   map[string]any{"replicas": 3},
+	})
+	if fs := mustFieldSelector(t, "", "replicationcontrollers", "status.replicas=3"); !fs.Matches(normal, nil) {
+		t.Error("status.replicas=3 should match replicas: 3")
+	}
+}
+
 // TestFieldSelector_NeedsFullObject drives the Table fallback decision.
 func TestFieldSelector_NeedsFullObject(t *testing.T) {
 	cases := []struct {

--- a/internal/store/fieldselector_test.go
+++ b/internal/store/fieldselector_test.go
@@ -644,6 +644,130 @@ func TestFieldSelector_OutOfRangeNumber(t *testing.T) {
 	}
 }
 
+// TestFieldSelector_DecodeMode pins which selectors can be answered from an
+// already-decoded K8sObject and which need the whole object. Getting this wrong
+// is silent in both directions — a raw-only path read from the struct resolves
+// to "" and matches nothing, and a struct-resolvable path sent through the raw
+// decode just costs time — so assert the classification directly.
+func TestFieldSelector_DecodeMode(t *testing.T) {
+	cases := []struct {
+		group, resource, sel string
+		want                 decodeMode
+	}{
+		// metadata, spec and status all live on the struct.
+		{"", "pods", "metadata.name=web", decodeFromObject},
+		{"", "pods", "spec.nodeName=node-a", decodeFromObject},
+		{"", "pods", "status.phase=Running", decodeFromObject},
+		{"", "pods", "spec.nodeName=node-a,status.phase=Running", decodeFromObject},
+		{"", "nodes", "spec.unschedulable=true", decodeFromObject},
+		{"", "namespaces", "status.phase=Active", decodeFromObject},
+		{"", "services", "spec.type=ClusterIP", decodeFromObject},
+		{"", "replicationcontrollers", "status.replicas=3", decodeFromObject},
+		{"batch", "jobs", "status.successful=1", decodeFromObject},
+		{"certificates.k8s.io", "certificatesigningrequests", "spec.signerName=x", decodeFromObject},
+		// Accepted but not selectable: resolves to "" from any source, so it
+		// needs no raw decode.
+		{"", "pods", "status.podIPs=10.0.0.1", decodeFromObject},
+		// Secrets keep type at the top level, outside spec/status.
+		{"", "secrets", "type=Opaque", decodeFromRaw},
+		// Every Event field the selectors read is top-level.
+		{"", "events", "involvedObject.kind=Pod", decodeFromRaw},
+		{"", "events", "reason=Scheduled", decodeFromRaw},
+		{"", "events", "type=Normal", decodeFromRaw},
+		{"", "events", "source=kubelet", decodeFromRaw},
+		{"events.k8s.io", "events", "regarding.kind=Pod", decodeFromRaw},
+		{"events.k8s.io", "events", "reportingController=kubelet", decodeFromRaw},
+		// One raw-only requirement forces the whole selector to raw.
+		{"", "events", "metadata.name=e1,reason=Scheduled", decodeFromRaw},
+	}
+	for _, tc := range cases {
+		fs := mustFieldSelector(t, tc.group, tc.resource, tc.sel)
+		if fs.mode != tc.want {
+			t.Errorf("[%s %s %q] mode = %v, want %v",
+				tc.group, tc.resource, tc.sel, fs.mode, tc.want)
+		}
+	}
+}
+
+// TestFieldSelector_StructPathIgnoresRaw proves the fast path really is taken:
+// with a decoded object supplied and the raw bytes deliberately unusable, a
+// spec/status selector must still filter correctly. If the mode ever regresses
+// to decodeFromRaw, the unmarshal fails and Matches returns true — an
+// over-match, which is the bug this whole change set is about.
+func TestFieldSelector_StructPathIgnoresRaw(t *testing.T) {
+	var onNodeA, onNodeB K8sObject
+	if err := json.Unmarshal(pod(t, "web-1", "demo", "node-a", "Running"), &onNodeA); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(pod(t, "web-2", "demo", "node-b", "Failed"), &onNodeB); err != nil {
+		t.Fatal(err)
+	}
+	unusable := json.RawMessage(`not json at all`)
+
+	for _, tc := range []struct {
+		sel        string
+		wantA      bool
+		wantB      bool
+		wantReason string
+	}{
+		{"spec.nodeName=node-a", true, false, "spec path"},
+		{"status.phase=Failed", false, true, "status path"},
+		{"metadata.name=web-1", true, false, "metadata path"},
+	} {
+		fs := mustFieldSelector(t, "", "pods", tc.sel)
+		if got := fs.Matches(unusable, &onNodeA); got != tc.wantA {
+			t.Errorf("[%s] web-1 (%s) = %v, want %v", tc.sel, tc.wantReason, got, tc.wantA)
+		}
+		if got := fs.Matches(unusable, &onNodeB); got != tc.wantB {
+			t.Errorf("[%s] web-2 (%s) = %v, want %v", tc.sel, tc.wantReason, got, tc.wantB)
+		}
+	}
+}
+
+// TestFieldSelector_RawPathWithDecodedObject is the mirror image: a selector on a
+// field outside metadata/spec/status must read the raw object even when a decoded
+// K8sObject is available, since the struct simply has nowhere to hold it.
+func TestFieldSelector_RawPathWithDecodedObject(t *testing.T) {
+	event := obj(t, map[string]any{
+		"metadata":       map[string]any{"name": "e1", "namespace": "demo"},
+		"involvedObject": map[string]any{"kind": "Pod", "name": "web-1"},
+		"reason":         "Scheduled",
+		"type":           "Normal",
+		"source":         map[string]any{"component": "default-scheduler"},
+	})
+	var decoded K8sObject
+	if err := json.Unmarshal(event, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	for _, sel := range []string{
+		"involvedObject.kind=Pod", "reason=Scheduled", "type=Normal", "source=default-scheduler",
+	} {
+		fs := mustFieldSelector(t, "", "events", sel)
+		if !fs.Matches(event, &decoded) {
+			t.Errorf("[%s] should match even with a decoded object supplied", sel)
+		}
+	}
+	// And a non-matching value still filters.
+	fs := mustFieldSelector(t, "", "events", "reason=Killing")
+	if fs.Matches(event, &decoded) {
+		t.Error("reason=Killing should not match a Scheduled event")
+	}
+
+	// Secrets keep type at the top level too.
+	secret := obj(t, map[string]any{
+		"metadata": map[string]any{"name": "s1", "namespace": "demo"},
+		"type":     "kubernetes.io/service-account-token",
+	})
+	var decodedSecret K8sObject
+	if err := json.Unmarshal(secret, &decodedSecret); err != nil {
+		t.Fatal(err)
+	}
+	fs = mustFieldSelector(t, "", "secrets", "type=kubernetes.io/service-account-token")
+	if !fs.Matches(secret, &decodedSecret) {
+		t.Error("secret type should match with a decoded object supplied")
+	}
+}
+
 // TestFieldSelector_NeedsFullObject drives the Table fallback decision.
 func TestFieldSelector_NeedsFullObject(t *testing.T) {
 	cases := []struct {

--- a/internal/store/fieldselector_test.go
+++ b/internal/store/fieldselector_test.go
@@ -567,6 +567,55 @@ func TestListIdentities_UndecodableItemIsKept(t *testing.T) {
 	}
 }
 
+// TestListIdentities_UndecodableIdentityFailsClosed covers what identityOnly
+// still cannot decode. Skipping such an item would silently drop the Table row
+// for an object the JSON list path keeps, so the whole identity set is reported
+// unusable and the caller falls back instead of filtering partially.
+func TestListIdentities_UndecodableIdentityFailsClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		item string
+	}{
+		{"numeric name", `{"metadata":{"name":5,"namespace":"demo"}}`},
+		{"metadata not an object", `{"metadata":"nope"}`},
+		{"item not an object", `"just-a-string"`},
+		{"namespace not a string", `{"metadata":{"name":"ok","namespace":[]}}`},
+	}
+	for _, tc := range cases {
+		raw := json.RawMessage(tc.item)
+		// Precondition: FilterItems keeps this item, which is what makes
+		// dropping its row a divergence rather than a wash.
+		kept := FilterItems([]json.RawMessage{raw}, "",
+			mustFieldSelector(t, "", "pods", "spec.nodeName=node-a"))
+		if len(kept) != 1 {
+			t.Errorf("[%s] FilterItems kept %d items, want 1 (undecodable items are never hidden)",
+				tc.name, len(kept))
+		}
+
+		body, err := json.Marshal(map[string]any{"items": []json.RawMessage{raw}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := ListIdentities(body); ok {
+			t.Errorf("[%s] ListIdentities reported ok; want it to fail closed so the "+
+				"caller falls back rather than dropping the row", tc.name)
+		}
+	}
+
+	// A well-formed list alongside is still usable — failing closed must not
+	// mean failing always.
+	body, err := json.Marshal(map[string]any{
+		"items": []json.RawMessage{pod(t, "web-1", "demo", "node-a", "Running")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids, ok := ListIdentities(body)
+	if !ok || !ids[ObjectIdentity{"demo", "web-1"}] {
+		t.Errorf("well-formed list should still yield identities: ok=%v ids=%v", ok, ids)
+	}
+}
+
 // TestFieldSelector_OutOfRangeNumber checks a count that cannot fit in an int64.
 // Converting an out-of-range float64 to int64 is undefined in Go, so without a
 // range check a wildly large value stringifies to something arbitrary — and

--- a/internal/store/fieldselector_test.go
+++ b/internal/store/fieldselector_test.go
@@ -542,6 +542,63 @@ func TestFieldSelector_NeedsFullObject(t *testing.T) {
 	}
 }
 
+// TestFilterItemsStrict_LabelSelectorOnly covers deletecollection with a
+// labelSelector and no fieldSelector, which passes a nil *FieldSelector through
+// to Restricts and Matches. Both are nil-safe by design; this keeps them so.
+func TestFilterItemsStrict_LabelSelectorOnly(t *testing.T) {
+	withLabels := func(name, app string) json.RawMessage {
+		return obj(t, map[string]any{
+			"metadata": map[string]any{
+				"name": name, "namespace": "demo",
+				"labels": map[string]any{"app": app},
+			},
+			"spec": map[string]any{"nodeName": "node-a"},
+		})
+	}
+	items := []json.RawMessage{withLabels("web-1", "web"), withLabels("db-1", "db")}
+
+	msg, filtered := FilterItemsStrict(items, "app=web", "", nil)
+	if msg != "" {
+		t.Fatalf("label-only deletecollection rejected: %q", msg)
+	}
+	if len(filtered) != 1 {
+		t.Fatalf("filtered %d items, want 1", len(filtered))
+	}
+	var o K8sObject
+	if err := json.Unmarshal(filtered[0], &o); err != nil {
+		t.Fatal(err)
+	}
+	if o.Metadata.Name != "web-1" {
+		t.Errorf("kept %q, want web-1", o.Metadata.Name)
+	}
+
+	// Neither selector supplied: items pass through untouched.
+	msg, filtered = FilterItemsStrict(items, "", "", nil)
+	if msg != "" || len(filtered) != 2 {
+		t.Errorf("no selectors: msg=%q, %d items; want no message and 2 items", msg, len(filtered))
+	}
+}
+
+// TestFieldSelector_NilReceiverIsSafe pins the contract the call sites rely on:
+// a nil *FieldSelector means "no field selector", and every method tolerates it
+// rather than panicking. Go permits calling a pointer-receiver method on a nil
+// pointer; these methods check the receiver before dereferencing it.
+func TestFieldSelector_NilReceiverIsSafe(t *testing.T) {
+	var fs *FieldSelector
+	if !fs.Matches(pod(t, "web", "demo", "node-a", "Running"), nil) {
+		t.Error("nil.Matches should match everything")
+	}
+	if fs.Restricts() {
+		t.Error("nil.Restricts should be false")
+	}
+	if fs.NeedsFullObject() {
+		t.Error("nil.NeedsFullObject should be false")
+	}
+	if fs.String() != "" {
+		t.Errorf("nil.String = %q, want empty", fs.String())
+	}
+}
+
 // TestFilterItemsStrict_FieldSelector covers deletecollection's path: the
 // per-kind contract now applies (so pods' spec.nodeName is accepted, where it
 // used to be rejected), while a selector that restricts nothing is still

--- a/internal/store/selector.go
+++ b/internal/store/selector.go
@@ -293,6 +293,19 @@ type ObjectIdentity struct {
 	Name      string
 }
 
+// identityOnly decodes just the fields ObjectIdentity needs. Decoding a full
+// K8sObject would impose type constraints this does not — its Labels is a
+// map[string]string, so an object with a non-string label value fails to
+// unmarshal entirely. That matters here: FilterItems *keeps* an item it cannot
+// decode rather than hiding it, so dropping the same item's identity would make
+// the Table path lose a row the JSON list path kept.
+type identityOnly struct {
+	Metadata struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"metadata"`
+}
+
 // ListIdentities returns the identity of every item in a JSON list body. ok is
 // false if the body is not a list, meaning the caller has no basis to filter a
 // Table against and should not pretend otherwise.
@@ -305,7 +318,7 @@ func ListIdentities(listBody []byte) (map[ObjectIdentity]bool, bool) {
 	}
 	out := make(map[ObjectIdentity]bool, len(list.Items))
 	for _, raw := range list.Items {
-		var o K8sObject
+		var o identityOnly
 		if err := json.Unmarshal(raw, &o); err != nil {
 			continue
 		}
@@ -340,7 +353,7 @@ func FilterTableRowsToIdentities(tableBody []byte, allow map[ObjectIdentity]bool
 	filtered := make([]json.RawMessage, 0, len(table.Rows))
 	for _, row := range table.Rows {
 		var r struct {
-			Object K8sObject `json:"object"`
+			Object identityOnly `json:"object"`
 		}
 		if err := json.Unmarshal(row, &r); err != nil {
 			filtered = append(filtered, row) // can't inspect — include to avoid data loss

--- a/internal/store/selector.go
+++ b/internal/store/selector.go
@@ -307,8 +307,16 @@ type identityOnly struct {
 }
 
 // ListIdentities returns the identity of every item in a JSON list body. ok is
-// false if the body is not a list, meaning the caller has no basis to filter a
-// Table against and should not pretend otherwise.
+// false if the body is not a list, or if any single item's identity cannot be
+// decoded — in both cases the caller has no sound basis to filter a Table and
+// should fall back rather than filter partially.
+//
+// Failing on one bad item rather than skipping it is deliberate. An item whose
+// identity won't decode cannot be correlated with a Table row at all, and
+// FilterItems *keeps* such an item rather than hiding it, so skipping it here
+// would drop a row the JSON list kept — the same divergence between the two read
+// paths that motivated this function. Falling back costs the captured columns
+// and cell values for that one response; partially filtering costs data.
 func ListIdentities(listBody []byte) (map[ObjectIdentity]bool, bool) {
 	var list struct {
 		Items []json.RawMessage `json:"items"`
@@ -320,7 +328,7 @@ func ListIdentities(listBody []byte) (map[ObjectIdentity]bool, bool) {
 	for _, raw := range list.Items {
 		var o identityOnly
 		if err := json.Unmarshal(raw, &o); err != nil {
-			continue
+			return nil, false
 		}
 		out[ObjectIdentity{o.Metadata.Namespace, o.Metadata.Name}] = true
 	}

--- a/internal/store/selector.go
+++ b/internal/store/selector.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -177,93 +176,23 @@ func MatchesLabels(obj *K8sObject, reqs []LabelRequirement) bool {
 	return true
 }
 
-// FieldSelectorReq is one parsed field= or field!= requirement.
-type FieldSelectorReq struct {
-	Field string
-	Op    string // "=" or "!="
-	Value string
-}
-
-// parseFieldSelectorSegment parses one fieldSelector segment ("key=val",
-// "key==val", or "key!=val") into a requirement. ok is false if the segment
-// matches none of those forms.
-func parseFieldSelectorSegment(seg string) (FieldSelectorReq, bool) {
-	if i := strings.Index(seg, "!="); i >= 0 {
-		return FieldSelectorReq{strings.TrimSpace(seg[:i]), "!=", strings.TrimSpace(seg[i+2:])}, true
-	}
-	if i := strings.Index(seg, "=="); i >= 0 {
-		return FieldSelectorReq{strings.TrimSpace(seg[:i]), "=", strings.TrimSpace(seg[i+2:])}, true
-	}
-	if i := strings.Index(seg, "="); i >= 0 {
-		return FieldSelectorReq{strings.TrimSpace(seg[:i]), "=", strings.TrimSpace(seg[i+1:])}, true
-	}
-	return FieldSelectorReq{}, false
-}
-
-// ParseFieldSelector parses a comma-separated fieldSelector for reads.
-// Supported fields: metadata.name, metadata.namespace. An unparseable segment
-// is silently skipped — best-effort, matching MatchesFields' generous
-// handling of unsupported keys — safe for a read, where "matches more than
-// intended" only affects display fidelity. deletecollection uses
-// FilterItemsStrict instead (see below), which parses with apimachinery's
-// real selector grammar rather than this lenient one, since the same
-// leniency there would risk deleting more than the caller asked for.
-func ParseFieldSelector(selector string) []FieldSelectorReq {
-	if selector == "" {
-		return nil
-	}
-	var reqs []FieldSelectorReq
-	for _, seg := range strings.Split(selector, ",") {
-		if req, ok := parseFieldSelectorSegment(strings.TrimSpace(seg)); ok {
-			reqs = append(reqs, req)
-		}
-	}
-	return reqs
-}
-
-// supportedFieldSelectorKeys are the metadata fields MatchesFields (and
-// fieldsAdapter, below) actually filter on; FilterItemsStrict rejects any
-// other key.
-var supportedFieldSelectorKeys = map[string]bool{
-	"metadata.name":      true,
-	"metadata.namespace": true,
-}
-
-// fieldsAdapter exposes a K8sObject's supported field-selector keys through
-// k8s.io/apimachinery/pkg/fields.Fields, so fields.Selector.Matches can
-// evaluate it directly.
-type fieldsAdapter struct{ obj *K8sObject }
-
-func (f fieldsAdapter) Has(field string) bool { return supportedFieldSelectorKeys[field] }
-
-func (f fieldsAdapter) Get(field string) string {
-	switch field {
-	case "metadata.name":
-		return f.obj.Metadata.Name
-	case "metadata.namespace":
-		return f.obj.Metadata.Namespace
-	default:
-		return ""
-	}
-}
-
-// FilterItemsStrict filters items for deletecollection using
-// k8s.io/apimachinery's own label/field selector grammar and matching
-// (labels.Parse, fields.ParseSelector) instead of FilterItems' best-effort,
-// hand-rolled parser. Multiple rounds of review turned up ever-more-specific
-// ways the hand-rolled parser leniently accepted a malformed selector as
-// "matches everything" (empty keys, empty segments, unbalanced set syntax,
-// invalid key characters, ...) — using the real, exhaustively-validated
-// parser closes off that entire class of gaps at once rather than patching
-// one shape of malformed input at a time. The read path (ApplySelectors,
-// FilterTableRows) is unaffected — it keeps its existing best-effort
-// FilterItems, where "matches more than intended" only affects display
-// fidelity, not what gets deleted.
+// FilterItemsStrict filters items for deletecollection. The field selector
+// arrives already parsed and validated by ParseFieldSelector (which uses
+// apimachinery's real grammar and the per-kind field-label contract), so this
+// only adds the write path's extra strictness on top: labels parsed with
+// labels.Parse rather than the best-effort ParseRequirements, and a selector
+// that parses to zero requirements rejected instead of treated as "matches
+// everything". Multiple rounds of review turned up ever-more-specific ways the
+// hand-rolled label parser leniently accepted a malformed selector as "matches
+// everything" (empty keys, empty segments, unbalanced set syntax, invalid key
+// characters, ...) — using the real, exhaustively-validated parser closes off
+// that entire class of gaps at once rather than patching one shape of malformed
+// input at a time.
 //
 // Returns an error message suitable for a 400 response (with items nil), or
 // ("", filtered) on success — filtered is items unchanged if both selectors
 // are empty.
-func FilterItemsStrict(items []json.RawMessage, labelSelector, fieldSelector string) (string, []json.RawMessage) {
+func FilterItemsStrict(items []json.RawMessage, labelSelector, fieldSelector string, fieldSel *FieldSelector) (string, []json.RawMessage) {
 	var labelSel labels.Selector
 	if labelSelector != "" {
 		sel, err := labels.Parse(labelSelector)
@@ -280,24 +209,13 @@ func FilterItemsStrict(items []json.RawMessage, labelSelector, fieldSelector str
 		}
 		labelSel = sel
 	}
-	var fieldSel fields.Selector
-	if fieldSelector != "" {
-		sel, err := fields.ParseSelector(fieldSelector)
-		if err != nil {
-			return "invalid fieldSelector: " + err.Error(), nil
-		}
-		// fields.ParseSelector is, unlike labels.Parse, lenient about a stray
-		// comma (e.g. "," or "a,,b" parses to zero requirements rather than
-		// erroring) — same vacuous "matches everything" risk as above.
-		if sel.Empty() {
-			return fmt.Sprintf("invalid fieldSelector %q: does not restrict the selection", fieldSelector), nil
-		}
-		for _, r := range sel.Requirements() {
-			if !supportedFieldSelectorKeys[r.Field] {
-				return fmt.Sprintf("unsupported fieldSelector key %q", r.Field), nil
-			}
-		}
-		fieldSel = sel
+	// fields.ParseSelector is, unlike labels.Parse, lenient about a stray comma
+	// (e.g. "," or "a,,b" parses to zero requirements rather than erroring) —
+	// same vacuous "matches everything" risk as above. A real apiserver accepts
+	// that and deletes everything matching the remaining requirements; refusing
+	// is a deliberate divergence on the write path only.
+	if fieldSelector != "" && !fieldSel.Restricts() {
+		return fmt.Sprintf("invalid fieldSelector %q: does not restrict the selection", fieldSelector), nil
 	}
 	if labelSel == nil && fieldSel == nil {
 		return "", items
@@ -313,7 +231,7 @@ func FilterItemsStrict(items []json.RawMessage, labelSelector, fieldSelector str
 		if labelSel != nil && !labelSel.Matches(labels.Set(obj.Metadata.Labels)) {
 			continue
 		}
-		if fieldSel != nil && !fieldSel.Matches(fieldsAdapter{&obj}) {
+		if !fieldSel.Matches(raw, &obj) {
 			continue
 		}
 		filtered = append(filtered, raw)
@@ -321,40 +239,12 @@ func FilterItemsStrict(items []json.RawMessage, labelSelector, fieldSelector str
 	return "", filtered
 }
 
-// MatchesFields returns true if the object satisfies all field selector requirements.
-// Only metadata.name and metadata.namespace are supported.
-func MatchesFields(obj *K8sObject, reqs []FieldSelectorReq) bool {
-	for _, r := range reqs {
-		var actual string
-		switch r.Field {
-		case "metadata.name":
-			actual = obj.Metadata.Name
-		case "metadata.namespace":
-			actual = obj.Metadata.Namespace
-		default:
-			// Unknown field — skip (generous, avoids false negatives on unsupported fields).
-			continue
-		}
-		switch r.Op {
-		case "=":
-			if actual != r.Value {
-				return false
-			}
-		case "!=":
-			if actual == r.Value {
-				return false
-			}
-		}
-	}
-	return true
-}
-
 // FilterTableRows applies label/field selectors to a Table-format response,
 // keeping only rows whose embedded object satisfies both selectors. Returns the
 // original body unchanged if selectors are empty, the body cannot be decoded as
 // a Table, or the rows array is absent.
-func FilterTableRows(tableBody []byte, labelSelector, fieldSelector string) ([]byte, error) {
-	if labelSelector == "" && fieldSelector == "" {
+func FilterTableRows(tableBody []byte, labelSelector string, fieldSel *FieldSelector) ([]byte, error) {
+	if labelSelector == "" && fieldSel == nil {
 		return tableBody, nil
 	}
 
@@ -362,8 +252,80 @@ func FilterTableRows(tableBody []byte, labelSelector, fieldSelector string) ([]b
 	if err != nil {
 		return tableBody, nil // malformed selector — serve unfiltered (best-effort)
 	}
-	fieldReqs := ParseFieldSelector(fieldSelector)
 
+	var table struct {
+		APIVersion        json.RawMessage   `json:"apiVersion"`
+		Kind              json.RawMessage   `json:"kind"`
+		Metadata          json.RawMessage   `json:"metadata"`
+		ColumnDefinitions json.RawMessage   `json:"columnDefinitions"`
+		Rows              []json.RawMessage `json:"rows"`
+	}
+	if err := json.Unmarshal(tableBody, &table); err != nil || table.Rows == nil {
+		return tableBody, nil
+	}
+
+	filtered := make([]json.RawMessage, 0, len(table.Rows))
+	for _, row := range table.Rows {
+		var r struct {
+			Object json.RawMessage `json:"object"`
+		}
+		if err := json.Unmarshal(row, &r); err != nil {
+			filtered = append(filtered, row) // can't inspect — include to avoid data loss
+			continue
+		}
+		var obj K8sObject
+		if err := json.Unmarshal(r.Object, &obj); err != nil {
+			filtered = append(filtered, row)
+			continue
+		}
+		if MatchesLabels(&obj, labelReqs) && fieldSel.Matches(r.Object, &obj) {
+			filtered = append(filtered, row)
+		}
+	}
+	table.Rows = filtered
+	return json.Marshal(table)
+}
+
+// ObjectIdentity is a namespace/name pair — enough to match a Table row back to
+// the list item it was projected from.
+type ObjectIdentity struct {
+	Namespace string
+	Name      string
+}
+
+// ListIdentities returns the identity of every item in a JSON list body. ok is
+// false if the body is not a list, meaning the caller has no basis to filter a
+// Table against and should not pretend otherwise.
+func ListIdentities(listBody []byte) (map[ObjectIdentity]bool, bool) {
+	var list struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(listBody, &list); err != nil || list.Items == nil {
+		return nil, false
+	}
+	out := make(map[ObjectIdentity]bool, len(list.Items))
+	for _, raw := range list.Items {
+		var o K8sObject
+		if err := json.Unmarshal(raw, &o); err != nil {
+			continue
+		}
+		out[ObjectIdentity{o.Metadata.Namespace, o.Metadata.Name}] = true
+	}
+	return out, true
+}
+
+// FilterTableRowsToIdentities keeps only the Table rows whose embedded object is
+// in allow.
+//
+// A stored Table's rows embed a PartialObjectMetadata — metadata only, since
+// that is what the apiserver serves for a Table projection — so a selector on
+// spec or status cannot be evaluated against them at all. A real apiserver
+// filters the full objects and *then* projects to Table; this reproduces that
+// order by intersecting with the identities that survived on the JSON list,
+// which was filtered with the full objects in hand.
+//
+// Returns the body unchanged if it cannot be decoded as a Table or has no rows.
+func FilterTableRowsToIdentities(tableBody []byte, allow map[ObjectIdentity]bool) ([]byte, error) {
 	var table struct {
 		APIVersion        json.RawMessage   `json:"apiVersion"`
 		Kind              json.RawMessage   `json:"kind"`
@@ -384,7 +346,7 @@ func FilterTableRows(tableBody []byte, labelSelector, fieldSelector string) ([]b
 			filtered = append(filtered, row) // can't inspect — include to avoid data loss
 			continue
 		}
-		if MatchesLabels(&r.Object, labelReqs) && MatchesFields(&r.Object, fieldReqs) {
+		if allow[ObjectIdentity{r.Object.Metadata.Namespace, r.Object.Metadata.Name}] {
 			filtered = append(filtered, row)
 		}
 	}
@@ -392,23 +354,20 @@ func FilterTableRows(tableBody []byte, labelSelector, fieldSelector string) ([]b
 	return json.Marshal(table)
 }
 
-// FilterItems returns the subset of items matching both labelSelector and
-// fieldSelector. Best-effort, matching ApplySelectors (the only caller): a
-// malformed labelSelector returns items unfiltered rather than erroring, and
-// an item that fails to unmarshal is kept (never silently hidden) — safe for
-// a read, where "matches more than intended" only affects display fidelity.
-// The writable overlay's deletecollection uses the stricter FilterItemsStrict
-// instead (below), where the same leniency would risk deleting more than the
-// caller asked for.
-func FilterItems(items []json.RawMessage, labelSelector, fieldSelector string) []json.RawMessage {
-	if labelSelector == "" && fieldSelector == "" {
+// FilterItems returns the subset of items matching both selectors. The field
+// selector arrives already parsed and validated per-kind by ParseFieldSelector,
+// so an unsupported label never reaches here — it was rejected as a 400 by the
+// caller. Label handling stays best-effort: a malformed labelSelector returns
+// items unfiltered rather than erroring, and an item that fails to unmarshal is
+// kept (never silently hidden).
+func FilterItems(items []json.RawMessage, labelSelector string, fieldSel *FieldSelector) []json.RawMessage {
+	if labelSelector == "" && fieldSel == nil {
 		return items
 	}
 	labelReqs, err := ParseRequirements(labelSelector)
 	if err != nil {
 		return items // malformed selector — best-effort, same as ApplySelectors
 	}
-	fieldReqs := ParseFieldSelector(fieldSelector)
 
 	filtered := items[:0]
 	for _, raw := range items {
@@ -418,7 +377,7 @@ func FilterItems(items []json.RawMessage, labelSelector, fieldSelector string) [
 			filtered = append(filtered, raw)
 			continue
 		}
-		if MatchesLabels(&obj, labelReqs) && MatchesFields(&obj, fieldReqs) {
+		if MatchesLabels(&obj, labelReqs) && fieldSel.Matches(raw, &obj) {
 			filtered = append(filtered, raw)
 		}
 	}
@@ -426,10 +385,10 @@ func FilterItems(items []json.RawMessage, labelSelector, fieldSelector string) [
 }
 
 // ApplySelectors filters a JSON list body keeping only items that match both
-// labelSelector and fieldSelector. Returns the original body unchanged if
-// both selectors are empty or if the body is not a list.
-func ApplySelectors(body []byte, labelSelector, fieldSelector string) ([]byte, error) {
-	if labelSelector == "" && fieldSelector == "" {
+// selectors. Returns the original body unchanged if both selectors are empty or
+// if the body is not a list.
+func ApplySelectors(body []byte, labelSelector string, fieldSel *FieldSelector) ([]byte, error) {
+	if labelSelector == "" && fieldSel == nil {
 		return body, nil
 	}
 
@@ -445,6 +404,6 @@ func ApplySelectors(body []byte, labelSelector, fieldSelector string) ([]byte, e
 		return body, nil
 	}
 
-	list.Items = FilterItems(list.Items, labelSelector, fieldSelector)
+	list.Items = FilterItems(list.Items, labelSelector, fieldSel)
 	return json.Marshal(list)
 }

--- a/internal/store/selector_test.go
+++ b/internal/store/selector_test.go
@@ -91,7 +91,7 @@ func TestApplySelectors_LabelFilter(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		filtered, err := ApplySelectors(list, tc.sel, "")
+		filtered, err := ApplySelectors(list, tc.sel, nil)
 		if err != nil {
 			t.Fatalf("[%q] error: %v", tc.sel, err)
 		}
@@ -116,14 +116,10 @@ func TestApplySelectors_FieldFilter(t *testing.T) {
 		{"metadata.name!=nginx", []string{"redis"}},
 		{"metadata.namespace=kube-system", []string{"redis"}},
 		{"metadata.namespace!=kube-system", []string{"nginx"}},
-		// Whitespace around the operator must be trimmed from both sides, not
-		// just the key — "= nginx" (with a leading space in the value) should
-		// still match "nginx".
-		{"metadata.name = nginx", []string{"nginx"}},
 	}
 
 	for _, tc := range cases {
-		filtered, err := ApplySelectors(list, "", tc.sel)
+		filtered, err := ApplySelectors(list, "", mustFieldSelector(t, "", "pods", tc.sel))
 		if err != nil {
 			t.Fatalf("[%q] error: %v", tc.sel, err)
 		}
@@ -136,7 +132,7 @@ func TestApplySelectors_FieldFilter(t *testing.T) {
 
 func TestApplySelectors_EmptySelector(t *testing.T) {
 	list := listWithPods([]podSpec{{name: "nginx", labels: map[string]string{"app": "nginx"}}})
-	out, err := ApplySelectors(list, "", "")
+	out, err := ApplySelectors(list, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +144,7 @@ func TestApplySelectors_EmptySelector(t *testing.T) {
 
 func TestApplySelectors_NotAList(t *testing.T) {
 	body := []byte(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"nginx"}}`)
-	out, err := ApplySelectors(body, "app=nginx", "")
+	out, err := ApplySelectors(body, "app=nginx", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,7 +300,7 @@ func TestFilterTableRows_LabelFilter(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		filtered, err := FilterTableRows(table, tc.sel, "")
+		filtered, err := FilterTableRows(table, tc.sel, nil)
 		if err != nil {
 			t.Fatalf("[%q] error: %v", tc.sel, err)
 		}
@@ -331,7 +327,7 @@ func TestFilterTableRows_FieldFilter(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		filtered, err := FilterTableRows(table, "", tc.sel)
+		filtered, err := FilterTableRows(table, "", mustFieldSelector(t, "", "pods", tc.sel))
 		if err != nil {
 			t.Fatalf("[%q] error: %v", tc.sel, err)
 		}
@@ -344,7 +340,7 @@ func TestFilterTableRows_FieldFilter(t *testing.T) {
 
 func TestFilterTableRows_EmptySelector(t *testing.T) {
 	table := tableWithPods([]podSpec{{name: "nginx", labels: map[string]string{"app": "nginx"}}})
-	out, err := FilterTableRows(table, "", "")
+	out, err := FilterTableRows(table, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -355,7 +351,7 @@ func TestFilterTableRows_EmptySelector(t *testing.T) {
 
 func TestFilterTableRows_NotATable(t *testing.T) {
 	body := []byte(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"nginx"}}`)
-	out, err := FilterTableRows(body, "app=nginx", "")
+	out, err := FilterTableRows(body, "app=nginx", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -123,6 +123,13 @@ resources:
   - { group: apps, version: v1, resource: deployments, namespaces: [conf-test], interval: 5s }
   - { group: apps, version: v1, resource: replicasets, namespaces: [conf-test], interval: 5s }
   - { group: batch, version: v1, resource: jobs, namespaces: [conf-test], interval: 5s }
+  # Events, in both API groups, so the field-selector differential (section G)
+  # can exercise involvedObject.*/regarding.* — the kinds with the most
+  # interesting field-label contract, including the events.k8s.io alias
+  # mapping. kube-system is used because a fresh KinD cluster reliably has
+  # control-plane events there.
+  - { version: v1, resource: events, namespaces: [kube-system], interval: 5s }
+  - { group: events.k8s.io, version: v1, resource: events, namespaces: [kube-system], interval: 5s }
 YAML
 "$BINARY" --config "$CAPTURE_CONFIG" capture
 [[ -s "$CAPTURE_FILE" ]] || die "capture archive missing/empty"

--- a/scripts/conformance_diff.py
+++ b/scripts/conformance_diff.py
@@ -640,8 +640,14 @@ def field_selector_probes(live, mock):
     probes = []
     pods_path = f"/api/v1/namespaces/{PROBE_NS}/pods"
 
-    def add(label, path, selector):
-        probes.append((label, f"{path}?fieldSelector={urllib.parse.quote(selector)}"))
+    # churn marks a kind whose contents change while the run is in flight, so an
+    # exact live-vs-mock set comparison could never hold: the capture is a
+    # snapshot and the live cluster keeps emitting. For those, base is the
+    # unfiltered list path, and the comparison asserts the properties that still
+    # hold — see check_field_selectors.
+    def add(label, path, selector, churn=False):
+        probes.append((label, f"{path}?fieldSelector={urllib.parse.quote(selector)}",
+                       path if churn else None))
 
     # Pods: the kind with the largest selectable set, and the one the issue was
     # filed against.
@@ -686,12 +692,15 @@ def field_selector_probes(live, mock):
         "type=kubernetes.io/service-account-token")
 
     events_path = "/api/v1/namespaces/kube-system/events"
-    add("events involvedObject.kind=Pod", events_path, "involvedObject.kind=Pod")
-    add("events type=Normal", events_path, "type=Normal")
-    add("events source (unsupported on events.k8s.io)",
-        "/apis/events.k8s.io/v1/namespaces/kube-system/events", "source=kubelet")
-    add("events regarding.kind=Pod",
-        "/apis/events.k8s.io/v1/namespaces/kube-system/events", "regarding.kind=Pod")
+    new_events_path = "/apis/events.k8s.io/v1/namespaces/kube-system/events"
+    add("events involvedObject.kind=Pod", events_path, "involvedObject.kind=Pod", churn=True)
+    add("events type=Normal", events_path, "type=Normal", churn=True)
+    # Must match nothing on both sides regardless of churn, so it stays an exact
+    # comparison — the cheapest possible over-match detector.
+    add("events involvedObject.kind (no match)", events_path,
+        "involvedObject.kind=K8sharkNoSuchKind")
+    add("events source (unsupported on events.k8s.io)", new_events_path, "source=kubelet")
+    add("events regarding.kind=Pod", new_events_path, "regarding.kind=Pod", churn=True)
 
     # apps registers no conversion func at all, so everything but the metadata
     # keys is a 400 — an easy one to get wrong by assuming status.replicas works.
@@ -704,7 +713,7 @@ def field_selector_probes(live, mock):
 
 def check_field_selectors(live, mock):
     print(f"\n{BOLD}{CYN}== G. Field selectors =={RST}")
-    for label, path in field_selector_probes(live, mock):
+    for label, path, base in field_selector_probes(live, mock):
         lc, lb = live.get_json(path)
         mc, mb = mock.get_json(path)
         # A transport failure against live tells us nothing about the mock.
@@ -717,25 +726,50 @@ def check_field_selectors(live, mock):
                    f"status live={lc} mock={mc}; mock body={str(mb)[:200]}")
             continue
         if lc != 200:
-            # Both rejected (or both 404'd) — agreement on the error is the point.
+            # Both rejected (or both 404'd) — agreement on the error is the point,
+            # and it is the signal that matters most: it is the per-kind
+            # field-label contract, independent of what the capture contains.
             record("fieldselector", label, "PASS", f"live=mock={lc}")
             continue
         live_names = sorted(name for name, _ in named_items(lb))
         mock_names = sorted(name for name, _ in named_items(mb))
-        if live_names == mock_names:
-            record("fieldselector", label, "PASS", f"{len(live_names)} item(s) both sides")
+
+        if base is None:
+            if live_names == mock_names:
+                record("fieldselector", label, "PASS", f"{len(live_names)} item(s) both sides")
+                continue
+            only_live = [n for n in live_names if n not in set(mock_names)]
+            only_mock = [n for n in mock_names if n not in set(live_names)]
+            detail = f"live={live_names} mock={mock_names}"
+            if only_mock and not only_live:
+                detail = f"mock over-matched: extra={only_mock} ({detail})"
+            record("fieldselector", label, "UNEXPECTED", detail)
             continue
-        only_live = [n for n in live_names if n not in set(mock_names)]
-        only_mock = [n for n in mock_names if n not in set(live_names)]
-        # A capture is a point-in-time snapshot, so a set difference is only
-        # meaningful as a *selector* bug when the mock returns strictly more than
-        # it should relative to its own unfiltered list. Report the difference
-        # either way, but name the over-matching case explicitly since that is
-        # the silent-failure mode.
-        detail = f"live={live_names} mock={mock_names}"
-        if only_mock and not only_live:
-            detail = f"mock over-matched: extra={only_mock} ({detail})"
-        record("fieldselector", label, "UNEXPECTED", detail)
+
+        # Churn-prone kind. The capture froze a snapshot and the live cluster has
+        # kept emitting since, so live is expected to be a strict superset and an
+        # equality check could never pass. Two properties still hold, and between
+        # them they catch both failure directions:
+        #
+        #   over-match — the mock must not return an item the live server, with
+        #     the same selector, filtered out;
+        #   under-match — if the mock holds items for this kind at all, a
+        #     selector the live server matched something with must match
+        #     something here too, rather than silently filtering everything away.
+        extra = [n for n in mock_names if n not in set(live_names)]
+        if extra:
+            record("fieldselector", label, "UNEXPECTED",
+                   f"mock over-matched: returned {len(extra)} item(s) live filtered out: {extra[:5]}")
+            continue
+        _, unfiltered = mock.get_json(base)
+        held = sorted(name for name, _ in named_items(unfiltered))
+        if held and live_names and not mock_names:
+            record("fieldselector", label, "UNEXPECTED",
+                   f"mock under-matched: 0 of its {len(held)} captured item(s) matched, "
+                   f"but live matched {len(live_names)}")
+            continue
+        record("fieldselector", label, "PASS",
+               f"mock {len(mock_names)}/{len(held)} captured, live {len(live_names)} (churn-tolerant)")
 
 
 # ── summary ──────────────────────────────────────────────────────────────────────

--- a/scripts/conformance_diff.py
+++ b/scripts/conformance_diff.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 
 LIVE_KC = os.environ["LIVE_KUBECONFIG"]
@@ -214,6 +215,7 @@ def main():
         check_resources(live, mock)
         check_health(live, mock)
         check_errors(live, mock)
+        check_field_selectors(live, mock)
     finally:
         live.stop()
         mock.stop()
@@ -617,6 +619,123 @@ def check_errors(live, mock):
     else:
         record("errors", "404 for unknown group/version", "UNEXPECTED",
                f"mock status={mc} (live=404) body={mb}")
+
+
+# ── G. Field selectors ──────────────────────────────────────────────────────────
+# The mock hand-maintains the apiserver's per-kind field-label tables (see
+# internal/store/fieldselector.go), because upstream registers them in
+# k8s.io/kubernetes's internal API packages, which are not importable from
+# k8s.io/api or client-go. This check is the behavioral half of keeping them in
+# sync: the live apiserver *is* the table, so if upstream adds, removes, or
+# renames a selectable field, the mock's answer stops matching and the run
+# reports a new divergence. scripts/fieldselector_drift.py covers the kinds a
+# capture may not contain.
+#
+# Each probe compares the full response — status code *and* the matched set — so
+# it catches both failure directions: rejecting a key upstream accepts, and
+# silently matching everything for a key upstream filters on (#339).
+def field_selector_probes(live, mock):
+    """Build the probe list, resolving real object names from the live cluster so
+    an equality probe has something to match. Returns a list of (label, path)."""
+    probes = []
+    pods_path = f"/api/v1/namespaces/{PROBE_NS}/pods"
+
+    def add(label, path, selector):
+        probes.append((label, f"{path}?fieldSelector={urllib.parse.quote(selector)}"))
+
+    # Pods: the kind with the largest selectable set, and the one the issue was
+    # filed against.
+    _, lb = live.get_json(pods_path)
+    _, mb = mock.get_json(pods_path)
+    pod_name = first_common_name(lb, mb)
+    if pod_name:
+        add("pods metadata.name", pods_path, f"metadata.name={pod_name}")
+    node_name = None
+    for _, item in named_items(lb):
+        node_name = (item.get("spec") or {}).get("nodeName")
+        if node_name:
+            break
+    if node_name:
+        # The query `kubectl describe node` issues, and the one from #339.
+        add("pods spec.nodeName (match)", pods_path, f"spec.nodeName={node_name}")
+    add("pods spec.nodeName (no match)", pods_path, "spec.nodeName=k8shark-no-such-node")
+    add("pods status.phase=Running", pods_path, "status.phase=Running")
+    add("pods status.phase=Failed", pods_path, "status.phase=Failed")
+    add("pods spec.restartPolicy=Always", pods_path, "spec.restartPolicy=Always")
+    add("pods spec.hostNetwork=false", pods_path, "spec.hostNetwork=false")
+    add("pods spec.serviceAccountName=default", pods_path, "spec.serviceAccountName=default")
+    # Accepted by the conversion func but never set by ToSelectableFields, so
+    # upstream accepts the request and matches nothing.
+    add("pods status.podIPs (accepted, not selectable)", pods_path, "status.podIPs=10.0.0.1")
+    # Legacy alias, rewritten to spec.nodeName upstream.
+    if node_name:
+        add("pods spec.host (legacy alias)", pods_path, f"spec.host={node_name}")
+    # Unsupported for pods — must be a 400, not a full list.
+    add("pods spec.bogus (unsupported)", pods_path, "spec.bogus=x")
+    add("pods spec.unschedulable (other kind's key)", pods_path, "spec.unschedulable=true")
+
+    # Cluster-scoped kinds restrict metadata.namespace, which is a 400 upstream
+    # rather than an empty result.
+    add("nodes spec.unschedulable=false", "/api/v1/nodes", "spec.unschedulable=false")
+    add("nodes metadata.namespace (unsupported)", "/api/v1/nodes", "metadata.namespace=default")
+
+    add("services spec.type=ClusterIP", f"/api/v1/namespaces/{PROBE_NS}/services",
+        "spec.type=ClusterIP")
+    add("namespaces status.phase=Active", "/api/v1/namespaces", "status.phase=Active")
+    add("secrets type", f"/api/v1/namespaces/{PROBE_NS}/secrets",
+        "type=kubernetes.io/service-account-token")
+
+    events_path = "/api/v1/namespaces/kube-system/events"
+    add("events involvedObject.kind=Pod", events_path, "involvedObject.kind=Pod")
+    add("events type=Normal", events_path, "type=Normal")
+    add("events source (unsupported on events.k8s.io)",
+        "/apis/events.k8s.io/v1/namespaces/kube-system/events", "source=kubelet")
+    add("events regarding.kind=Pod",
+        "/apis/events.k8s.io/v1/namespaces/kube-system/events", "regarding.kind=Pod")
+
+    # apps registers no conversion func at all, so everything but the metadata
+    # keys is a 400 — an easy one to get wrong by assuming status.replicas works.
+    deploys = f"/apis/apps/v1/namespaces/{PROBE_NS}/deployments"
+    add("deployments status.replicas (unsupported)", deploys, "status.replicas=1")
+    add("deployments metadata.name (supported)", deploys, "metadata.name=nonexistent-xyz")
+
+    return probes
+
+
+def check_field_selectors(live, mock):
+    print(f"\n{BOLD}{CYN}== G. Field selectors =={RST}")
+    for label, path in field_selector_probes(live, mock):
+        lc, lb = live.get_json(path)
+        mc, mb = mock.get_json(path)
+        # A transport failure against live tells us nothing about the mock.
+        if lc == 0:
+            record("fieldselector", label, "UNEXPECTED",
+                   f"live transport error, cannot compare: {lb}")
+            continue
+        if lc != mc:
+            record("fieldselector", label, "UNEXPECTED",
+                   f"status live={lc} mock={mc}; mock body={str(mb)[:200]}")
+            continue
+        if lc != 200:
+            # Both rejected (or both 404'd) — agreement on the error is the point.
+            record("fieldselector", label, "PASS", f"live=mock={lc}")
+            continue
+        live_names = sorted(name for name, _ in named_items(lb))
+        mock_names = sorted(name for name, _ in named_items(mb))
+        if live_names == mock_names:
+            record("fieldselector", label, "PASS", f"{len(live_names)} item(s) both sides")
+            continue
+        only_live = [n for n in live_names if n not in set(mock_names)]
+        only_mock = [n for n in mock_names if n not in set(live_names)]
+        # A capture is a point-in-time snapshot, so a set difference is only
+        # meaningful as a *selector* bug when the mock returns strictly more than
+        # it should relative to its own unfiltered list. Report the difference
+        # either way, but name the over-matching case explicitly since that is
+        # the silent-failure mode.
+        detail = f"live={live_names} mock={mock_names}"
+        if only_mock and not only_live:
+            detail = f"mock over-matched: extra={only_mock} ({detail})"
+        record("fieldselector", label, "UNEXPECTED", detail)
 
 
 # ── summary ──────────────────────────────────────────────────────────────────────

--- a/scripts/conformance_diff.py
+++ b/scripts/conformance_diff.py
@@ -642,9 +642,16 @@ def field_selector_probes(live, mock):
 
     # churn marks a kind whose contents change while the run is in flight, so an
     # exact live-vs-mock set comparison could never hold: the capture is a
-    # snapshot and the live cluster keeps emitting. For those, base is the
-    # unfiltered list path, and the comparison asserts the properties that still
-    # hold — see check_field_selectors.
+    # snapshot and the live cluster keeps emitting. Those probes are checked for
+    # self-consistency against the mock's own unfiltered list (base) instead —
+    # see check_field_selectors.
+    #
+    # Only set churn on a probe whose selector is a single key=value whose key is
+    # also the field's path in the served JSON, since that is what makes the
+    # local evaluation correct. pods' status.podIPs is the counterexample: the
+    # field is present in the object, so a local evaluator would expect a match,
+    # while upstream matches nothing because ToSelectableFields never sets that
+    # key — a correct mock would be marked wrong.
     def add(label, path, selector, churn=False):
         probes.append((label, f"{path}?fieldSelector={urllib.parse.quote(selector)}",
                        path if churn else None))
@@ -711,6 +718,23 @@ def field_selector_probes(live, mock):
     return probes
 
 
+def probe_key_value(path):
+    """('type', 'Normal') from a probe path's ?fieldSelector=type%3DNormal."""
+    query = urllib.parse.urlparse(path).query
+    selector = urllib.parse.parse_qs(query).get("fieldSelector", [""])[0]
+    key, _, value = selector.partition("=")
+    return key, value
+
+
+def dotted_get(obj, path):
+    """Walk a dotted path through a decoded JSON object; None if absent."""
+    for part in path.split("."):
+        if not isinstance(obj, dict):
+            return None
+        obj = obj.get(part)
+    return obj
+
+
 def check_field_selectors(live, mock):
     print(f"\n{BOLD}{CYN}== G. Field selectors =={RST}")
     for label, path, base in field_selector_probes(live, mock):
@@ -746,30 +770,42 @@ def check_field_selectors(live, mock):
             record("fieldselector", label, "UNEXPECTED", detail)
             continue
 
-        # Churn-prone kind. The capture froze a snapshot and the live cluster has
-        # kept emitting since, so live is expected to be a strict superset and an
-        # equality check could never pass. Two properties still hold, and between
-        # them they catch both failure directions:
+        # Churn-prone kind: the capture froze a snapshot and the live cluster has
+        # kept emitting since, so live holds items the mock has never seen and a
+        # live-vs-mock equality check could never pass. Compare the mock against
+        # *itself* instead — ask it for the unfiltered list, work out here which
+        # of those items the selector should match, and require its filtered
+        # answer to be exactly that. Both sides of the comparison come from the
+        # same capture, so churn cannot affect it and the check stays exact: a
+        # mock that returns 3 items where its own data implies 35 fails, which a
+        # subset-and-non-empty heuristic would have passed.
         #
-        #   over-match — the mock must not return an item the live server, with
-        #     the same selector, filtered out;
-        #   under-match — if the mock holds items for this kind at all, a
-        #     selector the live server matched something with must match
-        #     something here too, rather than silently filtering everything away.
-        extra = [n for n in mock_names if n not in set(live_names)]
-        if extra:
+        # Live still supplies the signal that matters most for these probes —
+        # agreement on the status code, checked above, which is the per-kind
+        # field-label contract itself.
+        key, value = probe_key_value(path)
+        if key == "" or "," in key or "," in value:
             record("fieldselector", label, "UNEXPECTED",
-                   f"mock over-matched: returned {len(extra)} item(s) live filtered out: {extra[:5]}")
+                   f"harness error: a churn probe must be one key=value requirement, got {key}={value}")
             continue
         _, unfiltered = mock.get_json(base)
         held = sorted(name for name, _ in named_items(unfiltered))
-        if held and live_names and not mock_names:
-            record("fieldselector", label, "UNEXPECTED",
-                   f"mock under-matched: 0 of its {len(held)} captured item(s) matched, "
-                   f"but live matched {len(live_names)}")
+        expected = sorted(name for name, item in named_items(unfiltered)
+                          if dotted_get(item, key) == value)
+        if mock_names == expected:
+            record("fieldselector", label, "PASS",
+                   f"{len(expected)} of the mock's {len(held)} captured item(s); live matched "
+                   f"{len(live_names)} (compared against the mock's own list — see above)")
             continue
-        record("fieldselector", label, "PASS",
-               f"mock {len(mock_names)}/{len(held)} captured, live {len(live_names)} (churn-tolerant)")
+        missing = [n for n in expected if n not in set(mock_names)]
+        extra = [n for n in mock_names if n not in set(expected)]
+        detail = (f"mock returned {len(mock_names)} item(s), but its own {len(held)} captured "
+                  f"item(s) imply {len(expected)}")
+        if extra:
+            detail += f"; over-matched: {extra[:5]}"
+        if missing:
+            detail += f"; under-matched: {missing[:5]}"
+        record("fieldselector", label, "UNEXPECTED", detail)
 
 
 # ── summary ──────────────────────────────────────────────────────────────────────

--- a/scripts/fieldselector-snapshot.json
+++ b/scripts/fieldselector-snapshot.json
@@ -1,0 +1,156 @@
+{
+  "accepted": {
+    "pkg/apis/apps/v1/conversion.go": {},
+    "pkg/apis/batch/v1/conversion.go": {
+      "Job": [
+        "metadata.name",
+        "metadata.namespace",
+        "status.successful"
+      ]
+    },
+    "pkg/apis/certificates/v1/conversion.go": {
+      "CertificateSigningRequest": [
+        "metadata.name",
+        "spec.signerName"
+      ]
+    },
+    "pkg/apis/core/v1/conversion.go": {
+      "Event": [
+        "involvedObject.apiVersion",
+        "involvedObject.fieldPath",
+        "involvedObject.kind",
+        "involvedObject.name",
+        "involvedObject.namespace",
+        "involvedObject.resourceVersion",
+        "involvedObject.uid",
+        "metadata.name",
+        "metadata.namespace",
+        "reason",
+        "reportingComponent",
+        "source",
+        "type"
+      ],
+      "Namespace": [
+        "metadata.name",
+        "status.phase"
+      ],
+      "Node": [
+        "metadata.name",
+        "spec.unschedulable"
+      ],
+      "Pod": [
+        "metadata.name",
+        "metadata.namespace",
+        "spec.host",
+        "spec.hostNetwork",
+        "spec.nodeName",
+        "spec.restartPolicy",
+        "spec.schedulerName",
+        "spec.serviceAccountName",
+        "status.nominatedNodeName",
+        "status.phase",
+        "status.podIP",
+        "status.podIPs"
+      ],
+      "ReplicationController": [
+        "metadata.name",
+        "metadata.namespace",
+        "status.replicas"
+      ],
+      "Secret": [
+        "metadata.name",
+        "metadata.namespace",
+        "type"
+      ],
+      "Service": [
+        "metadata.name",
+        "metadata.namespace",
+        "spec.clusterIP",
+        "spec.type"
+      ]
+    },
+    "pkg/apis/events/v1/conversion.go": {
+      "Event": [
+        "metadata.name",
+        "metadata.namespace",
+        "reason",
+        "regarding.apiVersion",
+        "regarding.fieldPath",
+        "regarding.kind",
+        "regarding.name",
+        "regarding.namespace",
+        "regarding.resourceVersion",
+        "regarding.uid",
+        "reportingController",
+        "type"
+      ]
+    }
+  },
+  "kubernetesVersion": "1.36",
+  "selectable": {
+    "pkg/registry/batch/job/strategy.go": {
+      "JobToSelectableFields": [
+        "status.successful"
+      ]
+    },
+    "pkg/registry/certificates/certificates/strategy.go": {
+      "SelectableFields": [
+        "spec.signerName"
+      ]
+    },
+    "pkg/registry/core/event/strategy.go": {
+      "ToSelectableFields": [
+        "involvedObject.apiVersion",
+        "involvedObject.fieldPath",
+        "involvedObject.kind",
+        "involvedObject.name",
+        "involvedObject.namespace",
+        "involvedObject.resourceVersion",
+        "involvedObject.uid",
+        "reason",
+        "reportingComponent",
+        "source",
+        "type"
+      ]
+    },
+    "pkg/registry/core/namespace/strategy.go": {
+      "NamespaceToSelectableFields": [
+        "name",
+        "status.phase"
+      ]
+    },
+    "pkg/registry/core/node/strategy.go": {
+      "NodeToSelectableFields": [
+        "spec.unschedulable"
+      ]
+    },
+    "pkg/registry/core/pod/strategy.go": {
+      "ToSelectableFields": [
+        "spec.hostNetwork",
+        "spec.nodeName",
+        "spec.restartPolicy",
+        "spec.schedulerName",
+        "spec.serviceAccountName",
+        "status.nominatedNodeName",
+        "status.phase",
+        "status.podIP"
+      ]
+    },
+    "pkg/registry/core/replicationcontroller/strategy.go": {
+      "ControllerToSelectableFields": [
+        "status.replicas"
+      ]
+    },
+    "pkg/registry/core/secret/strategy.go": {
+      "SelectableFields": [
+        "type"
+      ]
+    },
+    "pkg/registry/core/service/strategy.go": {
+      "SelectableFields": [
+        "spec.clusterIP",
+        "spec.type"
+      ]
+    }
+  }
+}

--- a/scripts/fieldselector_drift.py
+++ b/scripts/fieldselector_drift.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Detect drift between k8shark's field-label tables and upstream Kubernetes.
+
+internal/store/fieldselector.go hand-transcribes two upstream lists per kind:
+
+  1. the labels a fieldSelector may use — the per-kind funcs registered with
+     AddFieldLabelConversionFunc in pkg/apis/<group>/<version>/conversion.go;
+  2. the labels that actually resolve to a value — the registry strategy's
+     ToSelectableFields in pkg/registry/.../strategy.go.
+
+They are hand-maintained because upstream registers them in
+k8s.io/kubernetes's *internal* API packages, which are not reachable from
+k8s.io/api or client-go — there is nothing to reflect over at build time.
+
+The conformance differential (scripts/conformance_diff.py, section G) is the
+primary drift detector, since it compares behavior against a live apiserver. Its
+blind spot is any kind or key the capture does not contain: a KinD capture
+usually has no CertificateSigningRequest, so spec.signerName goes unexercised.
+This script covers that gap by parsing the upstream source at the Kubernetes
+minor version pinned in go.mod and diffing the extracted labels against a
+checked-in snapshot.
+
+It is text extraction, so it is brittle to upstream refactors *by design*: a
+parse that stops finding a known list is reported as drift to investigate, not
+silently ignored.
+
+Usage:
+    ./scripts/fieldselector_drift.py            # compare against the snapshot
+    ./scripts/fieldselector_drift.py --update   # rewrite the snapshot
+    ./scripts/fieldselector_drift.py --version 1.36   # override the k8s minor
+
+Exit codes: 0 no drift, 1 drift found, 2 could not complete the comparison.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+PROJ_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SNAPSHOT = os.path.join(PROJ_ROOT, "scripts", "fieldselector-snapshot.json")
+RAW = "https://raw.githubusercontent.com/kubernetes/kubernetes/release-{ver}/{path}"
+
+# Files to scrape, and what to pull out of each.
+#
+# `conversion` entries yield the accepted labels: every string literal appearing
+# as a `case "..."` inside an AddFieldLabelConversionFunc body.
+# `strategy` entries yield the selectable labels: every quoted key in the
+# fields.Set literal built by ToSelectableFields/SelectableFields.
+CONVERSION_FILES = [
+    "pkg/apis/core/v1/conversion.go",
+    "pkg/apis/batch/v1/conversion.go",
+    "pkg/apis/certificates/v1/conversion.go",
+    "pkg/apis/events/v1/conversion.go",
+    "pkg/apis/apps/v1/conversion.go",
+]
+
+STRATEGY_FILES = [
+    "pkg/registry/core/pod/strategy.go",
+    "pkg/registry/core/node/strategy.go",
+    "pkg/registry/core/namespace/strategy.go",
+    "pkg/registry/core/secret/strategy.go",
+    "pkg/registry/core/service/strategy.go",
+    "pkg/registry/core/replicationcontroller/strategy.go",
+    "pkg/registry/core/event/strategy.go",
+    "pkg/registry/batch/job/strategy.go",
+    "pkg/registry/certificates/certificates/strategy.go",
+]
+
+
+def k8s_minor_from_gomod() -> str:
+    """Read the k8s.io/api version from go.mod and map it to a release branch.
+
+    k8s.io/api v0.36.3 tracks kubernetes release-1.36.
+    """
+    gomod = os.path.join(PROJ_ROOT, "go.mod")
+    try:
+        with open(gomod, encoding="utf-8") as f:
+            text = f.read()
+    except OSError as e:
+        raise SystemExit(f"cannot read {gomod}: {e}")
+    m = re.search(r"^\s*k8s\.io/api\s+v0\.(\d+)\.\d+", text, re.MULTILINE)
+    if not m:
+        raise SystemExit("could not find a k8s.io/api v0.<minor>.<patch> require in go.mod")
+    return f"1.{m.group(1)}"
+
+
+def fetch(ver: str, path: str) -> str:
+    url = RAW.format(ver=ver, path=path)
+    req = urllib.request.Request(url, headers={"User-Agent": "k8shark-fieldselector-drift"})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return r.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        raise SystemExit(f"fetching {url}: HTTP {e.code}")
+    except Exception as e:  # noqa: BLE001
+        raise SystemExit(f"fetching {url}: {e}")
+
+
+# AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Pod"), func(...) { ... })
+CONV_START = re.compile(
+    r'AddFieldLabelConversionFunc\(\s*(?:\w+\.)*SchemeGroupVersion\.WithKind\(\s*"(\w+)"\s*\)',
+)
+CASE_LABELS = re.compile(r'case\s+((?:"[^"]+"\s*,?\s*)+):')
+# fields.Set{ "key": expr, ... } — capture the quoted keys.
+SET_KEY = re.compile(r'"([A-Za-z0-9_.]+)"\s*:')
+# Pods build their set imperatively — make(fields.Set, 10) followed by
+# podSpecificFieldsSet["spec.nodeName"] = ... — so index assignment counts too.
+SET_ASSIGN = re.compile(r'\w+\[\s*"([A-Za-z0-9_.]+)"\s*\]\s*=[^=]')
+
+
+def brace_block(text: str, start: int) -> str:
+    """Return the text from start through the matching close of the first '{'."""
+    open_at = text.find("{", start)
+    if open_at < 0:
+        return ""
+    depth = 0
+    for i in range(open_at, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_at:i + 1]
+    return ""
+
+
+def extract_accepted(src: str) -> dict[str, list[str]]:
+    """Kind -> sorted accepted field labels, from the conversion funcs.
+
+    Two upstream shapes are in use: a `switch label { case "...": }` (core/v1,
+    batch/v1, certificates/v1) and a `map[string]string` lookup whose keys are
+    the accepted labels (events/v1). The map is declared *before* the
+    AddFieldLabelConversionFunc call, so fall back to scanning the enclosing
+    function when the call's own body yields no case labels.
+    """
+    out: dict[str, list[str]] = {}
+    for m in CONV_START.finditer(src):
+        kind = m.group(1)
+        body = brace_block(src, m.end())
+        labels: set[str] = set()
+        for cm in CASE_LABELS.finditer(body):
+            labels.update(re.findall(r'"([^"]+)"', cm.group(1)))
+        if not labels:
+            labels.update(mapping_keys_in_enclosing_func(src, m.start()))
+        if labels:
+            out[kind] = sorted(labels)
+    return out
+
+
+def mapping_keys_in_enclosing_func(src: str, call_at: int) -> set[str]:
+    """Keys of any map[string]string literal in the func enclosing call_at."""
+    start = src.rfind("\nfunc ", 0, call_at)
+    if start < 0:
+        return set()
+    body = brace_block(src, start)
+    keys: set[str] = set()
+    for mm in re.finditer(r"map\[string\]string\{", body):
+        keys.update(SET_KEY.findall(brace_block(body, mm.end() - 1)))
+    return keys
+
+
+def extract_selectable(src: str) -> dict[str, list[str]]:
+    """Function name -> sorted selectable field labels, from fields.Set literals.
+
+    Keyed by the enclosing function so a file with several (e.g. a strategy plus
+    a helper) stays distinguishable.
+    """
+    out: dict[str, list[str]] = {}
+    for m in re.finditer(r"func\s+(\w*(?:SelectableFields|ToSelectableFields))\s*\(", src):
+        name = m.group(1)
+        body = brace_block(src, m.end())
+        keys = set()
+        for sm in re.finditer(r"fields\.Set\{", body):
+            keys.update(SET_KEY.findall(brace_block(body, sm.end() - 1)))
+        keys.update(SET_ASSIGN.findall(body))
+        if keys:
+            out[name] = sorted(keys)
+    return out
+
+
+def collect(ver: str) -> dict:
+    accepted: dict[str, dict[str, list[str]]] = {}
+    for path in CONVERSION_FILES:
+        found = extract_accepted(fetch(ver, path))
+        # apps/v1 legitimately registers none; record the empty result so the
+        # snapshot notices if upstream *adds* one.
+        accepted[path] = found
+    selectable: dict[str, dict[str, list[str]]] = {}
+    for path in STRATEGY_FILES:
+        found = extract_selectable(fetch(ver, path))
+        if not found:
+            # A strategy that suddenly yields nothing means the extraction broke
+            # or upstream restructured — either way a human should look.
+            print(f"warning: no selectable fields extracted from {path}", file=sys.stderr)
+        selectable[path] = found
+    return {"kubernetesVersion": ver, "accepted": accepted, "selectable": selectable}
+
+
+def diff(old: dict, new: dict) -> list[str]:
+    problems = []
+    for section in ("accepted", "selectable"):
+        o, n = old.get(section, {}), new.get(section, {})
+        for path in sorted(set(o) | set(n)):
+            ov, nv = o.get(path, {}), n.get(path, {})
+            for key in sorted(set(ov) | set(nv)):
+                before, after = ov.get(key, []), nv.get(key, [])
+                if before == after:
+                    continue
+                added = [x for x in after if x not in before]
+                removed = [x for x in before if x not in after]
+                bits = []
+                if added:
+                    bits.append(f"added {added}")
+                if removed:
+                    bits.append(f"removed {removed}")
+                problems.append(f"{section}: {path}:{key}: " + ", ".join(bits))
+    return problems
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--update", action="store_true", help="rewrite the snapshot from upstream")
+    ap.add_argument("--version", help="Kubernetes minor to scrape (default: from go.mod)")
+    args = ap.parse_args()
+
+    ver = args.version or k8s_minor_from_gomod()
+    print(f"scraping upstream field-label tables at release-{ver}")
+    new = collect(ver)
+
+    if args.update:
+        with open(SNAPSHOT, "w", encoding="utf-8") as f:
+            json.dump(new, f, indent=2, sort_keys=True)
+            f.write("\n")
+        print(f"wrote {SNAPSHOT}")
+        return 0
+
+    try:
+        with open(SNAPSHOT, encoding="utf-8") as f:
+            old = json.load(f)
+    except FileNotFoundError:
+        print(f"no snapshot at {SNAPSHOT}; run with --update to create it", file=sys.stderr)
+        return 2
+
+    if old.get("kubernetesVersion") != ver:
+        print(f"note: snapshot was taken at release-{old.get('kubernetesVersion')}, "
+              f"comparing against release-{ver}")
+
+    problems = diff(old, new)
+    if not problems:
+        print("no drift: upstream field-label tables match the snapshot")
+        return 0
+
+    print("\nDRIFT DETECTED — upstream field-label tables changed:\n", file=sys.stderr)
+    for p in problems:
+        print(f"  - {p}", file=sys.stderr)
+    print("\nUpdate internal/store/fieldselector.go to match, then re-run with "
+          "--update to refresh the snapshot.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fieldselector_drift.py
+++ b/scripts/fieldselector_drift.py
@@ -103,10 +103,24 @@ def fetch(ver: str, path: str) -> str:
 
 
 # AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Pod"), func(...) { ... })
+#
+# Both patterns avoid nesting one quantifier inside another. A grouped repetition
+# such as (?:\w+\.)* or (?:"[^"]+"\s*,?\s*)+ backtracks exponentially on input
+# that almost-but-never matches, which CodeQL flags as py/redos — and this script
+# runs over source fetched from the network.
 CONV_START = re.compile(
-    r'AddFieldLabelConversionFunc\(\s*(?:\w+\.)*SchemeGroupVersion\.WithKind\(\s*"(\w+)"\s*\)',
+    r'AddFieldLabelConversionFunc\(\s*(?:\w+\.)?SchemeGroupVersion\.WithKind\(\s*"(\w+)"\s*\)',
 )
-CASE_LABELS = re.compile(r'case\s+((?:"[^"]+"\s*,?\s*)+):')
+# The label list of a case clause, up to its colon. Quoted labels are pulled out
+# of the captured span separately. [^:]* is greedy but cannot cross a colon, so
+# it lands on the first one deterministically — and it spans newlines, which
+# matters because upstream wraps long lists:
+#
+#     case "metadata.name",
+#         "spec.signerName":
+#
+# Stopping at the first ":" is safe because no upstream field label contains one.
+CASE_LABELS = re.compile(r"\bcase\b([^:]*):")
 # fields.Set{ "key": expr, ... } — capture the quoted keys.
 SET_KEY = re.compile(r'"([A-Za-z0-9_.]+)"\s*:')
 # Pods build their set imperatively — make(fields.Set, 10) followed by


### PR DESCRIPTION
## Problem

On the read path, any `fieldSelector` key outside `metadata.name`/`metadata.namespace` was silently dropped, so the selector degenerated to match-all. `MatchesFields`' `default: continue` meant an unsupported requirement contributed nothing.

That fails in the one direction a real apiserver never does. A human reading a terminal sees extra rows and notices; a script (`--field-selector spec.nodeName=X -o name | xargs …`) or an agent driving kubectl against a replay does not, which is what makes a capture unusable as an evaluation fixture.

Reproduced on `main` against the shipped example capture, and confirmed fixed:

| Query | Before | After |
|---|---|---|
| `metadata.name=web-…-crbzf` | 1 pod ✅ | 1 pod ✅ |
| `spec.nodeName=k8shark-dev-control-plane` | 2 pods (coincidentally right) | 2 pods ✅ |
| `spec.nodeName=does-not-exist` | **2 pods** | `No resources found` ✅ |
| `spec.bogus=x` | **2 pods** | `400 field label not supported: spec.bogus` ✅ |
| `status.phase=Failed` | **2 pods** | `No resources found` ✅ |
| `kubectl get nodes --field-selector metadata.namespace=default` | 1 node | `400 field label not supported` ✅ |

## Approach

The apiserver evaluates a selector in **two independent layers**, and this reproduces both separately:

| Layer | Upstream source | Decides |
|---|---|---|
| Validation + aliasing | `AddFieldLabelConversionFunc` in `pkg/apis/<group>/<version>/conversion.go` | Which labels are accepted; unaccepted → **400**. Rewrites aliases (`spec.host` → `spec.nodeName`). |
| Matching | `ToSelectableFields` in `pkg/registry/.../strategy.go` | Which labels resolve to a value; absent → `""`. |

The two lists genuinely differ, so collapsing them would be wrong in both directions — pods accept `status.podIPs` but never select on it, so upstream accepts that request and then matches nothing. `internal/store/fieldselector.go` keeps them separate and reproduces that exactly.

Validation now runs on **read, watch and deletecollection** alike, which is where upstream runs it (`listOpts` in the generic endpoint handler, shared by all three).

kubectl itself contributes nothing: `Builder.FieldSelectorParam` trims the string, checks for a conflict with `--all`, and forwards it. There is no per-kind table anywhere in kubectl, so every guarantee a client expects is owed by the server.

## Two things the issue didn't cover

**Watch was affected too.** `watch_replay.go` routed through the same `ApplySelectors`, so a watch with `fieldSelector=spec.nodeName=does-not-exist` streamed `ADDED` for every pod. That matters more for the reporter's use case than the list path, since informer-based tooling watches rather than lists.

**In writable replay it was a data-mutation bug.** The issue notes deletecollection diverging in the *opposite* direction (400 on `spec.nodeName`, which upstream accepts) — true for a raw deletecollection. But `kubectl delete --field-selector` doesn't issue one: it **lists first, then deletes by name**. So `kubectl delete pods --field-selector spec.nodeName=<node>` went through the lenient read path and deleted pods that weren't on that node. `FilterItemsStrict` exists to prevent exactly this and kubectl walked around it. Both directions are fixed.

**Found while verifying:** a stored Table's rows embed `PartialObjectMetadata` — metadata only — so a `spec`/`status` selector can't be evaluated against them at all, turning over-matching into *under*-matching for default `kubectl get`. A real apiserver filters full objects and *then* projects to Table; the handler now mirrors that by intersecting with the identities that survived on the JSON list, which preserves the captured columns and cell values.

## Drift detection

The tables are hand-maintained — upstream registers them in `k8s.io/kubernetes`'s **internal** API packages, not reachable from `k8s.io/api` or `client-go`, so there is nothing to reflect over. Three mechanisms, each covering the others' blind spots:

1. **Conformance differential** (section G) — probes real `?fieldSelector=` queries against both servers, comparing status code *and* matched set. The live apiserver *is* the table, so an upstream change surfaces as a new divergence. Blind spot: only exercises kinds/keys the capture contains.
2. **`scripts/fieldselector_drift.py`** — parses upstream source at the k8s minor pinned in `go.mod`, diffs against `scripts/fieldselector-snapshot.json`. Covers what a capture lacks (no CSR in a KinD capture). Weekly + on PRs touching the tables.
3. **`TestFieldSelectorTables_*`** — asserts the Go tables match the snapshot, offline, on every `make test`. Without it the snapshot could track upstream perfectly while the Go code drifted from both. Also fails if a kind is added without being wired into the comparison.

Both detectors were verified to actually fire by perturbing the snapshot.

The extraction independently reproduced every list I had transcribed by hand, including the drift cases (`status.podIPs` accepted-not-selectable, Namespace's inert `name` key, Job's `status.successful` → `status.succeeded`).

## Behavior changes beyond the bug

- **Whitespace is no longer trimmed around the operator.** Upstream's `fields.ParseSelector` doesn't trim, so `metadata.name = x` yields the label `"metadata.name "` and 400s. k8shark's hand-rolled trimming was itself a divergence; the read path now uses apimachinery's grammar. One existing test encoded the old leniency and was updated.
- **`metadata.namespace` is not universal.** Node, Namespace and CertificateSigningRequest are cluster-scoped and don't accept it, so `kubectl get nodes --field-selector metadata.namespace=x` now 400s, as upstream does.
- **Unregistered kinds are strict.** Custom resources — and everything in the `apps` group, which registers no conversion func — accept only the metadata keys. `--field-selector status.replicas=3` on a Deployment now 400s, matching upstream.

Each moves in the reject-rather-than-over-match direction, which is the point of the fix, but they're worth a look since they go past what was reported.

## Testing

- New per-kind unit tests: acceptance/rejection per kind and per API group, alias rewriting, accepted-but-not-selectable, absent-field defaults (bool `"false"`, count `"0"`), bool/int stringification, both Event groups including `source`'s fallback.
- Server-level tests for all four surfaces: JSON list, Table (including the `PartialObjectMetadata` shape), watch, deletecollection.
- `make test`, `make test-race`, `make lint-ci`, `gofmt`, `go mod tidy` all clean.
- The conformance differential needs a KinD cluster, so it will get its first real run in CI on this PR.

Closes #339
