### PR TITLE
feat(anonymize): M2 — namespace anonymization end-to-end + kshrk anonymize (#137)

### DIFF
--- a/cmd/anonymize.go
+++ b/cmd/anonymize.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/phenixblue/k8shark/internal/anonymize"
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/spf13/cobra"
+)
+
+var anonymizeCmd = &cobra.Command{
+	Use:   "anonymize <capture.kshrk> --categories <category> [--out <anonymized.kshrk>]",
+	Short: "Anonymize identifying values across a capture archive, consistently",
+	Long: `Produces a new capture archive with values of the given categories replaced
+by stable, deterministic aliases: the same original value maps to the same
+alias everywhere it occurs in the archive, so relationships between objects
+(a Pod's namespace, a Namespace's own identity, an Event's involvedObject)
+stay intact. The original archive is not modified; the output defaults to
+<in>-anonymized.kshrk.
+
+This is a different tool than "kshrk redact": redact replaces one exact
+field path with a fixed constant, everywhere it's configured to look;
+anonymize replaces every occurrence of a value it recognizes, consistently,
+using a deterministic alias derived from a salt.
+
+Only one category is available so far: namespace. More land milestone by
+milestone -- see https://github.com/phenixblue/k8shark/issues/137.`,
+	Example: `  # Anonymize every namespace name in a capture
+  kshrk anonymize capture.kshrk --categories namespace
+
+  # Reproduce the exact same aliases on a re-run
+  kshrk anonymize capture.kshrk --categories namespace --anonymize-salt-file salt.txt
+
+  # Anonymize and write to a chosen path
+  kshrk anonymize capture.kshrk --out safe.kshrk --categories namespace`,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeArchiveArg,
+	RunE:              runAnonymize,
+}
+
+func init() {
+	rootCmd.AddCommand(anonymizeCmd)
+	anonymizeCmd.Flags().String("out", "", "output archive path (default: <in>-anonymized.kshrk)")
+	anonymizeCmd.Flags().StringArray("categories", nil, `category to anonymize (repeatable); only "namespace" is available so far`)
+	_ = anonymizeCmd.MarkFlagFilename("out", captureExt)
+	addAnonymizeFlags(anonymizeCmd)
+	// Write-side encryption for the anonymized output (read-side --decrypt-*
+	// are persistent flags from the root command, same as redact).
+	addEncryptFlags(anonymizeCmd)
+}
+
+// parseAnonymizeCategories validates --categories against what this build's
+// archive-rewrite path actually supports. Rejecting an unsupported category
+// here, before any archive I/O, matches the discipline (*Aliaser).Alias
+// enforces one layer down (alias.go) for the same reason: an unsupported
+// category should fail loudly, not silently anonymize nothing for it.
+func parseAnonymizeCategories(raw []string) ([]anonymize.Category, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf(`--categories is required; only "namespace" is available so far (see #137)`)
+	}
+	out := make([]anonymize.Category, 0, len(raw))
+	for _, c := range raw {
+		cat := anonymize.Category(strings.ToLower(strings.TrimSpace(c)))
+		if cat != anonymize.CategoryNamespace {
+			return nil, fmt.Errorf(`--categories %q: not yet supported; only "namespace" is available so far (see #137)`, c)
+		}
+		out = append(out, cat)
+	}
+	return out, nil
+}
+
+func runAnonymize(cmd *cobra.Command, args []string) error {
+	in := args[0]
+	out, _ := cmd.Flags().GetString("out")
+	categoryFlags, _ := cmd.Flags().GetStringArray("categories")
+
+	categories, err := parseAnonymizeCategories(categoryFlags)
+	if err != nil {
+		return err
+	}
+
+	if out == "" {
+		// Trim either the current or the legacy extension so anonymizing a
+		// "*.khsrk" capture yields "<in>-anonymized.kshrk", matching
+		// redact's identical handling.
+		base := strings.TrimSuffix(strings.TrimSuffix(in, ".kshrk"), ".khsrk")
+		out = base + "-anonymized.kshrk"
+	}
+
+	// Refuse to overwrite the source.
+	if err := rejectSamePath(in, out); err != nil {
+		return err
+	}
+
+	salt, err := resolveAnonymizeSalt(cmd)
+	if err != nil {
+		return err
+	}
+
+	// Read-side: decrypt an encrypted source archive if a key was supplied.
+	identities, err := resolveDecryptIdentities(cmd, in)
+	if err != nil {
+		return err
+	}
+
+	// Write-side: optionally encrypt the anonymized output (passphrase or
+	// recipient keys).
+	enc, err := resolveEncryption(cmd)
+	if err != nil {
+		return err
+	}
+	if !enc.enabled {
+		if srcEncrypted, _ := archive.IsEncrypted(in); srcEncrypted {
+			// The source is encrypted but no output encryption was
+			// requested — warn that the anonymized copy will be written in
+			// plaintext, matching redact's identical warning so an
+			// encrypted capture isn't silently downgraded by either command.
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"warning: source archive is encrypted but the anonymized output %q will be written in plaintext; pass a passphrase (--encrypt / --encrypt-passphrase-file) or recipient (--encrypt-recipient / --encrypt-recipients-file) flag to keep it encrypted\n", out)
+		}
+	}
+
+	result, err := anonymize.Archive(in, out, anonymize.Options{
+		Categories: categories,
+		Salt:       salt,
+		Identities: identities,
+		Recipients: enc.recipients,
+	})
+	if err != nil {
+		return err
+	}
+
+	fi, _ := os.Stat(out)
+	size := int64(0)
+	if fi != nil {
+		size = fi.Size()
+	}
+
+	fmt.Printf("Anonymized %d namespace(s) → %s (%d bytes)\n", result.NamespacesRenamed, out, size)
+	return nil
+}

--- a/cmd/anonymize_flags.go
+++ b/cmd/anonymize_flags.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// anonymizeSaltEnv is the environment variable consulted for the anonymize
+// salt when no --anonymize-salt-file is given. Read directly via os.Getenv,
+// never through Viper, for the same reason encryptPassphraseEnv is
+// (encrypt_flags.go): so it can never be bound from — or leak into — the
+// YAML config file. #137's design notes call this out specifically for the
+// anonymize salt: #139 wants these configs distributed as shared, versioned
+// artifacts across a team, and a salt sitting in a config file would
+// silently turn a personal secret into a team-shared one the moment a
+// profile is exported.
+const anonymizeSaltEnv = "KSHRK_ANONYMIZE_SALT"
+
+// addAnonymizeFlags registers the salt-resolution flag on cmd.
+//
+// Deliberately no inline --anonymize-salt=<value> flag, matching
+// resolveEncryptPassphrase's precedent for the same reason: a secret passed
+// as a literal command-line argument sits in shell history and is visible to
+// anyone on the box via `ps`. The salt is a materially smaller secret than an
+// encryption passphrase — knowing it only weakens anonymization, and only if
+// an attacker also has candidate original values to test against — but the
+// leak vector is exactly as cheap to hit by accident (a shared bastion host,
+// a copy-pasted command in a support ticket), so the same discipline applies.
+func addAnonymizeFlags(cmd *cobra.Command) {
+	cmd.Flags().String("anonymize-salt-file", "", "read the anonymize salt from this file (first line, hex-encoded) instead of $"+anonymizeSaltEnv+" or generating one")
+	_ = cmd.MarkFlagFilename("anonymize-salt-file")
+}
+
+// resolveAnonymizeSalt resolves the salt: --anonymize-salt-file, then
+// $KSHRK_ANONYMIZE_SALT, then a freshly generated 32-byte salt. A freshly
+// generated salt is printed once to stderr, hex-encoded, with a warning that
+// it must be saved to reproduce these exact aliases on a re-run — otherwise
+// every invocation without an explicit salt would anonymize the same capture
+// differently, which is not a re-run at all, just a fresh random one that
+// happens to share a namespace's *structure*.
+func resolveAnonymizeSalt(cmd *cobra.Command) ([]byte, error) {
+	if file, _ := cmd.Flags().GetString("anonymize-salt-file"); file != "" {
+		hexStr, err := readPassphraseFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("reading anonymize salt file: %w", err)
+		}
+		return decodeSaltHex(hexStr)
+	}
+
+	if hexStr := os.Getenv(anonymizeSaltEnv); hexStr != "" {
+		return decodeSaltHex(hexStr)
+	}
+
+	salt := make([]byte, 32)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, fmt.Errorf("generating anonymize salt: %w", err)
+	}
+	saltHex := hex.EncodeToString(salt)
+	fmt.Fprintf(cmd.ErrOrStderr(),
+		"generated anonymize salt (save this to reproduce these exact aliases on a re-run):\n  %s\n\n"+
+			"Pass it back with --anonymize-salt-file (a file containing this value) or $%s.\n",
+		saltHex, anonymizeSaltEnv)
+	return salt, nil
+}
+
+// decodeSaltHex decodes a hex-encoded salt string, as read from a file or an
+// environment variable. Rejected outright if it doesn't decode: a salt that
+// silently truncated or got mangled in transit would still "work" (any bytes
+// produce a valid HMAC key), so a decode error is the only signal available
+// that something is wrong, and it must not be swallowed.
+func decodeSaltHex(s string) ([]byte, error) {
+	s = strings.TrimSpace(s)
+	salt, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("anonymize salt %q is not valid hex: %w", s, err)
+	}
+	if len(salt) == 0 {
+		return nil, fmt.Errorf("anonymize salt is empty")
+	}
+	return salt, nil
+}

--- a/cmd/anonymize_flags.go
+++ b/cmd/anonymize_flags.go
@@ -73,11 +73,24 @@ func resolveAnonymizeSalt(cmd *cobra.Command) ([]byte, error) {
 // silently truncated or got mangled in transit would still "work" (any bytes
 // produce a valid HMAC key), so a decode error is the only signal available
 // that something is wrong, and it must not be swallowed.
+//
+// The error deliberately never echoes s itself — only its length, which is
+// low-sensitivity on its own (unlike the salt's content) but still enough to
+// tell a user "you pasted half of it" from "this isn't hex at all". The
+// salt is treated as a secret everywhere else in this file (no inline
+// --anonymize-salt flag, precisely to keep it out of shell history and
+// process listings); echoing it into an error message would undo that the
+// moment someone pastes the error into a log, a CI run, or a support
+// ticket — arguably an easier way for it to leak than the command-line
+// exposure the missing flag already avoids, since people share error
+// output to ask for help far more readily than they share commands.
+// hex.DecodeString's own error (wrapped via %w) is safe to include as-is:
+// it names at most one invalid byte or "odd length", never the input string.
 func decodeSaltHex(s string) ([]byte, error) {
 	s = strings.TrimSpace(s)
 	salt, err := hex.DecodeString(s)
 	if err != nil {
-		return nil, fmt.Errorf("anonymize salt %q is not valid hex: %w", s, err)
+		return nil, fmt.Errorf("anonymize salt (%d chars) is not valid hex: %w", len(s), err)
 	}
 	if len(salt) == 0 {
 		return nil, fmt.Errorf("anonymize salt is empty")

--- a/cmd/anonymize_flags_test.go
+++ b/cmd/anonymize_flags_test.go
@@ -134,4 +134,22 @@ func TestDecodeSaltHex(t *testing.T) {
 			t.Error("want an error for a whitespace-only salt")
 		}
 	})
+
+	// The salt is treated as a secret everywhere else in this file (no
+	// inline --anonymize-salt flag, precisely to keep it out of shell
+	// history) — an error that echoes the malformed value right back would
+	// undo that the moment someone pastes the error into a log or a support
+	// ticket. This asserts the invariant directly against a value that would
+	// be very easy to recognize if it leaked, rather than just trusting the
+	// implementation not to interpolate it.
+	t.Run("does not echo the malformed value into the error", func(t *testing.T) {
+		secret := "this-looks-like-a-leaked-secret-not-hex-zzz"
+		_, err := decodeSaltHex(secret)
+		if err == nil {
+			t.Fatal("want an error")
+		}
+		if strings.Contains(err.Error(), secret) {
+			t.Errorf("error %q leaks the malformed input value", err.Error())
+		}
+	})
 }

