### PR TITLE
fix(ci): call artifact-smoke from release.yml so it actually runs

### DIFF
--- a/.github/workflows/artifact-smoke.yml
+++ b/.github/workflows/artifact-smoke.yml
@@ -5,12 +5,38 @@ name: artifact-smoke
 # executes a release artifact, so a packaging or cross-compilation defect
 # present only in the shipped binary would not be caught there.
 #
-# Triggers on a published release (so every tag is covered automatically), and
-# on demand against any existing tag via workflow_dispatch.
+# Called by release.yml once GoReleaser has published (so every tag we cut is
+# covered automatically), and on demand against any existing tag via
+# workflow_dispatch.
+#
+# The workflow_call entry point is load-bearing, not a convenience: `on: release`
+# alone can never cover our own releases. GoReleaser creates the GitHub Release
+# with secrets.GITHUB_TOKEN, and GitHub deliberately does not start workflow runs
+# from events that token triggers (the recursion guard) — so `on: release` did not
+# fire for v1.0.0 and structurally never can for a release our pipeline creates
+# (#334). Being called from release.yml keeps it in the same run, where the token
+# restriction doesn't apply and a smoke failure marks the release run red.
+#
+# Do not "simplify" this back to a release-triggered workflow.
 
 on:
+  # Retained deliberately, and NOT the path that covers our own releases (see
+  # above). This only fires for a release created by a *user* — cut by hand in
+  # the web UI, or re-published later. Cheap to keep, and it is the one case
+  # release.yml cannot call us for.
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to smoke-test (e.g. v1.0.0)'
+        required: true
+        type: string
+      expect_contract:
+        description: 'Assert the v1.0 -o json shapes'
+        required: false
+        default: true
+        type: boolean
   # Mirrors release-check.yml (#315): exercise a change to this workflow or the
   # smoke script in the PR that makes it, rather than discovering it broke at
   # the next tag. Falls back to the latest published release as the subject.
@@ -73,17 +99,40 @@ jobs:
         # the smoke test reads.
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Resolve the tag
+      - name: Resolve the tag and the contract mode
         id: tag
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          # github.event.inputs.* rather than inputs.*: the latter is documented as
-          # a workflow_dispatch/workflow_call context. It does resolve to empty on
-          # other events in practice (verified on a pull_request run), but the
-          # release path is both the one that matters here and the least
-          # exercised, so don't lean on undocumented behavior for it.
-          EXPLICIT: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+          # inputs.* is the documented context for BOTH workflow_call and
+          # workflow_dispatch, and it is the only one that works for
+          # workflow_call: on a called workflow `github.event` is the *caller's*
+          # payload (a tag push), which carries no .inputs at all. The release
+          # path still reads github.event.release.tag_name rather than leaning on
+          # inputs.* resolving to empty on a release event.
+          EXPLICIT: ${{ inputs.tag || github.event.release.tag_name }}
+          # On a real release, enforce the frozen -o json shapes. On a PR the
+          # subject is whichever release happens to be latest, which may predate
+          # the contract (#320 landed after v1.0.0-rc.3) — so the PR run proves
+          # the harness works end-to-end on all six platforms, and the shape
+          # assertions are enforced where the version is known to have them.
+          #
+          # Keyed on inputs.expect_contract, NOT on github.event_name: for a
+          # workflow_call, github.event_name is the *caller's* event ('push' for
+          # a tag), so an event_name test would silently fall through to '0' and
+          # run every release with the contract assertions off — the exact
+          # "mechanism verified, reach not verified" failure this workflow keeps
+          # hitting (#334). The guard below exists because that mistake is
+          # invisible in a green run.
+          #
+          # format() rather than a bare truthiness check or a string compare,
+          # because the two entry points type this input differently: inputs.* is
+          # a real boolean for workflow_call/workflow_dispatch, but a bare check
+          # would read a literal "false" string as true (every non-empty string is
+          # truthy), and == 'true' would miss a real boolean. format('{0}', …)
+          # normalizes both to 'true'/'false', and an absent input (pull_request)
+          # to ''.
+          EXPECT_CONTRACT: ${{ (github.event_name == 'release' || format('{0}', inputs.expect_contract) == 'true') && '1' || '0' }}
         run: |
           set -euo pipefail
           tag="$EXPLICIT"
