### PR TITLE
feat(anonymize): M1 — core aliasing primitives (#137)

### DIFF
--- a/internal/anonymize/alias.go
+++ b/internal/anonymize/alias.go
@@ -3,6 +3,7 @@ package anonymize
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"fmt"
 )
 
 // Aliaser deterministically maps an original value to a stable, structurally
@@ -17,21 +18,21 @@ import (
 // The alternative — assign "the next sequential alias" the first time a
 // value is seen while walking an archive's records — would depend on the
 // order records are visited in. redact.Archive (internal/redact/redact.go)
-// visits records via `for apiPath, entry := range idx`, and Go's map
-// iteration order is randomized per process. That is harmless for redact
-// today because every field-redact replacement is a fixed constant, but it
-// would silently break anonymize's own stated requirement — "same input +
-// same salt ⇒ same output, so re-runs and diffs are stable" — because two
-// runs over the identical archive could assign different aliases to the
-// same real value depending on which run's random map order happened to
-// visit it first. A pure function of (category, value, salt) has no order
-// to depend on, so this can't happen.
+// visits every record in the archive by ranging directly over the decoded
+// index map, and Go's map iteration order is randomized per process. That is
+// harmless for redact today because every field-redact replacement is a
+// fixed constant, but it would silently break anonymize's own stated
+// requirement — "same input + same salt ⇒ same output, so re-runs and diffs
+// are stable" — because two runs over the identical archive could assign
+// different aliases to the same real value depending on which run's random
+// map order happened to visit it first. A pure function of (category,
+// value, salt) has no order to depend on, so this can't happen.
 //
 // It also gets consistency across the regular index and the watch index for
-// free: redact.Archive walks those in two separate loops (redact.go:96 and
-// redact.go:139). Because Alias holds no state, both loops independently
-// compute the identical alias for the same value without needing to
-// coordinate with each other.
+// free: redact.Archive walks those via two separate loops, one per index.
+// Because Alias holds no state, both loops independently compute the
+// identical alias for the same value without needing to coordinate with
+// each other.
 type Aliaser struct {
 	salt []byte
 }
@@ -45,16 +46,50 @@ func NewAliaser(salt []byte) *Aliaser {
 	return &Aliaser{salt: append([]byte(nil), salt...)}
 }
 
+// implementedCategories are the categories Alias currently knows how to
+// render. Deliberately explicit and exhaustive rather than "everything
+// except IP falls through to aliasName": CategoryURL and CategoryImage are
+// real constants (used by later milestones' matchers once those exist), but
+// their encoders don't exist yet — URL/hostname aliasing needs substring
+// splicing, and image aliasing needs registry-host-only rewriting, neither
+// of which is word-based name aliasing. Letting them silently render via
+// aliasName today would lock in an accidental encoding nobody decided on,
+// for categories whose real encoding is different milestones' work. Alias
+// panics for anything not listed here so that can't happen unnoticed;
+// TestAliaser_ImplementedCategoriesMatchDispatch pins this list against
+// Alias's own switch so the two can't drift apart.
+var implementedCategories = map[Category]bool{
+	CategoryIP:        true,
+	CategoryNode:      true,
+	CategoryNamespace: true,
+	CategoryPod:       true,
+	CategoryWorkload:  true,
+}
+
 // Alias returns the deterministic, category-appropriate replacement for
 // original. The returned value is always structurally valid for its
 // category (a parseable IP of the same family as original; a DNS-1123-safe
 // label otherwise) — see ip.go and name.go for the per-category encoders.
+//
+// Panics if category is not yet implemented (see implementedCategories) —
+// this is an internal package with no callers yet, so a loud failure now is
+// strictly better than a silently-wrong render that a later milestone would
+// have to notice and unwind.
 func (a *Aliaser) Alias(category Category, original string) string {
-	digest := a.digest(category, original)
-	if category == CategoryIP {
-		return aliasIP(digest, original)
+	if !implementedCategories[category] {
+		panic(fmt.Sprintf("anonymize: category %q has no encoder yet (see implementedCategories)", category))
 	}
-	return aliasName(category, digest)
+	digest := a.digest(category, original)
+	switch category {
+	case CategoryIP:
+		return aliasIP(digest, original)
+	case CategoryNode, CategoryNamespace, CategoryPod, CategoryWorkload:
+		return aliasName(category, digest)
+	default:
+		// Unreachable: implementedCategories and this switch are kept in
+		// sync by TestAliaser_ImplementedCategoriesMatchDispatch.
+		panic(fmt.Sprintf("anonymize: category %q is in implementedCategories but has no case in Alias's switch", category))
+	}
 }
 
 // digest returns a value's category-scoped HMAC-SHA256 digest under this

--- a/internal/anonymize/alias.go
+++ b/internal/anonymize/alias.go
@@ -1,0 +1,72 @@
+package anonymize
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+)
+
+// Aliaser deterministically maps an original value to a stable, structurally
+// valid replacement, given a fixed salt: Alias(cat, salt, x) always returns
+// the same string for the same (cat, salt, x).
+//
+// That determinism is the whole point of this package, and it is achieved by
+// construction rather than by bookkeeping: Alias is a pure function with no
+// shared mutable state across calls. That is deliberate, not an
+// implementation shortcut.
+//
+// The alternative — assign "the next sequential alias" the first time a
+// value is seen while walking an archive's records — would depend on the
+// order records are visited in. redact.Archive (internal/redact/redact.go)
+// visits records via `for apiPath, entry := range idx`, and Go's map
+// iteration order is randomized per process. That is harmless for redact
+// today because every field-redact replacement is a fixed constant, but it
+// would silently break anonymize's own stated requirement — "same input +
+// same salt ⇒ same output, so re-runs and diffs are stable" — because two
+// runs over the identical archive could assign different aliases to the
+// same real value depending on which run's random map order happened to
+// visit it first. A pure function of (category, value, salt) has no order
+// to depend on, so this can't happen.
+//
+// It also gets consistency across the regular index and the watch index for
+// free: redact.Archive walks those in two separate loops (redact.go:96 and
+// redact.go:139). Because Alias holds no state, both loops independently
+// compute the identical alias for the same value without needing to
+// coordinate with each other.
+type Aliaser struct {
+	salt []byte
+}
+
+// NewAliaser returns an Aliaser using salt. salt should be resolved by the
+// caller (CLI flag, file, or a freshly generated value that gets echoed back
+// to the user) — this package never generates, stores, or reads a salt from
+// anywhere on its own, precisely so it composes safely with however the
+// caller chooses to source one.
+func NewAliaser(salt []byte) *Aliaser {
+	return &Aliaser{salt: append([]byte(nil), salt...)}
+}
+
+// Alias returns the deterministic, category-appropriate replacement for
+// original. The returned value is always structurally valid for its
+// category (a parseable IP of the same family as original; a DNS-1123-safe
+// label otherwise) — see ip.go and name.go for the per-category encoders.
+func (a *Aliaser) Alias(category Category, original string) string {
+	digest := a.digest(category, original)
+	if category == CategoryIP {
+		return aliasIP(digest, original)
+	}
+	return aliasName(category, digest)
+}
+
+// digest returns a value's category-scoped HMAC-SHA256 digest under this
+// Aliaser's salt. Mixing the category into the MAC input (not just into the
+// rendering afterward) means a hash collision between categories would
+// require breaking HMAC-SHA256 itself, not just an unlucky rendering choice
+// — though in practice categories can't collide as *strings* anyway, since
+// each renders into its own disjoint space (see alias_test.go).
+func (a *Aliaser) digest(category Category, original string) []byte {
+	mac := hmac.New(sha256.New, a.salt)
+	mac.Write([]byte(category))
+	mac.Write([]byte(":"))
+	mac.Write([]byte(original))
+	return mac.Sum(nil)
+}

--- a/internal/anonymize/alias_test.go
+++ b/internal/anonymize/alias_test.go
@@ -1,0 +1,199 @@
+package anonymize
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// The central requirement: same (category, salt, original) always yields the
+// same alias, run after run, process after process. This is the property the
+// whole single-pass design exists to guarantee without any shared state.
+func TestAliaser_Deterministic(t *testing.T) {
+	salt := []byte("test-salt")
+	cases := []struct {
+		category Category
+		value    string
+	}{
+		{CategoryIP, "10.244.0.5"},
+		{CategoryIP, "2001:db8::1"},
+		{CategoryNode, "worker-node-3"},
+		{CategoryNamespace, "production"},
+		{CategoryPod, "widget-controller-7f9647f7b6-q6vh8"},
+		{CategoryWorkload, "widget-controller"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.category)+"/"+tc.value, func(t *testing.T) {
+			a1 := NewAliaser(salt)
+			a2 := NewAliaser(salt) // a fresh Aliaser, as a new process would construct
+			got1 := a1.Alias(tc.category, tc.value)
+			got2 := a2.Alias(tc.category, tc.value)
+			if got1 != got2 {
+				t.Errorf("nondeterministic: %q vs %q", got1, got2)
+			}
+			// And stable across repeated calls on the same Aliaser too —
+			// Alias must not mutate any state that would change its own
+			// next answer.
+			got3 := a1.Alias(tc.category, tc.value)
+			if got3 != got1 {
+				t.Errorf("Alias is not idempotent across repeated calls on the same Aliaser: %q then %q", got1, got3)
+			}
+		})
+	}
+}
+
+// A different salt must (with overwhelming probability) produce a different
+// alias — otherwise "salt" wouldn't be doing anything, which is exactly the
+// failure mode Open Question 1 in the design contrasts against a
+// salt-independent sorted-counter scheme.
+func TestAliaser_DifferentSaltDifferentAlias(t *testing.T) {
+	a1 := NewAliaser([]byte("salt-one"))
+	a2 := NewAliaser([]byte("salt-two"))
+	got1 := a1.Alias(CategoryNode, "worker-node-3")
+	got2 := a2.Alias(CategoryNode, "worker-node-3")
+	if got1 == got2 {
+		t.Errorf("two different salts produced the same alias %q for the same input", got1)
+	}
+}
+
+// Different original values under the same salt+category should (almost
+// always) diverge. A property test over a decent sample size rather than a
+// hard uniqueness proof, since collisions are possible in principle (see
+// name.go's wordsPerCategory comment) — this pins the *rate*, not a
+// guarantee, so a real regression (e.g. an encoder that ignores most of the
+// input) would show up as a large collision count, not just one.
+func TestAliaser_DistinctInputsMostlyDistinctAliases(t *testing.T) {
+	salt := []byte("distinctness-salt")
+	a := NewAliaser(salt)
+	r := rand.New(rand.NewSource(42)) // fixed seed: reproducible, not security-sensitive
+
+	const n = 500
+	seen := make(map[string]string, n) // alias -> first original that produced it
+	collisions := 0
+	for i := 0; i < n; i++ {
+		original := fmt.Sprintf("node-%d-%d", i, r.Int())
+		alias := a.Alias(CategoryNode, original)
+		if prior, ok := seen[alias]; ok && prior != original {
+			collisions++
+		}
+		seen[alias] = original
+	}
+	// 2-word node aliases have a 64*64 = 4096-combination space; by the
+	// birthday bound, 500 draws should produce on the order of tens of
+	// collisions, not hundreds. A generous ceiling — this test exists to
+	// catch a broken encoder (e.g. one that collapses to a handful of
+	// outputs), not to police the exact birthday-bound math.
+	const maxAcceptableCollisions = 100
+	if collisions > maxAcceptableCollisions {
+		t.Errorf("got %d collisions across %d distinct inputs, want <= %d — the encoder may not be using enough of the digest",
+			collisions, n, maxAcceptableCollisions)
+	}
+}
+
+// Two different categories must never render into the same string, for any
+// input — not as a probabilistic property, but structurally: each category
+// renders into its own disjoint space (an IP literal vs. "<category>-word-
+// word"), so this holds even if the underlying digests happened to collide.
+func TestAliaser_CategoriesNeverCollide(t *testing.T) {
+	a := NewAliaser([]byte("cross-category-salt"))
+	values := []string{"shared-value", "10.0.0.1", "prod", "worker-1"}
+
+	for _, v := range values {
+		byCategory := make(map[Category]string)
+		for _, cat := range AllCategories {
+			byCategory[cat] = a.Alias(cat, v)
+		}
+		seen := make(map[string]Category, len(byCategory))
+		for cat, alias := range byCategory {
+			if other, ok := seen[alias]; ok {
+				t.Errorf("value %q: categories %q and %q both produced alias %q", v, other, cat, alias)
+			}
+			seen[alias] = cat
+		}
+	}
+}
+
+// aliasName's output must always be a valid DNS-1123 label — this is a
+// consequence of the word list being pre-validated (wordlist_test.go), but
+// pin it at the Alias level too, since that's the contract callers actually
+// depend on.
+func TestAliaser_NameAliasesAreDNS1123Safe(t *testing.T) {
+	a := NewAliaser([]byte("name-salt"))
+	for _, cat := range []Category{CategoryNode, CategoryNamespace, CategoryPod, CategoryWorkload} {
+		for i := 0; i < 50; i++ {
+			original := fmt.Sprintf("%s-original-%d", cat, i)
+			alias := a.Alias(cat, original)
+			if errs := validation.IsDNS1123Label(alias); len(errs) > 0 {
+				t.Errorf("%s alias %q for input %q is not a valid DNS-1123 label: %v", cat, alias, original, errs)
+			}
+			if got := alias[:len(string(cat))]; got != string(cat) {
+				t.Errorf("%s alias %q does not start with the category prefix", cat, alias)
+			}
+		}
+	}
+}
+
+// IP aliases must parse back as valid IPs, land in the intended private
+// range, and preserve the input's address family.
+func TestAliaser_IPAliasesAreValidAndPrivate(t *testing.T) {
+	_, v4Net, err := net.ParseCIDR("10.0.0.0/8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, v6Net, err := net.ParseCIDR("fd00::/8")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a := NewAliaser([]byte("ip-salt"))
+	cases := []struct {
+		original string
+		wantV6   bool
+	}{
+		{"192.168.1.1", false},
+		{"172.16.5.9", false},
+		{"8.8.8.8", false},
+		{"2001:db8::1", true},
+		{"fe80::1", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.original, func(t *testing.T) {
+			alias := a.Alias(CategoryIP, tc.original)
+			parsed := net.ParseIP(alias)
+			if parsed == nil {
+				t.Fatalf("alias %q for %q does not parse as an IP", alias, tc.original)
+			}
+			isV4 := parsed.To4() != nil
+			if isV4 == tc.wantV6 {
+				t.Errorf("alias %q for %q has the wrong address family (isV4=%v, wantV6=%v)", alias, tc.original, isV4, tc.wantV6)
+			}
+			if isV4 {
+				if !v4Net.Contains(parsed) {
+					t.Errorf("IPv4 alias %q for %q is not in %s", alias, tc.original, v4Net)
+				}
+			} else {
+				if !v6Net.Contains(parsed) {
+					t.Errorf("IPv6 alias %q for %q is not in %s", alias, tc.original, v6Net)
+				}
+			}
+		})
+	}
+}
+
+// aliasIP's documented fallback: an input that doesn't parse as an IP at all
+// still returns a valid (IPv4) alias rather than panicking, since
+// Aliaser.Alias has no error return. Exercised directly here because
+// Aliaser.Alias's category dispatch is the only caller in this milestone,
+// and it's easy to lose this behavior in a future refactor without a test
+// pinning it.
+func TestAliasIP_MalformedInputFallsBackToIPv4(t *testing.T) {
+	a := NewAliaser([]byte("fallback-salt"))
+	alias := a.Alias(CategoryIP, "not-an-ip-at-all")
+	parsed := net.ParseIP(alias)
+	if parsed == nil || parsed.To4() == nil {
+		t.Errorf("malformed-input fallback: got %q, want a valid IPv4 alias", alias)
+	}
+}

--- a/internal/anonymize/alias_test.go
+++ b/internal/anonymize/alias_test.go
@@ -101,9 +101,12 @@ func TestAliaser_CategoriesNeverCollide(t *testing.T) {
 	a := NewAliaser([]byte("cross-category-salt"))
 	values := []string{"shared-value", "10.0.0.1", "prod", "worker-1"}
 
+	// implementedCategories, not AllCategories: AllCategories is the eventual
+	// full set (#137's design target), and Alias panics on the categories in
+	// it that aren't implemented yet — see TestAliaser_PanicsOnUnimplementedCategory.
 	for _, v := range values {
 		byCategory := make(map[Category]string)
-		for _, cat := range AllCategories {
+		for cat := range implementedCategories {
 			byCategory[cat] = a.Alias(cat, v)
 		}
 		seen := make(map[string]Category, len(byCategory))
@@ -181,6 +184,54 @@ func TestAliaser_IPAliasesAreValidAndPrivate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Calling Alias with a category that isn't implemented yet must panic, not
+// silently render something through the wrong encoder. This is the guard
+// that makes CategoryURL/CategoryImage safe to define now (for later
+// milestones to reference) without accidentally locking in an encoding
+// nobody has designed.
+func TestAliaser_PanicsOnUnimplementedCategory(t *testing.T) {
+	a := NewAliaser([]byte("panic-salt"))
+	for _, cat := range []Category{CategoryURL, CategoryImage, Category("bogus")} {
+		t.Run(string(cat), func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("Alias(%q, ...) did not panic", cat)
+				}
+			}()
+			a.Alias(cat, "some-value")
+		})
+	}
+}
+
+// implementedCategories (used by Alias's guard) and the case list in Alias's
+// own switch must agree exactly — pinned here so the two can't quietly drift
+// apart (a category added to one without the other would either panic
+// despite being "implemented," or silently reach the switch's unreachable
+// default panic branch instead of the clearer guard message).
+func TestAliaser_ImplementedCategoriesMatchDispatch(t *testing.T) {
+	a := NewAliaser([]byte("dispatch-sync-salt"))
+	for _, cat := range AllCategories {
+		implemented := implementedCategories[cat]
+		panicked := panics(func() { a.Alias(cat, "probe-value") })
+		if implemented == panicked {
+			t.Errorf("category %q: implementedCategories says implemented=%v but Alias panicked=%v — implementedCategories and Alias's switch have drifted apart",
+				cat, implemented, panicked)
+		}
+	}
+}
+
+// panics reports whether f panics, recovering so the test can assert on the
+// outcome rather than crash.
+func panics(f func()) (didPanic bool) {
+	defer func() {
+		if recover() != nil {
+			didPanic = true
+		}
+	}()
+	f()
+	return false
 }
 
 // aliasIP's documented fallback: an input that doesn't parse as an IP at all

--- a/internal/anonymize/anonymize.go
+++ b/internal/anonymize/anonymize.go
@@ -1,0 +1,53 @@
+// Package anonymize implements value/pattern-based anonymization of capture
+// archives: an IP, hostname, image registry, or resource name is replaced
+// consistently with the same alias everywhere it occurs in the archive,
+// unlike kshrk redact's field-path-based replacement (internal/redact),
+// which targets one exact field at a time with a fixed constant.
+//
+// The core primitive is Aliaser (alias.go): a pure function of
+// (category, original value, salt), with no shared mutable state across
+// records. That is a deliberate choice, not an implementation detail — see
+// the Aliaser doc comment for why a stateful first-seen-order counter would
+// be nondeterministic across runs.
+package anonymize
+
+// Category identifies which kind of value an alias is being generated for.
+// It is mixed into every alias's derivation, so the same original string
+// anonymized under two different categories never produces the same alias —
+// not because of a lookup, but because each category renders into its own
+// disjoint string space (see alias.go).
+type Category string
+
+const (
+	// CategoryIP covers pod/host/cluster/load-balancer IP addresses.
+	CategoryIP Category = "ip"
+	// CategoryURL covers URLs and bare hostnames (ingress hosts, webhook
+	// URLs, TLS SAN entries, the mock API server's own address).
+	CategoryURL Category = "url"
+	// CategoryImage covers container image registry hosts.
+	CategoryImage Category = "image"
+	// CategoryNode covers Node names.
+	CategoryNode Category = "node"
+	// CategoryNamespace covers Namespace names.
+	CategoryNamespace Category = "namespace"
+	// CategoryPod covers Pod names.
+	CategoryPod Category = "pod"
+	// CategoryWorkload covers Deployment/DaemonSet/StatefulSet/ReplicaSet/
+	// Job/CronJob names.
+	CategoryWorkload Category = "workload"
+)
+
+// AllCategories is every category anonymize supports, in a stable order
+// (used for --categories default, and for iterating deterministically in
+// reports). Not all are wired to the archive-rewrite path yet — see the
+// package's tracking issue (#137) milestones for what each build actually
+// covers; this list is the eventual full set.
+var AllCategories = []Category{
+	CategoryIP,
+	CategoryURL,
+	CategoryImage,
+	CategoryNode,
+	CategoryNamespace,
+	CategoryPod,
+	CategoryWorkload,
+}

--- a/internal/anonymize/anonymize.go
+++ b/internal/anonymize/anonymize.go
@@ -37,11 +37,14 @@ const (
 	CategoryWorkload Category = "workload"
 )
 
-// AllCategories is every category anonymize supports, in a stable order
-// (used for --categories default, and for iterating deterministically in
-// reports). Not all are wired to the archive-rewrite path yet — see the
-// package's tracking issue (#137) milestones for what each build actually
-// covers; this list is the eventual full set.
+// AllCategories is the full set of categories anonymize is designed to
+// eventually support, in a stable order — the target end-state from #137's
+// design, not what's implemented today. Most are not usable yet:
+// (*Aliaser).Alias panics for any category not in its own
+// implementedCategories set (alias.go), which is a strict subset of this
+// list until later milestones add the rest. Don't iterate AllCategories
+// expecting every entry to work; iterate implementedCategories (or call
+// Alias and let it panic loudly) if you need "what works right now."
 var AllCategories = []Category{
 	CategoryIP,
 	CategoryURL,

--- a/internal/anonymize/ip.go
+++ b/internal/anonymize/ip.go
@@ -1,0 +1,55 @@
+package anonymize
+
+import "net"
+
+// ipv4PrivatePrefix is the leading octet of the RFC 1918 /8 block anonymized
+// IPv4 addresses are placed in. 10.0.0.0/8 rather than 192.168.0.0/16 or
+// 172.16.0.0/12 purely because it's the largest of the three private blocks,
+// giving the most room to spread digest-derived addresses across.
+const ipv4PrivatePrefix = 10
+
+// ipv6ULAPrefix is the leading byte of the RFC 4193 Unique Local Address
+// range (fd00::/8) anonymized IPv6 addresses are placed in.
+const ipv6ULAPrefix = 0xfd
+
+// aliasIP returns a deterministic, structurally valid replacement IP for
+// original, derived from digest. The replacement is always in a private
+// range (RFC 1918 for IPv4, RFC 4193 ULA for IPv6) and matches original's
+// address family whenever original parses as an IP.
+//
+// original is used only to pick the address family; the replacement's actual
+// bytes come entirely from digest, so this never leaks any bit of the real
+// address. If original does not parse as an IP at all — which should not
+// happen in practice, since the caller's matcher is what decided this value
+// belongs to CategoryIP in the first place — this falls back to treating it
+// as IPv4 rather than panicking or erroring, since Aliaser.Alias has no
+// error return. That fallback is intentional and covered by a test, not an
+// oversight: see alias_test.go's malformed-input case.
+func aliasIP(digest []byte, original string) string {
+	parsed := net.ParseIP(original)
+	if parsed != nil && parsed.To4() == nil {
+		return aliasIPv6(digest)
+	}
+	return aliasIPv4(digest)
+}
+
+// aliasIPv4 builds a 10.x.x.x address from digest. The last octet is
+// clamped to [1,254] so the result never looks like a network or broadcast
+// address for a /24 subnet, even though nothing here actually depends on a
+// /24 mask being in play.
+func aliasIPv4(digest []byte) string {
+	b1, b2, b3 := digest[0], digest[1], digest[2]
+	last := 1 + (b3 % 254)
+	ip := net.IPv4(ipv4PrivatePrefix, b1, b2, last)
+	return ip.String()
+}
+
+// aliasIPv6 builds an fd00::/8 ULA address from digest. SHA-256 digests are
+// 32 bytes, so there is no risk of running out of digest material for the
+// remaining 15 bytes after the fixed leading byte.
+func aliasIPv6(digest []byte) string {
+	var b [16]byte
+	b[0] = ipv6ULAPrefix
+	copy(b[1:], digest[:15])
+	return net.IP(b[:]).String()
+}

--- a/internal/anonymize/name.go
+++ b/internal/anonymize/name.go
@@ -1,0 +1,61 @@
+package anonymize
+
+// wordsPerCategory is how many words from the adjective/noun lists are
+// chained together for a category's alias. Categories with realistically
+// high cardinality in a real cluster (pods, workloads) get an extra word to
+// keep the combination space large enough that a same-category collision
+// within one archive stays unlikely; node/namespace counts are realistically
+// much smaller, so two words keeps those aliases shorter and easier to read
+// in the common case without a meaningful collision-risk cost.
+//
+// This is a v1 sizing choice, not a correctness guarantee: two different
+// original values can still collide onto the same alias (see Aliaser's doc
+// comment on the archive-rewrite loop, which owns detecting and resolving an
+// actual collision against its own per-run accumulator — that requires
+// cross-record state this package deliberately does not hold).
+var wordsPerCategory = map[Category]int{
+	CategoryNode:      2,
+	CategoryNamespace: 2,
+	CategoryPod:       3,
+	CategoryWorkload:  3,
+}
+
+// defaultWords is used for any category not listed in wordsPerCategory
+// (currently CategoryURL and CategoryImage, which don't go through
+// aliasName in this milestone — they alias to a hostname-style string
+// instead — but the default keeps this function total rather than panicking
+// on an unrecognized category).
+const defaultWords = 2
+
+// aliasName renders digest as a "<category>-<word>-<word>[-<word>]" string.
+// Every word comes from the curated lists in wordlist.go, which are
+// lowercase-letters-only by construction (checked in wordlist_test.go), so
+// the result is always a valid DNS-1123 label regardless of which words are
+// picked — there is no separate validation step here because there is
+// nothing left for it to catch that the word list hasn't already ruled out.
+//
+// Each word position reads a distinct byte of digest (digest[i] for word i)
+// so the words vary independently rather than moving in lockstep. SHA-256
+// digests are 32 bytes and wordsPerCategory never exceeds 3, so digest[i] is
+// always in range without needing to wrap.
+func aliasName(category Category, digest []byte) string {
+	n, ok := wordsPerCategory[category]
+	if !ok {
+		n = defaultWords
+	}
+
+	out := string(category)
+	for i := 0; i < n; i++ {
+		out += "-" + wordAt(i, digest[i%len(digest)])
+	}
+	return out
+}
+
+// wordAt returns the word for alias position i (alternating adjective/noun
+// by position) selected by byte b.
+func wordAt(i int, b byte) string {
+	if i%2 == 0 {
+		return adjectives[int(b)%len(adjectives)]
+	}
+	return nouns[int(b)%len(nouns)]
+}

--- a/internal/anonymize/name.go
+++ b/internal/anonymize/name.go
@@ -20,11 +20,13 @@ var wordsPerCategory = map[Category]int{
 	CategoryWorkload:  3,
 }
 
-// defaultWords is used for any category not listed in wordsPerCategory
-// (currently CategoryURL and CategoryImage, which don't go through
-// aliasName in this milestone — they alias to a hostname-style string
-// instead — but the default keeps this function total rather than panicking
-// on an unrecognized category).
+// defaultWords is used for any category not listed in wordsPerCategory. In
+// practice Alias (alias.go) only ever calls aliasName with a category from
+// its own implementedCategories set, and every one of those is listed above
+// — so this path isn't reachable through Alias today. It exists so aliasName
+// stays total on its own terms rather than silently returning a 0-word
+// "<category>" alias for an unlisted one, independent of whatever Alias's
+// current dispatch policy happens to be.
 const defaultWords = 2
 
 // aliasName renders digest as a "<category>-<word>-<word>[-<word>]" string.

--- a/internal/anonymize/wordlist.go
+++ b/internal/anonymize/wordlist.go
@@ -1,0 +1,37 @@
+package anonymize
+
+// adjectives and nouns back the human-readable alias encoding in name.go
+// (e.g. "node-quiet-otter" instead of "node-3f9a2b1c"). Every entry must be
+// lowercase ASCII letters only — no digits, hyphens, or other characters —
+// so that joining words with "-" always produces a valid DNS-1123 label;
+// wordlist_test.go checks every entry against
+// k8s.io/apimachinery/pkg/util/validation.IsDNS1123Label individually to
+// catch a future editing mistake here (a typo'd space, an uppercase letter)
+// before it ships as a silently-invalid alias.
+//
+// 64 adjectives x 64 nouns = 4096 two-word combinations, and 64x64x64 =
+// 262144 three-word combinations (see name.go for which categories get
+// which word count). Sized for realistic capture sizes, not an arbitrarily
+// large namespace: a real cluster's distinct node/namespace count is
+// realistically in the tens to low hundreds, not the tens of thousands.
+var adjectives = []string{
+	"able", "ample", "arid", "avid", "blue", "bold", "brave", "brief",
+	"brisk", "broad", "calm", "clean", "clear", "close", "cool", "coral",
+	"crisp", "curt", "dark", "deep", "dim", "dry", "eager", "early",
+	"fair", "fast", "fine", "firm", "fond", "free", "fresh", "gentle",
+	"glad", "gold", "good", "grand", "gray", "great", "green", "happy",
+	"hardy", "keen", "kind", "large", "late", "level", "light", "little",
+	"lively", "loyal", "lucky", "mellow", "merry", "mild", "misty", "modest",
+	"neat", "nice", "noble", "plain", "quick", "quiet", "rapid", "steady",
+}
+
+var nouns = []string{
+	"badger", "bear", "beetle", "bison", "boar", "bobcat", "bream", "camel",
+	"canary", "cheetah", "cobra", "condor", "coyote", "crane", "crow", "deer",
+	"dingo", "dolphin", "dove", "eagle", "egret", "elk", "falcon", "ferret",
+	"finch", "fox", "gazelle", "gecko", "goose", "gopher", "grouse", "gull",
+	"hare", "hawk", "heron", "horse", "ibex", "ibis", "jackal", "jaguar",
+	"kite", "koala", "lemur", "leopard", "lion", "llama", "lynx", "magpie",
+	"marten", "mink", "mole", "moose", "otter", "owl", "panther", "parrot",
+	"perch", "quail", "rabbit", "raven", "robin", "seal", "shark", "wolf",
+}

--- a/internal/anonymize/wordlist_test.go
+++ b/internal/anonymize/wordlist_test.go
@@ -1,0 +1,47 @@
+package anonymize
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// Every word must independently be a valid DNS-1123 label, since aliasName
+// joins them with "-" and relies on the word list alone to guarantee
+// validity — this is the test that would catch a future editing mistake
+// (a stray space, an uppercase letter, a digit) before it ships as a
+// silently-invalid alias.
+func TestWordLists_EveryWordIsDNS1123Safe(t *testing.T) {
+	for _, list := range map[string][]string{"adjectives": adjectives, "nouns": nouns} {
+		for _, w := range list {
+			if errs := validation.IsDNS1123Label(w); len(errs) > 0 {
+				t.Errorf("word %q is not a valid DNS-1123 label: %v", w, errs)
+			}
+		}
+	}
+}
+
+func TestWordLists_NoDuplicates(t *testing.T) {
+	for name, list := range map[string][]string{"adjectives": adjectives, "nouns": nouns} {
+		seen := make(map[string]bool, len(list))
+		for _, w := range list {
+			if seen[w] {
+				t.Errorf("%s contains duplicate word %q", name, w)
+			}
+			seen[w] = true
+		}
+	}
+}
+
+// A short list defeats the whole point of adding a word layer on top of the
+// raw hash — pin a floor so the list can't quietly shrink back down without
+// a test noticing.
+func TestWordLists_MinimumSize(t *testing.T) {
+	const min = 32
+	if len(adjectives) < min {
+		t.Errorf("len(adjectives) = %d, want >= %d", len(adjectives), min)
+	}
+	if len(nouns) < min {
+		t.Errorf("len(nouns) = %d, want >= %d", len(nouns), min)
+	}
+}


### PR DESCRIPTION
Refs #137

First of six milestones (see the approved plan at `/Users/jsearcy/.claude/plans/declarative-soaring-flute.md`, mirrors how #117/archive-encryption was sequenced — one PR per milestone, checking in between). This one is pure, stateless primitives: no archive I/O, no CLI wiring, no config schema. `internal/anonymize` doesn't get used by anything yet.

## The problem this milestone exists to solve

`kshrk redact` does field-path-based replacement with a fixed constant — a different shape than anonymize needs, which is value/pattern-based replacement where the *same* source value must map to the *same* alias everywhere it occurs (a node name must read identically on the Node object, on every Pod's `spec.nodeName`, and on every Event that mentions it).

The naive way to get that consistency — assign "the next alias" the first time a value is seen while walking the archive — has a real, confirmed bug in it. `redact.Archive` visits records via `for apiPath, entry := range idx` (`internal/redact/redact.go:96`), and **Go randomizes map iteration order per process**. That's harmless for redact today because every replacement is a fixed constant, but it would break anonymize's own explicit requirement — "same input + same salt ⇒ same output, so re-runs and diffs are stable" — because two runs over the identical archive could assign different aliases to the same real value, depending on which run's random map order visited it first.

`Aliaser.Alias(category, original)` sidesteps this entirely: it's a **pure function** of `(category, original, salt)`, with no shared state across calls. That also gets "consistent across the regular index and the watch index" for free — those are two separate loops in `redact.Archive`, and a stateless function computes the identical answer in both without needing to coordinate.

## What's in this PR

- `alias = HMAC-SHA256(salt, category+":"+original)`, rendered per category:
  - **IP** (`ip.go`) — family-preserving, mapped into a fixed private range (`10.0.0.0/8` for v4, `fd00::/8` ULA for v6) using digest bytes. Never leaks a bit of the real address. Malformed input falls back to IPv4 rather than erroring (`Alias` has no error return) — covered by a dedicated test, not silently swallowed.
  - **names** (node/namespace/pod/workload, `name.go`) — `"<category>-<word>-<word>[-<word>]"` from a curated word list (`wordlist.go`), not raw hex, matching the issue's own preference for readable output (`node-1`, `app-2`). Every list entry is individually checked against `k8s.io/apimachinery/pkg/util/validation.IsDNS1123Label`, so a future editing mistake (stray space, uppercase letter) fails a test instead of shipping a silently-invalid alias.

## Verification — each test checked against a real break, not just a green run

Per the pattern from earlier work this cycle (#263's XSS scanner self-test): a test that's never seen its own target bug fail is a test I don't trust yet.

**Collapsed the word encoder to ignore its input byte** (`wordAt` always returns `adjectives[0]`/`nouns[0]`):
```
alias_test.go:91: got 499 collisions across 500 distinct inputs, want <= 100
--- FAIL: TestAliaser_DistinctInputsMostlyDistinctAliases
--- PASS: TestAliaser_CategoriesNeverCollide      (correctly unaffected — different property)
--- PASS: TestAliaser_NameAliasesAreDNS1123Safe    (correctly unaffected — different property)
```

**Made `digest()` ignore the salt entirely**:
```
--- PASS: TestAliaser_Deterministic              (a fixed constant is still deterministic!)
--- FAIL: TestAliaser_DifferentSaltDifferentAlias
```
That second experiment is the more important one — it shows `TestAliaser_Deterministic` alone would **not** have caught salt being ignored, since a hardcoded constant trivially satisfies "same input → same output." Both tests are needed; I wrote the second one specifically because the first wasn't sufficient.

Both breaks were reverted immediately after confirming the catch; `git diff --stat` was empty after each.

**Full sweep, clean:** `gofmt -l .`, `go build ./...`, `go vet ./...`, `go mod tidy` (no drift — `k8s.io/apimachinery` was already a dependency, so no new module), `go test -race ./...` (whole repo), `golangci-lint run`.

## Not in this PR (by design, see the plan)

No archive integration, no `kshrk anonymize` subcommand, no config schema, no URL/image-registry categories yet. M2 is namespace anonymization end-to-end — deliberately the hardest structural problem (rewriting `Record.APIPath` and the archive's own index keys, which live outside any JSON body) tackled first, on its own, before broadening to the other categories in M3/M4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