--- a/cmd/anonymize_flags_test.go
+++ b/cmd/anonymize_flags_test.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newTestAnonymizeCommand builds a command with just the anonymize flags so
+// resolveAnonymizeSalt can be exercised in isolation, mirroring
+// newTestEncryptCommand in encrypt_flags_test.go.
+func newTestAnonymizeCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	addAnonymizeFlags(cmd)
+	return cmd
+}
+
+func TestResolveAnonymizeSalt_File(t *testing.T) {
+	dir := t.TempDir()
+	saltFile := filepath.Join(dir, "salt.txt")
+	wantHex := strings.Repeat("ab", 32)
+	if err := os.WriteFile(saltFile, []byte(wantHex+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTestAnonymizeCommand()
+	_ = cmd.Flags().Set("anonymize-salt-file", saltFile)
+
+	got, err := resolveAnonymizeSalt(cmd)
+	if err != nil {
+		t.Fatalf("resolveAnonymizeSalt: %v", err)
+	}
+	want, _ := hex.DecodeString(wantHex)
+	if string(got) != string(want) {
+		t.Errorf("salt = %x, want %x", got, want)
+	}
+}
+
+func TestResolveAnonymizeSalt_FileTakesPrecedenceOverEnv(t *testing.T) {
+	dir := t.TempDir()
+	saltFile := filepath.Join(dir, "salt.txt")
+	fileHex := strings.Repeat("11", 32)
+	if err := os.WriteFile(saltFile, []byte(fileHex), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(anonymizeSaltEnv, strings.Repeat("22", 32))
+
+	cmd := newTestAnonymizeCommand()
+	_ = cmd.Flags().Set("anonymize-salt-file", saltFile)
+
+	got, err := resolveAnonymizeSalt(cmd)
+	if err != nil {
+		t.Fatalf("resolveAnonymizeSalt: %v", err)
+	}
+	want, _ := hex.DecodeString(fileHex)
+	if string(got) != string(want) {
+		t.Errorf("salt = %x, want the file's value %x, not the env var's", got, want)
+	}
+}
+
+func TestResolveAnonymizeSalt_Env(t *testing.T) {
+	wantHex := strings.Repeat("33", 32)
+	t.Setenv(anonymizeSaltEnv, wantHex)
+
+	cmd := newTestAnonymizeCommand()
+	got, err := resolveAnonymizeSalt(cmd)
+	if err != nil {
+		t.Fatalf("resolveAnonymizeSalt: %v", err)
+	}
+	want, _ := hex.DecodeString(wantHex)
+	if string(got) != string(want) {
+		t.Errorf("salt = %x, want %x", got, want)
+	}
+}
+
+// With neither a file nor the env var set, resolveAnonymizeSalt must
+// generate a usable salt on its own rather than erroring — an anonymize run
+// without an explicit salt is a legitimate first use, not a mistake — and it
+// must warn the caller (via stderr) that the value needs to be saved to
+// reproduce this run, since without that warning a fresh random salt every
+// invocation would look identical to a real re-run failing to reproduce.
+func TestResolveAnonymizeSalt_GeneratesAndWarnsWhenUnset(t *testing.T) {
+	cmd := newTestAnonymizeCommand()
+	var stderr strings.Builder
+	cmd.SetErr(&stderr)
+
+	got, err := resolveAnonymizeSalt(cmd)
+	if err != nil {
+		t.Fatalf("resolveAnonymizeSalt: %v", err)
+	}
+	if len(got) != 32 {
+		t.Errorf("generated salt is %d bytes, want 32", len(got))
+	}
+
+	printed := stderr.String()
+	if !strings.Contains(printed, "save this") {
+		t.Errorf("stderr does not warn to save the salt: %q", printed)
+	}
+	// The printed hex must decode back to exactly the salt that was returned
+	// — otherwise a user who dutifully saves what's printed would not
+	// actually reproduce this run.
+	printedHex := hex.EncodeToString(got)
+	if !strings.Contains(printed, printedHex) {
+		t.Errorf("stderr does not contain the hex encoding of the actual returned salt %x: %q", got, printed)
+	}
+}
+
+func TestDecodeSaltHex(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		got, err := decodeSaltHex("  " + strings.Repeat("ab", 16) + "\n")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 16 {
+			t.Errorf("len = %d, want 16", len(got))
+		}
+	})
+	t.Run("not hex", func(t *testing.T) {
+		if _, err := decodeSaltHex("not-hex-at-all"); err == nil {
+			t.Error("want an error for a non-hex string")
+		}
+	})
+	t.Run("empty", func(t *testing.T) {
+		if _, err := decodeSaltHex(""); err == nil {
+			t.Error("want an error for an empty salt")
+		}
+	})
+	t.Run("whitespace only", func(t *testing.T) {
+		if _, err := decodeSaltHex("   \n"); err == nil {
+			t.Error("want an error for a whitespace-only salt")
+		}
+	})
+}

--- a/cmd/anonymize_test.go
+++ b/cmd/anonymize_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/anonymize"
+)
+
+func TestParseAnonymizeCategories(t *testing.T) {
+	t.Run("namespace is accepted", func(t *testing.T) {
+		got, err := parseAnonymizeCategories([]string{"namespace"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0] != anonymize.CategoryNamespace {
+			t.Errorf("got %v, want [namespace]", got)
+		}
+	})
+
+	t.Run("case and whitespace are normalized", func(t *testing.T) {
+		got, err := parseAnonymizeCategories([]string{"  Namespace  "})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0] != anonymize.CategoryNamespace {
+			t.Errorf("got %v, want [namespace]", got)
+		}
+	})
+
+	t.Run("empty is rejected — --categories is required", func(t *testing.T) {
+		if _, err := parseAnonymizeCategories(nil); err == nil {
+			t.Error("want an error when no categories are given")
+		}
+	})
+
+	// This is the one that matters most: node/pod/workload/ip/url/image are
+	// all real Category constants that exist in internal/anonymize (later
+	// milestones' work), but the archive-rewrite path doesn't support them
+	// yet. Accepting them here would let a user believe --categories node
+	// did something when it silently anonymized nothing.
+	t.Run("a category not yet supported by archive rewriting is rejected", func(t *testing.T) {
+		for _, c := range []string{"node", "pod", "workload", "ip", "url", "image", "bogus"} {
+			if _, err := parseAnonymizeCategories([]string{c}); err == nil {
+				t.Errorf("category %q: want an error, got none", c)
+			}
+		}
+	})
+
+	t.Run("one bad category in a list rejects the whole list", func(t *testing.T) {
+		if _, err := parseAnonymizeCategories([]string{"namespace", "node"}); err == nil {
+			t.Error("want an error when any requested category is unsupported")
+		}
+	})
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -33,6 +33,7 @@ environment without direct connectivity.
 
 ### SEE ALSO
 
+* [kshrk anonymize](#kshrk-anonymize)	 - Anonymize identifying values across a capture archive, consistently
 * [kshrk capture](#kshrk-capture)	 - Capture Kubernetes cluster state to a .kshrk archive
 * [kshrk completion](#kshrk-completion)	 - Generate the autocompletion script for the specified shell
 * [kshrk decrypt](#kshrk-decrypt)	 - Decrypt an encrypted capture archive back to plaintext
@@ -48,6 +49,71 @@ environment without direct connectivity.
 * [kshrk ui](#kshrk-ui)	 - Open an interactive web explorer for a capture archive
 * [kshrk validate](#kshrk-validate)	 - Validate a capture config file without connecting to a cluster
 * [kshrk version](#kshrk-version)	 - Print the kshrk version
+
+
+## kshrk anonymize
+
+Anonymize identifying values across a capture archive, consistently
+
+### Synopsis
+
+Produces a new capture archive with values of the given categories replaced
+by stable, deterministic aliases: the same original value maps to the same
+alias everywhere it occurs in the archive, so relationships between objects
+(a Pod's namespace, a Namespace's own identity, an Event's involvedObject)
+stay intact. The original archive is not modified; the output defaults to
+<in>-anonymized.kshrk.
+
+This is a different tool than "kshrk redact": redact replaces one exact
+field path with a fixed constant, everywhere it's configured to look;
+anonymize replaces every occurrence of a value it recognizes, consistently,
+using a deterministic alias derived from a salt.
+
+Only one category is available so far: namespace. More land milestone by
+milestone -- see https://github.com/phenixblue/k8shark/issues/137.
+
+```
+kshrk anonymize <capture.kshrk> --categories <category> [--out <anonymized.kshrk>] [flags]
+```
+
+### Examples
+
+```
+  # Anonymize every namespace name in a capture
+  kshrk anonymize capture.kshrk --categories namespace
+
+  # Reproduce the exact same aliases on a re-run
+  kshrk anonymize capture.kshrk --categories namespace --anonymize-salt-file salt.txt
+
+  # Anonymize and write to a chosen path
+  kshrk anonymize capture.kshrk --out safe.kshrk --categories namespace
+```
+
+### Options
+
+```
+      --anonymize-salt-file string       read the anonymize salt from this file (first line, hex-encoded) instead of $KSHRK_ANONYMIZE_SALT or generating one
+      --categories stringArray           category to anonymize (repeatable); only "namespace" is available so far
+      --encrypt                          encrypt the output archive with a passphrase (age); from --encrypt-passphrase-file, $KSHRK_ENCRYPT_PASSPHRASE, or an interactive prompt
+      --encrypt-passphrase-file string   read the encryption passphrase from this file (first line) instead of prompting
+      --encrypt-recipient stringArray    age recipient public key (age1...) to encrypt to (repeatable); mutually exclusive with passphrase encryption
+      --encrypt-recipients-file string   file of age recipient public keys (one per line) to encrypt to
+  -h, --help                             help for anonymize
+      --out string                       output archive path (default: <in>-anonymized.kshrk)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string                    config file (default: ./config.yaml, then ~/.config/kshrk/config.yaml)
+      --decrypt-identity-file string     age identity (key) file to decrypt an encrypted archive
+      --decrypt-passphrase-file string   read the passphrase for an encrypted archive from this file (first line)
+  -v, --verbose                          enable verbose output
+```
+
+### SEE ALSO
+
+* [kshrk](#kshrk)	 - k8shark — Kubernetes cluster state capture and replay
 
 
 ## kshrk capture

--- a/internal/anonymize/apipath.go
+++ b/internal/anonymize/apipath.go
@@ -1,0 +1,39 @@
+package anonymize
+
+import "strings"
+
+// rewriteNamespaceInPath replaces the namespace segment of a captured API
+// path with alias(original), leaving every other segment untouched. It
+// deliberately does not reuse internal/store.ParseAPIPath, which is
+// documented as narrowly scoped to exact 5/6-segment LIST paths — its own
+// doc comment references a prior regression from loosening it, and
+// capture.Record.APIPath also carries item-level GET paths (and, in
+// principle, subresource paths) that function was never meant to parse.
+//
+// The approach here is simpler and more tolerant on purpose: find the
+// literal "namespaces" segment and replace whatever comes immediately after
+// it. That is always the namespace name, regardless of what (if anything)
+// follows — resource type, object name, subresource — because in every
+// namespaced Kubernetes API path shape, "namespaces/<ns>" appears as an
+// unbroken pair:
+//
+//	/api/v1/namespaces/<ns>                      (GET the Namespace itself)
+//	/api/v1/namespaces/<ns>/pods                 (namespaced list)
+//	/api/v1/namespaces/<ns>/pods/<name>          (namespaced object GET)
+//	/apis/apps/v1/namespaces/<ns>/deployments    (group/version form)
+//	/api/v1/namespaces/<ns>/pods/<name>/log      (a subresource, untouched)
+//
+// Returns the path unchanged (ok=false) for a path with no "namespaces"
+// segment (cluster-scoped, or the all-namespaces list form) and for the
+// Namespace collection endpoint itself (/api/v1/namespaces, where
+// "namespaces" is the last segment and there is nothing after it to alias).
+func rewriteNamespaceInPath(apiPath string, alias func(string) string) (string, bool) {
+	parts := strings.Split(apiPath, "/")
+	for i, seg := range parts {
+		if seg == "namespaces" && i+1 < len(parts) && parts[i+1] != "" {
+			parts[i+1] = alias(parts[i+1])
+			return strings.Join(parts, "/"), true
+		}
+	}
+	return apiPath, false
+}

--- a/internal/anonymize/apipath_test.go
+++ b/internal/anonymize/apipath_test.go
@@ -1,0 +1,107 @@
+package anonymize
+
+import "testing"
+
+func upper(s string) string { return s + "-ALIASED" }
+
+func TestRewriteNamespaceInPath(t *testing.T) {
+	cases := []struct {
+		name   string
+		path   string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "namespace GET",
+			path:   "/api/v1/namespaces/prod",
+			want:   "/api/v1/namespaces/prod-ALIASED",
+			wantOK: true,
+		},
+		{
+			name:   "namespaced list",
+			path:   "/api/v1/namespaces/prod/pods",
+			want:   "/api/v1/namespaces/prod-ALIASED/pods",
+			wantOK: true,
+		},
+		{
+			name:   "namespaced object GET",
+			path:   "/api/v1/namespaces/prod/pods/web-1",
+			want:   "/api/v1/namespaces/prod-ALIASED/pods/web-1",
+			wantOK: true,
+		},
+		{
+			name:   "apis group/version form",
+			path:   "/apis/apps/v1/namespaces/prod/deployments",
+			want:   "/apis/apps/v1/namespaces/prod-ALIASED/deployments",
+			wantOK: true,
+		},
+		{
+			name:   "apis group/version object GET",
+			path:   "/apis/apps/v1/namespaces/prod/deployments/web",
+			want:   "/apis/apps/v1/namespaces/prod-ALIASED/deployments/web",
+			wantOK: true,
+		},
+		{
+			name:   "subresource path — only the namespace segment moves",
+			path:   "/api/v1/namespaces/prod/pods/web-1/log",
+			want:   "/api/v1/namespaces/prod-ALIASED/pods/web-1/log",
+			wantOK: true,
+		},
+		{
+			name:   "cluster-scoped — no namespaces segment at all",
+			path:   "/api/v1/nodes",
+			want:   "/api/v1/nodes",
+			wantOK: false,
+		},
+		{
+			name:   "cluster-scoped object GET",
+			path:   "/api/v1/nodes/worker-1",
+			want:   "/api/v1/nodes/worker-1",
+			wantOK: false,
+		},
+		{
+			name:   "all-namespaces list — 'pods' is not 'namespaces'",
+			path:   "/api/v1/pods",
+			want:   "/api/v1/pods",
+			wantOK: false,
+		},
+		{
+			name:   "the namespace collection endpoint itself — nothing follows 'namespaces'",
+			path:   "/api/v1/namespaces",
+			want:   "/api/v1/namespaces",
+			wantOK: false,
+		},
+		{
+			name:   "trailing slash after namespaces — empty segment, nothing to alias",
+			path:   "/api/v1/namespaces/",
+			want:   "/api/v1/namespaces/",
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := rewriteNamespaceInPath(tc.path, upper)
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("rewriteNamespaceInPath(%q) = (%q, %v), want (%q, %v)",
+					tc.path, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+// Only the namespace segment must change — replacing by segment *position*,
+// not by a blind string substitution of the original namespace value
+// wherever it happens to appear in the path. Aliasing to a value that
+// collides with the resource-type segment's own literal text ("pods") is
+// exactly the case that would expose a blind-replace implementation: it
+// would turn the resource segment into something else too, or replace both
+// occurrences, instead of only the one namespace-segment position.
+func TestRewriteNamespaceInPath_ReplacesByPositionNotBySubstring(t *testing.T) {
+	alias := func(string) string { return "pods" }
+	got, ok := rewriteNamespaceInPath("/api/v1/namespaces/prod/pods", alias)
+	want := "/api/v1/namespaces/pods/pods"
+	if !ok || got != want {
+		t.Fatalf("rewriteNamespaceInPath(...) = (%q, %v), want (%q, true)", got, ok, want)
+	}
+}

--- a/internal/anonymize/archive.go
+++ b/internal/anonymize/archive.go
@@ -303,6 +303,15 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 		}
 	}
 
+	// meta was populated by ar.ReadMetadata(), so left untouched its Encrypted
+	// field still describes the *source* archive, not the one actually being
+	// written here. redact.Archive sets this explicitly for the identical
+	// reason (internal/redact/redact.go); anonymize needs the same
+	// correction, or an anonymized-and-now-plaintext copy of an encrypted
+	// source would misreport itself as encrypted, and vice versa for a
+	// plaintext source anonymized straight into an encrypted output.
+	meta.Encrypted = len(opts.Recipients) > 0
+
 	if err := sw.Finish(&meta, newIdx, newWI); err != nil {
 		return Result{}, fmt.Errorf("finishing output archive: %w", err)
 	}

--- a/internal/anonymize/archive.go
+++ b/internal/anonymize/archive.go
@@ -251,13 +251,12 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 			if rewritten, ok := rewriteNamespaceInPath(apiPath, namespaceAlias); ok {
 				newAPIPath = rewritten
 			}
-			// Check as soon as a collision could have been produced, rather
-			// than waiting until the whole pass finishes: the specific,
+			// Check as soon as a collision could have been produced by the
+			// *path* rewrite above, rather than waiting: the specific,
 			// actionable error from the tracker (naming the two colliding
 			// original values) is what a caller should see, not the generic
-			// one below — which exists only as a defensive backstop for a
-			// collision this check somehow didn't catch, and would fire on
-			// this same iteration if we let it run first.
+			// one below. This alone is not enough, though — see the second
+			// check after rewriteEntryRecords.
 			if err := namespaceTracker.Err(); err != nil {
 				return Result{}, err
 			}
@@ -268,6 +267,21 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 		newSeqs, err := rewriteEntryRecords(apiPath, newAPIPath, entry.Seqs)
 		if err != nil {
 			return Result{}, err
+		}
+		if doNamespace {
+			// A second check, after the records under this path have had
+			// their *bodies* rewritten too. The path-only check above can't
+			// see a collision that's only ever introduced by body content —
+			// e.g. two Namespace objects' metadata.name values colliding
+			// inside a /api/v1/namespaces NamespaceList response, which has
+			// no namespace path segment at all for rewriteNamespaceInPath to
+			// have looked at. Without this, that collision wouldn't be
+			// caught until the *next* loop iteration, and not at all if this
+			// were the last one — Archive would report success despite
+			// having detected a real collision.
+			if err := namespaceTracker.Err(); err != nil {
+				return Result{}, err
+			}
 		}
 		newIdx[newAPIPath] = &capture.IndexEntry{
 			APIPath: newAPIPath,
@@ -295,11 +309,30 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 		if err != nil {
 			return Result{}, err
 		}
+		if doNamespace {
+			if err := namespaceTracker.Err(); err != nil {
+				return Result{}, err
+			}
+		}
 		newWI[newAPIPath] = &capture.WatchIndexEntry{
 			APIPath:    newAPIPath,
 			Seqs:       newSeqs,
 			Times:      wiEntry.Times,
 			EventTypes: wiEntry.EventTypes,
+		}
+	}
+
+	// A final, unconditional check before Finish, independent of exactly
+	// where in the two loops above a collision happened to be introduced.
+	// This is the guarantee that actually matters — "no successful run has a
+	// collision" — and it should not depend on remembering to place a check
+	// after every single site that can call namespaceAlias. The per-iteration
+	// checks above exist so a doomed run fails fast rather than finishing all
+	// the remaining I/O first; this one exists so a gap in those doesn't
+	// matter.
+	if doNamespace {
+		if err := namespaceTracker.Err(); err != nil {
+			return Result{}, err
 		}
 	}
 

--- a/internal/anonymize/archive.go
+++ b/internal/anonymize/archive.go
@@ -3,6 +3,7 @@ package anonymize
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 
 	"filippo.io/age"
@@ -90,6 +91,17 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	if len(opts.Categories) == 0 {
 		return Result{}, fmt.Errorf("anonymize: no categories requested")
 	}
+	if len(opts.Salt) == 0 {
+		// An empty salt still produces deterministic aliases (HMAC accepts
+		// any key, including an empty one) — it just makes them trivially
+		// weak, and an empty Options.Salt is an easy mistake for a caller
+		// that isn't the CLI (which always resolves a non-empty one; see
+		// cmd/anonymize_flags.go) to make by accident, e.g. a test fixture
+		// or a future caller that forgets to wire salt resolution at all.
+		// Rejecting it here keeps the library API safe by default rather
+		// than relying on every caller to remember.
+		return Result{}, fmt.Errorf("anonymize: Options.Salt must not be empty")
+	}
 	doNamespace := false
 	for _, cat := range opts.Categories {
 		if !archiveCategories[cat] {
@@ -128,8 +140,15 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	}
 
 	aliaser := NewAliaser(opts.Salt)
-	namespaceAlias := func(original string) string { return aliaser.Alias(CategoryNamespace, original) }
-	seenNamespaces := make(map[string]bool)
+	// Wrapped in a collisionTracker rather than called directly: two distinct
+	// original namespace names landing on the same alias is a real
+	// possibility, not a theoretical one (see collision.go's doc comment for
+	// the numbers), and left unchecked it would let the index/watch-index
+	// rebuild below silently clobber one entry with another.
+	namespaceTracker := newCollisionTracker(CategoryNamespace, func(original string) string {
+		return aliaser.Alias(CategoryNamespace, original)
+	})
+	namespaceAlias := namespaceTracker.Alias
 
 	var sw *archive.StreamWriter
 	if len(opts.Recipients) > 0 {
@@ -141,9 +160,24 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 		return Result{}, fmt.Errorf("creating output archive: %w", err)
 	}
 	// Ensure the output writer's file handle is released if we return early
-	// (e.g. a malformed record) before Finish. Abort is a no-op once Finish
-	// has run, so the success path is unaffected.
-	defer func() { _ = sw.Abort() }()
+	// (e.g. a malformed record, or a detected alias collision) before Finish.
+	// Abort is a no-op once Finish has run, so the success path is
+	// unaffected. Abort only closes the file handle, though — it
+	// deliberately does not delete dstPath (matching redact.Archive's
+	// identical pattern), so on any early return this also removes the
+	// partial file. Otherwise a rejected run (e.g. a collision, forcing the
+	// user to pick a different salt and try again) would leave a stale,
+	// misleading file sitting at the requested output path even though
+	// Archive reported failure. Best-effort: the original error already
+	// explains what went wrong, so a removal error here is not surfaced —
+	// this is cleanup, not the primary failure.
+	finished := false
+	defer func() {
+		_ = sw.Abort()
+		if !finished {
+			_ = os.Remove(dstPath)
+		}
+	}()
 
 	newIdx := make(capture.Index, len(idx))
 	newWI := make(capture.WatchIndex, len(wi))
@@ -177,7 +211,7 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 			}
 
 			if doNamespace {
-				if _, err := rewriteNamespaceInRecord(&rec, namespaceAlias, seenNamespaces); err != nil {
+				if _, err := rewriteNamespaceInRecord(&rec, namespaceAlias); err != nil {
 					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
 				}
 			}
@@ -217,6 +251,19 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 			if rewritten, ok := rewriteNamespaceInPath(apiPath, namespaceAlias); ok {
 				newAPIPath = rewritten
 			}
+			// Check as soon as a collision could have been produced, rather
+			// than waiting until the whole pass finishes: the specific,
+			// actionable error from the tracker (naming the two colliding
+			// original values) is what a caller should see, not the generic
+			// one below — which exists only as a defensive backstop for a
+			// collision this check somehow didn't catch, and would fire on
+			// this same iteration if we let it run first.
+			if err := namespaceTracker.Err(); err != nil {
+				return Result{}, err
+			}
+		}
+		if existing, ok := newIdx[newAPIPath]; ok {
+			return Result{}, fmt.Errorf("anonymize: internal error: both %q and %q rewrite to output path %q — refusing to silently drop one", existing.APIPath, apiPath, newAPIPath)
 		}
 		newSeqs, err := rewriteEntryRecords(apiPath, newAPIPath, entry.Seqs)
 		if err != nil {
@@ -237,6 +284,12 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 			if rewritten, ok := rewriteNamespaceInPath(apiPath, namespaceAlias); ok {
 				newAPIPath = rewritten
 			}
+			if err := namespaceTracker.Err(); err != nil {
+				return Result{}, err
+			}
+		}
+		if existing, ok := newWI[newAPIPath]; ok {
+			return Result{}, fmt.Errorf("anonymize: internal error: both %q and %q rewrite to output watch-path %q — refusing to silently drop one", existing.APIPath, apiPath, newAPIPath)
 		}
 		newSeqs, err := rewriteEntryRecords(apiPath, newAPIPath, wiEntry.Seqs)
 		if err != nil {
@@ -253,6 +306,7 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	if err := sw.Finish(&meta, newIdx, newWI); err != nil {
 		return Result{}, fmt.Errorf("finishing output archive: %w", err)
 	}
+	finished = true
 
-	return Result{NamespacesRenamed: len(seenNamespaces)}, nil
+	return Result{NamespacesRenamed: namespaceTracker.Count()}, nil
 }

--- a/internal/anonymize/archive.go
+++ b/internal/anonymize/archive.go
@@ -1,0 +1,258 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"filippo.io/age"
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// sortedKeys returns m's keys sorted lexicographically, so a caller that
+// needs to visit a map's entries in a fixed, repeatable order (see Archive's
+// two index loops) doesn't inherit Go's per-process-randomized map iteration
+// order.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// archiveCategories are the categories Archive currently knows how to find
+// and rewrite occurrences of in a real archive. Namespace-only for this
+// milestone; node/pod/workload land in the next one, then IP/URL/image
+// (see #137's milestone plan).
+//
+// Deliberately a separate set from Aliaser's own implementedCategories
+// (alias.go): that one is about which categories the aliasing *primitive*
+// can render at all — a lower-level, already-broader set from M1 (it
+// already covers node/pod/workload, since Alias's per-category encoders
+// don't depend on knowing where in a record those values live). This one is
+// about which categories this package's archive-rewrite path knows how to
+// *find*. A category can be alias-ready before it's archive-ready; letting
+// Archive silently accept a category it can't actually locate occurrences
+// of would be the same mistake M1's review caught for Alias itself, one
+// layer up.
+var archiveCategories = map[Category]bool{
+	CategoryNamespace: true,
+}
+
+// Options controls what Archive() anonymizes.
+type Options struct {
+	// Categories is the set of categories to anonymize. Every entry must be
+	// in archiveCategories — checked up front, before any archive I/O, so
+	// an unsupported category fails loudly rather than silently doing
+	// nothing for it.
+	Categories []Category
+	// Salt is the Aliaser salt. Callers resolve this themselves (a CLI
+	// flag, a file, an environment variable, or a freshly generated value)
+	// — this package never generates, stores, or reads one on its own. See
+	// the package doc and #137's design notes on why a salt must never come
+	// from a config file: doing so would silently turn a personal secret
+	// into a team-shared one the moment a config profile is exported
+	// (relevant to #139, not built here, but worth designing away from).
+	Salt []byte
+	// Identities, when non-empty, decrypt an encrypted source archive
+	// before anonymizing. Mirrors redact.Options.Identities exactly.
+	Identities []age.Identity
+	// Recipients, when non-empty, cause the anonymized output archive to be
+	// written as an age-encrypted envelope. Mirrors redact.Options.Recipients.
+	Recipients []age.Recipient
+}
+
+// Result reports how many distinct values were anonymized, per category.
+type Result struct {
+	// NamespacesRenamed is the count of distinct original namespace names
+	// encountered, not the count of records touched — renaming a namespace
+	// that appears on 50 records still counts once.
+	NamespacesRenamed int
+}
+
+// Archive reads srcPath, anonymizes it per opts, and writes to dstPath. The
+// original archive is not modified.
+//
+// This mirrors internal/redact.Archive's overall shape (open; read
+// metadata/index/watch-index; stream every record through a rewrite into a
+// fresh archive; rebuild the index with corrected sequence numbers) but
+// keeps its own copy of that loop rather than sharing redact's. That's
+// deliberate, not an oversight: redact.Archive's loop never needs to change
+// the apiPath a record is stored under, and anonymize's namespace category
+// must — forcing that divergence into a shared abstraction before it had
+// proven out risked regressing a shipped, fuzz-tested command for an
+// unproven second caller. Revisit sharing once this package's shape is
+// settled across more categories.
+func Archive(srcPath, dstPath string, opts Options) (Result, error) {
+	if len(opts.Categories) == 0 {
+		return Result{}, fmt.Errorf("anonymize: no categories requested")
+	}
+	doNamespace := false
+	for _, cat := range opts.Categories {
+		if !archiveCategories[cat] {
+			return Result{}, fmt.Errorf("anonymize: category %q is not yet supported for archive rewriting", cat)
+		}
+		if cat == CategoryNamespace {
+			doNamespace = true
+		}
+	}
+
+	ar, err := archive.OpenWithIdentities(srcPath, opts.Identities)
+	if err != nil {
+		return Result{}, fmt.Errorf("opening archive: %w", err)
+	}
+	defer ar.Close()
+
+	meta, err := ar.ReadMetadata()
+	if err != nil {
+		return Result{}, fmt.Errorf("reading metadata: %w", err)
+	}
+	// The anonymized archive is written by the current writer, so stamp it
+	// with the current format version — same reasoning as redact.Archive.
+	meta.FormatVersion = capture.CurrentFormatVersion
+
+	idx, err := ar.ReadIndex()
+	if err != nil {
+		return Result{}, fmt.Errorf("reading index: %w", err)
+	}
+	// Watch-index may be absent for older archives, but a present-and-
+	// malformed one is a corrupt archive, not an absent one — surface that
+	// error rather than silently anonymizing as if it were never captured
+	// (same reasoning as redact.Archive).
+	wi, _, err := ar.ReadWatchIndex()
+	if err != nil {
+		return Result{}, fmt.Errorf("reading watch index: %w", err)
+	}
+
+	aliaser := NewAliaser(opts.Salt)
+	namespaceAlias := func(original string) string { return aliaser.Alias(CategoryNamespace, original) }
+	seenNamespaces := make(map[string]bool)
+
+	var sw *archive.StreamWriter
+	if len(opts.Recipients) > 0 {
+		sw, err = archive.NewEncryptedStreamWriter(dstPath, opts.Recipients)
+	} else {
+		sw, err = archive.NewStreamWriter(dstPath)
+	}
+	if err != nil {
+		return Result{}, fmt.Errorf("creating output archive: %w", err)
+	}
+	// Ensure the output writer's file handle is released if we return early
+	// (e.g. a malformed record) before Finish. Abort is a no-op once Finish
+	// has run, so the success path is unaffected.
+	defer func() { _ = sw.Abort() }()
+
+	newIdx := make(capture.Index, len(idx))
+	newWI := make(capture.WatchIndex, len(wi))
+
+	// rewriteEntryRecords reads every record under apiPath (the *original*
+	// path — that's what the source archive is keyed and stored under),
+	// rewrites each one's body and its own APIPath field, and writes it back
+	// under newAPIPath (the *rewritten* path). It returns the new sequence
+	// numbers assigned by the writer.
+	//
+	// newAPIPath is computed once, before this loop, by the caller — every
+	// record sharing one index entry shares one apiPath, so the rewrite is
+	// the same for all of them. The critical invariant callers must hold:
+	// newAPIPath must be the exact same string used both here (as the
+	// WriteRecordRaw argument) and as the key stored in newIdx/newWI.
+	// WriteRecordRaw derives the on-disk shard via a hash of whatever string
+	// it's given, so if the index key and the write argument ever diverge,
+	// the archive ends up structurally corrupt — the index points at one
+	// shard, the bytes live in another — in a way a body-content check alone
+	// would not catch.
+	rewriteEntryRecords := func(apiPath, newAPIPath string, seqs []int) ([]int, error) {
+		newSeqs := make([]int, 0, len(seqs))
+		for _, seq := range seqs {
+			data, err := ar.ReadRecord(apiPath, seq)
+			if err != nil {
+				return nil, fmt.Errorf("reading record %s seq %d: %w", apiPath, seq, err)
+			}
+			var rec capture.Record
+			if err := json.Unmarshal(data, &rec); err != nil {
+				return nil, fmt.Errorf("parsing record %s seq %d: %w", apiPath, seq, err)
+			}
+
+			if doNamespace {
+				if _, err := rewriteNamespaceInRecord(&rec, namespaceAlias, seenNamespaces); err != nil {
+					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
+				}
+			}
+			// Keep the record's own APIPath field in sync with wherever it's
+			// actually being stored, unconditionally — not just when a
+			// rewrite happened to fire. If this ever fell out of sync with
+			// newAPIPath, the record's body would disagree with the index
+			// entry it's filed under.
+			rec.APIPath = newAPIPath
+
+			newSeq, err := sw.WriteRecordRaw(newAPIPath, rec)
+			if err != nil {
+				return nil, fmt.Errorf("writing record %s seq %d: %w", newAPIPath, seq, err)
+			}
+			newSeqs = append(newSeqs, newSeq)
+		}
+		return newSeqs, nil
+	}
+
+	// Visit both indexes in sorted-by-original-key order, not Go's randomized
+	// map iteration order. This isn't about alias consistency — Alias itself
+	// is already order-independent by construction (see alias.go) — it's
+	// about the *physical layout* of the output ZIP: WriteRecordRaw appends
+	// to the archive in whatever order it's called, so without a fixed
+	// traversal order, two runs over the identical source with the identical
+	// salt would compute identical aliases but still emit byte-different
+	// archives, just because Go happened to range over the map differently.
+	// Sorting the *original* keys is enough: the source archive's key set is
+	// fixed from one run to the next, and the alias function is
+	// deterministic, so a fixed traversal of the original keys yields a
+	// fixed traversal of the rewritten ones too. TestArchive_Deterministic
+	// diffs two real runs' output bytes to hold this, not just infer it.
+	for _, apiPath := range sortedKeys(map[string]*capture.IndexEntry(idx)) {
+		entry := idx[apiPath]
+		newAPIPath := apiPath
+		if doNamespace {
+			if rewritten, ok := rewriteNamespaceInPath(apiPath, namespaceAlias); ok {
+				newAPIPath = rewritten
+			}
+		}
+		newSeqs, err := rewriteEntryRecords(apiPath, newAPIPath, entry.Seqs)
+		if err != nil {
+			return Result{}, err
+		}
+		newIdx[newAPIPath] = &capture.IndexEntry{
+			APIPath: newAPIPath,
+			Seqs:    newSeqs,
+			Times:   entry.Times,
+			Counts:  entry.Counts,
+		}
+	}
+
+	for _, apiPath := range sortedKeys(map[string]*capture.WatchIndexEntry(wi)) {
+		wiEntry := wi[apiPath]
+		newAPIPath := apiPath
+		if doNamespace {
+			if rewritten, ok := rewriteNamespaceInPath(apiPath, namespaceAlias); ok {
+				newAPIPath = rewritten
+			}
+		}
+		newSeqs, err := rewriteEntryRecords(apiPath, newAPIPath, wiEntry.Seqs)
+		if err != nil {
+			return Result{}, err
+		}
+		newWI[newAPIPath] = &capture.WatchIndexEntry{
+			APIPath:    newAPIPath,
+			Seqs:       newSeqs,
+			Times:      wiEntry.Times,
+			EventTypes: wiEntry.EventTypes,
+		}
+	}
+
+	if err := sw.Finish(&meta, newIdx, newWI); err != nil {
+		return Result{}, fmt.Errorf("finishing output archive: %w", err)
+	}
+
+	return Result{NamespacesRenamed: len(seenNamespaces)}, nil
+}

--- a/internal/anonymize/archive_test.go
+++ b/internal/anonymize/archive_test.go
@@ -2,8 +2,10 @@ package anonymize
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -289,6 +291,62 @@ func TestArchive_Deterministic(t *testing.T) {
 	}
 }
 
+// A real, found-not-constructed collision: "ns-66" and "ns-106" both alias to
+// "namespace-green-lynx" under this exact salt (found by brute-force search
+// over the namespace category's real HMAC-based Aliaser — it took only ~106
+// draws, consistent with collision.go's birthday-bound math for a
+// 64x64=4096-combination space). This exercises the real, wired-up
+// collisionTracker end to end through Archive(), not just the tracker in
+// isolation (collision_test.go) with an injected colliding function — a bug
+// in how the tracker is *wired into* the two index loops would not
+// necessarily show up there.
+const (
+	collidingNamespaceA    = "ns-66"
+	collidingNamespaceB    = "ns-106"
+	collidingNamespaceSalt = "fixed-test-salt-for-collision-search"
+)
+
+func TestArchive_DetectsRealNamespaceCollision(t *testing.T) {
+	nsBody := func(name string) string {
+		return fmt.Sprintf(`{"kind":"Namespace","apiVersion":"v1","metadata":{"name":%q}}`, name)
+	}
+	records := []*capture.Record{
+		{ID: "r1", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/" + collidingNamespaceA, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(nsBody(collidingNamespaceA))},
+		{ID: "r2", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/" + collidingNamespaceB, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(nsBody(collidingNamespaceB))},
+	}
+	src := buildAnonymizeTestArchive(t, records)
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+	_, err := Archive(src, dst, Options{
+		Categories: []Category{CategoryNamespace},
+		Salt:       []byte(collidingNamespaceSalt),
+	})
+	if err == nil {
+		t.Fatal("want a collision error; got none — a real archive with a genuine alias collision was silently accepted")
+	}
+	for _, want := range []string{collidingNamespaceA, collidingNamespaceB} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name the colliding value %q", err.Error(), want)
+		}
+	}
+	if _, statErr := os.Stat(dst); statErr == nil {
+		t.Error("no (corrupt) output file should be left behind on a detected collision")
+	}
+}
+
+func TestArchive_RejectsEmptySalt(t *testing.T) {
+	src := buildAnonymizeTestArchive(t, namespaceFixtureRecords())
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+	_, err := Archive(src, dst, Options{Categories: []Category{CategoryNamespace}, Salt: nil})
+	if err == nil {
+		t.Fatal("want an error for an empty salt")
+	}
+	if _, statErr := os.Stat(dst); statErr == nil {
+		t.Error("no output file should be left behind on a rejected empty salt")
+	}
+}
+
 func TestArchive_UnsupportedCategoryErrors(t *testing.T) {
 	src := buildAnonymizeTestArchive(t, namespaceFixtureRecords())
 	dst := filepath.Join(t.TempDir(), "out.kshrk")
@@ -311,10 +369,15 @@ func TestArchive_NoCategoriesErrors(t *testing.T) {
 	}
 }
 
-// Data with nothing to do with namespaces must survive byte-for-byte —
-// proving the rewrite is surgical, not a side effect of decoding and
-// re-marshaling every record through Go's map-based JSON representation
-// (which does not preserve key order or exact number formatting).
+// Fields that have nothing to do with namespaces (a ConfigMap's own name and
+// data) must survive with their values unchanged — proving the rewrite is
+// surgical, not a side effect of decoding and re-marshaling every record
+// through Go's map-based JSON representation. This checks semantic
+// preservation after decode, not byte-for-byte identity of the record: the
+// record's own api_path field is expected to change (its namespace segment
+// is aliased, same as every other record's), and a decode/re-encode round
+// trip doesn't preserve exact key order or number formatting anyway — this
+// test would not (and should not) catch either of those.
 func TestArchive_PreservesUnrelatedRecordUntouched(t *testing.T) {
 	cmBody := `{"kind":"ConfigMap","apiVersion":"v1","metadata":{"name":"settings","namespace":"prod"},"data":{"key":"value","count":"42"}}`
 	records := append(namespaceFixtureRecords(), &capture.Record{

--- a/internal/anonymize/archive_test.go
+++ b/internal/anonymize/archive_test.go
@@ -1,0 +1,357 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/store"
+)
+
+// fixedNow is used for every timestamp in these fixtures (never time.Now()),
+// so that TestArchive_Deterministic's byte-for-byte comparison isn't
+// confounded by wall-clock drift between the two source-archive builds it
+// diffs. Every ZIP entry's own on-disk mod-time is already fixed by
+// internal/archive (epochModTime) for the same reason — this pins the other
+// half: the JSON content's own timestamp fields.
+var fixedNow = time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+// buildAnonymizeTestArchive writes a minimal archive to a temp file and
+// returns its path. Mirrors internal/redact/redact_test.go's
+// buildTestArchive, with one deliberate difference: fixed timestamps
+// throughout rather than time.Now(), for the reason fixedNow's doc explains.
+func buildAnonymizeTestArchive(t *testing.T, records []*capture.Record) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	idx := capture.Index{}
+	pathSeq := map[string]int{}
+	for _, r := range records {
+		seq := pathSeq[r.APIPath]
+		pathSeq[r.APIPath] = seq + 1
+		e := idx[r.APIPath]
+		if e == nil {
+			e = &capture.IndexEntry{APIPath: r.APIPath}
+			idx[r.APIPath] = e
+		}
+		e.Seqs = append(e.Seqs, seq)
+		e.Times = append(e.Times, r.CapturedAt)
+	}
+
+	meta := &capture.CaptureMetadata{
+		CaptureID:         "anonymize-test",
+		CapturedAt:        fixedNow.Add(-time.Minute),
+		CapturedUntil:     fixedNow,
+		KubernetesVersion: "v1.34.0",
+		ServerAddress:     "https://127.0.0.1:6443",
+		RecordCount:       len(records),
+	}
+
+	outPath := filepath.Join(dir, "test.kshrk")
+	sw, err := archive.NewStreamWriter(outPath)
+	if err != nil {
+		t.Fatalf("NewStreamWriter: %v", err)
+	}
+	for _, r := range records {
+		if _, err := sw.WriteRecord(r); err != nil {
+			t.Fatalf("WriteRecord: %v", err)
+		}
+	}
+	if err := sw.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	return outPath
+}
+
+// namespaceFixtureRecords builds a small but representative set of records:
+// a Namespace object, a Pod living in it, and an Event about that Pod — the
+// three places a namespace name shows up that this milestone specifically
+// set out to keep consistent (see namespace.go's doc comment).
+func namespaceFixtureRecords() []*capture.Record {
+	nsBody := `{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"prod"}}`
+	podListBody := `{"kind":"PodList","apiVersion":"v1","items":[
+		{"metadata":{"name":"web-1","namespace":"prod"},"spec":{"containers":[{"name":"app"}]}}
+	]}`
+	eventListBody := `{"kind":"EventList","apiVersion":"v1","items":[
+		{"metadata":{"name":"web-1.abc","namespace":"prod"},
+		 "involvedObject":{"kind":"Pod","name":"web-1","namespace":"prod"},
+		 "message":"Started container app"}
+	]}`
+	return []*capture.Record{
+		{ID: "r1", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/prod", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(nsBody)},
+		{ID: "r2", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/prod/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(podListBody)},
+		{ID: "r3", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/prod/events", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(eventListBody)},
+	}
+}
+
+// The central proof for this milestone: the same real namespace name, seen
+// on three different Kinds via three different API paths (a Namespace's own
+// identity, a Pod's membership, and an Event's own namespace plus its
+// involvedObject reference), must come out as the exact same alias
+// everywhere — and the archive's own index keys must use that same alias
+// too, not just the record bodies.
+func TestArchive_NamespaceConsistentAcrossKindsAndPaths(t *testing.T) {
+	src := buildAnonymizeTestArchive(t, namespaceFixtureRecords())
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+	salt := []byte("integration-test-salt")
+	result, err := Archive(src, dst, Options{Categories: []Category{CategoryNamespace}, Salt: salt})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if result.NamespacesRenamed != 1 {
+		t.Errorf("NamespacesRenamed = %d, want 1 (one distinct namespace, seen on three records)", result.NamespacesRenamed)
+	}
+
+	wantAlias := NewAliaser(salt).Alias(CategoryNamespace, "prod")
+
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatalf("opening output archive: %v", err)
+	}
+	defer ar.Close()
+
+	idx, err := ar.ReadIndex()
+	if err != nil {
+		t.Fatalf("ReadIndex: %v", err)
+	}
+
+	wantPaths := []string{
+		"/api/v1/namespaces/" + wantAlias,
+		"/api/v1/namespaces/" + wantAlias + "/pods",
+		"/api/v1/namespaces/" + wantAlias + "/events",
+	}
+	for _, p := range wantPaths {
+		entry, ok := idx[p]
+		if !ok {
+			t.Errorf("index has no entry for %q (index keys: %v) — the namespace segment was not rewritten consistently with the alias used in record bodies", p, indexKeys(idx))
+			continue
+		}
+		if len(entry.Seqs) != 1 {
+			t.Errorf("%s: got %d seqs, want 1", p, len(entry.Seqs))
+		}
+	}
+	// And the original path must be gone — proves this is a rewrite, not an
+	// addition alongside the original.
+	if _, ok := idx["/api/v1/namespaces/prod/pods"]; ok {
+		t.Error("the original, unaliased path is still present in the index")
+	}
+
+	// Now check every body.
+	readBody := func(apiPath string) map[string]interface{} {
+		data, err := ar.ReadRecord(apiPath, 0)
+		if err != nil {
+			t.Fatalf("ReadRecord(%q, 0): %v", apiPath, err)
+		}
+		var rec capture.Record
+		if err := json.Unmarshal(data, &rec); err != nil {
+			t.Fatalf("unmarshaling record: %v", err)
+		}
+		if rec.APIPath != apiPath {
+			t.Errorf("record's own APIPath = %q, want %q — it must match the index key it's filed under", rec.APIPath, apiPath)
+		}
+		var obj map[string]interface{}
+		if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+			t.Fatalf("unmarshaling body: %v", err)
+		}
+		return obj
+	}
+
+	nsObj := readBody("/api/v1/namespaces/" + wantAlias)
+	if got := nsObj["metadata"].(map[string]interface{})["name"]; got != wantAlias {
+		t.Errorf("Namespace object metadata.name = %v, want %v", got, wantAlias)
+	}
+
+	podList := readBody("/api/v1/namespaces/" + wantAlias + "/pods")
+	podItems := podList["items"].([]interface{})
+	podNS := podItems[0].(map[string]interface{})["metadata"].(map[string]interface{})["namespace"]
+	if podNS != wantAlias {
+		t.Errorf("Pod metadata.namespace = %v, want %v", podNS, wantAlias)
+	}
+
+	eventList := readBody("/api/v1/namespaces/" + wantAlias + "/events")
+	eventItem := eventList["items"].([]interface{})[0].(map[string]interface{})
+	eventNS := eventItem["metadata"].(map[string]interface{})["namespace"]
+	involvedNS := eventItem["involvedObject"].(map[string]interface{})["namespace"]
+	if eventNS != wantAlias {
+		t.Errorf("Event metadata.namespace = %v, want %v", eventNS, wantAlias)
+	}
+	if involvedNS != wantAlias {
+		t.Errorf("Event involvedObject.namespace = %v, want %v", involvedNS, wantAlias)
+	}
+}
+
+func indexKeys(idx capture.Index) []string {
+	out := make([]string, 0, len(idx))
+	for k := range idx {
+		out = append(out, k)
+	}
+	return out
+}
+
+// The sharpest regression risk named in the design plan: proving the output
+// archive is actually *readable* through the same store package the rest of
+// the CLI and the UI use, not just that its JSON bodies look right in
+// isolation. A bug that rewrote the body's metadata.namespace but missed the
+// index key (or vice versa) would pass a body-only check and fail here,
+// exactly as a real "kshrk open" on the output would.
+func TestArchive_RoundTripReadableViaStore(t *testing.T) {
+	src := buildAnonymizeTestArchive(t, namespaceFixtureRecords())
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+	salt := []byte("round-trip-salt")
+	if _, err := Archive(src, dst, Options{Categories: []Category{CategoryNamespace}, Salt: salt}); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	defer ar.Close()
+	cs, err := store.LoadStore(ar)
+	if err != nil {
+		t.Fatalf("store.LoadStore: %v", err)
+	}
+	defer cs.Close()
+
+	wantAlias := NewAliaser(salt).Alias(CategoryNamespace, "prod")
+	anonymizedPath := "/api/v1/namespaces/" + wantAlias + "/pods"
+
+	body, code, _, err := cs.SnapshotAt(anonymizedPath, fixedNow.Add(time.Second))
+	if err != nil {
+		t.Fatalf("SnapshotAt(%q): %v", anonymizedPath, err)
+	}
+	if code != 200 {
+		t.Fatalf("SnapshotAt(%q) returned code %d, want 200 — the store could not resolve the anonymized path", anonymizedPath, code)
+	}
+	var podList map[string]interface{}
+	if err := json.Unmarshal(body, &podList); err != nil {
+		t.Fatalf("unmarshaling snapshot body: %v", err)
+	}
+	items, _ := podList["items"].([]interface{})
+	if len(items) != 1 {
+		t.Fatalf("got %d items via the store, want 1", len(items))
+	}
+
+	// And the pre-anonymization path must be genuinely gone, not just
+	// shadowed — a 404 through the same store API a real reader would use.
+	_, code, _, err = cs.SnapshotAt("/api/v1/namespaces/prod/pods", fixedNow.Add(time.Second))
+	if err != nil {
+		t.Fatalf("SnapshotAt(original path): %v", err)
+	}
+	if code != 404 {
+		t.Errorf("SnapshotAt(original path) returned code %d, want 404 — the original namespace path should no longer resolve", code)
+	}
+}
+
+// Running Archive twice over the identical source with the identical salt
+// must produce byte-identical output — this is the property the whole
+// single-pass, stateless design in alias.go exists to guarantee. Comparing
+// the two output *archives'* raw bytes (not just re-deriving an alias and
+// checking it matches) also exercises internal/archive's own
+// reproducible-ZIP-entry-timestamp behavior (epochModTime) as a side effect,
+// which is what makes this comparison meaningful rather than incidentally
+// flaky.
+func TestArchive_Deterministic(t *testing.T) {
+	src := buildAnonymizeTestArchive(t, namespaceFixtureRecords())
+	salt := []byte("determinism-salt")
+
+	dst1 := filepath.Join(t.TempDir(), "out1.kshrk")
+	dst2 := filepath.Join(t.TempDir(), "out2.kshrk")
+
+	if _, err := Archive(src, dst1, Options{Categories: []Category{CategoryNamespace}, Salt: salt}); err != nil {
+		t.Fatalf("first Archive run: %v", err)
+	}
+	if _, err := Archive(src, dst2, Options{Categories: []Category{CategoryNamespace}, Salt: salt}); err != nil {
+		t.Fatalf("second Archive run: %v", err)
+	}
+
+	b1, err := os.ReadFile(dst1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b2, err := os.ReadFile(dst2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(b1) != len(b2) {
+		t.Fatalf("outputs differ in length: %d vs %d bytes", len(b1), len(b2))
+	}
+	for i := range b1 {
+		if b1[i] != b2[i] {
+			t.Fatalf("outputs diverge at byte offset %d", i)
+		}
+	}
+}
+
+func TestArchive_UnsupportedCategoryErrors(t *testing.T) {
+	src := buildAnonymizeTestArchive(t, namespaceFixtureRecords())
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+	_, err := Archive(src, dst, Options{Categories: []Category{CategoryIP}, Salt: []byte("s")})
+	if err == nil {
+		t.Fatal("want an error for a category not yet supported by archive rewriting")
+	}
+	if _, statErr := os.Stat(dst); statErr == nil {
+		t.Error("no output file should be left behind on a rejected category")
+	}
+}
+
+func TestArchive_NoCategoriesErrors(t *testing.T) {
+	src := buildAnonymizeTestArchive(t, namespaceFixtureRecords())
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+	if _, err := Archive(src, dst, Options{Salt: []byte("s")}); err == nil {
+		t.Fatal("want an error when no categories are requested")
+	}
+}
+
+// Data with nothing to do with namespaces must survive byte-for-byte —
+// proving the rewrite is surgical, not a side effect of decoding and
+// re-marshaling every record through Go's map-based JSON representation
+// (which does not preserve key order or exact number formatting).
+func TestArchive_PreservesUnrelatedRecordUntouched(t *testing.T) {
+	cmBody := `{"kind":"ConfigMap","apiVersion":"v1","metadata":{"name":"settings","namespace":"prod"},"data":{"key":"value","count":"42"}}`
+	records := append(namespaceFixtureRecords(), &capture.Record{
+		ID: "r4", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/prod/configmaps/settings",
+		HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(cmBody),
+	})
+	src := buildAnonymizeTestArchive(t, records)
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+	salt := []byte("preserve-salt")
+
+	if _, err := Archive(src, dst, Options{Categories: []Category{CategoryNamespace}, Salt: salt}); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	wantAlias := NewAliaser(salt).Alias(CategoryNamespace, "prod")
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ar.Close()
+	data, err := ar.ReadRecord("/api/v1/namespaces/"+wantAlias+"/configmaps/settings", 0)
+	if err != nil {
+		t.Fatalf("ReadRecord: %v", err)
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatal(err)
+	}
+	var obj map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+		t.Fatal(err)
+	}
+	cmData := obj["data"].(map[string]interface{})
+	if cmData["key"] != "value" || cmData["count"] != "42" {
+		t.Errorf("ConfigMap data was modified: %v", cmData)
+	}
+	if obj["metadata"].(map[string]interface{})["name"] != "settings" {
+		t.Errorf("ConfigMap's own name was modified: %v", obj["metadata"])
+	}
+}

--- a/internal/anonymize/archive_test.go
+++ b/internal/anonymize/archive_test.go
@@ -335,6 +335,48 @@ func TestArchive_DetectsRealNamespaceCollision(t *testing.T) {
 	}
 }
 
+// The same collision, but introduced purely by record *body* content, with
+// no per-namespace URL segment anywhere for rewriteNamespaceInPath to have
+// already caught it: a single /api/v1/namespaces NamespaceList response
+// listing both colliding names in items[].metadata.name. This is also the
+// only (hence last) apiPath in the archive.
+//
+// This is the specific gap a real review caught: the collision check
+// originally sat only between the *path* rewrite and the *body* rewrite for
+// each entry, so a collision introduced by body content wasn't observed
+// until the next loop iteration — and not at all if, as here, there is no
+// next iteration. Archive() would report success despite having detected a
+// real collision. Confirmed against the code before fixing: reverting to
+// only the path-adjacent check reproduces this exact false success.
+func TestArchive_DetectsCollisionIntroducedOnlyByRecordBody(t *testing.T) {
+	body := fmt.Sprintf(`{"kind":"NamespaceList","apiVersion":"v1","items":[
+		{"metadata":{"name":%q}},
+		{"metadata":{"name":%q}}
+	]}`, collidingNamespaceA, collidingNamespaceB)
+	rec := &capture.Record{
+		ID: "r1", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces",
+		HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body),
+	}
+	src := buildAnonymizeTestArchive(t, []*capture.Record{rec})
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+	_, err := Archive(src, dst, Options{
+		Categories: []Category{CategoryNamespace},
+		Salt:       []byte(collidingNamespaceSalt),
+	})
+	if err == nil {
+		t.Fatal("want a collision error; got none — a collision introduced only by record body content, on the archive's only apiPath, was silently accepted")
+	}
+	for _, want := range []string{collidingNamespaceA, collidingNamespaceB} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name the colliding value %q", err.Error(), want)
+		}
+	}
+	if _, statErr := os.Stat(dst); statErr == nil {
+		t.Error("no (corrupt) output file should be left behind on a detected collision")
+	}
+}
+
 func TestArchive_RejectsEmptySalt(t *testing.T) {
 	src := buildAnonymizeTestArchive(t, namespaceFixtureRecords())
 	dst := filepath.Join(t.TempDir(), "out.kshrk")

--- a/internal/anonymize/archive_test.go
+++ b/internal/anonymize/archive_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
 	"github.com/phenixblue/k8shark/internal/store"
@@ -345,6 +346,137 @@ func TestArchive_RejectsEmptySalt(t *testing.T) {
 	if _, statErr := os.Stat(dst); statErr == nil {
 		t.Error("no output file should be left behind on a rejected empty salt")
 	}
+}
+
+// buildAnonymizeEncryptedTestArchive mirrors buildAnonymizeTestArchive but
+// writes the source as an age-encrypted archive, its own metadata.Encrypted
+// set true (as a real capture/redact/encrypt run would leave it) — needed to
+// exercise the plaintext-source-to-encrypted-output direction, and the
+// reverse, for the meta.Encrypted regression below.
+func buildAnonymizeEncryptedTestArchive(t *testing.T, records []*capture.Record, recipients []age.Recipient) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	idx := capture.Index{}
+	pathSeq := map[string]int{}
+	for _, r := range records {
+		seq := pathSeq[r.APIPath]
+		pathSeq[r.APIPath] = seq + 1
+		e := idx[r.APIPath]
+		if e == nil {
+			e = &capture.IndexEntry{APIPath: r.APIPath}
+			idx[r.APIPath] = e
+		}
+		e.Seqs = append(e.Seqs, seq)
+		e.Times = append(e.Times, r.CapturedAt)
+	}
+
+	meta := &capture.CaptureMetadata{
+		CaptureID:     "anonymize-encrypted-test",
+		CapturedAt:    fixedNow.Add(-time.Minute),
+		CapturedUntil: fixedNow,
+		RecordCount:   len(records),
+		Encrypted:     true,
+	}
+
+	outPath := filepath.Join(dir, "test.kshrk")
+	sw, err := archive.NewEncryptedStreamWriter(outPath, recipients)
+	if err != nil {
+		t.Fatalf("NewEncryptedStreamWriter: %v", err)
+	}
+	defer func() { _ = sw.Abort() }() // no-op after a successful Finish
+	for _, r := range records {
+		if _, err := sw.WriteRecord(r); err != nil {
+			t.Fatalf("WriteRecord: %v", err)
+		}
+	}
+	if err := sw.Finish(meta, idx, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	return outPath
+}
+
+// readOutputMetadataEncrypted opens dst (assumed plaintext) and returns its
+// own metadata.Encrypted value.
+func readOutputMetadataEncrypted(t *testing.T, dst string) bool {
+	t.Helper()
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatalf("archive.Open(%s): %v", dst, err)
+	}
+	defer ar.Close()
+	meta, err := ar.ReadMetadata()
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	return meta.Encrypted
+}
+
+// meta is populated straight from the source archive's own metadata
+// (ar.ReadMetadata()), so left untouched it describes the *source*, not the
+// archive actually being written. Both directions of the resulting mismatch
+// are real: a plaintext source anonymized straight into an encrypted output
+// would under-report itself as unencrypted, and — the more concerning
+// direction, checked second — an encrypted source anonymized into a
+// plaintext output (no --encrypt-* flags on the CLI) would over-report
+// itself as still encrypted, which could give a consumer false confidence
+// about a file that is, in fact, sitting on disk in the clear.
+func TestArchive_MetadataEncryptedReflectsOutputNotSource(t *testing.T) {
+	t.Run("plaintext source, encrypted output -> Encrypted true", func(t *testing.T) {
+		id, err := age.GenerateX25519Identity()
+		if err != nil {
+			t.Fatal(err)
+		}
+		src := buildAnonymizeTestArchive(t, namespaceFixtureRecords()) // plaintext, Encrypted: false
+		dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+		_, err = Archive(src, dst, Options{
+			Categories: []Category{CategoryNamespace},
+			Salt:       []byte("salt"),
+			Recipients: []age.Recipient{id.Recipient()},
+		})
+		if err != nil {
+			t.Fatalf("Archive: %v", err)
+		}
+
+		// The output is encrypted, so open it directly rather than through
+		// readOutputMetadataEncrypted (which assumes plaintext).
+		ar, err := archive.OpenWithIdentities(dst, []age.Identity{id})
+		if err != nil {
+			t.Fatalf("OpenWithIdentities: %v", err)
+		}
+		defer ar.Close()
+		meta, err := ar.ReadMetadata()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !meta.Encrypted {
+			t.Error("output metadata.Encrypted = false, want true — the output actually is encrypted")
+		}
+	})
+
+	t.Run("encrypted source, plaintext output -> Encrypted false", func(t *testing.T) {
+		id, err := age.GenerateX25519Identity()
+		if err != nil {
+			t.Fatal(err)
+		}
+		src := buildAnonymizeEncryptedTestArchive(t, namespaceFixtureRecords(), []age.Recipient{id.Recipient()})
+		dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+		_, err = Archive(src, dst, Options{
+			Categories: []Category{CategoryNamespace},
+			Salt:       []byte("salt"),
+			Identities: []age.Identity{id}, // decrypt the source
+			// No Recipients: the output is written plaintext.
+		})
+		if err != nil {
+			t.Fatalf("Archive: %v", err)
+		}
+
+		if got := readOutputMetadataEncrypted(t, dst); got {
+			t.Error("output metadata.Encrypted = true, want false — the output is plaintext, only the source was encrypted")
+		}
+	})
 }
 
 func TestArchive_UnsupportedCategoryErrors(t *testing.T) {

--- a/internal/anonymize/collision.go
+++ b/internal/anonymize/collision.go
@@ -1,0 +1,70 @@
+package anonymize
+
+import "fmt"
+
+// collisionTracker wraps a category's alias function with collision
+// detection. Two distinct original values landing on the same alias is not
+// astronomically unlikely — for the namespace category's 2-word encoding
+// (4096 combinations, see name.go's wordsPerCategory), a cluster with 50
+// namespaces has roughly a 1-in-4 chance of at least one collision, and 100
+// namespaces roughly 2-in-3, by the ordinary birthday bound. Silently
+// proceeding on a collision is not an acceptable failure mode here: it means
+// two distinct source API paths would rewrite to the same destination key,
+// and the archive-rewrite loop's index/watch-index rebuild would silently
+// let the second one clobber the first — records vanish from the archive
+// with no indication anything went wrong. Detected and reported as a hard
+// error instead: this milestone does not attempt to resolve a collision
+// (e.g. by widening the encoding for just the colliding values), only to
+// refuse producing an archive that has one.
+type collisionTracker struct {
+	category   Category
+	alias      func(string) string
+	aliasOf    map[string]string // original -> alias (memoizes repeat lookups)
+	originalOf map[string]string // alias -> the first original that produced it
+	err        error
+}
+
+// newCollisionTracker wraps alias (typically an Aliaser's Alias method bound
+// to one category) with collision detection. alias is injected rather than
+// this type constructing its own Aliaser so it can be tested with a
+// deliberately colliding function, without needing to find or brute-force a
+// real HMAC collision.
+func newCollisionTracker(category Category, alias func(string) string) *collisionTracker {
+	return &collisionTracker{
+		category:   category,
+		alias:      alias,
+		aliasOf:    make(map[string]string),
+		originalOf: make(map[string]string),
+	}
+}
+
+// Alias returns the alias for original. Once a collision has been detected,
+// it keeps returning a value (never panics) so callers already mid-loop
+// don't need their own error-plumbing through every intermediate function —
+// but that value must not be trusted or written anywhere durable. Callers
+// MUST check Err() and abort before finishing the archive.
+func (c *collisionTracker) Alias(original string) string {
+	if a, ok := c.aliasOf[original]; ok {
+		return a
+	}
+	a := c.alias(original)
+	if prior, ok := c.originalOf[a]; ok && prior != original {
+		if c.err == nil {
+			c.err = fmt.Errorf(
+				"anonymize: alias collision for category %q under this salt: both %q and %q map to %q — use a different --anonymize-salt-file value and try again",
+				c.category, prior, original, a)
+		}
+	} else {
+		c.originalOf[a] = original
+	}
+	c.aliasOf[original] = a
+	return a
+}
+
+// Err returns the first collision detected, or nil if none was.
+func (c *collisionTracker) Err() error { return c.err }
+
+// Count returns the number of distinct original values seen so far —
+// exactly the bookkeeping Result's per-category counts need, and a
+// byproduct of collision detection rather than separate state to maintain.
+func (c *collisionTracker) Count() int { return len(c.aliasOf) }

--- a/internal/anonymize/collision_test.go
+++ b/internal/anonymize/collision_test.go
@@ -1,0 +1,88 @@
+package anonymize
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCollisionTracker_NoCollision(t *testing.T) {
+	tr := newCollisionTracker(CategoryNamespace, upper) // upper: s -> s+"-ALIASED", injective
+	if got := tr.Alias("prod"); got != "prod-ALIASED" {
+		t.Errorf("Alias(prod) = %q, want prod-ALIASED", got)
+	}
+	if got := tr.Alias("staging"); got != "staging-ALIASED" {
+		t.Errorf("Alias(staging) = %q, want staging-ALIASED", got)
+	}
+	if err := tr.Err(); err != nil {
+		t.Errorf("Err() = %v, want nil", err)
+	}
+	if got := tr.Count(); got != 2 {
+		t.Errorf("Count() = %d, want 2", got)
+	}
+}
+
+func TestCollisionTracker_RepeatedCallSameOriginal_NotACollision(t *testing.T) {
+	tr := newCollisionTracker(CategoryNamespace, upper)
+	first := tr.Alias("prod")
+	second := tr.Alias("prod")
+	third := tr.Alias("prod")
+	if first != second || second != third {
+		t.Errorf("repeated calls for the same original returned different aliases: %q, %q, %q", first, second, third)
+	}
+	if err := tr.Err(); err != nil {
+		t.Errorf("Err() = %v, want nil — the same value seen repeatedly is not a collision", err)
+	}
+	if got := tr.Count(); got != 1 {
+		t.Errorf("Count() = %d, want 1 (one distinct original, however many times it was looked up)", got)
+	}
+}
+
+// The central case: two DISTINCT original values that happen to map to the
+// same alias (a deliberately collision-prone injected function, since
+// finding two real strings that collide under the real HMAC-based Aliaser
+// isn't practical to do in a unit test) must be detected and reported, not
+// silently allowed through.
+func TestCollisionTracker_DetectsCollision(t *testing.T) {
+	alwaysSame := func(string) string { return "namespace-same-alias" }
+	tr := newCollisionTracker(CategoryNamespace, alwaysSame)
+
+	if got := tr.Alias("prod"); got != "namespace-same-alias" {
+		t.Fatalf("Alias(prod) = %q", got)
+	}
+	if err := tr.Err(); err != nil {
+		t.Fatalf("Err() after the first distinct value = %v, want nil", err)
+	}
+
+	tr.Alias("staging") // a second, distinct original -> the same alias
+	err := tr.Err()
+	if err == nil {
+		t.Fatal("want a collision error after two distinct originals map to the same alias")
+	}
+	// The error must name both real values and the category — this is what
+	// makes it actionable rather than a generic "something collided".
+	for _, want := range []string{"prod", "staging", "namespace-same-alias", string(CategoryNamespace)} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err.Error(), want)
+		}
+	}
+}
+
+// Once a collision is detected, Err() must keep reporting it (a caller might
+// check it more than once, e.g. once per loop iteration as archive.go does)
+// and it must not be overwritten by a later, different collision — the
+// first one found is the one reported.
+func TestCollisionTracker_ErrSticksToTheFirstCollision(t *testing.T) {
+	alwaysSame := func(string) string { return "same-alias" }
+	tr := newCollisionTracker(CategoryNamespace, alwaysSame)
+	tr.Alias("a")
+	tr.Alias("b") // first collision: a vs b
+	first := tr.Err()
+	tr.Alias("c") // also collides, but should not replace the first error
+	second := tr.Err()
+	if first == nil {
+		t.Fatal("want a collision error after the second distinct value")
+	}
+	if first != second {
+		t.Errorf("Err() changed after a second collision: %v -> %v, want it to stay the same", first, second)
+	}
+}

--- a/internal/anonymize/namespace.go
+++ b/internal/anonymize/namespace.go
@@ -73,10 +73,11 @@ func rewriteNamespaceInObject(obj map[string]interface{}, kind string, alias fun
 
 // rewriteNamespaceInRecord decodes rec's body, rewrites every namespace
 // occurrence it recognizes using alias, and re-encodes the body if anything
-// changed. seen accumulates every distinct original namespace name
-// encountered — used only for the reported count (Result.NamespacesRenamed),
-// not for the aliasing itself, so its accumulation order has no bearing on
-// determinism.
+// changed. Tracking which distinct original values were seen (for
+// Result.NamespacesRenamed and for collision detection) is alias's own job
+// now — see collisionTracker — not this function's; it used to take a
+// separate seen map for that, which became redundant bookkeeping once the
+// tracker existed to do the same thing more safely.
 //
 // Handles both a single-object response and a List response's items[],
 // mirroring internal/redact/fields.go's ApplyRules list-handling. Records
@@ -87,7 +88,7 @@ func rewriteNamespaceInObject(obj map[string]interface{}, kind string, alias fun
 // for the archive-rewrite path in this milestone: Table rows have no field
 // names, so it needs a different, value-pattern-based approach layered on
 // top of this schema-aware one, not a fix to this function.
-func rewriteNamespaceInRecord(rec *capture.Record, alias func(string) string, seen map[string]bool) (bool, error) {
+func rewriteNamespaceInRecord(rec *capture.Record, alias func(string) string) (bool, error) {
 	var obj map[string]interface{}
 	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
 		return false, nil
@@ -95,11 +96,6 @@ func rewriteNamespaceInRecord(rec *capture.Record, alias func(string) string, se
 
 	kind, _ := obj["kind"].(string)
 	modified := false
-
-	track := func(original string) string {
-		seen[original] = true
-		return alias(original)
-	}
 
 	if strings.HasSuffix(kind, "List") {
 		items, _ := obj["items"].([]interface{})
@@ -113,12 +109,12 @@ func rewriteNamespaceInRecord(rec *capture.Record, alias func(string) string, se
 			if k, ok := item["kind"].(string); ok && k != "" {
 				ik = k
 			}
-			if rewriteNamespaceInObject(item, ik, track) {
+			if rewriteNamespaceInObject(item, ik, alias) {
 				items[i] = item
 				modified = true
 			}
 		}
-	} else if rewriteNamespaceInObject(obj, kind, track) {
+	} else if rewriteNamespaceInObject(obj, kind, alias) {
 		modified = true
 	}
 

--- a/internal/anonymize/namespace.go
+++ b/internal/anonymize/namespace.go
@@ -1,0 +1,119 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// rewriteNamespaceInObject rewrites the namespace identity in a single
+// decoded JSON object (not a list), using alias for whatever occurrences it
+// finds. kind is the object's own Kind, passed down by the caller rather
+// than re-extracted here — the same convention internal/redact/fields.go
+// uses.
+//
+// A Namespace object's OWN identity is its metadata.name — Namespace is
+// cluster-scoped, so it has no metadata.namespace field at all. Every other
+// Kind's membership in a namespace lives in ITS OWN metadata.namespace
+// field instead. Getting this backwards doesn't error, it just silently
+// anonymizes nothing for that object — which is exactly why it's called out
+// here in a comment rather than left to be discovered via a failing
+// round-trip test.
+//
+// Event objects carry a second, independent namespace reference:
+// involvedObject.namespace, naming the namespace of whatever the Event is
+// about. That is in addition to the Event's own metadata.namespace (an
+// Event is itself namespaced, so the generic case above already covers
+// that), not instead of it.
+func rewriteNamespaceInObject(obj map[string]interface{}, kind string, alias func(string) string) bool {
+	meta, _ := obj["metadata"].(map[string]interface{})
+	if meta == nil {
+		return false
+	}
+
+	modified := false
+	if kind == "Namespace" {
+		if name, ok := meta["name"].(string); ok && name != "" {
+			meta["name"] = alias(name)
+			modified = true
+		}
+	} else if ns, ok := meta["namespace"].(string); ok && ns != "" {
+		meta["namespace"] = alias(ns)
+		modified = true
+	}
+
+	if kind == "Event" {
+		if involved, ok := obj["involvedObject"].(map[string]interface{}); ok {
+			if ns, ok := involved["namespace"].(string); ok && ns != "" {
+				involved["namespace"] = alias(ns)
+				modified = true
+			}
+		}
+	}
+
+	return modified
+}
+
+// rewriteNamespaceInRecord decodes rec's body, rewrites every namespace
+// occurrence it recognizes using alias, and re-encodes the body if anything
+// changed. seen accumulates every distinct original namespace name
+// encountered — used only for the reported count (Result.NamespacesRenamed),
+// not for the aliasing itself, so its accumulation order has no bearing on
+// determinism.
+//
+// Handles both a single-object response and a List response's items[],
+// mirroring internal/redact/fields.go's ApplyRules list-handling. Records
+// that don't decode into a JSON object at all — a meta.k8s.io/v1 Table
+// response's rows[], or a discovery/OpenAPI document — are left untouched,
+// matching internal/redact's existing precedent for the same case. Catching
+// a namespace name inside an opaque Table cell is deliberately out of scope
+// for the archive-rewrite path in this milestone: Table rows have no field
+// names, so it needs a different, value-pattern-based approach layered on
+// top of this schema-aware one, not a fix to this function.
+func rewriteNamespaceInRecord(rec *capture.Record, alias func(string) string, seen map[string]bool) (bool, error) {
+	var obj map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+		return false, nil
+	}
+
+	kind, _ := obj["kind"].(string)
+	modified := false
+
+	track := func(original string) string {
+		seen[original] = true
+		return alias(original)
+	}
+
+	if strings.HasSuffix(kind, "List") {
+		items, _ := obj["items"].([]interface{})
+		itemKind := strings.TrimSuffix(kind, "List")
+		for i, itemRaw := range items {
+			item, ok := itemRaw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			ik := itemKind
+			if k, ok := item["kind"].(string); ok && k != "" {
+				ik = k
+			}
+			if rewriteNamespaceInObject(item, ik, track) {
+				items[i] = item
+				modified = true
+			}
+		}
+	} else if rewriteNamespaceInObject(obj, kind, track) {
+		modified = true
+	}
+
+	if !modified {
+		return false, nil
+	}
+	newBody, err := json.Marshal(obj)
+	if err != nil {
+		return false, fmt.Errorf("re-marshaling record: %w", err)
+	}
+	rec.ResponseBody = newBody
+	return true, nil
+}

--- a/internal/anonymize/namespace.go
+++ b/internal/anonymize/namespace.go
@@ -80,14 +80,19 @@ func rewriteNamespaceInObject(obj map[string]interface{}, kind string, alias fun
 // tracker existed to do the same thing more safely.
 //
 // Handles both a single-object response and a List response's items[],
-// mirroring internal/redact/fields.go's ApplyRules list-handling. Records
-// that don't decode into a JSON object at all — a meta.k8s.io/v1 Table
-// response's rows[], or a discovery/OpenAPI document — are left untouched,
-// matching internal/redact's existing precedent for the same case. Catching
-// a namespace name inside an opaque Table cell is deliberately out of scope
-// for the archive-rewrite path in this milestone: Table rows have no field
-// names, so it needs a different, value-pattern-based approach layered on
-// top of this schema-aware one, not a fix to this function.
+// mirroring internal/redact/fields.go's ApplyRules list-handling. Two
+// different kinds of record are left untouched, and it's worth keeping them
+// straight: a body that isn't valid JSON at all (rare — a corrupt record)
+// fails the initial Unmarshal and returns immediately; a meta.k8s.io/v1
+// Table response's rows[] or a discovery/OpenAPI document decodes into obj
+// just fine (they're ordinary JSON) but has no metadata/items shaped like a
+// Kubernetes object or list, so nothing below ever matches and modified
+// stays false. Both end up untouched, but for different reasons — this
+// mirrors internal/redact's identical precedent for the same two cases.
+// Catching a namespace name inside an opaque Table cell is deliberately out
+// of scope for the archive-rewrite path in this milestone: Table rows have
+// no field names, so it needs a different, value-pattern-based approach
+// layered on top of this schema-aware one, not a fix to this function.
 func rewriteNamespaceInRecord(rec *capture.Record, alias func(string) string) (bool, error) {
 	var obj map[string]interface{}
 	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {

--- a/internal/anonymize/namespace.go
+++ b/internal/anonymize/namespace.go
@@ -22,11 +22,22 @@ import (
 // here in a comment rather than left to be discovered via a failing
 // round-trip test.
 //
-// Event objects carry a second, independent namespace reference:
-// involvedObject.namespace, naming the namespace of whatever the Event is
-// about. That is in addition to the Event's own metadata.namespace (an
-// Event is itself namespaced, so the generic case above already covers
-// that), not instead of it.
+// Event objects carry a second, independent namespace reference, in
+// addition to the Event's own metadata.namespace (an Event is itself
+// namespaced, so the generic case above already covers that) — but which
+// field holds it depends on which Events API produced the record, and a
+// real cluster emits both depending on client/version:
+//
+//   - core/v1 Event: involvedObject.namespace
+//   - events.k8s.io/v1 Event: regarding.namespace, and optionally
+//     related.namespace (an additional secondary reference introduced by
+//     the newer API and absent from core/v1)
+//
+// Both events.k8s.io/v1's "regarding" and "related" are the same
+// ObjectReference shape as core/v1's "involvedObject" — different field
+// *names* on the parent Event, same Namespace field within. All three are
+// checked unconditionally; whichever ones a given record doesn't have are
+// simply absent from the decoded map and the corresponding check is a no-op.
 func rewriteNamespaceInObject(obj map[string]interface{}, kind string, alias func(string) string) bool {
 	meta, _ := obj["metadata"].(map[string]interface{})
 	if meta == nil {
@@ -45,9 +56,13 @@ func rewriteNamespaceInObject(obj map[string]interface{}, kind string, alias fun
 	}
 
 	if kind == "Event" {
-		if involved, ok := obj["involvedObject"].(map[string]interface{}); ok {
-			if ns, ok := involved["namespace"].(string); ok && ns != "" {
-				involved["namespace"] = alias(ns)
+		for _, field := range []string{"involvedObject", "regarding", "related"} {
+			ref, ok := obj[field].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if ns, ok := ref["namespace"].(string); ok && ns != "" {
+				ref["namespace"] = alias(ns)
 				modified = true
 			}
 		}

--- a/internal/anonymize/namespace_test.go
+++ b/internal/anonymize/namespace_test.go
@@ -44,7 +44,7 @@ func TestRewriteNamespaceInObject(t *testing.T) {
 		}
 	})
 
-	t.Run("Event aliases both its own metadata.namespace and involvedObject.namespace", func(t *testing.T) {
+	t.Run("core/v1 Event aliases both its own metadata.namespace and involvedObject.namespace", func(t *testing.T) {
 		obj := map[string]interface{}{
 			"kind":           "Event",
 			"metadata":       map[string]interface{}{"name": "web-1.abc", "namespace": "prod"},
@@ -60,6 +60,34 @@ func TestRewriteNamespaceInObject(t *testing.T) {
 		}
 		if got := involved["namespace"]; got != "prod-ALIASED" {
 			t.Errorf("involvedObject.namespace = %v, want prod-ALIASED", got)
+		}
+	})
+
+	// events.k8s.io/v1 is the Events API a real cluster actually emits by
+	// default (core/v1 Event is the older, still-supported shape) — missing
+	// this would anonymize metadata.namespace and the API path correctly
+	// while leaving the real namespace name sitting in regarding.namespace
+	// on the majority of Events a real capture contains.
+	t.Run("events.k8s.io/v1 Event aliases regarding.namespace and related.namespace", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind":      "Event",
+			"metadata":  map[string]interface{}{"name": "web-1.abc", "namespace": "prod"},
+			"regarding": map[string]interface{}{"kind": "Pod", "name": "web-1", "namespace": "prod"},
+			"related":   map[string]interface{}{"kind": "ReplicaSet", "name": "web-1-rs", "namespace": "prod"},
+		}
+		if !rewriteNamespaceInObject(obj, "Event", alias) {
+			t.Fatal("want modified=true")
+		}
+		regarding := obj["regarding"].(map[string]interface{})
+		related := obj["related"].(map[string]interface{})
+		if got := regarding["namespace"]; got != "prod-ALIASED" {
+			t.Errorf("regarding.namespace = %v, want prod-ALIASED", got)
+		}
+		if got := related["namespace"]; got != "prod-ALIASED" {
+			t.Errorf("related.namespace = %v, want prod-ALIASED", got)
+		}
+		if got := regarding["name"]; got != "web-1" {
+			t.Errorf("regarding.name = %v, want unchanged web-1", got)
 		}
 	})
 

--- a/internal/anonymize/namespace_test.go
+++ b/internal/anonymize/namespace_test.go
@@ -120,8 +120,7 @@ func TestRewriteNamespaceInRecord(t *testing.T) {
 		rec := &capture.Record{
 			ResponseBody: json.RawMessage(`{"kind":"Namespace","metadata":{"name":"prod"}}`),
 		}
-		seen := map[string]bool{}
-		changed, err := rewriteNamespaceInRecord(rec, alias, seen)
+		changed, err := rewriteNamespaceInRecord(rec, alias)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -136,9 +135,6 @@ func TestRewriteNamespaceInRecord(t *testing.T) {
 		if got := meta["name"]; got != "prod-ALIASED" {
 			t.Errorf("metadata.name = %v, want prod-ALIASED", got)
 		}
-		if !seen["prod"] {
-			t.Error("seen[\"prod\"] should be tracked")
-		}
 	})
 
 	t.Run("list response rewrites every item, using each item's own kind", func(t *testing.T) {
@@ -147,8 +143,7 @@ func TestRewriteNamespaceInRecord(t *testing.T) {
 			{"metadata":{"name":"web-2","namespace":"staging"}}
 		]}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
-		seen := map[string]bool{}
-		changed, err := rewriteNamespaceInRecord(rec, alias, seen)
+		changed, err := rewriteNamespaceInRecord(rec, alias)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -178,16 +173,13 @@ func TestRewriteNamespaceInRecord(t *testing.T) {
 		if out.Items[0].Metadata.Name != "web-1" || out.Items[1].Metadata.Name != "web-2" {
 			t.Errorf("item names must survive unchanged, got %q and %q", out.Items[0].Metadata.Name, out.Items[1].Metadata.Name)
 		}
-		if !seen["prod"] || !seen["staging"] {
-			t.Errorf("both distinct namespaces should be tracked, got seen=%v", seen)
-		}
 	})
 
 	t.Run("a Table-format body is left untouched, not an error", func(t *testing.T) {
 		body := `{"kind":"Table","apiVersion":"meta.k8s.io/v1","rows":[{"cells":["web-1","Running"]}]}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
 		orig := string(rec.ResponseBody)
-		changed, err := rewriteNamespaceInRecord(rec, alias, map[string]bool{})
+		changed, err := rewriteNamespaceInRecord(rec, alias)
 		if err != nil {
 			t.Fatalf("Table-format body should not error, got: %v", err)
 		}
@@ -210,7 +202,7 @@ func TestRewriteNamespaceInRecord(t *testing.T) {
 		body := `{"kind":"Node","metadata":{"name":"worker-1"}}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
 		orig := string(rec.ResponseBody)
-		changed, err := rewriteNamespaceInRecord(rec, alias, map[string]bool{})
+		changed, err := rewriteNamespaceInRecord(rec, alias)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/anonymize/namespace_test.go
+++ b/internal/anonymize/namespace_test.go
@@ -1,0 +1,196 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+func TestRewriteNamespaceInObject(t *testing.T) {
+	alias := upper // from apipath_test.go: s + "-ALIASED"
+
+	t.Run("Namespace object aliases its own metadata.name", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind":     "Namespace",
+			"metadata": map[string]interface{}{"name": "prod"},
+		}
+		if !rewriteNamespaceInObject(obj, "Namespace", alias) {
+			t.Fatal("want modified=true")
+		}
+		meta := obj["metadata"].(map[string]interface{})
+		if got := meta["name"]; got != "prod-ALIASED" {
+			t.Errorf("metadata.name = %v, want prod-ALIASED", got)
+		}
+		if _, has := meta["namespace"]; has {
+			t.Error("a Namespace object must not gain a metadata.namespace field")
+		}
+	})
+
+	t.Run("namespaced object aliases its own metadata.namespace, not metadata.name", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind":     "Pod",
+			"metadata": map[string]interface{}{"name": "web-1", "namespace": "prod"},
+		}
+		if !rewriteNamespaceInObject(obj, "Pod", alias) {
+			t.Fatal("want modified=true")
+		}
+		meta := obj["metadata"].(map[string]interface{})
+		if got := meta["namespace"]; got != "prod-ALIASED" {
+			t.Errorf("metadata.namespace = %v, want prod-ALIASED", got)
+		}
+		if got := meta["name"]; got != "web-1" {
+			t.Errorf("metadata.name = %v, want unchanged web-1 — the pod's own name is not a namespace occurrence", got)
+		}
+	})
+
+	t.Run("Event aliases both its own metadata.namespace and involvedObject.namespace", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind":           "Event",
+			"metadata":       map[string]interface{}{"name": "web-1.abc", "namespace": "prod"},
+			"involvedObject": map[string]interface{}{"kind": "Pod", "name": "web-1", "namespace": "prod"},
+		}
+		if !rewriteNamespaceInObject(obj, "Event", alias) {
+			t.Fatal("want modified=true")
+		}
+		meta := obj["metadata"].(map[string]interface{})
+		involved := obj["involvedObject"].(map[string]interface{})
+		if got := meta["namespace"]; got != "prod-ALIASED" {
+			t.Errorf("metadata.namespace = %v, want prod-ALIASED", got)
+		}
+		if got := involved["namespace"]; got != "prod-ALIASED" {
+			t.Errorf("involvedObject.namespace = %v, want prod-ALIASED", got)
+		}
+	})
+
+	t.Run("cluster-scoped object with no metadata.namespace is left alone", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind":     "Node",
+			"metadata": map[string]interface{}{"name": "worker-1"},
+		}
+		if rewriteNamespaceInObject(obj, "Node", alias) {
+			t.Error("want modified=false for an object with no namespace occurrence")
+		}
+		meta := obj["metadata"].(map[string]interface{})
+		if got := meta["name"]; got != "worker-1" {
+			t.Errorf("metadata.name = %v, want unchanged worker-1", got)
+		}
+	})
+
+	t.Run("object with no metadata at all is left alone, not a crash", func(t *testing.T) {
+		obj := map[string]interface{}{"kind": "Status"}
+		if rewriteNamespaceInObject(obj, "Status", alias) {
+			t.Error("want modified=false")
+		}
+	})
+}
+
+func TestRewriteNamespaceInRecord(t *testing.T) {
+	alias := upper
+
+	t.Run("single object", func(t *testing.T) {
+		rec := &capture.Record{
+			ResponseBody: json.RawMessage(`{"kind":"Namespace","metadata":{"name":"prod"}}`),
+		}
+		seen := map[string]bool{}
+		changed, err := rewriteNamespaceInRecord(rec, alias, seen)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed {
+			t.Fatal("want changed=true")
+		}
+		var out map[string]interface{}
+		if err := json.Unmarshal(rec.ResponseBody, &out); err != nil {
+			t.Fatal(err)
+		}
+		meta := out["metadata"].(map[string]interface{})
+		if got := meta["name"]; got != "prod-ALIASED" {
+			t.Errorf("metadata.name = %v, want prod-ALIASED", got)
+		}
+		if !seen["prod"] {
+			t.Error("seen[\"prod\"] should be tracked")
+		}
+	})
+
+	t.Run("list response rewrites every item, using each item's own kind", func(t *testing.T) {
+		body := `{"kind":"PodList","items":[
+			{"metadata":{"name":"web-1","namespace":"prod"}},
+			{"metadata":{"name":"web-2","namespace":"staging"}}
+		]}`
+		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
+		seen := map[string]bool{}
+		changed, err := rewriteNamespaceInRecord(rec, alias, seen)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed {
+			t.Fatal("want changed=true")
+		}
+		var out struct {
+			Items []struct {
+				Metadata struct {
+					Name      string `json:"name"`
+					Namespace string `json:"namespace"`
+				} `json:"metadata"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal(rec.ResponseBody, &out); err != nil {
+			t.Fatal(err)
+		}
+		if len(out.Items) != 2 {
+			t.Fatalf("got %d items, want 2", len(out.Items))
+		}
+		if out.Items[0].Metadata.Namespace != "prod-ALIASED" {
+			t.Errorf("item 0 namespace = %q, want prod-ALIASED", out.Items[0].Metadata.Namespace)
+		}
+		if out.Items[1].Metadata.Namespace != "staging-ALIASED" {
+			t.Errorf("item 1 namespace = %q, want staging-ALIASED", out.Items[1].Metadata.Namespace)
+		}
+		if out.Items[0].Metadata.Name != "web-1" || out.Items[1].Metadata.Name != "web-2" {
+			t.Errorf("item names must survive unchanged, got %q and %q", out.Items[0].Metadata.Name, out.Items[1].Metadata.Name)
+		}
+		if !seen["prod"] || !seen["staging"] {
+			t.Errorf("both distinct namespaces should be tracked, got seen=%v", seen)
+		}
+	})
+
+	t.Run("a Table-format body is left untouched, not an error", func(t *testing.T) {
+		body := `{"kind":"Table","apiVersion":"meta.k8s.io/v1","rows":[{"cells":["web-1","Running"]}]}`
+		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
+		orig := string(rec.ResponseBody)
+		changed, err := rewriteNamespaceInRecord(rec, alias, map[string]bool{})
+		if err != nil {
+			t.Fatalf("Table-format body should not error, got: %v", err)
+		}
+		// A Table body IS valid JSON (decodes into map[string]interface{}
+		// fine — it just has "rows" instead of "items", and no top-level
+		// metadata.namespace), so this exercises the "decodes but has
+		// nothing to rewrite" path, not the "doesn't decode as JSON at all"
+		// path. Both should leave the body untouched; this covers the one
+		// this package will most often actually see, since discovery/OpenAPI
+		// documents (the true non-object case) are rare in a real capture.
+		if changed {
+			t.Error("want changed=false for a Table-format body")
+		}
+		if string(rec.ResponseBody) != orig {
+			t.Error("body must be byte-identical when nothing was rewritten")
+		}
+	})
+
+	t.Run("a record with no namespace occurrence at all is left untouched", func(t *testing.T) {
+		body := `{"kind":"Node","metadata":{"name":"worker-1"}}`
+		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
+		orig := string(rec.ResponseBody)
+		changed, err := rewriteNamespaceInRecord(rec, alias, map[string]bool{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if changed {
+			t.Error("want changed=false")
+		}
+		if string(rec.ResponseBody) != orig {
+			t.Error("body must be byte-identical when nothing was rewritten")
+		}
+	})
+}


### PR DESCRIPTION
Refs #137

Second of six milestones (plan: `/Users/jsearcy/.claude/plans/declarative-soaring-flute.md`; M1 was #346). Ships `kshrk anonymize`, scoped to `--categories namespace` only — deliberately the single hardest category first, since it's the one that forces the structural problem the plan set this milestone aside to solve.

## The problem this milestone had to solve

`capture.Record.APIPath` (e.g. `/api/v1/namespaces/prod/pods`) carries the namespace name **in the URL path itself**, not just inside `ResponseBody` — and `capture.Index`/`WatchIndex` are keyed by that same string. Anonymizing `metadata.namespace` without rewriting `APIPath` and the index keys in lockstep leaves the real name sitting in the archive's own structure even after every JSON body looks clean.

`internal/anonymize/apipath.go`'s `rewriteNamespaceInPath` is simpler than what I'd originally sketched in the plan: find the literal `"namespaces"` segment and replace whatever follows it, regardless of what (if anything) comes after that. It deliberately doesn't reuse `internal/store.ParseAPIPath` — that function's own doc comment says it's narrowly scoped to exact 5/6-segment list paths, and `Record.APIPath` also carries item-level and subresource paths that function never parses at all.

`internal/anonymize/namespace.go` gets the Kind-aware split right that a naive "always alias `metadata.namespace`" implementation would get backwards: a `Namespace` object's own identity is its `metadata.name` (it's cluster-scoped — no `metadata.namespace` field exists on it), while every *other* Kind's membership lives in its own `metadata.namespace`. Events carry a second, independent occurrence — `involvedObject.namespace` — on top of their own `metadata.namespace`.

`internal/anonymize/archive.go`'s `Archive()` mirrors `redact.Archive`'s shape but keeps its own copy of the read-rewrite-write loop rather than sharing it, per the plan — `redact.Archive`'s loop never needs to change the `apiPath` a record is stored under, and this one must. One rule threaded through every write: **the record's own `APIPath` field is kept in sync with wherever it's actually stored unconditionally**, not just when a rewrite fires. Letting those two diverge is exactly the archive corruption (index points at one shard, bytes live in another) a body-only check wouldn't catch.

## A second bug, found by testing rather than reasoning

`TestArchive_Deterministic` initially failed — two runs over the identical input diverged at byte offset 54. Not an aliasing bug: `Alias` is already order-independent by construction (M1). The cause was one level up — `Archive`'s own `for apiPath, entry := range idx` loop determines the order records get appended to the output ZIP, and Go randomizes map iteration per process. Fixed by visiting both indexes in a fixed, sorted-by-original-key order. Verified across **8 fresh process invocations** rather than `-count=N` (which reuses one process and one randomization seed, so it wouldn't have caught this).

## Verification — every test checked against a real break

Consistent with the pattern from M1 and earlier this cycle: a test that's never seen its target bug fail isn't trusted yet.

**Disabled the `APIPath` rewrite while leaving the body rewrite in place** — both `TestArchive_NamespaceConsistentAcrossKindsAndPaths` and `TestArchive_RoundTripReadableViaStore` failed, the second surfacing the exact `"record not found in archive"` symptom real corruption would produce:
```
ReadRecord("/api/v1/namespaces/namespace-arid-wolf", 0): reading record ...:
entry "k8shark-capture/records/f43583520ca890a7/0.json.zst" not found in archive
```

**Dropped Event's `involvedObject.namespace` handling** — caught at both the unit level (`TestRewriteNamespaceInObject`) and the integration level (`TestArchive_NamespaceConsistentAcrossKindsAndPaths`).

Both breaks reverted immediately after confirming the catch.

**Manual, beyond the test suite** — anonymized a real repo example (`examples/multi-namespace/capture.kshrk`):
```
$ kshrk anonymize capture.kshrk --categories namespace
generated anonymize salt (save this to reproduce these exact aliases on a re-run):
  06461dc37c28f2d88f2aed7387eea129cb19a7583ee5092b009324a1046e4e2b
Anonymized 3 namespace(s) → capture-anonymized.kshrk (1051572 bytes)

$ kshrk inspect capture-anonymized.kshrk --wide
RESOURCE     ... NAMESPACES
pods         ... namespace-keen-moose, namespace-light-hare, namespace-misty-dove
services     ... namespace-keen-moose, namespace-light-hare, namespace-misty-dove
deployments  ... namespace-keen-moose, namespace-light-hare, namespace-misty-dove
```
Re-ran with the printed salt saved to a file — output was **byte-identical** (sha256 match) to the first run. Then started `kshrk ui` against the anonymized archive and hit `/v2/api/pods`, `/v2/api/overview`, and `/v2/api/namespace?ns=namespace-keen-moose` directly — all resolved real data through the anonymized path, the same store-layer read the rest of the CLI and UI use.

## Salt handling

Deferred from M1 (there was no command yet to attach flag-resolution to). Follows `resolveEncryptPassphrase`'s precedent deliberately, including its most important property: **no inline `--anonymize-salt=<value>` flag.** A secret argument sits in shell history and is visible via `ps`. The salt is a smaller secret than an encryption passphrase (knowing it only weakens anonymization, and only paired with candidate values to test against) but the leak vector is exactly as cheap to hit by accident — a shared bastion host, a copy-pasted command in a support ticket. `--anonymize-salt-file` and `$KSHRK_ANONYMIZE_SALT` only; an unset salt auto-generates and prints once to stderr with a save-this warning.

## Everything green

`gofmt`, `go build ./...`, `go vet ./...`, `go mod tidy` (no drift), `go test -race ./...`, `golangci-lint run`, `make docs` (new command's reference entry included in this diff), and `cmd/help_examples_test.go`'s `TestUserFacingCommandsHaveExamples` gate (the new command has a populated `Example`).

## Not in this milestone, by design

- node/pod/workload/IP/URL/image categories — M3/M4.
- `--config` and `-o json` reporting — M5.
- Any `scripts/e2e.sh` coverage. `redact` has substantial e2e phases there (real KinD cluster, real HTTP responses through the mock server); adding an equivalent `anonymize` phase is a reasonable M6 candidate once more categories exist, but wasn't required to satisfy this milestone's own bar (the plan's stated M2 check is a full round-trip through `internal/store`, which `TestArchive_RoundTripReadableViaStore` provides, plus the manual verification above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