@@ -93,6 +142,27 @@ jobs:
             echo "no tag given; using the latest release: $tag"
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "expect_contract=$EXPECT_CONTRACT" >> "$GITHUB_OUTPUT"
+          echo "resolved: event=$GITHUB_EVENT_NAME tag=$tag expect_contract=$EXPECT_CONTRACT"
+
+          # Fail loudly rather than smoke a real release with the shape
+          # assertions off. Without this, a regression in the expression above
+          # degrades every release run to a weaker check that still reports
+          # green — which is the same class of defect as #334 itself.
+          #
+          # 'push' means release.yml called us for a tag (this workflow has no
+          # push trigger of its own); 'release' is a hand-cut release. Both are
+          # real releases and must assert the contract. workflow_dispatch is
+          # exempt on purpose: EXPECT_CONTRACT=0 is the documented way to smoke a
+          # pre-#320 artifact such as v1.0.0-rc.3.
+          case "$GITHUB_EVENT_NAME" in
+            push | release)
+              if [ "$EXPECT_CONTRACT" != "1" ]; then
+                echo "::error::refusing to smoke release $tag with EXPECT_CONTRACT=$EXPECT_CONTRACT — the -o json contract assertions must be on for a real release (see #334)"
+                exit 1
+              fi
+              ;;
+          esac
 
       - name: Download and verify the artifact
         shell: bash
@@ -126,15 +196,9 @@ jobs:
         shell: bash
         env:
           TAG: ${{ steps.tag.outputs.tag }}
