### PR TITLE
fix(ui): working step-forward on the scrubber; legible code/log/diff in the light theme

### DIFF
--- a/internal/ui/v2/static/app.css
+++ b/internal/ui/v2/static/app.css
@@ -9,7 +9,11 @@
   --border-strong: #2d3748;
   --fg: #e5e7eb;
   --fg-dim: #9ca3af;
-  --fg-faint: #6b7280;
+  /* Was #6b7280 — 3.21:1 on --bg-row-hover and below AA on every surface it
+   * carries body text on, in the dark theme too, not just the light one (#258).
+   * Picked as near the AA floor as the palette allows (4.75:1 worst case) so it
+   * stays visibly recessive against --fg-dim rather than collapsing into it. */
+  --fg-faint: #858f9e;
   --accent: #38bdf8;
   --accent-2: #818cf8;
   --good: #22c55e;
@@ -20,7 +24,31 @@
   --pod: #38bdf8;
   --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif;
   --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  /* Code surfaces (.code, .json-view, .yaml-view, .log-preview, .diff).
+   *
+   * These get their own tokens rather than borrowing the semantic UI colors,
+   * because --accent/--good/--warn/--bad are tuned for panel backgrounds and
+   * were never checked against --code-bg. In the light theme that mismatch made
+   * every code, log and diff view unreadable — plain text sat at 1.18:1 (#258).
+   * Every value below is verified >= 4.5:1 against --code-bg in its own theme.
+   *
+   * --code-dim is "readable but recessive" (log bodies, diff context);
+   * --code-com is for comments and timestamps; --code-punc for braces and
+   * brackets, which are structural and so kept a touch stronger than comments. */
   --code-bg: #07090f;
