### PR TITLE
feat(anonymize): M3 — node/pod/workload resource-name categories (#137)

### DIFF
--- a/cmd/anonymize.go
+++ b/cmd/anonymize.go
@@ -25,10 +25,13 @@ field path with a fixed constant, everywhere it's configured to look;
 anonymize replaces every occurrence of a value it recognizes, consistently,
 using a deterministic alias derived from a salt.
 
-Only one category is available so far: namespace. More land milestone by
-milestone -- see https://github.com/phenixblue/k8shark/issues/137.`,
+Categories available so far: namespace, node, pod, workload. More land
+milestone by milestone -- see https://github.com/phenixblue/k8shark/issues/137.`,
 	Example: `  # Anonymize every namespace name in a capture
   kshrk anonymize capture.kshrk --categories namespace
+
+  # Anonymize multiple categories in one pass
+  kshrk anonymize capture.kshrk --categories namespace --categories node --categories pod
 
   # Reproduce the exact same aliases on a re-run
   kshrk anonymize capture.kshrk --categories namespace --anonymize-salt-file salt.txt
@@ -43,12 +46,26 @@ milestone -- see https://github.com/phenixblue/k8shark/issues/137.`,
 func init() {
 	rootCmd.AddCommand(anonymizeCmd)
 	anonymizeCmd.Flags().String("out", "", "output archive path (default: <in>-anonymized.kshrk)")
-	anonymizeCmd.Flags().StringArray("categories", nil, `category to anonymize (repeatable); only "namespace" is available so far`)
+	anonymizeCmd.Flags().StringArray("categories", nil, `category to anonymize (repeatable); supported: namespace, node, pod, workload`)
 	_ = anonymizeCmd.MarkFlagFilename("out", captureExt)
 	addAnonymizeFlags(anonymizeCmd)
 	// Write-side encryption for the anonymized output (read-side --decrypt-*
 	// are persistent flags from the root command, same as redact).
 	addEncryptFlags(anonymizeCmd)
+}
+
+// supportedAnonymizeCategories must track internal/anonymize's own
+// archiveCategories (archive.go) — kept as a separate list here (rather
+// than exporting and reusing that one) because this is user-facing
+// validation with its own error message, not the library's internal gate.
+// internal/anonymize/archive_test.go's node/pod/workload integration tests
+// are the real proof that Archive actually supports whatever this list
+// claims; this list just needs to not get ahead of or behind that.
+var supportedAnonymizeCategories = map[anonymize.Category]bool{
+	anonymize.CategoryNamespace: true,
+	anonymize.CategoryNode:      true,
+	anonymize.CategoryPod:       true,
+	anonymize.CategoryWorkload:  true,
 }
 
 // parseAnonymizeCategories validates --categories against what this build's
@@ -58,13 +75,13 @@ func init() {
 // category should fail loudly, not silently anonymize nothing for it.
 func parseAnonymizeCategories(raw []string) ([]anonymize.Category, error) {
 	if len(raw) == 0 {
-		return nil, fmt.Errorf(`--categories is required; only "namespace" is available so far (see #137)`)
+		return nil, fmt.Errorf(`--categories is required; supported categories: namespace, node, pod, workload (see #137)`)
 	}
 	out := make([]anonymize.Category, 0, len(raw))
 	for _, c := range raw {
 		cat := anonymize.Category(strings.ToLower(strings.TrimSpace(c)))
-		if cat != anonymize.CategoryNamespace {
-			return nil, fmt.Errorf(`--categories %q: not yet supported; only "namespace" is available so far (see #137)`, c)
+		if !supportedAnonymizeCategories[cat] {
+			return nil, fmt.Errorf(`--categories %q: not yet supported; supported categories: namespace, node, pod, workload (see #137)`, c)
 		}
 		out = append(out, cat)
 	}
@@ -138,6 +155,7 @@ func runAnonymize(cmd *cobra.Command, args []string) error {
 		size = fi.Size()
 	}
 
-	fmt.Printf("Anonymized %d namespace(s) → %s (%d bytes)\n", result.NamespacesRenamed, out, size)
+	fmt.Printf("Anonymized %d namespace(s), %d node(s), %d pod(s), %d workload(s) → %s (%d bytes)\n",
+		result.NamespacesRenamed, result.NodesRenamed, result.PodsRenamed, result.WorkloadsRenamed, out, size)
 	return nil
 }

--- a/cmd/anonymize_test.go
+++ b/cmd/anonymize_test.go
@@ -33,13 +33,40 @@ func TestParseAnonymizeCategories(t *testing.T) {
 		}
 	})
 
-	// This is the one that matters most: node/pod/workload/ip/url/image are
-	// all real Category constants that exist in internal/anonymize (later
-	// milestones' work), but the archive-rewrite path doesn't support them
-	// yet. Accepting them here would let a user believe --categories node
-	// did something when it silently anonymized nothing.
+	t.Run("node, pod, and workload are accepted", func(t *testing.T) {
+		for cat, want := range map[string]anonymize.Category{
+			"node":     anonymize.CategoryNode,
+			"pod":      anonymize.CategoryPod,
+			"workload": anonymize.CategoryWorkload,
+		} {
+			got, err := parseAnonymizeCategories([]string{cat})
+			if err != nil {
+				t.Errorf("category %q: unexpected error: %v", cat, err)
+				continue
+			}
+			if len(got) != 1 || got[0] != want {
+				t.Errorf("category %q: got %v, want [%v]", cat, got, want)
+			}
+		}
+	})
+
+	t.Run("multiple supported categories in one call are all accepted", func(t *testing.T) {
+		got, err := parseAnonymizeCategories([]string{"namespace", "node", "pod", "workload"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 4 {
+			t.Errorf("got %v, want 4 categories", got)
+		}
+	})
+
+	// This is the one that matters most: ip/url/image are real Category
+	// constants that exist in internal/anonymize (later milestones' work),
+	// but the archive-rewrite path doesn't support them yet. Accepting them
+	// here would let a user believe --categories ip did something when it
+	// silently anonymized nothing.
 	t.Run("a category not yet supported by archive rewriting is rejected", func(t *testing.T) {
-		for _, c := range []string{"node", "pod", "workload", "ip", "url", "image", "bogus"} {
+		for _, c := range []string{"ip", "url", "image", "bogus"} {
 			if _, err := parseAnonymizeCategories([]string{c}); err == nil {
 				t.Errorf("category %q: want an error, got none", c)
 			}
@@ -47,7 +74,7 @@ func TestParseAnonymizeCategories(t *testing.T) {
 	})
 
 	t.Run("one bad category in a list rejects the whole list", func(t *testing.T) {
-		if _, err := parseAnonymizeCategories([]string{"namespace", "node"}); err == nil {
+		if _, err := parseAnonymizeCategories([]string{"namespace", "ip"}); err == nil {
 			t.Error("want an error when any requested category is unsupported")
 		}
 	})

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -69,8 +69,8 @@ field path with a fixed constant, everywhere it's configured to look;
 anonymize replaces every occurrence of a value it recognizes, consistently,
 using a deterministic alias derived from a salt.
 
-Only one category is available so far: namespace. More land milestone by
-milestone -- see https://github.com/phenixblue/k8shark/issues/137.
+Categories available so far: namespace, node, pod, workload. More land
+milestone by milestone -- see https://github.com/phenixblue/k8shark/issues/137.
 
 ```
 kshrk anonymize <capture.kshrk> --categories <category> [--out <anonymized.kshrk>] [flags]
@@ -81,6 +81,9 @@ kshrk anonymize <capture.kshrk> --categories <category> [--out <anonymized.kshrk
 ```
   # Anonymize every namespace name in a capture
   kshrk anonymize capture.kshrk --categories namespace
+
+  # Anonymize multiple categories in one pass
+  kshrk anonymize capture.kshrk --categories namespace --categories node --categories pod
 
   # Reproduce the exact same aliases on a re-run
   kshrk anonymize capture.kshrk --categories namespace --anonymize-salt-file salt.txt
@@ -93,7 +96,7 @@ kshrk anonymize <capture.kshrk> --categories <category> [--out <anonymized.kshrk
 
 ```
       --anonymize-salt-file string       read the anonymize salt from this file (first line, hex-encoded) instead of $KSHRK_ANONYMIZE_SALT or generating one
-      --categories stringArray           category to anonymize (repeatable); only "namespace" is available so far
+      --categories stringArray           category to anonymize (repeatable); supported: namespace, node, pod, workload
       --encrypt                          encrypt the output archive with a passphrase (age); from --encrypt-passphrase-file, $KSHRK_ENCRYPT_PASSPHRASE, or an interactive prompt
       --encrypt-passphrase-file string   read the encryption passphrase from this file (first line) instead of prompting
       --encrypt-recipient stringArray    age recipient public key (age1...) to encrypt to (repeatable); mutually exclusive with passphrase encryption

--- a/internal/anonymize/archive.go
+++ b/internal/anonymize/archive.go
@@ -25,22 +25,23 @@ func sortedKeys[V any](m map[string]V) []string {
 }
 
 // archiveCategories are the categories Archive currently knows how to find
-// and rewrite occurrences of in a real archive. Namespace-only for this
-// milestone; node/pod/workload land in the next one, then IP/URL/image
-// (see #137's milestone plan).
+// and rewrite occurrences of in a real archive. Namespace, node, pod, and
+// workload names for this milestone; IP/URL/image land next (see #137's
+// milestone plan).
 //
 // Deliberately a separate set from Aliaser's own implementedCategories
 // (alias.go): that one is about which categories the aliasing *primitive*
-// can render at all — a lower-level, already-broader set from M1 (it
-// already covers node/pod/workload, since Alias's per-category encoders
-// don't depend on knowing where in a record those values live). This one is
-// about which categories this package's archive-rewrite path knows how to
-// *find*. A category can be alias-ready before it's archive-ready; letting
-// Archive silently accept a category it can't actually locate occurrences
-// of would be the same mistake M1's review caught for Alias itself, one
-// layer up.
+// can render at all — a lower-level, already-broader set from M1. This one
+// is about which categories this package's archive-rewrite path knows how
+// to *find*. A category can be alias-ready before it's archive-ready;
+// letting Archive silently accept a category it can't actually locate
+// occurrences of would be the same mistake M1's review caught for Alias
+// itself, one layer up.
 var archiveCategories = map[Category]bool{
 	CategoryNamespace: true,
+	CategoryNode:      true,
+	CategoryPod:       true,
+	CategoryWorkload:  true,
 }
 
 // Options controls what Archive() anonymizes.
@@ -67,11 +68,14 @@ type Options struct {
 }
 
 // Result reports how many distinct values were anonymized, per category.
+// Every count is the number of distinct original values encountered, not
+// the number of records touched — a value that appears on 50 records still
+// counts once.
 type Result struct {
-	// NamespacesRenamed is the count of distinct original namespace names
-	// encountered, not the count of records touched — renaming a namespace
-	// that appears on 50 records still counts once.
 	NamespacesRenamed int
+	NodesRenamed      int
+	PodsRenamed       int
+	WorkloadsRenamed  int
 }
 
 // Archive reads srcPath, anonymizes it per opts, and writes to dstPath. The
@@ -103,14 +107,34 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 		return Result{}, fmt.Errorf("anonymize: Options.Salt must not be empty")
 	}
 	doNamespace := false
+	doNode := false
+	doPod := false
+	doWorkload := false
 	for _, cat := range opts.Categories {
 		if !archiveCategories[cat] {
 			return Result{}, fmt.Errorf("anonymize: category %q is not yet supported for archive rewriting", cat)
 		}
-		if cat == CategoryNamespace {
+		switch cat {
+		case CategoryNamespace:
 			doNamespace = true
+		case CategoryNode:
+			doNode = true
+		case CategoryPod:
+			doPod = true
+		case CategoryWorkload:
+			doWorkload = true
 		}
 	}
+	// enabledResource gates rewriteResourceNameInObject/InPath's field-level
+	// checks: a field belonging to a category not requested this run is left
+	// untouched even where it's recognized, e.g. --categories pod alone must
+	// not also alias a Pod's spec.nodeName.
+	enabledResource := map[Category]bool{
+		CategoryNode:     doNode,
+		CategoryPod:      doPod,
+		CategoryWorkload: doWorkload,
+	}
+	doResourceName := doNode || doPod || doWorkload
 
 	ar, err := archive.OpenWithIdentities(srcPath, opts.Identities)
 	if err != nil {
@@ -140,15 +164,52 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	}
 
 	aliaser := NewAliaser(opts.Salt)
-	// Wrapped in a collisionTracker rather than called directly: two distinct
-	// original namespace names landing on the same alias is a real
-	// possibility, not a theoretical one (see collision.go's doc comment for
-	// the numbers), and left unchecked it would let the index/watch-index
-	// rebuild below silently clobber one entry with another.
+	// Each category gets its own collisionTracker rather than being called
+	// directly: two distinct original values landing on the same alias is a
+	// real possibility, not a theoretical one (see collision.go's doc
+	// comment for the numbers), and left unchecked it would let the
+	// index/watch-index rebuild below silently clobber one entry with
+	// another.
 	namespaceTracker := newCollisionTracker(CategoryNamespace, func(original string) string {
 		return aliaser.Alias(CategoryNamespace, original)
 	})
+	nodeTracker := newCollisionTracker(CategoryNode, func(original string) string {
+		return aliaser.Alias(CategoryNode, original)
+	})
+	podTracker := newCollisionTracker(CategoryPod, func(original string) string {
+		return aliaser.Alias(CategoryPod, original)
+	})
+	workloadTracker := newCollisionTracker(CategoryWorkload, func(original string) string {
+		return aliaser.Alias(CategoryWorkload, original)
+	})
 	namespaceAlias := namespaceTracker.Alias
+	// resourceAlias dispatches to the tracker for whichever category a
+	// resourcename.go call site determined a given occurrence belongs to.
+	// Only ever called for a category enabledResource already gated on, so
+	// the default case is unreachable in practice, not a real error path.
+	resourceAlias := func(cat Category, original string) string {
+		switch cat {
+		case CategoryNode:
+			return nodeTracker.Alias(original)
+		case CategoryPod:
+			return podTracker.Alias(original)
+		case CategoryWorkload:
+			return workloadTracker.Alias(original)
+		default:
+			panic(fmt.Sprintf("anonymize: internal error: resourceAlias called with unexpected category %q", cat))
+		}
+	}
+	// firstCollisionErr checks every tracker, not just the ones this run
+	// actually enabled — an unused tracker's Err() is always nil, so this
+	// stays correct without needing to be told which categories are active.
+	firstCollisionErr := func() error {
+		for _, t := range []*collisionTracker{namespaceTracker, nodeTracker, podTracker, workloadTracker} {
+			if err := t.Err(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 
 	var sw *archive.StreamWriter
 	if len(opts.Recipients) > 0 {
@@ -215,6 +276,11 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
 				}
 			}
+			if doResourceName {
+				if _, err := rewriteResourceNameInRecord(&rec, enabledResource, resourceAlias); err != nil {
+					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
+				}
+			}
 			// Keep the record's own APIPath field in sync with wherever it's
 			// actually being stored, unconditionally — not just when a
 			// rewrite happened to fire. If this ever fell out of sync with
@@ -257,7 +323,19 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 			// original values) is what a caller should see, not the generic
 			// one below. This alone is not enough, though — see the second
 			// check after rewriteEntryRecords.
-			if err := namespaceTracker.Err(); err != nil {
+			if err := firstCollisionErr(); err != nil {
+				return Result{}, err
+			}
+		}
+		if doResourceName {
+			// Chained onto newAPIPath, not the original apiPath: the
+			// namespace segment (if any) has already been rewritten above,
+			// and this must combine with it into one final path, not
+			// separately rewrite the pre-namespace-alias string.
+			if rewritten, ok := rewriteResourceNameInPath(newAPIPath, enabledResource, resourceAlias); ok {
+				newAPIPath = rewritten
+			}
+			if err := firstCollisionErr(); err != nil {
 				return Result{}, err
 			}
 		}
@@ -268,20 +346,18 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 		if err != nil {
 			return Result{}, err
 		}
-		if doNamespace {
-			// A second check, after the records under this path have had
-			// their *bodies* rewritten too. The path-only check above can't
-			// see a collision that's only ever introduced by body content —
-			// e.g. two Namespace objects' metadata.name values colliding
-			// inside a /api/v1/namespaces NamespaceList response, which has
-			// no namespace path segment at all for rewriteNamespaceInPath to
-			// have looked at. Without this, that collision wouldn't be
-			// caught until the *next* loop iteration, and not at all if this
-			// were the last one — Archive would report success despite
-			// having detected a real collision.
-			if err := namespaceTracker.Err(); err != nil {
-				return Result{}, err
-			}
+		// A second check, after the records under this path have had their
+		// *bodies* rewritten too. The path-only checks above can't see a
+		// collision that's only ever introduced by body content — e.g. two
+		// Namespace objects' metadata.name values colliding inside a
+		// /api/v1/namespaces NamespaceList response, which has no namespace
+		// path segment at all for rewriteNamespaceInPath to have looked at.
+		// Without this, that collision wouldn't be caught until the *next*
+		// loop iteration, and not at all if this were the last one —
+		// Archive would report success despite having detected a real
+		// collision.
+		if err := firstCollisionErr(); err != nil {
+			return Result{}, err
 		}
 		newIdx[newAPIPath] = &capture.IndexEntry{
 			APIPath: newAPIPath,
@@ -298,7 +374,15 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 			if rewritten, ok := rewriteNamespaceInPath(apiPath, namespaceAlias); ok {
 				newAPIPath = rewritten
 			}
-			if err := namespaceTracker.Err(); err != nil {
+			if err := firstCollisionErr(); err != nil {
+				return Result{}, err
+			}
+		}
+		if doResourceName {
+			if rewritten, ok := rewriteResourceNameInPath(newAPIPath, enabledResource, resourceAlias); ok {
+				newAPIPath = rewritten
+			}
+			if err := firstCollisionErr(); err != nil {
 				return Result{}, err
 			}
 		}
@@ -309,10 +393,8 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 		if err != nil {
 			return Result{}, err
 		}
-		if doNamespace {
-			if err := namespaceTracker.Err(); err != nil {
-				return Result{}, err
-			}
+		if err := firstCollisionErr(); err != nil {
+			return Result{}, err
 		}
 		newWI[newAPIPath] = &capture.WatchIndexEntry{
 			APIPath:    newAPIPath,
@@ -326,14 +408,12 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	// where in the two loops above a collision happened to be introduced.
 	// This is the guarantee that actually matters — "no successful run has a
 	// collision" — and it should not depend on remembering to place a check
-	// after every single site that can call namespaceAlias. The per-iteration
-	// checks above exist so a doomed run fails fast rather than finishing all
-	// the remaining I/O first; this one exists so a gap in those doesn't
-	// matter.
-	if doNamespace {
-		if err := namespaceTracker.Err(); err != nil {
-			return Result{}, err
-		}
+	// after every single site that can call an alias function. The
+	// per-iteration checks above exist so a doomed run fails fast rather
+	// than finishing all the remaining I/O first; this one exists so a gap
+	// in those doesn't matter.
+	if err := firstCollisionErr(); err != nil {
+		return Result{}, err
 	}
 
 	// meta was populated by ar.ReadMetadata(), so left untouched its Encrypted
@@ -350,5 +430,10 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	}
 	finished = true
 
-	return Result{NamespacesRenamed: namespaceTracker.Count()}, nil
+	return Result{
+		NamespacesRenamed: namespaceTracker.Count(),
+		NodesRenamed:      nodeTracker.Count(),
+		PodsRenamed:       podTracker.Count(),
+		WorkloadsRenamed:  workloadTracker.Count(),
+	}, nil
 }

--- a/internal/anonymize/archive_test.go
+++ b/internal/anonymize/archive_test.go
@@ -592,3 +592,267 @@ func TestArchive_PreservesUnrelatedRecordUntouched(t *testing.T) {
 		t.Errorf("ConfigMap's own name was modified: %v", obj["metadata"])
 	}
 }
+
+// resourceNameFixtureRecords builds a small but representative set of
+// records covering all three M3 categories at once, plus namespace,
+// mirroring namespaceFixtureRecords' role for M2: a Node (its own identity
+// plus its Hostname address), a Pod living on that node and owned by a
+// ReplicaSet, the ReplicaSet itself, and an Event about the Pod that also
+// names the node it ran on.
+func resourceNameFixtureRecords() []*capture.Record {
+	nodeBody := `{"kind":"Node","apiVersion":"v1","metadata":{"name":"worker-1"},
+		"status":{"addresses":[{"type":"InternalIP","address":"10.0.0.5"},{"type":"Hostname","address":"worker-1"}]}}`
+	podListBody := `{"kind":"PodList","apiVersion":"v1","items":[
+		{"metadata":{"name":"web-1","namespace":"prod","ownerReferences":[{"kind":"ReplicaSet","name":"web-rs"}]},
+		 "spec":{"nodeName":"worker-1","containers":[{"name":"app"}]}}
+	]}`
+	rsBody := `{"kind":"ReplicaSet","apiVersion":"apps/v1","metadata":{"name":"web-rs","namespace":"prod"}}`
+	eventListBody := `{"kind":"EventList","apiVersion":"v1","items":[
+		{"metadata":{"name":"web-1.abc","namespace":"prod"},
+		 "involvedObject":{"kind":"Pod","name":"web-1","namespace":"prod"},
+		 "source":{"component":"kubelet","host":"worker-1"},
+		 "message":"Started container app"}
+	]}`
+	return []*capture.Record{
+		{ID: "r1", CapturedAt: fixedNow, APIPath: "/api/v1/nodes/worker-1", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(nodeBody)},
+		{ID: "r2", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/prod/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(podListBody)},
+		{ID: "r3", CapturedAt: fixedNow, APIPath: "/apis/apps/v1/namespaces/prod/replicasets/web-rs", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(rsBody)},
+		{ID: "r4", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/prod/events", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(eventListBody)},
+	}
+}
+
+// The M3 analogue of TestArchive_NamespaceConsistentAcrossKindsAndPaths: the
+// same real node name, seen on the Node's own identity, a Hostname address,
+// a Pod's spec.nodeName, and an Event's source.host, must come out as the
+// same alias everywhere — and likewise for the pod name (its own identity
+// plus an Event's involvedObject.name) and the workload name (the
+// ReplicaSet's own identity, its APIPath's object-name segment, plus the
+// Pod's ownerReferences[0].name). Runs all four categories in one pass, as
+// the CLI's own --categories example now does.
+func TestArchive_ResourceNamesConsistentAcrossKindsAndPaths(t *testing.T) {
+	src := buildAnonymizeTestArchive(t, resourceNameFixtureRecords())
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+	salt := []byte("resourcename-integration-test-salt")
+	result, err := Archive(src, dst, Options{
+		Categories: []Category{CategoryNamespace, CategoryNode, CategoryPod, CategoryWorkload},
+		Salt:       salt,
+	})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if result.NamespacesRenamed != 1 || result.NodesRenamed != 1 || result.PodsRenamed != 1 || result.WorkloadsRenamed != 1 {
+		t.Errorf("counts = %+v, want 1 distinct value renamed per category", result)
+	}
+
+	a := NewAliaser(salt)
+	nsAlias := a.Alias(CategoryNamespace, "prod")
+	nodeAlias := a.Alias(CategoryNode, "worker-1")
+	podAlias := a.Alias(CategoryPod, "web-1")
+	workloadAlias := a.Alias(CategoryWorkload, "web-rs")
+
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatalf("opening output archive: %v", err)
+	}
+	defer ar.Close()
+
+	idx, err := ar.ReadIndex()
+	if err != nil {
+		t.Fatalf("ReadIndex: %v", err)
+	}
+	readBody := func(apiPath string) map[string]interface{} {
+		t.Helper()
+		if _, ok := idx[apiPath]; !ok {
+			t.Fatalf("index has no entry for %q (index keys: %v)", apiPath, indexKeys(idx))
+		}
+		data, err := ar.ReadRecord(apiPath, 0)
+		if err != nil {
+			t.Fatalf("ReadRecord(%q, 0): %v", apiPath, err)
+		}
+		var rec capture.Record
+		if err := json.Unmarshal(data, &rec); err != nil {
+			t.Fatalf("unmarshaling record: %v", err)
+		}
+		var obj map[string]interface{}
+		if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+			t.Fatalf("unmarshaling body: %v", err)
+		}
+		return obj
+	}
+
+	nodeObj := readBody("/api/v1/nodes/" + nodeAlias)
+	if got := nodeObj["metadata"].(map[string]interface{})["name"]; got != nodeAlias {
+		t.Errorf("Node metadata.name = %v, want %v", got, nodeAlias)
+	}
+	addrs := nodeObj["status"].(map[string]interface{})["addresses"].([]interface{})
+	hostAddr := addrs[1].(map[string]interface{})
+	if got := hostAddr["address"]; got != nodeAlias {
+		t.Errorf("Node Hostname address = %v, want %v", got, nodeAlias)
+	}
+
+	podList := readBody("/api/v1/namespaces/" + nsAlias + "/pods")
+	podItem := podList["items"].([]interface{})[0].(map[string]interface{})
+	podMeta := podItem["metadata"].(map[string]interface{})
+	if got := podMeta["name"]; got != podAlias {
+		t.Errorf("Pod metadata.name = %v, want %v", got, podAlias)
+	}
+	if got := podItem["spec"].(map[string]interface{})["nodeName"]; got != nodeAlias {
+		t.Errorf("Pod spec.nodeName = %v, want %v", got, nodeAlias)
+	}
+	ownerRef := podMeta["ownerReferences"].([]interface{})[0].(map[string]interface{})
+	if got := ownerRef["name"]; got != workloadAlias {
+		t.Errorf("Pod ownerReferences[0].name = %v, want %v", got, workloadAlias)
+	}
+
+	rsObj := readBody("/apis/apps/v1/namespaces/" + nsAlias + "/replicasets/" + workloadAlias)
+	if got := rsObj["metadata"].(map[string]interface{})["name"]; got != workloadAlias {
+		t.Errorf("ReplicaSet metadata.name = %v, want %v", got, workloadAlias)
+	}
+
+	eventList := readBody("/api/v1/namespaces/" + nsAlias + "/events")
+	eventItem := eventList["items"].([]interface{})[0].(map[string]interface{})
+	if got := eventItem["involvedObject"].(map[string]interface{})["name"]; got != podAlias {
+		t.Errorf("Event involvedObject.name = %v, want %v", got, podAlias)
+	}
+	if got := eventItem["source"].(map[string]interface{})["host"]; got != nodeAlias {
+		t.Errorf("Event source.host = %v, want %v", got, nodeAlias)
+	}
+}
+
+// Requesting only --categories pod must not also alias node-category fields
+// it happens to recognize (a Pod's spec.nodeName, a Node's own identity) —
+// the enabled-gating unit-tested directly in resourcename_test.go, exercised
+// here end to end through Archive().
+func TestArchive_CategoryGatingRestrictsWhichFieldsChange(t *testing.T) {
+	src := buildAnonymizeTestArchive(t, resourceNameFixtureRecords())
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+	salt := []byte("gating-test-salt")
+
+	result, err := Archive(src, dst, Options{Categories: []Category{CategoryPod}, Salt: salt})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if result.NodesRenamed != 0 || result.WorkloadsRenamed != 0 || result.NamespacesRenamed != 0 {
+		t.Errorf("counts = %+v, want only PodsRenamed set", result)
+	}
+
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ar.Close()
+
+	// The node's own path and identity must be untouched.
+	data, err := ar.ReadRecord("/api/v1/nodes/worker-1", 0)
+	if err != nil {
+		t.Fatalf("ReadRecord(node): %v — the node path should not have been rewritten", err)
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatal(err)
+	}
+	var nodeObj map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &nodeObj); err != nil {
+		t.Fatal(err)
+	}
+	if got := nodeObj["metadata"].(map[string]interface{})["name"]; got != "worker-1" {
+		t.Errorf("Node metadata.name = %v, want unchanged worker-1", got)
+	}
+
+	// The Pod's own name is aliased, but its spec.nodeName (a node-category
+	// occurrence) is not.
+	podAlias := NewAliaser(salt).Alias(CategoryPod, "web-1")
+	data, err = ar.ReadRecord("/api/v1/namespaces/prod/pods", 0)
+	if err != nil {
+		t.Fatalf("ReadRecord(pods): %v", err)
+	}
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatal(err)
+	}
+	var podList map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &podList); err != nil {
+		t.Fatal(err)
+	}
+	podItem := podList["items"].([]interface{})[0].(map[string]interface{})
+	if got := podItem["metadata"].(map[string]interface{})["name"]; got != podAlias {
+		t.Errorf("Pod metadata.name = %v, want %v", got, podAlias)
+	}
+	if got := podItem["spec"].(map[string]interface{})["nodeName"]; got != "worker-1" {
+		t.Errorf("Pod spec.nodeName = %v, want unchanged worker-1 — node category was not requested", got)
+	}
+}
+
+// A real, found-not-constructed collision for the node category (the same
+// approach as collidingNamespaceA/B, using CategoryNode's own 2-word
+// encoding): "node-95" and "node-130" both alias to "node-noble-gull" under
+// this exact salt. Proves the collisionTracker wiring generalizes to a
+// category beyond namespace, not just that namespace's own wiring works.
+const (
+	collidingNodeA    = "node-95"
+	collidingNodeB    = "node-130"
+	collidingNodeSalt = "fixed-test-salt-for-collision-search"
+)
+
+func TestArchive_DetectsRealNodeCollision(t *testing.T) {
+	nodeBody := func(name string) string {
+		return fmt.Sprintf(`{"kind":"Node","apiVersion":"v1","metadata":{"name":%q}}`, name)
+	}
+	records := []*capture.Record{
+		{ID: "r1", CapturedAt: fixedNow, APIPath: "/api/v1/nodes/" + collidingNodeA, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(nodeBody(collidingNodeA))},
+		{ID: "r2", CapturedAt: fixedNow, APIPath: "/api/v1/nodes/" + collidingNodeB, HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(nodeBody(collidingNodeB))},
+	}
+	src := buildAnonymizeTestArchive(t, records)
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+	_, err := Archive(src, dst, Options{
+		Categories: []Category{CategoryNode},
+		Salt:       []byte(collidingNodeSalt),
+	})
+	if err == nil {
+		t.Fatal("want a collision error; got none — a real archive with a genuine alias collision was silently accepted")
+	}
+	for _, want := range []string{collidingNodeA, collidingNodeB} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name the colliding value %q", err.Error(), want)
+		}
+	}
+	if _, statErr := os.Stat(dst); statErr == nil {
+		t.Error("no (corrupt) output file should be left behind on a detected collision")
+	}
+}
+
+// The node-category analogue of
+// TestArchive_DetectsCollisionIntroducedOnlyByRecordBody: both colliding
+// names appear only inside a NodeList response's items[].metadata.name, on
+// the archive's only (cluster-scoped, no per-object segment) apiPath —
+// proving the shared firstCollisionErr() checkpoint placement catches a
+// body-only collision for this category too, not just namespace's.
+func TestArchive_DetectsNodeCollisionIntroducedOnlyByRecordBody(t *testing.T) {
+	body := fmt.Sprintf(`{"kind":"NodeList","apiVersion":"v1","items":[
+		{"metadata":{"name":%q}},
+		{"metadata":{"name":%q}}
+	]}`, collidingNodeA, collidingNodeB)
+	rec := &capture.Record{
+		ID: "r1", CapturedAt: fixedNow, APIPath: "/api/v1/nodes",
+		HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body),
+	}
+	src := buildAnonymizeTestArchive(t, []*capture.Record{rec})
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+	_, err := Archive(src, dst, Options{
+		Categories: []Category{CategoryNode},
+		Salt:       []byte(collidingNodeSalt),
+	})
+	if err == nil {
+		t.Fatal("want a collision error; got none — a collision introduced only by record body content, on the archive's only apiPath, was silently accepted")
+	}
+	for _, want := range []string{collidingNodeA, collidingNodeB} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name the colliding value %q", err.Error(), want)
+		}
+	}
+	if _, statErr := os.Stat(dst); statErr == nil {
+		t.Error("no (corrupt) output file should be left behind on a detected collision")
+	}
+}

--- a/internal/anonymize/resourcename.go
+++ b/internal/anonymize/resourcename.go
@@ -14,11 +14,13 @@ import (
 // object-body side (keyed by Kind) and the APIPath side (keyed by the path's
 // resource-type segment) can't drift apart the way alias.go's
 // implementedCategories/switch pairing already has a test guarding against.
-var resourceKindTable = []struct {
+type resourceKindEntry struct {
 	Kind         string
 	ResourceType string
 	Category     Category
-}{
+}
+
+var resourceKindTable = []resourceKindEntry{
 	{"Node", "nodes", CategoryNode},
 	{"Pod", "pods", CategoryPod},
 	{"Deployment", "deployments", CategoryWorkload},

--- a/internal/anonymize/resourcename.go
+++ b/internal/anonymize/resourcename.go
@@ -221,7 +221,7 @@ func rewriteResourceNameInRecord(rec *capture.Record, enabled map[Category]bool,
 //	/api/v1/nodes/<name>                                (cluster-scoped GET)
 //	/api/v1/namespaces/<ns>/pods/<name>                 (namespaced GET)
 //	/apis/apps/v1/namespaces/<ns>/deployments/<name>    (group/version form)
-//	/api/v1/namespaces/<ns>/pods/<name>/log             (subresource, untouched)
+//	/api/v1/namespaces/<ns>/pods/<name>/log             (<name> still rewritten; only "log" is untouched)
 //
 // Returns the path unchanged (ok=false) for a list path (nothing follows
 // the resource-type segment), a resource type this package doesn't

--- a/internal/anonymize/resourcename.go
+++ b/internal/anonymize/resourcename.go
@@ -1,0 +1,262 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// resourceKindEntry is one row of the single source of truth mapping a Kind
+// to both its anonymize Category and its lowercase REST resource-type path
+// segment. Kept as one table, rather than two hand-maintained maps, so the
+// object-body side (keyed by Kind) and the APIPath side (keyed by the path's
+// resource-type segment) can't drift apart the way alias.go's
+// implementedCategories/switch pairing already has a test guarding against.
+var resourceKindTable = []struct {
+	Kind         string
+	ResourceType string
+	Category     Category
+}{
+	{"Node", "nodes", CategoryNode},
+	{"Pod", "pods", CategoryPod},
+	{"Deployment", "deployments", CategoryWorkload},
+	{"ReplicaSet", "replicasets", CategoryWorkload},
+	{"StatefulSet", "statefulsets", CategoryWorkload},
+	{"DaemonSet", "daemonsets", CategoryWorkload},
+	{"Job", "jobs", CategoryWorkload},
+	{"CronJob", "cronjobs", CategoryWorkload},
+	{"ReplicationController", "replicationcontrollers", CategoryWorkload},
+}
+
+var kindCategories = func() map[string]Category {
+	m := make(map[string]Category, len(resourceKindTable))
+	for _, e := range resourceKindTable {
+		m[e.Kind] = e.Category
+	}
+	return m
+}()
+
+var resourceTypeCategories = func() map[string]Category {
+	m := make(map[string]Category, len(resourceKindTable))
+	for _, e := range resourceKindTable {
+		m[e.ResourceType] = e.Category
+	}
+	return m
+}()
+
+// rewriteResourceNameInObject rewrites node/pod/workload resource-name
+// occurrences in a single decoded JSON object (not a list) — kind is the
+// object's own Kind, passed down by the caller, same convention as
+// rewriteNamespaceInObject. enabled gates which categories are actually
+// requested this run: a field belonging to a category not in enabled is
+// left untouched even if it's recognized, so e.g. --categories pod alone
+// doesn't also alias a Pod's spec.nodeName.
+//
+// Schema-aware only, matching this milestone's scope: catching a resource
+// name as a substring inside free text (an annotation value, an Event
+// message) or an opaque Table cell is deliberately deferred — there is no
+// generic pattern for "this token is a Kubernetes name" the way there is
+// for an IP literal, so recall would need a candidate set built from these
+// same structured fields first (see #137's plan, Open Question 5).
+func rewriteResourceNameInObject(obj map[string]interface{}, kind string, enabled map[Category]bool, alias func(Category, string) string) bool {
+	modified := false
+
+	if meta, ok := obj["metadata"].(map[string]interface{}); ok {
+		if cat, ok := kindCategories[kind]; ok && enabled[cat] {
+			if name, ok := meta["name"].(string); ok && name != "" {
+				meta["name"] = alias(cat, name)
+				modified = true
+			}
+		}
+		// ownerReferences[*].name: an owning Node never occurs in practice,
+		// but a Pod or any workload Kind can be an owner (e.g. a Job owning
+		// a Pod, a Deployment owning a ReplicaSet owning a Pod) — categorize
+		// by the *reference's own* kind, not the enclosing object's.
+		if ownerRefs, ok := meta["ownerReferences"].([]interface{}); ok {
+			for _, raw := range ownerRefs {
+				ref, ok := raw.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				ownerKind, _ := ref["kind"].(string)
+				cat, ok := kindCategories[ownerKind]
+				if !ok || !enabled[cat] {
+					continue
+				}
+				if name, ok := ref["name"].(string); ok && name != "" {
+					ref["name"] = alias(cat, name)
+					modified = true
+				}
+			}
+		}
+	}
+
+	if kind == "Pod" && enabled[CategoryNode] {
+		if spec, ok := obj["spec"].(map[string]interface{}); ok {
+			if nodeName, ok := spec["nodeName"].(string); ok && nodeName != "" {
+				spec["nodeName"] = alias(CategoryNode, nodeName)
+				modified = true
+			}
+		}
+	}
+
+	if kind == "Node" && enabled[CategoryNode] {
+		if status, ok := obj["status"].(map[string]interface{}); ok {
+			if addrs, ok := status["addresses"].([]interface{}); ok {
+				for _, raw := range addrs {
+					addr, ok := raw.(map[string]interface{})
+					if !ok || addr["type"] != "Hostname" {
+						continue
+					}
+					if address, ok := addr["address"].(string); ok && address != "" {
+						addr["address"] = alias(CategoryNode, address)
+						modified = true
+					}
+				}
+			}
+		}
+	}
+
+	if kind == "Event" {
+		// Same "both API shapes" requirement namespace.go's fix already
+		// established for events.k8s.io/v1: involvedObject (core/v1) vs.
+		// regarding/related (events.k8s.io/v1) are the same ObjectReference
+		// shape under different field names.
+		for _, field := range []string{"involvedObject", "regarding", "related"} {
+			ref, ok := obj[field].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			refKind, _ := ref["kind"].(string)
+			cat, ok := kindCategories[refKind]
+			if !ok || !enabled[cat] {
+				continue
+			}
+			if name, ok := ref["name"].(string); ok && name != "" {
+				ref["name"] = alias(cat, name)
+				modified = true
+			}
+		}
+		// source.host (core/v1) / deprecatedSource.host (events.k8s.io/v1,
+		// carried for back-compat with the core/v1 shape) both hold the node
+		// name the event was generated on.
+		if enabled[CategoryNode] {
+			for _, field := range []string{"source", "deprecatedSource"} {
+				src, ok := obj[field].(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if host, ok := src["host"].(string); ok && host != "" {
+					src["host"] = alias(CategoryNode, host)
+					modified = true
+				}
+			}
+		}
+	}
+
+	return modified
+}
+
+// rewriteResourceNameInRecord decodes rec's body, rewrites every node/pod/
+// workload name occurrence rewriteResourceNameInObject recognizes, and
+// re-encodes the body if anything changed. Mirrors
+// rewriteNamespaceInRecord's list-handling exactly (see its own doc comment
+// for why a non-JSON or Table/discovery body is left untouched rather than
+// erroring).
+func rewriteResourceNameInRecord(rec *capture.Record, enabled map[Category]bool, alias func(Category, string) string) (bool, error) {
+	var obj map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+		return false, nil
+	}
+
+	kind, _ := obj["kind"].(string)
+	modified := false
+
+	if strings.HasSuffix(kind, "List") {
+		items, _ := obj["items"].([]interface{})
+		itemKind := strings.TrimSuffix(kind, "List")
+		for i, itemRaw := range items {
+			item, ok := itemRaw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			ik := itemKind
+			if k, ok := item["kind"].(string); ok && k != "" {
+				ik = k
+			}
+			if rewriteResourceNameInObject(item, ik, enabled, alias) {
+				items[i] = item
+				modified = true
+			}
+		}
+	} else if rewriteResourceNameInObject(obj, kind, enabled, alias) {
+		modified = true
+	}
+
+	if !modified {
+		return false, nil
+	}
+	newBody, err := json.Marshal(obj)
+	if err != nil {
+		return false, fmt.Errorf("re-marshaling record: %w", err)
+	}
+	rec.ResponseBody = newBody
+	return true, nil
+}
+
+// rewriteResourceNameInPath replaces the object-name segment of a captured
+// API path with alias(category, original), when that path names a single
+// object of a category in enabled. Unlike rewriteNamespaceInPath's
+// literal-segment search (safe there because "namespaces" is a fixed
+// keyword), this walks the path's actual api/apis+group+version[+namespaces
+// pair]+resourceType+name structure — a resource-type segment like "pods"
+// can otherwise coincidentally equal a real namespace *value* elsewhere in
+// the same path, and a literal search for "pods" would then mistake that
+// value for the resource-type segment itself.
+//
+//	/api/v1/nodes/<name>                                (cluster-scoped GET)
+//	/api/v1/namespaces/<ns>/pods/<name>                 (namespaced GET)
+//	/apis/apps/v1/namespaces/<ns>/deployments/<name>    (group/version form)
+//	/api/v1/namespaces/<ns>/pods/<name>/log             (subresource, untouched)
+//
+// Returns the path unchanged (ok=false) for a list path (nothing follows
+// the resource-type segment), a resource type this package doesn't
+// recognize, or a recognized one whose category isn't in enabled.
+func rewriteResourceNameInPath(apiPath string, enabled map[Category]bool, alias func(Category, string) string) (string, bool) {
+	parts := strings.Split(apiPath, "/")
+
+	i := 1
+	if i >= len(parts) {
+		return apiPath, false
+	}
+	switch parts[i] {
+	case "api":
+		i += 2 // "api", <version>
+	case "apis":
+		i += 3 // "apis", <group>, <version>
+	default:
+		return apiPath, false
+	}
+	if i >= len(parts) {
+		return apiPath, false
+	}
+	if parts[i] == "namespaces" {
+		i += 2 // "namespaces", <ns>
+	}
+	if i >= len(parts) {
+		return apiPath, false
+	}
+
+	cat, ok := resourceTypeCategories[parts[i]]
+	if !ok || !enabled[cat] {
+		return apiPath, false
+	}
+	nameIdx := i + 1
+	if nameIdx >= len(parts) || parts[nameIdx] == "" {
+		return apiPath, false
+	}
+	parts[nameIdx] = alias(cat, parts[nameIdx])
+	return strings.Join(parts, "/"), true
+}

--- a/internal/anonymize/resourcename_test.go
+++ b/internal/anonymize/resourcename_test.go
@@ -1,0 +1,378 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// allResourceCategories enables node, pod, and workload — the common case
+// for tests that aren't specifically checking the enabled-gating behavior.
+var allResourceCategories = map[Category]bool{
+	CategoryNode:     true,
+	CategoryPod:      true,
+	CategoryWorkload: true,
+}
+
+func aliasByCategory(cat Category, original string) string {
+	return string(cat) + ":" + original + "-ALIASED"
+}
+
+func TestRewriteResourceNameInObject(t *testing.T) {
+	t.Run("Node aliases its own metadata.name", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind":     "Node",
+			"metadata": map[string]interface{}{"name": "worker-1"},
+		}
+		if !rewriteResourceNameInObject(obj, "Node", allResourceCategories, aliasByCategory) {
+			t.Fatal("want modified=true")
+		}
+		meta := obj["metadata"].(map[string]interface{})
+		if got, want := meta["name"], "node:worker-1-ALIASED"; got != want {
+			t.Errorf("metadata.name = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("Pod aliases its own metadata.name and spec.nodeName, using different categories", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind":     "Pod",
+			"metadata": map[string]interface{}{"name": "web-1", "namespace": "prod"},
+			"spec":     map[string]interface{}{"nodeName": "worker-1"},
+		}
+		if !rewriteResourceNameInObject(obj, "Pod", allResourceCategories, aliasByCategory) {
+			t.Fatal("want modified=true")
+		}
+		meta := obj["metadata"].(map[string]interface{})
+		spec := obj["spec"].(map[string]interface{})
+		if got, want := meta["name"], "pod:web-1-ALIASED"; got != want {
+			t.Errorf("metadata.name = %v, want %v", got, want)
+		}
+		if got, want := spec["nodeName"], "node:worker-1-ALIASED"; got != want {
+			t.Errorf("spec.nodeName = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("Deployment aliases its own metadata.name as workload", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind":     "Deployment",
+			"metadata": map[string]interface{}{"name": "web", "namespace": "prod"},
+		}
+		if !rewriteResourceNameInObject(obj, "Deployment", allResourceCategories, aliasByCategory) {
+			t.Fatal("want modified=true")
+		}
+		meta := obj["metadata"].(map[string]interface{})
+		if got, want := meta["name"], "workload:web-ALIASED"; got != want {
+			t.Errorf("metadata.name = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("ownerReferences[*].name is aliased by the reference's own kind", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind": "Pod",
+			"metadata": map[string]interface{}{
+				"name": "web-abc123",
+				"ownerReferences": []interface{}{
+					map[string]interface{}{"kind": "ReplicaSet", "name": "web-rs"},
+				},
+			},
+		}
+		if !rewriteResourceNameInObject(obj, "Pod", allResourceCategories, aliasByCategory) {
+			t.Fatal("want modified=true")
+		}
+		meta := obj["metadata"].(map[string]interface{})
+		refs := meta["ownerReferences"].([]interface{})
+		ref := refs[0].(map[string]interface{})
+		if got, want := ref["name"], "workload:web-rs-ALIASED"; got != want {
+			t.Errorf("ownerReferences[0].name = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("Node status.addresses aliases only the Hostname entry, not InternalIP", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind":     "Node",
+			"metadata": map[string]interface{}{"name": "worker-1"},
+			"status": map[string]interface{}{
+				"addresses": []interface{}{
+					map[string]interface{}{"type": "InternalIP", "address": "10.0.0.5"},
+					map[string]interface{}{"type": "Hostname", "address": "worker-1"},
+				},
+			},
+		}
+		if !rewriteResourceNameInObject(obj, "Node", allResourceCategories, aliasByCategory) {
+			t.Fatal("want modified=true")
+		}
+		addrs := obj["status"].(map[string]interface{})["addresses"].([]interface{})
+		internalIP := addrs[0].(map[string]interface{})
+		hostname := addrs[1].(map[string]interface{})
+		if got, want := internalIP["address"], "10.0.0.5"; got != want {
+			t.Errorf("InternalIP address = %v, want unchanged %v", got, want)
+		}
+		if got, want := hostname["address"], "node:worker-1-ALIASED"; got != want {
+			t.Errorf("Hostname address = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("core/v1 Event aliases involvedObject.name and source.host", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind":           "Event",
+			"metadata":       map[string]interface{}{"name": "web-1.abc", "namespace": "prod"},
+			"involvedObject": map[string]interface{}{"kind": "Pod", "name": "web-1", "namespace": "prod"},
+			"source":         map[string]interface{}{"component": "kubelet", "host": "worker-1"},
+		}
+		if !rewriteResourceNameInObject(obj, "Event", allResourceCategories, aliasByCategory) {
+			t.Fatal("want modified=true")
+		}
+		involved := obj["involvedObject"].(map[string]interface{})
+		source := obj["source"].(map[string]interface{})
+		if got, want := involved["name"], "pod:web-1-ALIASED"; got != want {
+			t.Errorf("involvedObject.name = %v, want %v", got, want)
+		}
+		if got, want := source["host"], "node:worker-1-ALIASED"; got != want {
+			t.Errorf("source.host = %v, want %v", got, want)
+		}
+	})
+
+	// events.k8s.io/v1 is what a real cluster actually emits by default —
+	// missing this would alias core/v1 Events correctly while leaving the
+	// real pod/node names sitting in regarding.name and
+	// deprecatedSource.host on the majority of Events a real capture
+	// contains. Mirrors namespace_test.go's identical events.k8s.io/v1
+	// coverage.
+	t.Run("events.k8s.io/v1 Event aliases regarding.name, related.name, and deprecatedSource.host", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind":             "Event",
+			"metadata":         map[string]interface{}{"name": "web-1.abc", "namespace": "prod"},
+			"regarding":        map[string]interface{}{"kind": "Pod", "name": "web-1", "namespace": "prod"},
+			"related":          map[string]interface{}{"kind": "ReplicaSet", "name": "web-1-rs", "namespace": "prod"},
+			"deprecatedSource": map[string]interface{}{"component": "kubelet", "host": "worker-1"},
+		}
+		if !rewriteResourceNameInObject(obj, "Event", allResourceCategories, aliasByCategory) {
+			t.Fatal("want modified=true")
+		}
+		regarding := obj["regarding"].(map[string]interface{})
+		related := obj["related"].(map[string]interface{})
+		depSource := obj["deprecatedSource"].(map[string]interface{})
+		if got, want := regarding["name"], "pod:web-1-ALIASED"; got != want {
+			t.Errorf("regarding.name = %v, want %v", got, want)
+		}
+		if got, want := related["name"], "workload:web-1-rs-ALIASED"; got != want {
+			t.Errorf("related.name = %v, want %v", got, want)
+		}
+		if got, want := depSource["host"], "node:worker-1-ALIASED"; got != want {
+			t.Errorf("deprecatedSource.host = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("enabled gates by category — pod alone must not alias spec.nodeName", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind":     "Pod",
+			"metadata": map[string]interface{}{"name": "web-1"},
+			"spec":     map[string]interface{}{"nodeName": "worker-1"},
+		}
+		enabled := map[Category]bool{CategoryPod: true}
+		if !rewriteResourceNameInObject(obj, "Pod", enabled, aliasByCategory) {
+			t.Fatal("want modified=true for the pod name itself")
+		}
+		meta := obj["metadata"].(map[string]interface{})
+		spec := obj["spec"].(map[string]interface{})
+		if got, want := meta["name"], "pod:web-1-ALIASED"; got != want {
+			t.Errorf("metadata.name = %v, want %v", got, want)
+		}
+		if got, want := spec["nodeName"], "worker-1"; got != want {
+			t.Errorf("spec.nodeName = %v, want unchanged %v — node category was not enabled", got, want)
+		}
+	})
+
+	t.Run("namespace category is out of scope for this function", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind":     "Namespace",
+			"metadata": map[string]interface{}{"name": "prod"},
+		}
+		if rewriteResourceNameInObject(obj, "Namespace", allResourceCategories, aliasByCategory) {
+			t.Error("want modified=false — Namespace is not a node/pod/workload kind")
+		}
+	})
+
+	t.Run("object with no metadata at all is left alone, not a crash", func(t *testing.T) {
+		obj := map[string]interface{}{"kind": "Status"}
+		if rewriteResourceNameInObject(obj, "Status", allResourceCategories, aliasByCategory) {
+			t.Error("want modified=false")
+		}
+	})
+}
+
+func TestRewriteResourceNameInRecord(t *testing.T) {
+	t.Run("single object", func(t *testing.T) {
+		rec := &capture.Record{
+			ResponseBody: json.RawMessage(`{"kind":"Node","metadata":{"name":"worker-1"}}`),
+		}
+		changed, err := rewriteResourceNameInRecord(rec, allResourceCategories, aliasByCategory)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed {
+			t.Fatal("want changed=true")
+		}
+		var out map[string]interface{}
+		if err := json.Unmarshal(rec.ResponseBody, &out); err != nil {
+			t.Fatal(err)
+		}
+		meta := out["metadata"].(map[string]interface{})
+		if got, want := meta["name"], "node:worker-1-ALIASED"; got != want {
+			t.Errorf("metadata.name = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("list response rewrites every item, using each item's own kind", func(t *testing.T) {
+		body := `{"kind":"PodList","items":[
+			{"metadata":{"name":"web-1"},"spec":{"nodeName":"worker-1"}},
+			{"metadata":{"name":"web-2"},"spec":{"nodeName":"worker-2"}}
+		]}`
+		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
+		changed, err := rewriteResourceNameInRecord(rec, allResourceCategories, aliasByCategory)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed {
+			t.Fatal("want changed=true")
+		}
+		var out struct {
+			Items []struct {
+				Metadata struct {
+					Name string `json:"name"`
+				} `json:"metadata"`
+				Spec struct {
+					NodeName string `json:"nodeName"`
+				} `json:"spec"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal(rec.ResponseBody, &out); err != nil {
+			t.Fatal(err)
+		}
+		if len(out.Items) != 2 {
+			t.Fatalf("got %d items, want 2", len(out.Items))
+		}
+		if out.Items[0].Metadata.Name != "pod:web-1-ALIASED" || out.Items[1].Metadata.Name != "pod:web-2-ALIASED" {
+			t.Errorf("item names = %q, %q", out.Items[0].Metadata.Name, out.Items[1].Metadata.Name)
+		}
+		if out.Items[0].Spec.NodeName != "node:worker-1-ALIASED" || out.Items[1].Spec.NodeName != "node:worker-2-ALIASED" {
+			t.Errorf("item nodeNames = %q, %q", out.Items[0].Spec.NodeName, out.Items[1].Spec.NodeName)
+		}
+	})
+
+	t.Run("a record with no recognized occurrence at all is left untouched", func(t *testing.T) {
+		body := `{"kind":"Namespace","metadata":{"name":"prod"}}`
+		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
+		orig := string(rec.ResponseBody)
+		changed, err := rewriteResourceNameInRecord(rec, allResourceCategories, aliasByCategory)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if changed {
+			t.Error("want changed=false")
+		}
+		if string(rec.ResponseBody) != orig {
+			t.Error("body must be byte-identical when nothing was rewritten")
+		}
+	})
+}
+
+func TestRewriteResourceNameInPath(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		enabled map[Category]bool
+		want    string
+		wantOK  bool
+	}{
+		{
+			name:    "cluster-scoped node GET",
+			path:    "/api/v1/nodes/worker-1",
+			enabled: allResourceCategories,
+			want:    "/api/v1/nodes/node:worker-1-ALIASED",
+			wantOK:  true,
+		},
+		{
+			name:    "namespaced pod GET",
+			path:    "/api/v1/namespaces/prod/pods/web-1",
+			enabled: allResourceCategories,
+			want:    "/api/v1/namespaces/prod/pods/pod:web-1-ALIASED",
+			wantOK:  true,
+		},
+		{
+			name:    "group/version workload GET",
+			path:    "/apis/apps/v1/namespaces/prod/deployments/web",
+			enabled: allResourceCategories,
+			want:    "/apis/apps/v1/namespaces/prod/deployments/workload:web-ALIASED",
+			wantOK:  true,
+		},
+		{
+			name:    "subresource path — only the name segment moves",
+			path:    "/api/v1/namespaces/prod/pods/web-1/log",
+			enabled: allResourceCategories,
+			want:    "/api/v1/namespaces/prod/pods/pod:web-1-ALIASED/log",
+			wantOK:  true,
+		},
+		{
+			name:    "namespaced pod list — nothing follows the resource type",
+			path:    "/api/v1/namespaces/prod/pods",
+			enabled: allResourceCategories,
+			want:    "/api/v1/namespaces/prod/pods",
+			wantOK:  false,
+		},
+		{
+			name:    "all-namespaces pod list",
+			path:    "/api/v1/pods",
+			enabled: allResourceCategories,
+			want:    "/api/v1/pods",
+			wantOK:  false,
+		},
+		{
+			name:    "cluster-scoped list — no name segment",
+			path:    "/api/v1/nodes",
+			enabled: allResourceCategories,
+			want:    "/api/v1/nodes",
+			wantOK:  false,
+		},
+		{
+			name:    "unrecognized resource type",
+			path:    "/api/v1/namespaces/prod/configmaps/my-config",
+			enabled: allResourceCategories,
+			want:    "/api/v1/namespaces/prod/configmaps/my-config",
+			wantOK:  false,
+		},
+		{
+			name:    "recognized resource type but its category is not enabled",
+			path:    "/api/v1/nodes/worker-1",
+			enabled: map[Category]bool{CategoryPod: true, CategoryWorkload: true},
+			want:    "/api/v1/nodes/worker-1",
+			wantOK:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := rewriteResourceNameInPath(tc.path, tc.enabled, aliasByCategory)
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("rewriteResourceNameInPath(%q) = (%q, %v), want (%q, %v)",
+					tc.path, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+// A namespace value that happens to equal a real resource-type segment (e.g.
+// a namespace literally named "pods") must not be mistaken for the
+// resource-type segment itself — this is exactly the failure mode a
+// literal-segment search (like rewriteNamespaceInPath's) would fall into,
+// which is why this function instead walks the path's actual structural
+// position.
+func TestRewriteResourceNameInPath_NamespaceValueEqualToResourceTypeIsNotConfused(t *testing.T) {
+	path := "/api/v1/namespaces/pods/pods/web-1"
+	got, ok := rewriteResourceNameInPath(path, allResourceCategories, aliasByCategory)
+	want := "/api/v1/namespaces/pods/pods/pod:web-1-ALIASED"
+	if !ok || got != want {
+		t.Fatalf("rewriteResourceNameInPath(%q) = (%q, %v), want (%q, true)", path, got, ok, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Extends `kshrk anonymize` with three more categories — `node`, `pod`, and `workload` (Deployment/ReplicaSet/StatefulSet/DaemonSet/Job/CronJob/ReplicationController) — reusing M2's alias/collision/index-key-rewrite plumbing rather than adding a parallel mechanism.
- New `internal/anonymize/resourcename.go` handles both the record-body rewrite (`metadata.name`, `spec.nodeName`, `ownerReferences[*].name`, Node `status.addresses[type=Hostname]`, and both core/v1 and events.k8s.io/v1 Event reference/source shapes) and the `APIPath` object-name-segment rewrite, walking the path's actual `api|apis/.../[namespaces/<ns>/]<resourceType>/<name>` structure rather than a literal-segment search — this avoids a real ambiguity a literal search would hit if a namespace's own value happened to equal a resource-type segment like `pods` (covered by `TestRewriteResourceNameInPath_NamespaceValueEqualToResourceTypeIsNotConfused`).
- `Archive()` now runs up to four collision trackers (namespace/node/pod/workload) and gates every resourcename field by which categories were actually requested, so e.g. `--categories pod` alone does not also alias a Pod's `spec.nodeName`.
- Schema-aware whole-value only, per the design plan (Open Question 5): catching a resource name as a substring inside free text or an opaque Table cell stays explicitly deferred.

## Test plan
- [x] `go test ./internal/anonymize/... ./cmd/...` — new unit tests for the object/record/path rewriters, plus end-to-end `Archive()` integration tests (consistency across kinds/paths, category gating, two real found-not-constructed alias collisions for the node category, both the path-adjacent and body-only collision-detection checkpoints)
- [x] `go test -race ./...` — full suite green
- [x] `make lint-ci`, `gofmt -w .`, `go mod tidy` — clean
- [x] `make docs` — `docs/cli-reference.md` regenerated for the updated `--categories` help text and examples
- [x] Revert-and-reconfirm: manually reverted the enabled-category gate and confirmed `TestArchive_CategoryGatingRestrictsWhichFieldsChange` catches it; reverted the `Result` field additions and confirmed the new tests fail to build against the old `archive.go`
- [x] Manual smoke test against `examples/auto-discovery/capture.kshrk` with all four categories combined — verified via `kshrk query`/`kshrk diagnose` that pod/node/workload names and their cross-references (Pod → Node via `spec.nodeName`, ReplicaSet → Deployment via `ownerReferences`, Event → Pod via `involvedObject.name`) all resolve to the same alias consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)