-          # On a real release, enforce the frozen -o json shapes. On a PR the
-          # subject is whichever release happens to be latest, which may predate
-          # the contract (#320 landed after v1.0.0-rc.3) — so the PR run proves
-          # the harness works end-to-end on all six platforms, and the shape
-          # assertions are enforced where the version is known to have them.
-          # Compared to the string 'true' on purpose: github.event.inputs values
-          # are strings, so a bare truthiness check would read the literal
-          # "false" as true — every non-empty string is truthy here.
-          EXPECT_CONTRACT: ${{ (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.expect_contract == 'true')) && '1' || '0' }}
+          # Resolved and guarded in the step above, so the decision lives in one
+          # place rather than being restated here.
+          EXPECT_CONTRACT: ${{ steps.tag.outputs.expect_contract }}
         run: |
           set -euo pipefail
           bin=bin/kshrk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,3 +57,32 @@ jobs:
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: dist/*.tar.gz,dist/*.zip
+
+  # Smoke-test the bytes we just published, on all six shipped platforms.
+  #
+  # This has to be called from here rather than left to artifact-smoke.yml's own
+  # `on: release` trigger: GoReleaser creates the release with secrets.GITHUB_TOKEN,
+  # and GitHub does not start workflow runs from events that token triggers, so
+  # `on: release` never fired for v1.0.0 and never can for a release this pipeline
+  # creates (#334). Calling it keeps the smoke run inside this workflow run, where
+  # that restriction doesn't apply and a failure turns the release run red instead
+  # of waiting for someone to remember to dispatch it by hand.
+  #
+  # Deliberately not `if: !prerelease` — an -rc tag is exactly when we most want to
+  # find a packaging defect, and rc.1/rc.2 existed to exercise this pipeline.
+  #
+  # goreleaser's release: block sets draft: false, so the assets are downloadable
+  # as soon as that job completes and no extra wait is needed here.
+  smoke:
+    needs: goreleaser
+    uses: ./.github/workflows/artifact-smoke.yml
+    permissions:
+      contents: read
+    with:
+      # github.ref_name is the tag that triggered this run — the same value passed
+      # to GoReleaser as GORELEASER_CURRENT_TAG, so both resolve the same release
+      # even when two tags point at one commit.
+      tag: ${{ github.ref_name }}
+      # Every release from v1.0.0 on carries the frozen -o json shapes (#320), so
+      # the contract assertions are always on for a real release.
+      expect_contract: true


### PR DESCRIPTION
Closes #334

`artifact-smoke.yml` declared `on: release: [published]` and never fired — not for `v1.0.0`, and structurally not for any release our own pipeline creates. GoReleaser publishes the release with `secrets.GITHUB_TOKEN`, and GitHub does not start workflow runs from events that token triggers.

Takes option 1 from the issue: add a `workflow_call` entry point and call it from `release.yml` with `needs: goreleaser`. Same workflow run, so the token restriction doesn't apply, and a smoke failure turns the release run red instead of waiting for someone to remember to dispatch it by hand.

## Two traps that had to be handled

Adding `workflow_call` is three lines. The two things that would have made those three lines a false comfort:

**Tag resolution.** `github.event.inputs.tag` cannot work for a called workflow — `github.event` is the *caller's* payload (a tag push), which carries no `.inputs` at all. Moved to `inputs.tag`, the documented context for both `workflow_call` and `workflow_dispatch`. The release path still reads `github.event.release.tag_name`, so nothing leans on `inputs.*` resolving to empty on an event that doesn't define it — which is what the previous comment there was guarding against.

**`EXPECT_CONTRACT` could no longer key on `github.event_name`.** For a `workflow_call` that value is the *caller's* event — `push` for a tag — not `workflow_call`. The old expression tested `event_name == 'release' || event_name == 'workflow_dispatch'`, so wiring this up naively would have silently fallen through to `0` and smoked **every release with the `-o json` shape assertions off**, while still reporting green. It now keys on `inputs.expect_contract`, normalized through `format()` so it reads correctly whether the input arrives as a real boolean or a string (a bare truthiness check reads the literal `"false"` as true; `== 'true'` misses a real boolean).

That second failure mode is the same shape as the bug this PR fixes — a check that looks like it ran and didn't — so it gets a guard rather than just a correct expression. On a real release (`push` via release.yml, or `release` for a hand-cut one) the workflow now refuses to run with `EXPECT_CONTRACT != 1`. `workflow_dispatch` stays exempt, since `expect_contract=false` is the documented way to smoke a pre-#320 artifact such as `v1.0.0-rc.3`. Resolution happens once and is echoed, so the mode is visible in the log rather than inferable.

## Verification

The issue notes this is the third time in this cycle a mechanism was verified while its *reach* was not, so I exercised the actual call path rather than just linting it. A temporary caller workflow triggered by a branch push reaches `artifact-smoke.yml` through `workflow_call` and produces `github.event_name == 'push'` inside it — identical to what a tag push into `release.yml` produces. Removed before this PR; the two temp commits are not in the branch.

**Positive — all six platforms green through `workflow_call`** ([run 31409114393](https://github.com/phenixblue/k8shark/actions/runs/31409114393)):

```
✓ smoke (ubuntu-latest, linux, amd64) in 10s
✓ smoke (ubuntu-24.04-arm, linux, arm64) in 10s
✓ smoke (macos-latest, darwin, arm64) in 22s
✓ smoke (macos-15-intel, darwin, amd64) in 13s
✓ smoke (windows-latest, windows, amd64) in 37s
✓ smoke (windows-11-arm, windows, arm64) in 26s
```

Green was never the interesting part, so confirmed the assertions actually ran:

```
resolved: event=push tag=v1.0.0 expect_contract=1
  EXPECT_CONTRACT: 1
  [OK]   inspect -o json read a real archive
  [OK]   inspect has schema_version
```

`event=push` with `expect_contract=1` is the release path resolving correctly, and `schema_version` is a #320 contract assertion — not the `[skip] -o json shape checks` line.

**Negative — the guard fires** ([run 31411406360](https://github.com/phenixblue/k8shark/actions/runs/31411406360)): flipped the caller to `expect_contract: false` and all six legs failed at tag resolution, before downloading anything:

```
resolved: event=push tag=v1.0.0 expect_contract=0
##[error]refusing to smoke release v1.0.0 with EXPECT_CONTRACT=0 — the -o json
         contract assertions must be on for a real release (see #334)
```

That also confirms `format('{0}', false)` yields `'false'` rather than reading as truthy, which is the specific coercion the expression depends on.

**Lint:** `actionlint v1.7.7` reports no new findings. The two `runner-label` warnings for `macos-15-intel` and `windows-11-arm` are pre-existing (present on `main`, same count) — actionlint's built-in label list predates both images.

## What this does not cover

The `pull_request` trigger tests `artifact-smoke.yml` standalone against whatever release is latest; it cannot exercise the call wiring, since that only happens on a tag push. I deliberately did **not** add `release.yml` to the `pull_request` paths filter — it would run the smoke workflow on changes to the caller without actually testing the call path, which is the same false-comfort shape as the original bug. The temp-caller runs above are the evidence that the wiring works; after this merges, the next tag is the standing proof.

The `release:` trigger is kept on purpose. It cannot cover our own releases, but it is the one case `release.yml` cannot call us for — a release cut by hand in the web UI — and it costs nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