+  --code-fg: #e5e7eb;
+  --code-dim: #a8b0bd;
+  --code-com: #8b95a5;
+  --code-punc: #a3adbb;
+  --code-key: #93c5fd;
+  --code-str: #fcd34d;
+  --code-num: #c4b5fd;
+  --code-lit: #6ee7b7;
+  --diff-add-fg: #4ade80;
+  --diff-del-fg: #f87171;
+  --diff-add-bg: rgba(34, 197, 94, 0.12);
+  --diff-del-bg: rgba(239, 68, 68, 0.12);
 }
 :root[data-theme="light"] {
   --bg: #f6f7f9;
@@ -32,16 +60,36 @@
   --border-strong: #cfd6dd;
   --fg: #1b2733;
   --fg-dim: #51606e;
-  --fg-faint: #8a97a5;
-  --accent: #0b76d0;
+  /* Was #8a97a5 — 2.49:1 on --bg-row-hover, and below AA on every surface it is
+   * used as body text on (#258). */
+  --fg-faint: #5c6875;
+  /* Was #0b76d0 — 4.34:1 as a link on --bg. */
+  --accent: #0a67b8;
   --accent-2: #5b4bd6;
   --good: #15803d;
   --warn: #b45309;
-  --bad: #dc2626;
+  /* Was #dc2626 — 4.34:1 on --bg-row. */
+  --bad: #c62222;
   --tag-bg: #eef1f4;
   --workload: #7c5cff;
   --pod: #0b76d0;
-  --code-bg: #0f1726;
+
+  /* A light theme gets a light code surface. The previous value was #0f1726 —
+   * dark navy — while the consumers kept light-theme foregrounds, so plain text
+   * rendered at 1.18:1 and every syntax token failed AA (#258). */
+  --code-bg: #f8fafc;
+  --code-fg: #10202e;
+  --code-dim: #47566a;
+  --code-com: #5a6675;
+  --code-punc: #46525f;
+  --code-key: #0a5aa0;
+  --code-str: #0c6b3a;
+  --code-num: #8a4b00;
+  --code-lit: #5333c4;
+  --diff-add-fg: #0a6b34;
+  --diff-del-fg: #b91c1c;
+  --diff-add-bg: rgba(22, 163, 74, 0.14);
+  --diff-del-bg: rgba(220, 38, 38, 0.1);
 }
 .theme-toggle {
   background: var(--bg-row); border: 1px solid var(--border-strong); color: var(--fg-dim);
@@ -400,11 +448,11 @@ a { color: inherit; }
 .container-meta .v.good { color: var(--good); }
 .log-preview {
   background: var(--code-bg); border: 1px solid var(--border); border-radius: 5px;
-  padding: 8px 10px; font: 11px var(--mono); color: var(--fg-dim);
+  padding: 8px 10px; font: 11px var(--mono); color: var(--code-dim);
   white-space: pre-wrap; max-height: 110px; overflow: auto;
 }
-.log-preview .err { color: var(--bad); }
-.log-preview .ts { color: var(--fg-faint); }
+.log-preview .err { color: var(--diff-del-fg); }
+.log-preview .ts { color: var(--code-com); }
 
 /* Events */
 .events { display: flex; flex-direction: column; gap: 6px; }
@@ -447,26 +495,36 @@ a { color: inherit; }
 .json-view, .yaml-view {
   background: var(--code-bg); border: 1px solid var(--border); border-radius: 6px;
   padding: 14px; font: 12px var(--mono); white-space: pre-wrap; word-break: break-word;
-  color: var(--fg); overflow: auto; max-height: 70vh;
+  color: var(--code-fg); overflow: auto; max-height: 70vh;
 }
-.json-view .k { color: #93c5fd; }
-.json-view .s { color: #fcd34d; }
-.json-view .n { color: #c4b5fd; }
-.json-view .b { color: #6ee7b7; }
-.json-view .c { color: var(--fg-faint); font-style: italic; }
+/* Were hardcoded dark-theme hex values, which left the light theme with no way
+ * to be legible at all (#258). The dark-theme tokens carry those exact values
+ * forward, so the dark appearance here is unchanged. */
+.json-view .k { color: var(--code-key); }
+.json-view .s { color: var(--code-str); }
+.json-view .n { color: var(--code-num); }
+.json-view .b { color: var(--code-lit); }
+.json-view .c { color: var(--code-com); font-style: italic; }
 
 /* Diff view */
 /* Syntax-highlighted code (object YAML/JSON view). */
 .code {
   font: 12px var(--mono); white-space: pre; background: var(--code-bg); border: 1px solid var(--border);
-  border-radius: 6px; overflow: auto; color: var(--fg);
+  border-radius: 6px; overflow: auto; color: var(--code-fg);
 }
-.code .k-key { color: var(--accent); }
-.code .k-str { color: var(--good); }
-.code .k-num { color: var(--warn); }
-.code .k-lit { color: var(--accent-2); }
-.code .k-com { color: var(--fg-faint); font-style: italic; }
-.code .k-punc { color: var(--fg-faint); }
+/* The plain `color` above is what codeBlock falls back to when it skips
+ * highlighting past its 300 KB cutoff, so it carries whole large objects on its
+ * own — it was the 1.18:1 case in #258, not an edge case.
+ *
+ * These were the semantic UI tokens (--accent/--good/--warn/--accent-2), which
+ * are tuned for panel backgrounds; they now share the purpose-built code
+ * palette with .json-view, so the two highlighters finally agree. */
+.code .k-key { color: var(--code-key); }
+.code .k-str { color: var(--code-str); }
+.code .k-num { color: var(--code-num); }
+.code .k-lit { color: var(--code-lit); }
+.code .k-com { color: var(--code-com); font-style: italic; }
+.code .k-punc { color: var(--code-punc); }
 
 /* Resources catalog page. */
 .cat-group {
@@ -501,10 +559,12 @@ a { color: inherit; }
 .capmeta .k { font-size: 10.5px; color: var(--fg-faint); text-transform: uppercase; letter-spacing: .05em; }
 .capmeta .v { font: 12.5px var(--mono); color: var(--fg); overflow: hidden; text-overflow: ellipsis; }
 
-.diff { font: 12px var(--mono); white-space: pre; background: var(--code-bg); border: 1px solid var(--border); border-radius: 6px; overflow: auto; }
-.diff .add { background: rgba(34,197,94,0.12); color: var(--good); }
-.diff .del { background: rgba(239,68,68,0.12); color: var(--bad); }
-.diff .ctx { color: var(--fg-dim); }
+.diff { font: 12px var(--mono); white-space: pre; background: var(--code-bg); border: 1px solid var(--border); border-radius: 6px; overflow: auto; color: var(--code-fg); }
+/* The row tint blends over --code-bg, so the foregrounds are checked against
+ * that composite rather than against --code-bg alone (#258). */
+.diff .add { background: var(--diff-add-bg); color: var(--diff-add-fg); }
+.diff .del { background: var(--diff-del-bg); color: var(--diff-del-fg); }
+.diff .ctx { color: var(--code-dim); }
 
 /* Toasts */
 #toasts { position: fixed; right: 18px; bottom: 18px; display: flex; flex-direction: column; gap: 8px; z-index: 10; }

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -87,8 +87,17 @@
   // ── State ────────────────────────────────────────────────────────────────
   const state = {
     captureMeta: null,
-    snapshots: [],   // RFC3339 strings
+    snapshots: [],   // RFC3339 strings, distinct and ascending (see #257)
     at: '',          // selected snapshot timestamp ('' = latest / follow clock in replay)
+    // Scrubber position, kept in lockstep with `at` by selectSnapshot().
+    // null = not explicitly positioned, so derive it from `at`.
+    //
+    // The scrubber is positioned by index rather than by looking `at` back up in
+    // `snapshots`: a reverse lookup returns the *first* match, so any repeated
+    // stop was a dead zone that stepping forward could never leave (#257). The
+    // server no longer emits duplicates, but the lookup is also simply wrong for
+    // an `at` that isn't itself a stop, which a deep link can hand us.
+    atIndex: null,
     route: { name: 'overview' },
     // Replay transport (populated from /v2/api/replay when replay mode is on).
     replay: {
@@ -176,7 +185,7 @@
     const maxIdx = Math.max(0, state.snapshots.length - 1);
     // In replay mode the thumb tracks the live clock position; otherwise it
     // tracks the manually-selected snapshot.
-    const idxNow = replay ? replaySnapshotIndex(state.replay.position) : currentSnapshotIndex();
+    const idxNow = replay ? snapshotIndexAtOrBefore(state.replay.position) : currentSnapshotIndex();
     const prev = el('button', { class: 'btn', onclick: () => (replay ? seekSnapshot(-1) : stepSnapshot(-1)), title: 'Step back' }, '◀');
     const next = el('button', { class: 'btn', onclick: () => (replay ? seekSnapshot(+1) : stepSnapshot(+1)), title: 'Step forward' }, '▶');
     const range = el('input', { type: 'range', min: '0', max: String(maxIdx), value: String(idxNow) });
@@ -190,11 +199,11 @@
       });
     } else {
       range.addEventListener('input', () => {
-        state.at = state.snapshots[Number(range.value)] || '';
+        selectSnapshot(Number(range.value));
         ts.textContent = formatTS(state.at);
       });
       range.addEventListener('change', () => {
-        state.at = state.snapshots[Number(range.value)] || '';
+        selectSnapshot(Number(range.value));
         render();
       });
     }
@@ -207,11 +216,14 @@
   // ── Replay transport ───────────────────────────────────────────────────────
   const REPLAY_SPEEDS = [0.25, 0.5, 1, 2];
 
-  // replaySnapshotIndex returns the index of the latest snapshot at or before
-  // the given time (floor). Using the floor (not the nearest) means the view
-  // re-renders exactly when the clock crosses a snapshot, rather than at the
-  // midpoint between two snapshots.
-  function replaySnapshotIndex(rfc3339) {
+  // snapshotIndexAtOrBefore returns the index of the latest snapshot at or
+  // before the given time (floor). Using the floor (not the nearest) means the
+  // view re-renders exactly when the clock crosses a snapshot, rather than at
+  // the midpoint between two snapshots.
+  //
+  // Used by the replay clock and, as a fallback, to place an `at` that isn't
+  // itself one of the stops.
+  function snapshotIndexAtOrBefore(rfc3339) {
     if (!rfc3339 || state.snapshots.length === 0) return Math.max(0, state.snapshots.length - 1);
     const t = Date.parse(rfc3339);
     let idx = 0;
@@ -289,7 +301,7 @@
 
   // seekSnapshot seeks the clock to the neighbouring snapshot (step buttons).
   function seekSnapshot(delta) {
-    const idx = Math.max(0, Math.min(state.snapshots.length - 1, replaySnapshotIndex(state.replay.position) + delta));
+    const idx = Math.max(0, Math.min(state.snapshots.length - 1, snapshotIndexAtOrBefore(state.replay.position) + delta));
     const to = state.snapshots[idx];
     if (to) replayControl('seek', { to });
   }
@@ -327,7 +339,7 @@
     // Live-update the scrubber thumb + label without a full re-render.
     const s = $('scrubber');
     const range = s && s.querySelector('input[type=range]');
-    const idx = replaySnapshotIndex(rp.position);
+    const idx = snapshotIndexAtOrBefore(rp.position);
     if (range) range.value = String(idx);
     const tsEl = s && s.querySelector('.ts');
     if (tsEl) tsEl.textContent = formatTS(rp.position);
@@ -378,14 +390,39 @@
   }
 
   function currentSnapshotIndex() {
-    if (!state.at) return state.snapshots.length - 1; // latest
+    if (state.snapshots.length === 0) return 0;
+    const last = state.snapshots.length - 1;
+    // The tracked position wins when we have one, so stepping and dragging never
+    // depend on finding `at` in the list.
+    if (Number.isInteger(state.atIndex) && state.atIndex >= 0 && state.atIndex <= last) {
+      return state.atIndex;
+    }
+    if (!state.at) return last; // latest
     const i = state.snapshots.indexOf(state.at);
-    return i >= 0 ? i : state.snapshots.length - 1;
+    if (i >= 0) return i;
+    // An `at` that is not itself a stop — a deep link, or a sampled list on a
+    // long capture. Land on the stop at or before it rather than silently
+    // jumping to the end of the range, which is what the old fallback did.
+    return snapshotIndexAtOrBefore(state.at);
+  }
+
+  // selectSnapshot moves the scrubber to an index, keeping `at` (what the API is
+  // queried with) and `atIndex` (where the thumb sits) in lockstep. Every
+  // scrubber interaction goes through this — letting the two drift apart is what
+  // made the forward button a no-op and made dragging snap backward (#257).
+  function selectSnapshot(idx) {
+    if (state.snapshots.length === 0) {
+      state.at = '';
+      state.atIndex = null;
+      return;
+    }
+    const clamped = Math.max(0, Math.min(state.snapshots.length - 1, idx));
+    state.atIndex = clamped;
+    state.at = state.snapshots[clamped] || '';
   }
 
   function stepSnapshot(delta) {
-    const idx = Math.max(0, Math.min(state.snapshots.length - 1, currentSnapshotIndex() + delta));
-    state.at = state.snapshots[idx] || '';
+    selectSnapshot(currentSnapshotIndex() + delta);
     render();
   }
 
@@ -2637,7 +2674,12 @@
       };
       if (state.captureMeta) {
         $('capture-meta').textContent =
-          `${state.captureMeta.captured_at?.slice(0, 19) ?? ''} → ${state.captureMeta.captured_until?.slice(0, 19) ?? ''} · ${state.captureMeta.total_count} records`;
+          // "snapshots", not "records": total_count has always been the count of
+          // distinct scrubber stops, never a record count. The mislabel was easy
+          // to miss while the stop list was inflated by duplicates (#257) — now
+          // that it reports distinct stops the number is visibly smaller, so call
+          // it what it is.
+          `${state.captureMeta.captured_at?.slice(0, 19) ?? ''} → ${state.captureMeta.captured_until?.slice(0, 19) ?? ''} · ${state.captureMeta.total_count} snapshots`;
       }
     } catch (e) {
       // Timestamps endpoint not implemented yet — keep going with empty snapshots.

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -299,7 +299,7 @@
     }
   }
 
-  // seekSnapshot seeks the clock to the neighbouring snapshot (step buttons).
+  // seekSnapshot seeks the clock to the neighboring snapshot (step buttons).
   function seekSnapshot(delta) {
     const idx = Math.max(0, Math.min(state.snapshots.length - 1, snapshotIndexAtOrBefore(state.replay.position) + delta));
     const to = state.snapshots[idx];

--- a/internal/ui/v2/timestamps.go
+++ b/internal/ui/v2/timestamps.go
@@ -9,6 +9,10 @@ import (
 // TimestampsResponse is what /v2/api/timestamps returns. Sampled when the
 // capture has more than ~180 distinct event timestamps so the scrubber stays
 // usable on long captures.
+//
+// TotalCount counts distinct *scrubber stops* — event timestamps at the second
+// precision Timestamps is emitted in — not records. Timestamps is guaranteed
+// free of duplicates (#257); the client indexes the scrubber by position in it.
 type TimestampsResponse struct {
 	CapturedAt    time.Time `json:"captured_at"`
 	CapturedUntil time.Time `json:"captured_until"`
@@ -29,16 +33,35 @@ func (h *Handler) timestampsHandler(w http.ResponseWriter, _ *http.Request) {
 		resp.DefaultAt = h.At.UTC().Format(time.RFC3339)
 	}
 
+	// Dedupe at the precision we actually emit (see the RFC3339 Format below),
+	// NOT at the nanosecond precision the index carries. Keying this map on the
+	// full-precision time produced a list whose *string* values repeated — on
+	// examples/auto-discovery/capture.kshrk, 180 stops with 4 distinct values,
+	// one of them 96 times. The client keys the scrubber off those strings, so
+	// every duplicate run was a dead zone: stepping forward landed on an
+	// identical value and snapped back, making the button a permanent no-op
+	// (#257).
+	//
+	// Second precision is deliberate rather than a concession. Every `at` in
+	// this API is RFC3339 seconds — parsed that way, echoed back that way by
+	// each handler, rendered by formatTS and by the diff pickers, and accepted
+	// from `--at`. Emitting RFC3339Nano would keep more stops but would put
+	// nine decimal places into the scrubber label and the diff dropdowns, and
+	// would make the stops disagree with the `at` every handler echoes. A stop
+	// the rest of the contract cannot address is not a usable stop.
 	uniq := make(map[time.Time]struct{})
+	add := func(t time.Time) {
+		if t.IsZero() {
+			return
+		}
+		uniq[t.UTC().Truncate(time.Second)] = struct{}{}
+	}
 	for _, entry := range h.Store.Index {
 		if entry == nil {
 			continue
 		}
 		for _, t := range entry.Times {
-			if t.IsZero() {
-				continue
-			}
-			uniq[t.UTC()] = struct{}{}
+			add(t)
 		}
 	}
 	for _, wi := range h.Store.WatchIndex {
@@ -46,10 +69,7 @@ func (h *Handler) timestampsHandler(w http.ResponseWriter, _ *http.Request) {
 			continue
 		}
 		for _, t := range wi.Times {
-			if t.IsZero() {
-				continue
-			}
-			uniq[t.UTC()] = struct{}{}
+			add(t)
 		}
 	}
 

--- a/internal/ui/v2/timestamps_test.go
+++ b/internal/ui/v2/timestamps_test.go
@@ -3,6 +3,7 @@ package v2
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -37,6 +38,130 @@ func TestServeTimestamps(t *testing.T) {
 	}
 	if !resp.CapturedUntil.Equal(t1) {
 		t.Errorf("CapturedUntil = %v, want %v", resp.CapturedUntil, t1)
+	}
+}
+
+// The scrubber indexes stops by position in Timestamps, so a repeated string
+// value is a dead zone the step buttons cannot cross (#257). The bug was a
+// dedupe at nanosecond precision feeding a second-precision Format, so the
+// records here deliberately share a wall-clock second while differing in their
+// sub-second parts — the exact shape that produced 180 stops with 4 distinct
+// values on a real capture.
+func TestServeTimestamps_NoDuplicateStops(t *testing.T) {
+	base := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	// Three records inside second :00 and two inside :01 → 2 distinct stops.
+	times := []time.Time{
+		base,
+		base.Add(10 * time.Millisecond),
+		base.Add(750 * time.Microsecond),
+		base.Add(time.Second),
+		base.Add(time.Second + 300*time.Millisecond),
+	}
+	pods := `{"apiVersion":"v1","kind":"PodList","items":[{"metadata":{"name":"web","namespace":"default"}}]}`
+	path := "/api/v1/namespaces/default/pods"
+	recs := make([]*capture.Record, 0, len(times))
+	seqs := make([]int, 0, len(times))
+	counts := make([]int, 0, len(times))
+	for i, ts := range times {
+		recs = append(recs, &capture.Record{
+			ID: "p" + strconv.Itoa(i), CapturedAt: ts, APIPath: path,
+			HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(pods),
+		})
+		seqs = append(seqs, i)
+		counts = append(counts, 1)
+	}
+	idx := capture.Index{path: {APIPath: path, Seqs: seqs, Times: times, Counts: counts}}
+	meta := &capture.CaptureMetadata{
+		CaptureID: "ts-dupes", CapturedAt: base.Add(-time.Minute),
+		CapturedUntil: times[len(times)-1], RecordCount: len(recs),
+	}
+	h := &Handler{Store: buildV2TestStore(t, recs, idx, meta)}
+
+	var resp TimestampsResponse
+	if code := getJSONInto(t, h, h.serveTimestamps, "/v2/api/timestamps", "", &resp); code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+
+	seen := make(map[string]int, len(resp.Timestamps))
+	for _, ts := range resp.Timestamps {
+		seen[ts]++
+	}
+	for ts, n := range seen {
+		if n > 1 {
+			t.Errorf("timestamp %q emitted %d times; the scrubber cannot step across a repeated stop", ts, n)
+		}
+	}
+	if len(seen) != len(resp.Timestamps) {
+		t.Errorf("len(Timestamps) = %d but only %d are distinct", len(resp.Timestamps), len(seen))
+	}
+	// 5 records collapsing to the 2 wall-clock seconds they fall in.
+	if len(resp.Timestamps) != 2 {
+		t.Errorf("len(Timestamps) = %d, want 2 (one stop per distinct second), got %v", len(resp.Timestamps), resp.Timestamps)
+	}
+	// TotalCount is distinct stops, so it must agree with the emitted list
+	// whenever nothing was sampled away.
+	if resp.Sampled {
+		t.Fatalf("Sampled = true, want false for 2 stops")
+	}
+	if resp.TotalCount != len(resp.Timestamps) {
+		t.Errorf("TotalCount = %d, want %d (unsampled, so it must equal the stop count)", resp.TotalCount, len(resp.Timestamps))
+	}
+	// Ordering must survive the dedupe.
+	for i := 1; i < len(resp.Timestamps); i++ {
+		if resp.Timestamps[i-1] >= resp.Timestamps[i] {
+			t.Errorf("Timestamps not strictly increasing at %d: %v", i, resp.Timestamps)
+		}
+	}
+}
+
+// sampleTimes runs after the dedupe, so a capture with more distinct stops than
+// the cap must still come back duplicate-free — sampling an already-unique list
+// cannot reintroduce repeats, and this pins that down.
+func TestServeTimestamps_SampledStopsStayDistinct(t *testing.T) {
+	base := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	n := scrubberMaxStops * 2
+	times := make([]time.Time, 0, n)
+	for i := 0; i < n; i++ {
+		times = append(times, base.Add(time.Duration(i)*time.Second))
+	}
+	pods := `{"apiVersion":"v1","kind":"PodList","items":[{"metadata":{"name":"web","namespace":"default"}}]}`
+	path := "/api/v1/namespaces/default/pods"
+	recs := make([]*capture.Record, 0, n)
+	seqs := make([]int, 0, n)
+	counts := make([]int, 0, n)
+	for i, ts := range times {
+		recs = append(recs, &capture.Record{
+			ID: "p" + strconv.Itoa(i), CapturedAt: ts, APIPath: path,
+			HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(pods),
+		})
+		seqs = append(seqs, i)
+		counts = append(counts, 1)
+	}
+	idx := capture.Index{path: {APIPath: path, Seqs: seqs, Times: times, Counts: counts}}
+	meta := &capture.CaptureMetadata{
+		CaptureID: "ts-sampled", CapturedAt: base, CapturedUntil: times[n-1], RecordCount: n,
+	}
+	h := &Handler{Store: buildV2TestStore(t, recs, idx, meta)}
+
+	var resp TimestampsResponse
+	if code := getJSONInto(t, h, h.serveTimestamps, "/v2/api/timestamps", "", &resp); code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	if !resp.Sampled {
+		t.Errorf("Sampled = false, want true for %d stops", n)
+	}
+	if resp.TotalCount != n {
+		t.Errorf("TotalCount = %d, want %d", resp.TotalCount, n)
+	}
+	if len(resp.Timestamps) > scrubberMaxStops {
+		t.Errorf("len(Timestamps) = %d, want <= %d", len(resp.Timestamps), scrubberMaxStops)
+	}
+	seen := make(map[string]struct{}, len(resp.Timestamps))
+	for _, ts := range resp.Timestamps {
+		if _, dup := seen[ts]; dup {
+			t.Errorf("sampled list repeats %q", ts)
+		}
+		seen[ts] = struct{}{}
 	}
 }
 


### PR DESCRIPTION
Closes #257
Closes #258

Two of the three items #311 names as the minimum bar for dropping the web UI's "experimental" label. One commit each; they touch disjoint files (`app.js` + Go for #257, `app.css` for #258).

---

## #257 — the scrubber's step-forward button

`timestamps.go` deduped in a `map[time.Time]` (nanosecond) but emitted `t.Format(time.RFC3339)` (second), so the list came back with repeated *string* values — 180 stops with 4 distinct values on `examples/auto-discovery/capture.kshrk`, one of them 96 times. The client keyed off those strings, so `indexOf(at) + 1` landed on another index holding the identical value and the reverse lookup snapped back.

Fixed on both sides, because either alone leaves a hole:

**Dedupe at the precision actually emitted.** Second precision is deliberate, not a concession. Every `at` in this API is RFC3339 seconds — parsed that way, echoed back that way by each handler, rendered by `formatTS` and the diff pickers, accepted from `--at`. `RFC3339Nano` would keep more stops but put nine decimal places into the scrubber label and the diff dropdowns, and leave stops the rest of the contract can't address. **Nothing real is lost:** on that capture the 180 stops were 4 moments inflated 45× by identical strings.

**Track the index in state.** A reverse lookup returns the first match, so it was wrong for duplicates — and it is *still* wrong for an `at` that isn't itself a stop, which a deep link or a sampled list on a long capture produces. `selectSnapshot()` is now the single writer keeping `at` and `atIndex` in lockstep, and the fallback floor-resolves instead of silently jumping to the end of the range. `replaySnapshotIndex` → `snapshotIndexAtOrBefore`, since both paths use it now.

### Verification

The endpoint, against the exact capture from the report:

```
total_count : 4          (was 180)
len(stops)  : 4
distinct    : 4
duplicates  : NONE
ascending   : True
```

In the browser, driving the real buttons and events:

```
initial idx=3 latest      drag→1  holds 1   (no snap-back)
back 1  idx=2 22:07:08    drag→2  holds 2
back 2  idx=1 22:06:58    drag→0  holds 0
back 3  idx=0 22:06:57
fwd 1   idx=1 22:06:58    ← this is what never moved before
fwd 2   idx=2 22:07:08
fwd 3   idx=3 22:07:18
```

All three acceptance criteria: handler test asserts no duplicates, forward advances one stop at a time through the whole range, dragging doesn't snap backward.

The new test **fails on the old dedupe** — I reverted the one-line fix to confirm it, rather than trusting a green run:

```
timestamp "2026-04-10T10:00:00Z" emitted 3 times; the scrubber cannot step across a repeated stop
len(Timestamps) = 5 but only 2 are distinct
```

A second test pins that sampling (which runs *after* the dedupe) can't reintroduce duplicates.

### One knock-on

`TotalCount` now counts distinct stops, so it reads visibly smaller. It feeds the header label, which said "N **records**" — it was never a record count. Corrected to "snapshots". One word, but it would otherwise look like the fix broke the count.

---

## #258 — light theme code/log/diff legibility

Light theme set `--code-bg: #0f1726` (dark navy) while consumers kept light-theme foregrounds. Plain `.code`/`.json-view` text sat at **1.18:1**. Not an edge case: `codeBlock` skips highlighting above 300 KB, so large objects rendered as fully invisible text, and JSON mode leaves braces and indentation untokenized at that same ratio.

The root cause is that code surfaces borrowed the semantic UI colors, which are tuned for panel backgrounds and were never checked against `--code-bg`. They now get their own per-theme palette (`--code-fg/-dim/-com/-punc/-key/-str/-num/-lit`, plus diff foregrounds and row tints), and the light theme gets a light `--code-bg` (`#f8fafc`).

`.json-view`'s tokens were hardcoded dark-theme hex, so light had no way to be legible; the dark tokens carry those exact values forward, leaving dark `.json-view` pixel-identical. `.code` adopts the same purpose-built palette — a visible but coherent change to `.code` in dark mode, and the two highlighters finally agree.

Also fixes the "also worth fixing" item: `--fg-faint` failed AA as body text in **both** themes (3.21:1 on `--bg-row-hover` in dark, not just light). Both values sit near the AA floor deliberately, so the token stays recessive against `--fg-dim` rather than collapsing into it.

### Measurement

Checked every foreground/background pair the stylesheet actually renders with a WCAG 2.1 checker, including the diff foregrounds **composited over their translucent row tints** rather than over `--code-bg` alone. It reproduces the report's figures exactly — 1.18, 2.92, 2.77, 3.86, ~3.6 — which is what makes the rest of its output trustworthy.

**21 failing pairs before; all 70 pass now, lowest 4.51:1.** Worst cases before → after:

| | before | after |
|---|---|---|
| `.code` plain text, light | **1.18** | 14.50 |
| `--fg-faint` on `--bg-row-hover`, light | 2.49 | 4.75 |
| `.log-preview` / `.diff .ctx`, light | 2.77 | 7.15 |
| `.code .k-lit`, light | 2.92 | 7.61 |
| `--fg-faint` on `--bg-row-hover`, **dark** | 3.21 | 4.75 |
| `.code .k-key`, light | 3.86 | 6.73 |

Two failures the report didn't list, both light and both fixed: `--accent` as a link on `--bg` (4.34) and `--bad` on `--bg-row` (4.34).

Verified in the browser in both themes across YAML, JSON, diff and log-preview, reading computed styles rather than eyeballing.

---

## Not done: screenshot regeneration

#258 asks for regenerated screenshots. I did **not** do this, and it should not block the fix — three reasons, in order of weight:

1. **They're unreproducible from this repo.** All 13 images under `docs/images/v2/` come from a ~493 MiB capture of a real OpenShift cluster — 153 namespaces, 759 workloads, 566 pods, 44,412 records. The richest repo example (`auto-discovery`) has 1 namespace and 1 pod; `multi-namespace` has 3 namespaces and 5 pods. Regenerating from an example would visibly thin out the docs rather than refresh them.
2. **No existing screenshot documents the bug.** `object-view.png` is the only one showing a code surface and it is a *dark*-theme shot. `overview-light.png` is the only light one and the overview page has no code surface. So the docs never displayed the 1.18:1 state.
3. **They're already stale for an unrelated reason** — every one shows a "Legacy UI ↗" button in the topbar, and the legacy UI was removed in #91. So a refresh is already owed independently of this change.

Worth a follow-up issue, and it needs a capture only you have. Two things to decide when you do it: the shots also predate the current header format, and they carry the source cluster's API server hostname and its namespace/workload inventory in public docs — regeneration is the natural moment to reconsider that.

## Also noticed, not changed

`.json-view` / `.yaml-view` are **unreferenced** — `grep` finds no `json-view` or `yaml-view` in `app.js`; the live surfaces are `.code`, `.log-preview` and `.diff`. #258 lists them as consumers, so they looked live. I tokenized them along with the rest so they'd be correct if revived, rather than deleting rules in a contrast fix. Removing them is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
