### PR TITLE
feat(anonymize): M4 — IP, URL/hostname, and image registry categories (#137)

### DIFF
--- a/cmd/anonymize.go
+++ b/cmd/anonymize.go
@@ -87,7 +87,7 @@ func parseAnonymizeCategories(raw []string) ([]anonymize.Category, error) {
 	for _, c := range raw {
 		cat := anonymize.Category(strings.ToLower(strings.TrimSpace(c)))
 		if !supportedAnonymizeCategories[cat] {
-			return nil, fmt.Errorf(`--categories %q: not yet supported; supported categories: namespace, node, pod, workload, ip, url, image (see #137)`, c)
+			return nil, fmt.Errorf(`--categories %q: unsupported; supported categories: namespace, node, pod, workload, ip, url, image (see #137)`, c)
 		}
 		out = append(out, cat)
 	}

--- a/cmd/anonymize.go
+++ b/cmd/anonymize.go
@@ -25,13 +25,16 @@ field path with a fixed constant, everywhere it's configured to look;
 anonymize replaces every occurrence of a value it recognizes, consistently,
 using a deterministic alias derived from a salt.
 
-Categories available so far: namespace, node, pod, workload. More land
-milestone by milestone -- see https://github.com/phenixblue/k8shark/issues/137.`,
+Categories available: namespace, node, pod, workload, ip, url, image -- see
+https://github.com/phenixblue/k8shark/issues/137.`,
 	Example: `  # Anonymize every namespace name in a capture
   kshrk anonymize capture.kshrk --categories namespace
 
   # Anonymize multiple categories in one pass
   kshrk anonymize capture.kshrk --categories namespace --categories node --categories pod
+
+  # Anonymize IPs, hostnames, and image registries
+  kshrk anonymize capture.kshrk --categories ip --categories url --categories image
 
   # Reproduce the exact same aliases on a re-run
   kshrk anonymize capture.kshrk --categories namespace --anonymize-salt-file salt.txt
@@ -46,7 +49,7 @@ milestone by milestone -- see https://github.com/phenixblue/k8shark/issues/137.`
 func init() {
 	rootCmd.AddCommand(anonymizeCmd)
 	anonymizeCmd.Flags().String("out", "", "output archive path (default: <in>-anonymized.kshrk)")
-	anonymizeCmd.Flags().StringArray("categories", nil, `category to anonymize (repeatable); supported: namespace, node, pod, workload`)
+	anonymizeCmd.Flags().StringArray("categories", nil, `category to anonymize (repeatable); supported: namespace, node, pod, workload, ip, url, image`)
 	_ = anonymizeCmd.MarkFlagFilename("out", captureExt)
 	addAnonymizeFlags(anonymizeCmd)
 	// Write-side encryption for the anonymized output (read-side --decrypt-*
@@ -66,6 +69,9 @@ var supportedAnonymizeCategories = map[anonymize.Category]bool{
 	anonymize.CategoryNode:      true,
 	anonymize.CategoryPod:       true,
 	anonymize.CategoryWorkload:  true,
+	anonymize.CategoryIP:        true,
+	anonymize.CategoryURL:       true,
+	anonymize.CategoryImage:     true,
 }
 
 // parseAnonymizeCategories validates --categories against what this build's
@@ -75,13 +81,13 @@ var supportedAnonymizeCategories = map[anonymize.Category]bool{
 // category should fail loudly, not silently anonymize nothing for it.
 func parseAnonymizeCategories(raw []string) ([]anonymize.Category, error) {
 	if len(raw) == 0 {
-		return nil, fmt.Errorf(`--categories is required; supported categories: namespace, node, pod, workload (see #137)`)
+		return nil, fmt.Errorf(`--categories is required; supported categories: namespace, node, pod, workload, ip, url, image (see #137)`)
 	}
 	out := make([]anonymize.Category, 0, len(raw))
 	for _, c := range raw {
 		cat := anonymize.Category(strings.ToLower(strings.TrimSpace(c)))
 		if !supportedAnonymizeCategories[cat] {
-			return nil, fmt.Errorf(`--categories %q: not yet supported; supported categories: namespace, node, pod, workload (see #137)`, c)
+			return nil, fmt.Errorf(`--categories %q: not yet supported; supported categories: namespace, node, pod, workload, ip, url, image (see #137)`, c)
 		}
 		out = append(out, cat)
 	}
@@ -155,7 +161,8 @@ func runAnonymize(cmd *cobra.Command, args []string) error {
 		size = fi.Size()
 	}
 
-	fmt.Printf("Anonymized %d namespace(s), %d node(s), %d pod(s), %d workload(s) → %s (%d bytes)\n",
-		result.NamespacesRenamed, result.NodesRenamed, result.PodsRenamed, result.WorkloadsRenamed, out, size)
+	fmt.Printf("Anonymized %d namespace(s), %d node(s), %d pod(s), %d workload(s), %d IP(s), %d host(s), %d registries → %s (%d bytes)\n",
+		result.NamespacesRenamed, result.NodesRenamed, result.PodsRenamed, result.WorkloadsRenamed,
+		result.IPsRenamed, result.HostsRenamed, result.RegistriesRenamed, out, size)
 	return nil
 }

--- a/cmd/anonymize.go
+++ b/cmd/anonymize.go
@@ -161,7 +161,7 @@ func runAnonymize(cmd *cobra.Command, args []string) error {
 		size = fi.Size()
 	}
 
-	fmt.Printf("Anonymized %d namespace(s), %d node(s), %d pod(s), %d workload(s), %d IP(s), %d host(s), %d registries → %s (%d bytes)\n",
+	fmt.Printf("Anonymized %d namespace(s), %d node(s), %d pod(s), %d workload(s), %d IP(s), %d host(s), %d registry host(s) → %s (%d bytes)\n",
 		result.NamespacesRenamed, result.NodesRenamed, result.PodsRenamed, result.WorkloadsRenamed,
 		result.IPsRenamed, result.HostsRenamed, result.RegistriesRenamed, out, size)
 	return nil

--- a/cmd/anonymize_test.go
+++ b/cmd/anonymize_test.go
@@ -50,31 +50,45 @@ func TestParseAnonymizeCategories(t *testing.T) {
 		}
 	})
 
-	t.Run("multiple supported categories in one call are all accepted", func(t *testing.T) {
-		got, err := parseAnonymizeCategories([]string{"namespace", "node", "pod", "workload"})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(got) != 4 {
-			t.Errorf("got %v, want 4 categories", got)
-		}
-	})
-
-	// This is the one that matters most: ip/url/image are real Category
-	// constants that exist in internal/anonymize (later milestones' work),
-	// but the archive-rewrite path doesn't support them yet. Accepting them
-	// here would let a user believe --categories ip did something when it
-	// silently anonymized nothing.
-	t.Run("a category not yet supported by archive rewriting is rejected", func(t *testing.T) {
-		for _, c := range []string{"ip", "url", "image", "bogus"} {
-			if _, err := parseAnonymizeCategories([]string{c}); err == nil {
-				t.Errorf("category %q: want an error, got none", c)
+	t.Run("ip, url, and image are accepted", func(t *testing.T) {
+		for cat, want := range map[string]anonymize.Category{
+			"ip":    anonymize.CategoryIP,
+			"url":   anonymize.CategoryURL,
+			"image": anonymize.CategoryImage,
+		} {
+			got, err := parseAnonymizeCategories([]string{cat})
+			if err != nil {
+				t.Errorf("category %q: unexpected error: %v", cat, err)
+				continue
+			}
+			if len(got) != 1 || got[0] != want {
+				t.Errorf("category %q: got %v, want [%v]", cat, got, want)
 			}
 		}
 	})
 
+	t.Run("multiple supported categories in one call are all accepted", func(t *testing.T) {
+		got, err := parseAnonymizeCategories([]string{"namespace", "node", "pod", "workload", "ip", "url", "image"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 7 {
+			t.Errorf("got %v, want 7 categories", got)
+		}
+	})
+
+	// As of M4 (#137), every real Category constant is supported by the
+	// archive-rewrite path — there's no longer a real category name left to
+	// exercise this with. A made-up category string still needs to be
+	// rejected, though.
+	t.Run("a made-up category is rejected", func(t *testing.T) {
+		if _, err := parseAnonymizeCategories([]string{"bogus"}); err == nil {
+			t.Error("want an error for a made-up category")
+		}
+	})
+
 	t.Run("one bad category in a list rejects the whole list", func(t *testing.T) {
-		if _, err := parseAnonymizeCategories([]string{"namespace", "ip"}); err == nil {
+		if _, err := parseAnonymizeCategories([]string{"namespace", "bogus"}); err == nil {
 			t.Error("want an error when any requested category is unsupported")
 		}
 	})

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -69,8 +69,8 @@ field path with a fixed constant, everywhere it's configured to look;
 anonymize replaces every occurrence of a value it recognizes, consistently,
 using a deterministic alias derived from a salt.
 
-Categories available so far: namespace, node, pod, workload. More land
-milestone by milestone -- see https://github.com/phenixblue/k8shark/issues/137.
+Categories available: namespace, node, pod, workload, ip, url, image -- see
+https://github.com/phenixblue/k8shark/issues/137.
 
 ```
 kshrk anonymize <capture.kshrk> --categories <category> [--out <anonymized.kshrk>] [flags]
@@ -85,6 +85,9 @@ kshrk anonymize <capture.kshrk> --categories <category> [--out <anonymized.kshrk
   # Anonymize multiple categories in one pass
   kshrk anonymize capture.kshrk --categories namespace --categories node --categories pod
 
+  # Anonymize IPs, hostnames, and image registries
+  kshrk anonymize capture.kshrk --categories ip --categories url --categories image
+
   # Reproduce the exact same aliases on a re-run
   kshrk anonymize capture.kshrk --categories namespace --anonymize-salt-file salt.txt
 
@@ -96,7 +99,7 @@ kshrk anonymize <capture.kshrk> --categories <category> [--out <anonymized.kshrk
 
 ```
       --anonymize-salt-file string       read the anonymize salt from this file (first line, hex-encoded) instead of $KSHRK_ANONYMIZE_SALT or generating one
-      --categories stringArray           category to anonymize (repeatable); supported: namespace, node, pod, workload
+      --categories stringArray           category to anonymize (repeatable); supported: namespace, node, pod, workload, ip, url, image
       --encrypt                          encrypt the output archive with a passphrase (age); from --encrypt-passphrase-file, $KSHRK_ENCRYPT_PASSPHRASE, or an interactive prompt
       --encrypt-passphrase-file string   read the encryption passphrase from this file (first line) instead of prompting
       --encrypt-recipient stringArray    age recipient public key (age1...) to encrypt to (repeatable); mutually exclusive with passphrase encryption

--- a/internal/anonymize/alias.go
+++ b/internal/anonymize/alias.go
@@ -47,19 +47,22 @@ func NewAliaser(salt []byte) *Aliaser {
 }
 
 // implementedCategories are the categories Alias currently knows how to
-// render. Deliberately explicit and exhaustive rather than "everything
-// except IP falls through to aliasName": CategoryURL and CategoryImage are
-// real constants (used by later milestones' matchers once those exist), but
-// their encoders don't exist yet — URL/hostname aliasing needs substring
-// splicing, and image aliasing needs registry-host-only rewriting, neither
-// of which is word-based name aliasing. Letting them silently render via
-// aliasName today would lock in an accidental encoding nobody decided on,
-// for categories whose real encoding is different milestones' work. Alias
-// panics for anything not listed here so that can't happen unnoticed;
+// render. Alias panics for anything not listed here so an unimplemented
+// category can't render silently through the wrong encoder;
 // TestAliaser_ImplementedCategoriesMatchDispatch pins this list against
 // Alias's own switch so the two can't drift apart.
+//
+// CategoryURL and CategoryImage render through the same word-based
+// aliasName as the resource-name categories: a bare "url-word-word" or
+// "image-word-word" is itself a valid single-label hostname, which is all
+// that's needed here — the *splicing* (finding the host/registry substring
+// inside a larger URL or image reference and replacing only that part) is
+// this package's archive-rewrite layer's job (urlmatch.go, imagematch.go),
+// not this primitive's.
 var implementedCategories = map[Category]bool{
 	CategoryIP:        true,
+	CategoryURL:       true,
+	CategoryImage:     true,
 	CategoryNode:      true,
 	CategoryNamespace: true,
 	CategoryPod:       true,
@@ -83,7 +86,7 @@ func (a *Aliaser) Alias(category Category, original string) string {
 	switch category {
 	case CategoryIP:
 		return aliasIP(digest, original)
-	case CategoryNode, CategoryNamespace, CategoryPod, CategoryWorkload:
+	case CategoryNode, CategoryNamespace, CategoryPod, CategoryWorkload, CategoryURL, CategoryImage:
 		return aliasName(category, digest)
 	default:
 		// Unreachable: implementedCategories and this switch are kept in

--- a/internal/anonymize/alias.go
+++ b/internal/anonymize/alias.go
@@ -52,13 +52,15 @@ func NewAliaser(salt []byte) *Aliaser {
 // TestAliaser_ImplementedCategoriesMatchDispatch pins this list against
 // Alias's own switch so the two can't drift apart.
 //
-// CategoryURL and CategoryImage render through the same word-based
-// aliasName as the resource-name categories: a bare "url-word-word" or
-// "image-word-word" is itself a valid single-label hostname, which is all
-// that's needed here — the *splicing* (finding the host/registry substring
-// inside a larger URL or image reference and replacing only that part) is
-// this package's archive-rewrite layer's job (urlmatch.go, imagematch.go),
-// not this primitive's.
+// CategoryURL renders through the same word-based aliasName as the
+// resource-name categories: a bare "url-word-word" is itself a valid
+// single-label hostname, which is all that's needed here. CategoryImage
+// needs one thing more than that — see aliasRegistryHost's own doc comment
+// for why a bare "image-word-word" isn't enough on its own. Either way, the
+// *splicing* (finding the host/registry substring inside a larger URL or
+// image reference and replacing only that part) is this package's
+// archive-rewrite layer's job (urlmatch.go, imagematch.go), not this
+// primitive's.
 var implementedCategories = map[Category]bool{
 	CategoryIP:        true,
 	CategoryURL:       true,
@@ -86,7 +88,9 @@ func (a *Aliaser) Alias(category Category, original string) string {
 	switch category {
 	case CategoryIP:
 		return aliasIP(digest, original)
-	case CategoryNode, CategoryNamespace, CategoryPod, CategoryWorkload, CategoryURL, CategoryImage:
+	case CategoryImage:
+		return aliasRegistryHost(digest)
+	case CategoryNode, CategoryNamespace, CategoryPod, CategoryWorkload, CategoryURL:
 		return aliasName(category, digest)
 	default:
 		// Unreachable: implementedCategories and this switch are kept in

--- a/internal/anonymize/alias_test.go
+++ b/internal/anonymize/alias_test.go
@@ -125,7 +125,7 @@ func TestAliaser_CategoriesNeverCollide(t *testing.T) {
 // depend on.
 func TestAliaser_NameAliasesAreDNS1123Safe(t *testing.T) {
 	a := NewAliaser([]byte("name-salt"))
-	for _, cat := range []Category{CategoryNode, CategoryNamespace, CategoryPod, CategoryWorkload} {
+	for _, cat := range []Category{CategoryNode, CategoryNamespace, CategoryPod, CategoryWorkload, CategoryURL} {
 		for i := 0; i < 50; i++ {
 			original := fmt.Sprintf("%s-original-%d", cat, i)
 			alias := a.Alias(cat, original)
@@ -135,6 +135,29 @@ func TestAliaser_NameAliasesAreDNS1123Safe(t *testing.T) {
 			if got := alias[:len(string(cat))]; got != string(cat) {
 				t.Errorf("%s alias %q does not start with the category prefix", cat, alias)
 			}
+		}
+	}
+}
+
+// A CategoryImage alias must itself "look like a registry host" under
+// imagematch.go's own looksLikeRegistryHost heuristic (contains a '.' or
+// ':', or is exactly "localhost") — otherwise substituting it as an image
+// reference's leading segment would silently turn an explicit registry into
+// what Docker's tooling treats as an implicit Docker Hub namespace instead,
+// defeating the very distinction rewriteImageRegistryHost exists to
+// preserve. It must also still be a valid DNS-1123 *subdomain* (multiple
+// dot-separated labels are allowed here, unlike the single-label categories
+// TestAliaser_NameAliasesAreDNS1123Safe checks).
+func TestAliaser_ImageAliasesLookLikeRegistryHosts(t *testing.T) {
+	a := NewAliaser([]byte("image-registry-salt"))
+	for i := 0; i < 50; i++ {
+		original := fmt.Sprintf("registry-%d.example.com", i)
+		alias := a.Alias(CategoryImage, original)
+		if !looksLikeRegistryHost(alias) {
+			t.Errorf("alias %q for input %q does not look like a registry host (no '.' or ':', and isn't \"localhost\")", alias, original)
+		}
+		if errs := validation.IsDNS1123Subdomain(alias); len(errs) > 0 {
+			t.Errorf("alias %q for input %q is not a valid DNS-1123 subdomain: %v", alias, original, errs)
 		}
 	}
 }

--- a/internal/anonymize/alias_test.go
+++ b/internal/anonymize/alias_test.go
@@ -186,14 +186,11 @@ func TestAliaser_IPAliasesAreValidAndPrivate(t *testing.T) {
 	}
 }
 
-// Calling Alias with a category that isn't implemented yet must panic, not
-// silently render something through the wrong encoder. This is the guard
-// that makes CategoryURL/CategoryImage safe to define now (for later
-// milestones to reference) without accidentally locking in an encoding
-// nobody has designed.
+// Calling Alias with a category that isn't implemented at all must panic,
+// not silently render something through the wrong encoder.
 func TestAliaser_PanicsOnUnimplementedCategory(t *testing.T) {
 	a := NewAliaser([]byte("panic-salt"))
-	for _, cat := range []Category{CategoryURL, CategoryImage, Category("bogus")} {
+	for _, cat := range []Category{Category("bogus")} {
 		t.Run(string(cat), func(t *testing.T) {
 			defer func() {
 				if recover() == nil {

--- a/internal/anonymize/anonymize.go
+++ b/internal/anonymize/anonymize.go
@@ -38,13 +38,11 @@ const (
 )
 
 // AllCategories is the full set of categories anonymize is designed to
-// eventually support, in a stable order — the target end-state from #137's
-// design, not what's implemented today. Most are not usable yet:
-// (*Aliaser).Alias panics for any category not in its own
-// implementedCategories set (alias.go), which is a strict subset of this
-// list until later milestones add the rest. Don't iterate AllCategories
-// expecting every entry to work; iterate implementedCategories (or call
-// Alias and let it panic loudly) if you need "what works right now."
+// support, in a stable order. Every entry now has a working (*Aliaser).Alias
+// encoder (alias.go's implementedCategories), but that is a lower-level
+// concern than whether Archive() actually knows how to *find* occurrences of
+// a category in a real archive — see archive.go's archiveCategories for
+// that, narrower, gate.
 var AllCategories = []Category{
 	CategoryIP,
 	CategoryURL,

--- a/internal/anonymize/archive.go
+++ b/internal/anonymize/archive.go
@@ -130,7 +130,7 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	doImage := false
 	for _, cat := range opts.Categories {
 		if !archiveCategories[cat] {
-			return Result{}, fmt.Errorf("anonymize: category %q is not yet supported for archive rewriting", cat)
+			return Result{}, fmt.Errorf("anonymize: category %q is not supported for archive rewriting", cat)
 		}
 		switch cat {
 		case CategoryNamespace:

--- a/internal/anonymize/archive.go
+++ b/internal/anonymize/archive.go
@@ -80,8 +80,13 @@ type Result struct {
 	WorkloadsRenamed  int
 	// IPsRenamed counts distinct IP literals.
 	IPsRenamed int
-	// HostsRenamed counts distinct hostnames — both bare (an Ingress host)
-	// and the host portion spliced out of a scheme://host URL.
+	// HostsRenamed counts distinct URL-category values: bare hostnames (an
+	// Ingress host, a Service externalName) and whatever occupies a
+	// scheme://host URL's host position — which is not always a DNS name.
+	// CaptureMetadata.ServerAddress (e.g. "https://127.0.0.1:6443") goes
+	// through this same category, so an IP literal sitting in a URL's host
+	// position counts here too, not under IPsRenamed — see Archive's own
+	// ServerAddress-rewrite comment for why that's the deliberate choice.
 	HostsRenamed int
 	// RegistriesRenamed counts distinct container-image registry hosts
 	// (the leading host[:port] segment of an image reference).

--- a/internal/anonymize/archive.go
+++ b/internal/anonymize/archive.go
@@ -25,9 +25,8 @@ func sortedKeys[V any](m map[string]V) []string {
 }
 
 // archiveCategories are the categories Archive currently knows how to find
-// and rewrite occurrences of in a real archive. Namespace, node, pod, and
-// workload names for this milestone; IP/URL/image land next (see #137's
-// milestone plan).
+// and rewrite occurrences of in a real archive — every category #137's
+// design plan calls out is now covered.
 //
 // Deliberately a separate set from Aliaser's own implementedCategories
 // (alias.go): that one is about which categories the aliasing *primitive*
@@ -42,6 +41,9 @@ var archiveCategories = map[Category]bool{
 	CategoryNode:      true,
 	CategoryPod:       true,
 	CategoryWorkload:  true,
+	CategoryIP:        true,
+	CategoryURL:       true,
+	CategoryImage:     true,
 }
 
 // Options controls what Archive() anonymizes.
@@ -76,6 +78,14 @@ type Result struct {
 	NodesRenamed      int
 	PodsRenamed       int
 	WorkloadsRenamed  int
+	// IPsRenamed counts distinct IP literals.
+	IPsRenamed int
+	// HostsRenamed counts distinct hostnames — both bare (an Ingress host)
+	// and the host portion spliced out of a scheme://host URL.
+	HostsRenamed int
+	// RegistriesRenamed counts distinct container-image registry hosts
+	// (the leading host[:port] segment of an image reference).
+	RegistriesRenamed int
 }
 
 // Archive reads srcPath, anonymizes it per opts, and writes to dstPath. The
@@ -110,6 +120,9 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	doNode := false
 	doPod := false
 	doWorkload := false
+	doIP := false
+	doURL := false
+	doImage := false
 	for _, cat := range opts.Categories {
 		if !archiveCategories[cat] {
 			return Result{}, fmt.Errorf("anonymize: category %q is not yet supported for archive rewriting", cat)
@@ -123,6 +136,12 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 			doPod = true
 		case CategoryWorkload:
 			doWorkload = true
+		case CategoryIP:
+			doIP = true
+		case CategoryURL:
+			doURL = true
+		case CategoryImage:
+			doImage = true
 		}
 	}
 	// enabledResource gates rewriteResourceNameInObject/InPath's field-level
@@ -182,7 +201,19 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	workloadTracker := newCollisionTracker(CategoryWorkload, func(original string) string {
 		return aliaser.Alias(CategoryWorkload, original)
 	})
+	ipTracker := newCollisionTracker(CategoryIP, func(original string) string {
+		return aliaser.Alias(CategoryIP, original)
+	})
+	urlTracker := newCollisionTracker(CategoryURL, func(original string) string {
+		return aliaser.Alias(CategoryURL, original)
+	})
+	imageTracker := newCollisionTracker(CategoryImage, func(original string) string {
+		return aliaser.Alias(CategoryImage, original)
+	})
 	namespaceAlias := namespaceTracker.Alias
+	ipAlias := ipTracker.Alias
+	urlAlias := urlTracker.Alias
+	imageAlias := imageTracker.Alias
 	// resourceAlias dispatches to the tracker for whichever category a
 	// resourcename.go call site determined a given occurrence belongs to.
 	// Only ever called for a category enabledResource already gated on, so
@@ -203,7 +234,7 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	// actually enabled — an unused tracker's Err() is always nil, so this
 	// stays correct without needing to be told which categories are active.
 	firstCollisionErr := func() error {
-		for _, t := range []*collisionTracker{namespaceTracker, nodeTracker, podTracker, workloadTracker} {
+		for _, t := range []*collisionTracker{namespaceTracker, nodeTracker, podTracker, workloadTracker, ipTracker, urlTracker, imageTracker} {
 			if err := t.Err(); err != nil {
 				return err
 			}
@@ -278,6 +309,21 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 			}
 			if doResourceName {
 				if _, err := rewriteResourceNameInRecord(&rec, enabledResource, resourceAlias); err != nil {
+					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
+				}
+			}
+			if doIP {
+				if _, err := rewriteIPInRecord(&rec, ipAlias); err != nil {
+					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
+				}
+			}
+			if doURL {
+				if _, err := rewriteURLInRecord(&rec, urlAlias); err != nil {
+					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
+				}
+			}
+			if doImage {
+				if _, err := rewriteImageRegistryInRecord(&rec, imageAlias); err != nil {
 					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
 				}
 			}
@@ -425,6 +471,21 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	// plaintext source anonymized straight into an encrypted output.
 	meta.Encrypted = len(opts.Recipients) > 0
 
+	// CaptureMetadata.ServerAddress lives on the metadata, not inside any
+	// Record body, so it needs its own rewrite here rather than going
+	// through rewriteEntryRecords — but it's the exact same URL shape
+	// (e.g. "https://127.0.0.1:6443") spliceURLHosts already handles, so it
+	// shares urlTracker/urlAlias with every other URL-category occurrence
+	// rather than getting a special-cased alias of its own.
+	if doURL {
+		if rewritten, ok := spliceURLHosts(meta.ServerAddress, urlAlias); ok {
+			meta.ServerAddress = rewritten
+		}
+		if err := firstCollisionErr(); err != nil {
+			return Result{}, err
+		}
+	}
+
 	if err := sw.Finish(&meta, newIdx, newWI); err != nil {
 		return Result{}, fmt.Errorf("finishing output archive: %w", err)
 	}
@@ -435,5 +496,8 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 		NodesRenamed:      nodeTracker.Count(),
 		PodsRenamed:       podTracker.Count(),
 		WorkloadsRenamed:  workloadTracker.Count(),
+		IPsRenamed:        ipTracker.Count(),
+		HostsRenamed:      urlTracker.Count(),
+		RegistriesRenamed: imageTracker.Count(),
 	}, nil
 }

--- a/internal/anonymize/archive_test.go
+++ b/internal/anonymize/archive_test.go
@@ -521,13 +521,19 @@ func TestArchive_MetadataEncryptedReflectsOutputNotSource(t *testing.T) {
 	})
 }
 
+// As of M4 (#137), every real Category constant is supported by Archive()'s
+// archiveCategories — there's no longer a real, still-unsupported category
+// to exercise this with (unlike the M2/M3 version of this test, which used
+// CategoryIP before this milestone implemented it). A made-up category
+// string still needs to be rejected, though — this is the same guard,
+// tested against the only kind of value that can still trigger it.
 func TestArchive_UnsupportedCategoryErrors(t *testing.T) {
 	src := buildAnonymizeTestArchive(t, namespaceFixtureRecords())
 	dst := filepath.Join(t.TempDir(), "out.kshrk")
 
-	_, err := Archive(src, dst, Options{Categories: []Category{CategoryIP}, Salt: []byte("s")})
+	_, err := Archive(src, dst, Options{Categories: []Category{Category("bogus")}, Salt: []byte("s")})
 	if err == nil {
-		t.Fatal("want an error for a category not yet supported by archive rewriting")
+		t.Fatal("want an error for a category not supported by archive rewriting")
 	}
 	if _, statErr := os.Stat(dst); statErr == nil {
 		t.Error("no output file should be left behind on a rejected category")
@@ -848,6 +854,215 @@ func TestArchive_DetectsNodeCollisionIntroducedOnlyByRecordBody(t *testing.T) {
 		t.Fatal("want a collision error; got none — a collision introduced only by record body content, on the archive's only apiPath, was silently accepted")
 	}
 	for _, want := range []string{collidingNodeA, collidingNodeB} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name the colliding value %q", err.Error(), want)
+		}
+	}
+	if _, statErr := os.Stat(dst); statErr == nil {
+		t.Error("no (corrupt) output file should be left behind on a detected collision")
+	}
+}
+
+// ipURLImageFixtureRecords covers all three M4 categories at once, plus a
+// deliberate cross-record consistency case: the Node's own InternalIP and
+// the Pod's status.podIP are the same real address, and the Ingress's own
+// bare spec.rules[*].host and its annotation's embedded
+// https://app.example.com/webhook are the same real hostname — one via the
+// schema-aware whole-value path, the other via the full-tree scheme-splice
+// path. Both pairs must come out as the same alias.
+func ipURLImageFixtureRecords() []*capture.Record {
+	nodeBody := `{"kind":"Node","apiVersion":"v1","metadata":{"name":"worker-1"},
+		"status":{"addresses":[{"type":"InternalIP","address":"10.1.2.3"}]}}`
+	podListBody := `{"kind":"PodList","apiVersion":"v1","items":[
+		{"metadata":{"name":"web-1","namespace":"prod"},
+		 "spec":{"containers":[{"name":"app","image":"registry.internal.corp/team/app:v1.2.3"}]},
+		 "status":{"podIP":"10.1.2.3"}}
+	]}`
+	ingressBody := `{"kind":"Ingress","apiVersion":"networking.k8s.io/v1","metadata":{"name":"web","namespace":"prod",
+		"annotations":{"webhook":"https://app.example.com/webhook"}},
+		"spec":{"rules":[{"host":"app.example.com"}]}}`
+	serviceBody := `{"kind":"Service","apiVersion":"v1","metadata":{"name":"db","namespace":"prod"},
+		"spec":{"type":"ExternalName","externalName":"db.upstream.example.com"}}`
+	return []*capture.Record{
+		{ID: "r1", CapturedAt: fixedNow, APIPath: "/api/v1/nodes/worker-1", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(nodeBody)},
+		{ID: "r2", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/prod/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(podListBody)},
+		{ID: "r3", CapturedAt: fixedNow, APIPath: "/apis/networking.k8s.io/v1/namespaces/prod/ingresses/web", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(ingressBody)},
+		{ID: "r4", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/prod/services/db", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(serviceBody)},
+	}
+}
+
+// The M4 analogue of TestArchive_NamespaceConsistentAcrossKindsAndPaths and
+// TestArchive_ResourceNamesConsistentAcrossKindsAndPaths: the same IP
+// appearing on a Node's own address and a Pod's status.podIP, the same
+// hostname appearing bare (Ingress spec.rules[*].host) and spliced out of a
+// URL (an annotation), and the registry host inside a container image, must
+// all come out as their category's consistent alias — and
+// CaptureMetadata.ServerAddress, which lives outside any record body
+// entirely, must be spliced through the same URL alias space.
+func TestArchive_IPURLImageConsistentAcrossKindsAndPaths(t *testing.T) {
+	src := buildAnonymizeTestArchive(t, ipURLImageFixtureRecords())
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+	salt := []byte("ip-url-image-integration-test-salt")
+	result, err := Archive(src, dst, Options{
+		Categories: []Category{CategoryIP, CategoryURL, CategoryImage},
+		Salt:       salt,
+	})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if result.IPsRenamed != 1 {
+		t.Errorf("IPsRenamed = %d, want 1 (one distinct IP, seen on two records)", result.IPsRenamed)
+	}
+	// app.example.com, db.upstream.example.com, and the ServerAddress host
+	// 127.0.0.1 (see buildAnonymizeTestArchive) — three distinct hosts.
+	if result.HostsRenamed != 3 {
+		t.Errorf("HostsRenamed = %d, want 3", result.HostsRenamed)
+	}
+	if result.RegistriesRenamed != 1 {
+		t.Errorf("RegistriesRenamed = %d, want 1", result.RegistriesRenamed)
+	}
+
+	a := NewAliaser(salt)
+	ipAlias := a.Alias(CategoryIP, "10.1.2.3")
+	hostAlias := a.Alias(CategoryURL, "app.example.com")
+	registryAlias := a.Alias(CategoryImage, "registry.internal.corp")
+	serverAddrHostAlias := a.Alias(CategoryURL, "127.0.0.1")
+
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatalf("opening output archive: %v", err)
+	}
+	defer ar.Close()
+
+	meta, err := ar.ReadMetadata()
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	wantServerAddress := "https://" + serverAddrHostAlias + ":6443"
+	if meta.ServerAddress != wantServerAddress {
+		t.Errorf("ServerAddress = %q, want %q", meta.ServerAddress, wantServerAddress)
+	}
+
+	readBody := func(apiPath string) map[string]interface{} {
+		t.Helper()
+		data, err := ar.ReadRecord(apiPath, 0)
+		if err != nil {
+			t.Fatalf("ReadRecord(%q, 0): %v", apiPath, err)
+		}
+		var rec capture.Record
+		if err := json.Unmarshal(data, &rec); err != nil {
+			t.Fatalf("unmarshaling record: %v", err)
+		}
+		var obj map[string]interface{}
+		if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+			t.Fatalf("unmarshaling body: %v", err)
+		}
+		return obj
+	}
+
+	nodeObj := readBody("/api/v1/nodes/worker-1")
+	nodeAddr := nodeObj["status"].(map[string]interface{})["addresses"].([]interface{})[0].(map[string]interface{})
+	if got := nodeAddr["address"]; got != ipAlias {
+		t.Errorf("Node InternalIP = %v, want %v", got, ipAlias)
+	}
+
+	podList := readBody("/api/v1/namespaces/prod/pods")
+	podItem := podList["items"].([]interface{})[0].(map[string]interface{})
+	if got := podItem["status"].(map[string]interface{})["podIP"]; got != ipAlias {
+		t.Errorf("Pod status.podIP = %v, want %v — must match the Node's own address alias", got, ipAlias)
+	}
+	image := podItem["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["image"]
+	if got, want := image, registryAlias+"/team/app:v1.2.3"; got != want {
+		t.Errorf("container image = %v, want %v", got, want)
+	}
+
+	ingressObj := readBody("/apis/networking.k8s.io/v1/namespaces/prod/ingresses/web")
+	if got := ingressObj["spec"].(map[string]interface{})["rules"].([]interface{})[0].(map[string]interface{})["host"]; got != hostAlias {
+		t.Errorf("Ingress spec.rules[0].host = %v, want %v", got, hostAlias)
+	}
+	annotation := ingressObj["metadata"].(map[string]interface{})["annotations"].(map[string]interface{})["webhook"]
+	if got, want := annotation, "https://"+hostAlias+"/webhook"; got != want {
+		t.Errorf("Ingress webhook annotation = %v, want %v — the spliced host must match the bare host field's own alias", got, want)
+	}
+}
+
+// Requesting only --categories ip must not also alias URL/image-category
+// occurrences it happens to be structurally adjacent to.
+func TestArchive_IPURLImageCategoryGatingRestrictsWhichFieldsChange(t *testing.T) {
+	src := buildAnonymizeTestArchive(t, ipURLImageFixtureRecords())
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+	salt := []byte("ip-url-image-gating-test-salt")
+
+	result, err := Archive(src, dst, Options{Categories: []Category{CategoryIP}, Salt: salt})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if result.HostsRenamed != 0 || result.RegistriesRenamed != 0 {
+		t.Errorf("counts = %+v, want only IPsRenamed set", result)
+	}
+
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ar.Close()
+
+	meta, err := ar.ReadMetadata()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.ServerAddress != "https://127.0.0.1:6443" {
+		t.Errorf("ServerAddress = %q, want unchanged — URL category was not requested", meta.ServerAddress)
+	}
+
+	data, err := ar.ReadRecord("/apis/networking.k8s.io/v1/namespaces/prod/ingresses/web", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatal(err)
+	}
+	var ingressObj map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &ingressObj); err != nil {
+		t.Fatal(err)
+	}
+	if got := ingressObj["spec"].(map[string]interface{})["rules"].([]interface{})[0].(map[string]interface{})["host"]; got != "app.example.com" {
+		t.Errorf("Ingress host = %v, want unchanged app.example.com", got)
+	}
+}
+
+// A real, found-not-constructed collision for the url category (proving the
+// tracker wiring works for the substring-splicing category, not just the
+// whole-value-swap categories already covered): "host-21.example.com" and
+// "host-133.example.com" both alias to "url-clean-lemur" under this exact
+// salt.
+const (
+	collidingURLA    = "host-21.example.com"
+	collidingURLB    = "host-133.example.com"
+	collidingURLSalt = "fixed-test-salt-for-collision-search"
+)
+
+func TestArchive_DetectsRealURLCollision(t *testing.T) {
+	svcBody := func(host string) string {
+		return fmt.Sprintf(`{"kind":"Service","apiVersion":"v1","metadata":{"name":"svc"},"spec":{"type":"ExternalName","externalName":%q}}`, host)
+	}
+	records := []*capture.Record{
+		{ID: "r1", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/a/services/svc", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(svcBody(collidingURLA))},
+		{ID: "r2", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/b/services/svc", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(svcBody(collidingURLB))},
+	}
+	src := buildAnonymizeTestArchive(t, records)
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+	_, err := Archive(src, dst, Options{
+		Categories: []Category{CategoryURL},
+		Salt:       []byte(collidingURLSalt),
+	})
+	if err == nil {
+		t.Fatal("want a collision error; got none — a real archive with a genuine alias collision was silently accepted")
+	}
+	for _, want := range []string{collidingURLA, collidingURLB} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error %q does not name the colliding value %q", err.Error(), want)
 		}

--- a/internal/anonymize/imagematch.go
+++ b/internal/anonymize/imagematch.go
@@ -147,16 +147,34 @@ func rewriteContainerImages(node interface{}, alias func(string) string) bool {
 // The whole leading segment (including ":<port>", if present) is aliased as
 // one atomic value, not split further — a registry's host and port
 // together identify one logical endpoint.
+//
+// image may itself be prefixed with a CRI scheme, not just a bare
+// reference: status.containerStatuses[*].imageID from CRI-O (rather than
+// containerd/dockershim) commonly reads
+// "docker-pullable://docker.io/library/nginx@sha256:...". Splitting on the
+// first "/" without accounting for this would land inside the scheme
+// separator's own "://" — "docker-pullable:" contains a ':' and would be
+// misidentified as the registry host, corrupting the CRI scheme instead of
+// rewriting the real one. Stripping a leading "<scheme>://" first, then
+// applying the same heuristic to what remains, handles both a bare
+// reference (no such prefix — most images, and every spec-side one) and a
+// CRI-prefixed imageID uniformly.
 func rewriteImageRegistryHost(image string, alias func(string) string) (string, bool) {
-	slash := strings.IndexByte(image, '/')
+	prefix := ""
+	rest := image
+	if i := strings.Index(image, "://"); i >= 0 {
+		prefix, rest = image[:i+len("://")], image[i+len("://"):]
+	}
+
+	slash := strings.IndexByte(rest, '/')
 	if slash < 0 {
 		return image, false
 	}
-	first := image[:slash]
+	first := rest[:slash]
 	if !looksLikeRegistryHost(first) {
 		return image, false
 	}
-	return alias(first) + image[slash:], true
+	return prefix + alias(first) + rest[slash:], true
 }
 
 func looksLikeRegistryHost(segment string) bool {

--- a/internal/anonymize/imagematch.go
+++ b/internal/anonymize/imagematch.go
@@ -19,6 +19,22 @@ import (
 var containerListFields = []string{"containers", "initContainers", "ephemeralContainers"}
 var containerStatusFields = []string{"containerStatuses", "initContainerStatuses", "ephemeralContainerStatuses"}
 
+// containerFieldNames is the fixed set of the six field names above, built
+// once rather than as a map literal per rewriteContainerImages call: the
+// set of keys the recursive descent skips re-walking never changes call to
+// call, so there is nothing to gain from reallocating it at every map node
+// visited in the tree.
+var containerFieldNames = func() map[string]bool {
+	m := make(map[string]bool, len(containerListFields)+len(containerStatusFields))
+	for _, f := range containerListFields {
+		m[f] = true
+	}
+	for _, f := range containerStatusFields {
+		m[f] = true
+	}
+	return m
+}()
+
 // rewriteImageRegistryInRecord decodes rec's body and rewrites the leading
 // registry host of every container image reference it finds, wherever a
 // recognizable containers/initContainers/ephemeralContainers (spec-side) or
@@ -57,18 +73,12 @@ func rewriteContainerImages(node interface{}, alias func(string) string) bool {
 	switch v := node.(type) {
 	case map[string]interface{}:
 		modified := false
-		// handled tracks which top-level keys of v were already fully
-		// processed by the explicit container-list logic below, so the
-		// generic recursive descent at the end doesn't redundantly re-walk
-		// them looking for nothing new.
-		handled := make(map[string]bool)
 
 		for _, field := range containerListFields {
 			list, ok := v[field].([]interface{})
 			if !ok {
 				continue
 			}
-			handled[field] = true
 			for _, raw := range list {
 				c, ok := raw.(map[string]interface{})
 				if !ok {
@@ -87,7 +97,6 @@ func rewriteContainerImages(node interface{}, alias func(string) string) bool {
 			if !ok {
 				continue
 			}
-			handled[field] = true
 			for _, raw := range list {
 				c, ok := raw.(map[string]interface{})
 				if !ok {
@@ -108,9 +117,13 @@ func rewriteContainerImages(node interface{}, alias func(string) string) bool {
 		// list at whatever depth a given Kind happens to nest its
 		// PodTemplateSpec (e.g. spec.template.spec for a Deployment,
 		// spec.jobTemplate.spec.template.spec for a CronJob) without this
-		// function needing to know any of those paths by name.
+		// function needing to know any of those paths by name. Skipping
+		// containerFieldNames here, rather than re-descending into them,
+		// avoids redundant work: those six fields were already fully
+		// handled above, whether or not they were actually present as a
+		// []interface{} on this particular v.
 		for k, val := range v {
-			if handled[k] {
+			if containerFieldNames[k] {
 				continue
 			}
 			if rewriteContainerImages(val, alias) {

--- a/internal/anonymize/imagematch.go
+++ b/internal/anonymize/imagematch.go
@@ -1,0 +1,167 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// containerListFields and containerStatusFields are the field names that
+// hold a container's own image reference, at whatever depth they occur.
+// Kept as name lists rather than per-Kind field paths (spec.template.spec
+// for a Deployment, spec.jobTemplate.spec.template.spec for a CronJob, and
+// so on) because every workload Kind embeds a PodTemplateSpec at a
+// different nesting depth — walking the whole tree looking for these
+// recognizable container-list shapes finds every one of them without
+// needing a separate hardcoded path per Kind.
+var containerListFields = []string{"containers", "initContainers", "ephemeralContainers"}
+var containerStatusFields = []string{"containerStatuses", "initContainerStatuses", "ephemeralContainerStatuses"}
+
+// rewriteImageRegistryInRecord decodes rec's body and rewrites the leading
+// registry host of every container image reference it finds, wherever a
+// recognizable containers/initContainers/ephemeralContainers (spec-side) or
+// containerStatuses/initContainerStatuses/ephemeralContainerStatuses
+// (status-side) list occurs in the tree — schema-aware in the sense that it
+// only ever touches an "image"/"imageID" field inside one of those specific
+// list shapes, never an arbitrary string anywhere in the body.
+//
+// V1 scope, per the design plan: only the leading registry host is
+// rewritten (Docker's own heuristic for "is there an explicit registry
+// here at all" — see registryHost). The repository path, tag, and digest
+// are left untouched; full OCI reference grammar reconstruction is real,
+// separate parsing work this milestone doesn't attempt.
+func rewriteImageRegistryInRecord(rec *capture.Record, alias func(string) string) (bool, error) {
+	var obj interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+		return false, nil
+	}
+
+	modified := rewriteContainerImages(obj, alias)
+
+	if !modified {
+		return false, nil
+	}
+	newBody, err := json.Marshal(obj)
+	if err != nil {
+		return false, fmt.Errorf("re-marshaling record: %w", err)
+	}
+	rec.ResponseBody = newBody
+	return true, nil
+}
+
+// rewriteContainerImages recursively walks node, rewriting "image"/"imageID"
+// string fields inside any container-list-shaped map it finds.
+func rewriteContainerImages(node interface{}, alias func(string) string) bool {
+	switch v := node.(type) {
+	case map[string]interface{}:
+		modified := false
+		// handled tracks which top-level keys of v were already fully
+		// processed by the explicit container-list logic below, so the
+		// generic recursive descent at the end doesn't redundantly re-walk
+		// them looking for nothing new.
+		handled := make(map[string]bool)
+
+		for _, field := range containerListFields {
+			list, ok := v[field].([]interface{})
+			if !ok {
+				continue
+			}
+			handled[field] = true
+			for _, raw := range list {
+				c, ok := raw.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if image, ok := c["image"].(string); ok && image != "" {
+					if rewritten, changed := rewriteImageRegistryHost(image, alias); changed {
+						c["image"] = rewritten
+						modified = true
+					}
+				}
+			}
+		}
+		for _, field := range containerStatusFields {
+			list, ok := v[field].([]interface{})
+			if !ok {
+				continue
+			}
+			handled[field] = true
+			for _, raw := range list {
+				c, ok := raw.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				for _, imgField := range []string{"image", "imageID"} {
+					if image, ok := c[imgField].(string); ok && image != "" {
+						if rewritten, changed := rewriteImageRegistryHost(image, alias); changed {
+							c[imgField] = rewritten
+							modified = true
+						}
+					}
+				}
+			}
+		}
+
+		// Recurse into everything else — this is what finds a container
+		// list at whatever depth a given Kind happens to nest its
+		// PodTemplateSpec (e.g. spec.template.spec for a Deployment,
+		// spec.jobTemplate.spec.template.spec for a CronJob) without this
+		// function needing to know any of those paths by name.
+		for k, val := range v {
+			if handled[k] {
+				continue
+			}
+			if rewriteContainerImages(val, alias) {
+				modified = true
+			}
+		}
+		return modified
+	case []interface{}:
+		modified := false
+		for _, val := range v {
+			if rewriteContainerImages(val, alias) {
+				modified = true
+			}
+		}
+		return modified
+	default:
+		return false
+	}
+}
+
+// rewriteImageRegistryHost rewrites only the leading registry host of image,
+// using Docker's own heuristic for whether one is even present: split on the
+// first "/" — if there isn't one, image is a single component like
+// "nginx:1.21" or "nginx@sha256:..." with no registry segment at all
+// (implicit docker.io/library/...), so there's nothing to rewrite. If there
+// is one, the segment before it counts as an explicit registry host only if
+// it contains a "." or ":" (a domain or a host:port) or is literally
+// "localhost" — otherwise it's just a Docker Hub organization/namespace
+// segment (e.g. "myorg/myapp"), not a registry, and is left alone: rewriting
+// an organization name isn't in scope here (the registry hostname is
+// normally the sensitive part; the plan's Open Question 6 punts on full
+// reference-grammar reconstruction for the same reason).
+//
+// The whole leading segment (including ":<port>", if present) is aliased as
+// one atomic value, not split further — a registry's host and port
+// together identify one logical endpoint.
+func rewriteImageRegistryHost(image string, alias func(string) string) (string, bool) {
+	slash := strings.IndexByte(image, '/')
+	if slash < 0 {
+		return image, false
+	}
+	first := image[:slash]
+	if !looksLikeRegistryHost(first) {
+		return image, false
+	}
+	return alias(first) + image[slash:], true
+}
+
+func looksLikeRegistryHost(segment string) bool {
+	if segment == "localhost" {
+		return true
+	}
+	return strings.ContainsAny(segment, ".:")
+}

--- a/internal/anonymize/imagematch_test.go
+++ b/internal/anonymize/imagematch_test.go
@@ -1,0 +1,184 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+func TestRewriteImageRegistryHost(t *testing.T) {
+	cases := []struct {
+		name   string
+		image  string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "explicit registry with dot",
+			image:  "registry.internal.corp/team/app:v1.2.3",
+			want:   "registry.internal.corp-ALIASED/team/app:v1.2.3",
+			wantOK: true,
+		},
+		{
+			name:   "explicit registry with host:port",
+			image:  "registry.internal.corp:5000/team/app:v1.2.3",
+			want:   "registry.internal.corp:5000-ALIASED/team/app:v1.2.3",
+			wantOK: true,
+		},
+		{
+			name:   "localhost registry",
+			image:  "localhost/myapp:dev",
+			want:   "localhost-ALIASED/myapp:dev",
+			wantOK: true,
+		},
+		{
+			name:   "port-only registry (no dot, has colon)",
+			image:  "myregistry:5000/team/app",
+			want:   "myregistry:5000-ALIASED/team/app",
+			wantOK: true,
+		},
+		{
+			name:   "no slash at all — implicit Docker Hub, single component",
+			image:  "nginx:1.21",
+			want:   "nginx:1.21",
+			wantOK: false,
+		},
+		{
+			name:   "no slash, digest form",
+			image:  "nginx@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			want:   "nginx@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			wantOK: false,
+		},
+		{
+			name:   "org/repo with no dot or colon — Docker Hub namespace, not a registry",
+			image:  "myorg/myapp:v1",
+			want:   "myorg/myapp:v1",
+			wantOK: false,
+		},
+		{
+			name:   "registry with a path and a digest",
+			image:  "gcr.io/my-project/my-app@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			want:   "gcr.io-ALIASED/my-project/my-app@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			wantOK: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := rewriteImageRegistryHost(tc.image, upper)
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("rewriteImageRegistryHost(%q) = (%q, %v), want (%q, %v)", tc.image, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestRewriteImageRegistryInRecord(t *testing.T) {
+	t.Run("Pod spec.containers and status.containerStatuses", func(t *testing.T) {
+		body := `{"kind":"Pod","spec":{"containers":[{"name":"app","image":"registry.internal.corp/team/app:v1"}]},
+			"status":{"containerStatuses":[{"name":"app","image":"registry.internal.corp/team/app:v1","imageID":"registry.internal.corp/team/app@sha256:abc"}]}}`
+		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
+		changed, err := rewriteImageRegistryInRecord(rec, upper)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed {
+			t.Fatal("want changed=true")
+		}
+		var out map[string]interface{}
+		if err := json.Unmarshal(rec.ResponseBody, &out); err != nil {
+			t.Fatal(err)
+		}
+		specImage := out["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["image"]
+		if got, want := specImage, "registry.internal.corp-ALIASED/team/app:v1"; got != want {
+			t.Errorf("spec.containers[0].image = %v, want %v", got, want)
+		}
+		cs := out["status"].(map[string]interface{})["containerStatuses"].([]interface{})[0].(map[string]interface{})
+		if got, want := cs["image"], "registry.internal.corp-ALIASED/team/app:v1"; got != want {
+			t.Errorf("status.containerStatuses[0].image = %v, want %v", got, want)
+		}
+		if got, want := cs["imageID"], "registry.internal.corp-ALIASED/team/app@sha256:abc"; got != want {
+			t.Errorf("status.containerStatuses[0].imageID = %v, want %v", got, want)
+		}
+	})
+
+	// Deployment nests its PodTemplateSpec at spec.template.spec — this is
+	// exactly what proves the generic recursive walk, not a hardcoded
+	// per-Kind field path.
+	t.Run("Deployment nested at spec.template.spec", func(t *testing.T) {
+		body := `{"kind":"Deployment","spec":{"template":{"spec":{"containers":[{"name":"app","image":"registry.internal.corp/team/app:v1"}]}}}}`
+		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
+		changed, err := rewriteImageRegistryInRecord(rec, upper)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed {
+			t.Fatal("want changed=true")
+		}
+		var out map[string]interface{}
+		if err := json.Unmarshal(rec.ResponseBody, &out); err != nil {
+			t.Fatal(err)
+		}
+		image := out["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["image"]
+		if got, want := image, "registry.internal.corp-ALIASED/team/app:v1"; got != want {
+			t.Errorf("nested image = %v, want %v", got, want)
+		}
+	})
+
+	// CronJob nests one level deeper still: spec.jobTemplate.spec.template.spec.
+	t.Run("CronJob nested at spec.jobTemplate.spec.template.spec", func(t *testing.T) {
+		body := `{"kind":"CronJob","spec":{"jobTemplate":{"spec":{"template":{"spec":{
+			"containers":[{"name":"app","image":"registry.internal.corp/team/app:v1"}]
+		}}}}}}`
+		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
+		changed, err := rewriteImageRegistryInRecord(rec, upper)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed {
+			t.Fatal("want changed=true")
+		}
+		var out map[string]interface{}
+		if err := json.Unmarshal(rec.ResponseBody, &out); err != nil {
+			t.Fatal(err)
+		}
+		spec := out["spec"].(map[string]interface{})
+		podSpec := spec["jobTemplate"].(map[string]interface{})["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})
+		image := podSpec["containers"].([]interface{})[0].(map[string]interface{})["image"]
+		if got, want := image, "registry.internal.corp-ALIASED/team/app:v1"; got != want {
+			t.Errorf("deeply nested image = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("an implicit Docker Hub image with no registry is left untouched", func(t *testing.T) {
+		body := `{"kind":"Pod","spec":{"containers":[{"name":"app","image":"nginx:1.21"}]}}`
+		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
+		orig := string(rec.ResponseBody)
+		changed, err := rewriteImageRegistryInRecord(rec, upper)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if changed {
+			t.Error("want changed=false — no explicit registry to anonymize")
+		}
+		if string(rec.ResponseBody) != orig {
+			t.Error("body must be byte-identical when nothing was rewritten")
+		}
+	})
+
+	t.Run("a record with no container list at all is left untouched", func(t *testing.T) {
+		body := `{"kind":"Namespace","metadata":{"name":"prod"}}`
+		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
+		orig := string(rec.ResponseBody)
+		changed, err := rewriteImageRegistryInRecord(rec, upper)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if changed {
+			t.Error("want changed=false")
+		}
+		if string(rec.ResponseBody) != orig {
+			t.Error("body must be byte-identical when nothing was rewritten")
+		}
+	})
+}

--- a/internal/anonymize/imagematch_test.go
+++ b/internal/anonymize/imagematch_test.go
@@ -62,6 +62,23 @@ func TestRewriteImageRegistryHost(t *testing.T) {
 			want:   "gcr.io-ALIASED/my-project/my-app@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 			wantOK: true,
 		},
+		// CRI-O's containerStatuses[*].imageID commonly carries a
+		// "docker-pullable://" scheme prefix ahead of the actual reference
+		// — without accounting for it, the first "/" lands inside the
+		// scheme separator's own "://", and "docker-pullable:" (which
+		// contains a ':') would be misidentified as the registry host.
+		{
+			name:   "CRI-prefixed imageID (docker-pullable://)",
+			image:  "docker-pullable://docker.io/library/nginx@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			want:   "docker-pullable://docker.io-ALIASED/library/nginx@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			wantOK: true,
+		},
+		{
+			name:   "CRI-prefixed imageID, implicit Docker Hub (no explicit registry)",
+			image:  "docker://nginx:alpine",
+			want:   "docker://nginx:alpine",
+			wantOK: false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/anonymize/ipmatch.go
+++ b/internal/anonymize/ipmatch.go
@@ -19,10 +19,20 @@ import (
 // therefore already covers every schema-aware location the design plan
 // calls out (status.podIP, status.podIPs[*].ip, status.hostIP,
 // spec.clusterIP(s), LoadBalancer ingress IPs, Endpoints addresses, Node
-// status.addresses[type=InternalIP|ExternalIP]) *and* stray occurrences in
-// annotations, Event messages, or Table cells, in a single pass — there are
-// two mechanisms in the design plan's own wording, but only one is needed in
-// the implementation.
+// status.addresses[type=InternalIP|ExternalIP]) with no allowlist needed —
+// there are two mechanisms in the design plan's own wording, but only one is
+// needed in the implementation.
+//
+// This is a whole-value match only, not substring splicing: a field whose
+// entire value is exactly an IP literal is caught wherever it occurs
+// (including an annotation or a Table cell that holds nothing else), but an
+// IP embedded inside a longer free-text string — the common shape for a
+// real Event message ("Pulling image ... from 10.1.2.3") — is not, since
+// walkStrings only ever replaces a whole leaf value net.ParseIP accepts as
+// one. Deliberately out of scope, same reasoning as the CIDR gap below:
+// recognizing an IP as a substring of arbitrary text needs its own
+// detector, not just net.ParseIP on the whole string. ipmatch_test.go's
+// stray-occurrence case documents this boundary directly.
 //
 // Out of scope: a CIDR string (e.g. a Node's spec.podCIDR, "10.244.0.0/16")
 // does not parse as a bare IP (net.ParseIP rejects the "/16" suffix), so it

--- a/internal/anonymize/ipmatch.go
+++ b/internal/anonymize/ipmatch.go
@@ -1,0 +1,54 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// rewriteIPInRecord decodes rec's body and replaces every string value that
+// parses as a valid IP literal (net.ParseIP) with alias(original), anywhere
+// in the tree.
+//
+// Unlike the node/pod/workload categories, this needs no schema-aware fast
+// path at all: an IP address is self-evidently a candidate the instant it
+// parses as one, with no field-path allowlist required to tell a real
+// occurrence from a false positive. One full-tree walk (walkStrings)
+// therefore already covers every schema-aware location the design plan
+// calls out (status.podIP, status.podIPs[*].ip, status.hostIP,
+// spec.clusterIP(s), LoadBalancer ingress IPs, Endpoints addresses, Node
+// status.addresses[type=InternalIP|ExternalIP]) *and* stray occurrences in
+// annotations, Event messages, or Table cells, in a single pass — there are
+// two mechanisms in the design plan's own wording, but only one is needed in
+// the implementation.
+//
+// Out of scope: a CIDR string (e.g. a Node's spec.podCIDR, "10.244.0.0/16")
+// does not parse as a bare IP (net.ParseIP rejects the "/16" suffix), so it
+// passes through unrecognized. Splitting a CIDR into its address and
+// prefix-length, aliasing just the address, is real additional work the
+// design plan doesn't call out for this milestone.
+func rewriteIPInRecord(rec *capture.Record, alias func(string) string) (bool, error) {
+	var obj interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+		return false, nil
+	}
+
+	changed := walkStrings(obj, func(s string) (string, bool) {
+		if net.ParseIP(s) == nil {
+			return "", false
+		}
+		return alias(s), true
+	})
+	if !changed {
+		return false, nil
+	}
+
+	newBody, err := json.Marshal(obj)
+	if err != nil {
+		return false, fmt.Errorf("re-marshaling record: %w", err)
+	}
+	rec.ResponseBody = newBody
+	return true, nil
+}

--- a/internal/anonymize/ipmatch_test.go
+++ b/internal/anonymize/ipmatch_test.go
@@ -1,0 +1,162 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+func TestRewriteIPInRecord(t *testing.T) {
+	t.Run("schema-aware field: status.podIP", func(t *testing.T) {
+		rec := &capture.Record{
+			ResponseBody: json.RawMessage(`{"kind":"Pod","status":{"podIP":"10.1.2.3"}}`),
+		}
+		changed, err := rewriteIPInRecord(rec, upper)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed {
+			t.Fatal("want changed=true")
+		}
+		var out map[string]interface{}
+		if err := json.Unmarshal(rec.ResponseBody, &out); err != nil {
+			t.Fatal(err)
+		}
+		if got := out["status"].(map[string]interface{})["podIP"]; got != "10.1.2.3-ALIASED" {
+			t.Errorf("status.podIP = %v, want 10.1.2.3-ALIASED", got)
+		}
+	})
+
+	t.Run("nested list: status.podIPs[*].ip", func(t *testing.T) {
+		rec := &capture.Record{
+			ResponseBody: json.RawMessage(`{"kind":"Pod","status":{"podIPs":[{"ip":"10.1.2.3"},{"ip":"fd00::1"}]}}`),
+		}
+		changed, err := rewriteIPInRecord(rec, upper)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed {
+			t.Fatal("want changed=true")
+		}
+		var out map[string]interface{}
+		if err := json.Unmarshal(rec.ResponseBody, &out); err != nil {
+			t.Fatal(err)
+		}
+		ips := out["status"].(map[string]interface{})["podIPs"].([]interface{})
+		if got := ips[0].(map[string]interface{})["ip"]; got != "10.1.2.3-ALIASED" {
+			t.Errorf("podIPs[0].ip = %v, want 10.1.2.3-ALIASED", got)
+		}
+		if got := ips[1].(map[string]interface{})["ip"]; got != "fd00::1-ALIASED" {
+			t.Errorf("podIPs[1].ip = %v, want fd00::1-ALIASED", got)
+		}
+	})
+
+	// The whole point of the full-tree approach: an IP literal sitting in an
+	// annotation value (not any of the schema-aware field names) is caught
+	// with no special-casing at all.
+	t.Run("stray occurrence in an annotation is caught by the full-tree walk", func(t *testing.T) {
+		rec := &capture.Record{
+			ResponseBody: json.RawMessage(`{"kind":"Pod","metadata":{"annotations":{"note":"reachable at 10.1.2.3 for now"}}}`),
+		}
+		orig := string(rec.ResponseBody)
+		// A bare exact-match alias func for this test: the annotation VALUE
+		// as a whole is "reachable at 10.1.2.3 for now", which is not itself
+		// a valid IP, so walkStrings won't touch it (whole-string match
+		// only, not substring splicing — that's the URL category's job, not
+		// IP's). This documents the boundary rather than asserting a
+		// substring-splice behavior IP doesn't implement.
+		changed, err := rewriteIPInRecord(rec, upper)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if changed {
+			t.Error("want changed=false — IP matching is whole-string only, not substring splicing inside free text")
+		}
+		if string(rec.ResponseBody) != orig {
+			t.Error("body must be byte-identical when nothing was rewritten")
+		}
+	})
+
+	t.Run("a whole-value annotation that is exactly an IP is caught", func(t *testing.T) {
+		rec := &capture.Record{
+			ResponseBody: json.RawMessage(`{"kind":"Pod","metadata":{"annotations":{"external-ip":"203.0.113.5"}}}`),
+		}
+		changed, err := rewriteIPInRecord(rec, upper)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed {
+			t.Fatal("want changed=true")
+		}
+		var out map[string]interface{}
+		if err := json.Unmarshal(rec.ResponseBody, &out); err != nil {
+			t.Fatal(err)
+		}
+		ann := out["metadata"].(map[string]interface{})["annotations"].(map[string]interface{})
+		if got := ann["external-ip"]; got != "203.0.113.5-ALIASED" {
+			t.Errorf("annotations[external-ip] = %v, want 203.0.113.5-ALIASED", got)
+		}
+	})
+
+	t.Run("a CIDR string is out of scope and left untouched", func(t *testing.T) {
+		rec := &capture.Record{
+			ResponseBody: json.RawMessage(`{"kind":"Node","spec":{"podCIDR":"10.244.0.0/16"}}`),
+		}
+		orig := string(rec.ResponseBody)
+		changed, err := rewriteIPInRecord(rec, upper)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if changed {
+			t.Error("want changed=false — a CIDR is not a bare IP literal")
+		}
+		if string(rec.ResponseBody) != orig {
+			t.Error("body must be byte-identical when nothing was rewritten")
+		}
+	})
+
+	t.Run("a record with no IP occurrence at all is left untouched", func(t *testing.T) {
+		body := `{"kind":"Namespace","metadata":{"name":"prod"}}`
+		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
+		orig := string(rec.ResponseBody)
+		changed, err := rewriteIPInRecord(rec, upper)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if changed {
+			t.Error("want changed=false")
+		}
+		if string(rec.ResponseBody) != orig {
+			t.Error("body must be byte-identical when nothing was rewritten")
+		}
+	})
+
+	t.Run("a Table-format body is left untouched, not an error", func(t *testing.T) {
+		body := `{"kind":"Table","apiVersion":"meta.k8s.io/v1","rows":[{"cells":["10.1.2.3","Running"]}]}`
+		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
+		// The design plan calls out Table cells as a stray-occurrence
+		// location, but Table rows[*].cells is a []interface{} of mixed
+		// scalar types decoded generically — walkStrings still visits a
+		// string cell like any other string leaf, so this is caught too,
+		// unlike the schema-aware categories' documented Table-cell gap.
+		changed, err := rewriteIPInRecord(rec, upper)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed {
+			t.Fatal("want changed=true — a Table cell is just a string leaf to the full-tree walk")
+		}
+		var out map[string]interface{}
+		if err := json.Unmarshal(rec.ResponseBody, &out); err != nil {
+			t.Fatal(err)
+		}
+		cells := out["rows"].([]interface{})[0].(map[string]interface{})["cells"].([]interface{})
+		if got := cells[0]; got != "10.1.2.3-ALIASED" {
+			t.Errorf("cells[0] = %v, want 10.1.2.3-ALIASED", got)
+		}
+		if got := cells[1]; got != "Running" {
+			t.Errorf("cells[1] = %v, want unchanged Running", got)
+		}
+	})
+}

--- a/internal/anonymize/ipmatch_test.go
+++ b/internal/anonymize/ipmatch_test.go
@@ -52,20 +52,17 @@ func TestRewriteIPInRecord(t *testing.T) {
 		}
 	})
 
-	// The whole point of the full-tree approach: an IP literal sitting in an
-	// annotation value (not any of the schema-aware field names) is caught
-	// with no special-casing at all.
-	t.Run("stray occurrence in an annotation is caught by the full-tree walk", func(t *testing.T) {
+	// Documents a real, deliberate boundary rather than asserting a
+	// substring-splice behavior IP doesn't implement: the annotation VALUE
+	// as a whole is "reachable at 10.1.2.3 for now", which is not itself a
+	// valid IP, so walkStrings won't touch it — whole-string match only,
+	// not substring splicing inside free text (see rewriteIPInRecord's own
+	// doc comment).
+	t.Run("an IP embedded in free text is NOT caught — whole-value match only", func(t *testing.T) {
 		rec := &capture.Record{
 			ResponseBody: json.RawMessage(`{"kind":"Pod","metadata":{"annotations":{"note":"reachable at 10.1.2.3 for now"}}}`),
 		}
 		orig := string(rec.ResponseBody)
-		// A bare exact-match alias func for this test: the annotation VALUE
-		// as a whole is "reachable at 10.1.2.3 for now", which is not itself
-		// a valid IP, so walkStrings won't touch it (whole-string match
-		// only, not substring splicing — that's the URL category's job, not
-		// IP's). This documents the boundary rather than asserting a
-		// substring-splice behavior IP doesn't implement.
 		changed, err := rewriteIPInRecord(rec, upper)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/anonymize/name.go
+++ b/internal/anonymize/name.go
@@ -18,6 +18,8 @@ var wordsPerCategory = map[Category]int{
 	CategoryNamespace: 2,
 	CategoryPod:       3,
 	CategoryWorkload:  3,
+	CategoryURL:       2,
+	CategoryImage:     2,
 }
 
 // defaultWords is used for any category not listed in wordsPerCategory. In

--- a/internal/anonymize/name.go
+++ b/internal/anonymize/name.go
@@ -63,3 +63,20 @@ func wordAt(i int, b byte) string {
 	}
 	return nouns[int(b)%len(nouns)]
 }
+
+// aliasRegistryHost renders a CategoryImage alias, guaranteed to itself
+// "look like a registry host" under imagematch.go's own
+// looksLikeRegistryHost heuristic (contains '.' or ':', or is exactly
+// "localhost") — a bare aliasName output like "image-quiet-otter" does not
+// (no dot, no colon), so substituting it as an image reference's leading
+// segment would silently turn what was an explicit registry into what
+// Docker's own tooling treats as an implicit Docker Hub namespace instead,
+// defeating the very distinction rewriteImageRegistryHost exists to
+// preserve — a second anonymize pass over the same archive, or any
+// downstream tool that re-applies the same "is there a registry"
+// heuristic, would misclassify it. The trailing ".internal" is what
+// supplies that dot; the word choice underneath is still the same
+// deterministic digest-derived encoding aliasName always uses.
+func aliasRegistryHost(digest []byte) string {
+	return aliasName(CategoryImage, digest) + ".internal"
+}

--- a/internal/anonymize/urlmatch.go
+++ b/internal/anonymize/urlmatch.go
@@ -9,21 +9,28 @@ import (
 	"github.com/phenixblue/k8shark/internal/capture"
 )
 
-// urlHostPattern matches a URL scheme prefix immediately followed by a
-// host, which is either a bracketed IPv6 literal (RFC 3986 requires the
-// brackets in a URL's host position, e.g. "https://[fd00::1]:6443") or a
-// DNS name: one mandatory label, then zero or more ".<label>" labels — so
-// a bare in-cluster service name ("https://webhook-svc:8443"), a
-// fully-qualified one ("https://webhook-svc.default.svc:8443"), and an
-// IPv6 cluster address all match. The scheme prefix is what makes this safe
-// as a full-tree, unscoped scan: it's the trigger that disambiguates a real
-// host from any other dot- or colon-containing string (a version number,
-// an image tag) which never appears right after "://". Deliberately does
-// not also match a bare hostname with no scheme — that would reintroduce
-// exactly the false-positive risk the scheme prefix exists to avoid; bare
-// hostnames are instead handled at their own known schema-aware field
-// locations (see rewriteURLInObject).
-var urlHostPattern = regexp.MustCompile(`(?i)((?:https?|wss?)://)(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)`)
+// urlHostPattern matches a URL scheme prefix, an optional "userinfo@" (RFC
+// 3986's "user[:password]@" form, e.g. "https://user:pass@host/path") which
+// is skipped over rather than captured, and then the actual host: either a
+// bracketed IPv6 literal (RFC 3986 requires the brackets in a URL's host
+// position, e.g. "https://[fd00::1]:6443") or a DNS name — one mandatory
+// label, then zero or more ".<label>" labels. So a bare in-cluster service
+// name ("https://webhook-svc:8443"), a fully-qualified one
+// ("https://webhook-svc.default.svc:8443"), an IPv6 cluster address, and a
+// URL carrying credentials all match, with the captured host group always
+// landing on the real host, not the username. The userinfo group excludes
+// "/" so it can only ever match up to the next "@" *before* the path even
+// starts — a literal "@" that shows up later, inside the path, can't be
+// mistaken for a userinfo separator this way. The scheme prefix is what
+// makes the whole pattern safe as a full-tree, unscoped scan: it's the
+// trigger that disambiguates a real host from any other dot- or
+// colon-containing string (a version number, an image tag) which never
+// appears right after "://". Deliberately does not also match a bare
+// hostname with no scheme — that would reintroduce exactly the
+// false-positive risk the scheme prefix exists to avoid; bare hostnames are
+// instead handled at their own known schema-aware field locations (see
+// rewriteURLInObject).
+var urlHostPattern = regexp.MustCompile(`(?i)((?:https?|wss?)://)(?:[^/@]*@)?(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)`)
 
 // spliceURLHosts rewrites every scheme://host occurrence in s, replacing
 // only the host substring with alias(host) — the scheme, any port, path,

--- a/internal/anonymize/urlmatch.go
+++ b/internal/anonymize/urlmatch.go
@@ -1,0 +1,164 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// urlHostPattern matches a URL scheme prefix immediately followed by a
+// host: one mandatory DNS label, then zero or more ".<label>" labels — so
+// both a bare in-cluster service name ("https://webhook-svc:8443") and a
+// fully-qualified one ("https://webhook-svc.default.svc:8443") match. The
+// scheme prefix is what makes this safe as a full-tree, unscoped scan: it's
+// the trigger that disambiguates a real host from any other dot-containing
+// string (a version number, an image tag) which never appears right after
+// "://". Deliberately does not also match a bare hostname with no scheme —
+// that would reintroduce exactly the false-positive risk the scheme prefix
+// exists to avoid; bare hostnames are instead handled at their own known
+// schema-aware field locations (see rewriteURLInObject).
+var urlHostPattern = regexp.MustCompile(`(?i)((?:https?|wss?)://)([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)`)
+
+// spliceURLHosts rewrites every scheme://host occurrence in s, replacing
+// only the host substring with alias(host) — the scheme, any port, path,
+// and query string are left untouched, unlike the whole-value swap the
+// resource-name categories use. This is what lets a hostname keep reading
+// consistently whether it shows up bare (an Ingress host field) or embedded
+// in a longer webhook URL string.
+func spliceURLHosts(s string, alias func(string) string) (string, bool) {
+	matches := urlHostPattern.FindAllStringSubmatchIndex(s, -1)
+	if len(matches) == 0 {
+		return s, false
+	}
+	var out strings.Builder
+	last := 0
+	for _, m := range matches {
+		hostStart, hostEnd := m[4], m[5]
+		out.WriteString(s[last:hostStart])
+		out.WriteString(alias(s[hostStart:hostEnd]))
+		last = hostEnd
+	}
+	out.WriteString(s[last:])
+	return out.String(), true
+}
+
+// rewriteURLInObject rewrites the known bare-hostname fields (no scheme, so
+// spliceURLHosts's regex wouldn't match them at all) for a single decoded
+// JSON object, using kind to know which fields apply:
+//
+//   - Ingress: spec.rules[*].host, spec.tls[*].hosts[*]
+//   - Service: spec.externalName
+//
+// Full-tree scheme://host occurrences (webhook URLs, cert-manager/
+// external-dns annotations, status condition messages) are handled
+// separately by rewriteURLInRecord's walkStrings pass over the whole body,
+// not here — these two mechanisms are mutually exclusive by construction
+// (one requires a scheme prefix, the other only ever looks at fields that
+// never have one), so there's no risk of double-aliasing the same value.
+func rewriteURLInObject(obj map[string]interface{}, kind string, alias func(string) string) bool {
+	modified := false
+
+	spec, ok := obj["spec"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	switch kind {
+	case "Ingress":
+		if rules, ok := spec["rules"].([]interface{}); ok {
+			for _, raw := range rules {
+				rule, ok := raw.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if host, ok := rule["host"].(string); ok && host != "" {
+					rule["host"] = alias(host)
+					modified = true
+				}
+			}
+		}
+		if tlsEntries, ok := spec["tls"].([]interface{}); ok {
+			for _, raw := range tlsEntries {
+				entry, ok := raw.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				hosts, ok := entry["hosts"].([]interface{})
+				if !ok {
+					continue
+				}
+				for i, h := range hosts {
+					host, ok := h.(string)
+					if !ok || host == "" {
+						continue
+					}
+					hosts[i] = alias(host)
+					modified = true
+				}
+			}
+		}
+	case "Service":
+		if externalName, ok := spec["externalName"].(string); ok && externalName != "" {
+			spec["externalName"] = alias(externalName)
+			modified = true
+		}
+	}
+
+	return modified
+}
+
+// rewriteURLInRecord decodes rec's body and rewrites every URL/hostname
+// occurrence it recognizes: the bare-hostname schema-aware fields
+// (rewriteURLInObject, list-aware the same way rewriteNamespaceInRecord and
+// rewriteResourceNameInRecord are) plus a full-tree walk for
+// scheme://host substrings anywhere in the body (webhook URLs,
+// cert-manager/external-dns annotations, status condition messages).
+func rewriteURLInRecord(rec *capture.Record, alias func(string) string) (bool, error) {
+	var obj map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+		return false, nil
+	}
+
+	kind, _ := obj["kind"].(string)
+	modified := false
+
+	if strings.HasSuffix(kind, "List") {
+		items, _ := obj["items"].([]interface{})
+		itemKind := strings.TrimSuffix(kind, "List")
+		for i, itemRaw := range items {
+			item, ok := itemRaw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			ik := itemKind
+			if k, ok := item["kind"].(string); ok && k != "" {
+				ik = k
+			}
+			if rewriteURLInObject(item, ik, alias) {
+				items[i] = item
+				modified = true
+			}
+		}
+	} else if rewriteURLInObject(obj, kind, alias) {
+		modified = true
+	}
+
+	if walkStrings(interface{}(obj), func(s string) (string, bool) {
+		return spliceURLHosts(s, alias)
+	}) {
+		modified = true
+	}
+
+	if !modified {
+		return false, nil
+	}
+	newBody, err := json.Marshal(obj)
+	if err != nil {
+		return false, fmt.Errorf("re-marshaling record: %w", err)
+	}
+	rec.ResponseBody = newBody
+	return true, nil
+}

--- a/internal/anonymize/urlmatch.go
+++ b/internal/anonymize/urlmatch.go
@@ -10,17 +10,20 @@ import (
 )
 
 // urlHostPattern matches a URL scheme prefix immediately followed by a
-// host: one mandatory DNS label, then zero or more ".<label>" labels — so
-// both a bare in-cluster service name ("https://webhook-svc:8443") and a
-// fully-qualified one ("https://webhook-svc.default.svc:8443") match. The
-// scheme prefix is what makes this safe as a full-tree, unscoped scan: it's
-// the trigger that disambiguates a real host from any other dot-containing
-// string (a version number, an image tag) which never appears right after
-// "://". Deliberately does not also match a bare hostname with no scheme —
-// that would reintroduce exactly the false-positive risk the scheme prefix
-// exists to avoid; bare hostnames are instead handled at their own known
-// schema-aware field locations (see rewriteURLInObject).
-var urlHostPattern = regexp.MustCompile(`(?i)((?:https?|wss?)://)([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)`)
+// host, which is either a bracketed IPv6 literal (RFC 3986 requires the
+// brackets in a URL's host position, e.g. "https://[fd00::1]:6443") or a
+// DNS name: one mandatory label, then zero or more ".<label>" labels — so
+// a bare in-cluster service name ("https://webhook-svc:8443"), a
+// fully-qualified one ("https://webhook-svc.default.svc:8443"), and an
+// IPv6 cluster address all match. The scheme prefix is what makes this safe
+// as a full-tree, unscoped scan: it's the trigger that disambiguates a real
+// host from any other dot- or colon-containing string (a version number,
+// an image tag) which never appears right after "://". Deliberately does
+// not also match a bare hostname with no scheme — that would reintroduce
+// exactly the false-positive risk the scheme prefix exists to avoid; bare
+// hostnames are instead handled at their own known schema-aware field
+// locations (see rewriteURLInObject).
+var urlHostPattern = regexp.MustCompile(`(?i)((?:https?|wss?)://)(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)`)
 
 // spliceURLHosts rewrites every scheme://host occurrence in s, replacing
 // only the host substring with alias(host) — the scheme, any port, path,
@@ -28,6 +31,12 @@ var urlHostPattern = regexp.MustCompile(`(?i)((?:https?|wss?)://)([a-zA-Z0-9](?:
 // resource-name categories use. This is what lets a hostname keep reading
 // consistently whether it shows up bare (an Ingress host field) or embedded
 // in a longer webhook URL string.
+//
+// A matched IPv6 literal's surrounding brackets are stripped before
+// aliasing and not reinstated: the replacement is always a DNS hostname
+// (alias.go's aliasName), never an IP literal, and only an IP literal needs
+// (or is allowed) brackets in a URL's host position — reinserting them
+// around a hostname would itself be invalid.
 func spliceURLHosts(s string, alias func(string) string) (string, bool) {
 	matches := urlHostPattern.FindAllStringSubmatchIndex(s, -1)
 	if len(matches) == 0 {
@@ -37,8 +46,9 @@ func spliceURLHosts(s string, alias func(string) string) (string, bool) {
 	last := 0
 	for _, m := range matches {
 		hostStart, hostEnd := m[4], m[5]
+		host := strings.TrimSuffix(strings.TrimPrefix(s[hostStart:hostEnd], "["), "]")
 		out.WriteString(s[last:hostStart])
-		out.WriteString(alias(s[hostStart:hostEnd]))
+		out.WriteString(alias(host))
 		last = hostEnd
 	}
 	out.WriteString(s[last:])

--- a/internal/anonymize/urlmatch_test.go
+++ b/internal/anonymize/urlmatch_test.go
@@ -45,6 +45,18 @@ func TestSpliceURLHosts(t *testing.T) {
 			wantOK: true,
 		},
 		{
+			name:   "bracketed IPv6 literal host — brackets are removed, not preserved",
+			s:      "https://[fd00::1]:6443/api",
+			want:   "https://fd00::1-ALIASED:6443/api",
+			wantOK: true,
+		},
+		{
+			name:   "bracketed IPv6 literal, no port",
+			s:      "wss://[2001:db8::5678]/ws",
+			want:   "wss://2001:db8::5678-ALIASED/ws",
+			wantOK: true,
+		},
+		{
 			name:   "no scheme at all — not matched, by design",
 			s:      "webhook-svc.default.svc.cluster.local",
 			want:   "webhook-svc.default.svc.cluster.local",

--- a/internal/anonymize/urlmatch_test.go
+++ b/internal/anonymize/urlmatch_test.go
@@ -45,6 +45,18 @@ func TestSpliceURLHosts(t *testing.T) {
 			wantOK: true,
 		},
 		{
+			name:   "URL with userinfo — the host is aliased, not the username",
+			s:      "https://user:pass@host.example.com/path",
+			want:   "https://user:pass@host.example.com-ALIASED/path",
+			wantOK: true,
+		},
+		{
+			name:   "a literal '@' inside the path is not mistaken for userinfo",
+			s:      "https://host.example.com/path@notuserinfo",
+			want:   "https://host.example.com-ALIASED/path@notuserinfo",
+			wantOK: true,
+		},
+		{
 			name:   "bracketed IPv6 literal host — brackets are removed, not preserved",
 			s:      "https://[fd00::1]:6443/api",
 			want:   "https://fd00::1-ALIASED:6443/api",

--- a/internal/anonymize/urlmatch_test.go
+++ b/internal/anonymize/urlmatch_test.go
@@ -1,0 +1,201 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+func TestSpliceURLHosts(t *testing.T) {
+	cases := []struct {
+		name   string
+		s      string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "https URL with port and path — only the host moves",
+			s:      "https://webhook.example.com:8443/validate",
+			want:   "https://webhook.example.com-ALIASED:8443/validate",
+			wantOK: true,
+		},
+		{
+			name:   "bare in-cluster service name, no dots",
+			s:      "https://webhook-svc:8443/validate",
+			want:   "https://webhook-svc-ALIASED:8443/validate",
+			wantOK: true,
+		},
+		{
+			name:   "http, no port, no path",
+			s:      "http://example.com",
+			want:   "http://example.com-ALIASED",
+			wantOK: true,
+		},
+		{
+			name:   "embedded in a longer sentence",
+			s:      "see https://status.example.com/health for details",
+			want:   "see https://status.example.com-ALIASED/health for details",
+			wantOK: true,
+		},
+		{
+			name:   "two distinct URLs in one string, each aliased independently",
+			s:      "primary https://a.example.com, backup https://b.example.com",
+			want:   "primary https://a.example.com-ALIASED, backup https://b.example.com-ALIASED",
+			wantOK: true,
+		},
+		{
+			name:   "no scheme at all — not matched, by design",
+			s:      "webhook-svc.default.svc.cluster.local",
+			want:   "webhook-svc.default.svc.cluster.local",
+			wantOK: false,
+		},
+		{
+			name:   "no URL anywhere",
+			s:      "just some plain text",
+			want:   "just some plain text",
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := spliceURLHosts(tc.s, upper)
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("spliceURLHosts(%q) = (%q, %v), want (%q, %v)", tc.s, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestRewriteURLInObject(t *testing.T) {
+	t.Run("Ingress aliases spec.rules[*].host and spec.tls[*].hosts[*]", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind": "Ingress",
+			"spec": map[string]interface{}{
+				"rules": []interface{}{
+					map[string]interface{}{"host": "app.example.com"},
+				},
+				"tls": []interface{}{
+					map[string]interface{}{"hosts": []interface{}{"app.example.com", "www.example.com"}},
+				},
+			},
+		}
+		if !rewriteURLInObject(obj, "Ingress", upper) {
+			t.Fatal("want modified=true")
+		}
+		spec := obj["spec"].(map[string]interface{})
+		rule := spec["rules"].([]interface{})[0].(map[string]interface{})
+		if got := rule["host"]; got != "app.example.com-ALIASED" {
+			t.Errorf("rules[0].host = %v, want app.example.com-ALIASED", got)
+		}
+		tlsHosts := spec["tls"].([]interface{})[0].(map[string]interface{})["hosts"].([]interface{})
+		if got := tlsHosts[0]; got != "app.example.com-ALIASED" {
+			t.Errorf("tls[0].hosts[0] = %v, want app.example.com-ALIASED", got)
+		}
+		if got := tlsHosts[1]; got != "www.example.com-ALIASED" {
+			t.Errorf("tls[0].hosts[1] = %v, want www.example.com-ALIASED", got)
+		}
+	})
+
+	t.Run("Service aliases spec.externalName", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind": "Service",
+			"spec": map[string]interface{}{"externalName": "db.upstream.example.com", "type": "ExternalName"},
+		}
+		if !rewriteURLInObject(obj, "Service", upper) {
+			t.Fatal("want modified=true")
+		}
+		spec := obj["spec"].(map[string]interface{})
+		if got := spec["externalName"]; got != "db.upstream.example.com-ALIASED" {
+			t.Errorf("spec.externalName = %v, want db.upstream.example.com-ALIASED", got)
+		}
+		if got := spec["type"]; got != "ExternalName" {
+			t.Errorf("spec.type = %v, want unchanged ExternalName", got)
+		}
+	})
+
+	t.Run("a ClusterIP Service with no externalName is left alone", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind": "Service",
+			"spec": map[string]interface{}{"clusterIP": "10.0.0.5"},
+		}
+		if rewriteURLInObject(obj, "Service", upper) {
+			t.Error("want modified=false")
+		}
+	})
+
+	t.Run("an object with no spec at all is left alone, not a crash", func(t *testing.T) {
+		obj := map[string]interface{}{"kind": "Status"}
+		if rewriteURLInObject(obj, "Status", upper) {
+			t.Error("want modified=false")
+		}
+	})
+}
+
+func TestRewriteURLInRecord(t *testing.T) {
+	t.Run("schema-aware field plus a full-tree URL in an annotation, in the same record", func(t *testing.T) {
+		body := `{"kind":"Ingress","metadata":{"annotations":{"cert-manager.io/issuer-url":"https://acme.example.com/directory"}},
+			"spec":{"rules":[{"host":"app.example.com"}]}}`
+		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
+		changed, err := rewriteURLInRecord(rec, upper)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed {
+			t.Fatal("want changed=true")
+		}
+		var out map[string]interface{}
+		if err := json.Unmarshal(rec.ResponseBody, &out); err != nil {
+			t.Fatal(err)
+		}
+		rule := out["spec"].(map[string]interface{})["rules"].([]interface{})[0].(map[string]interface{})
+		if got := rule["host"]; got != "app.example.com-ALIASED" {
+			t.Errorf("spec.rules[0].host = %v, want app.example.com-ALIASED", got)
+		}
+		ann := out["metadata"].(map[string]interface{})["annotations"].(map[string]interface{})
+		if got := ann["cert-manager.io/issuer-url"]; got != "https://acme.example.com-ALIASED/directory" {
+			t.Errorf("annotation URL = %v, want host-only splice", got)
+		}
+	})
+
+	t.Run("list response rewrites every item, using each item's own kind", func(t *testing.T) {
+		body := `{"kind":"IngressList","items":[
+			{"metadata":{"name":"a"},"spec":{"rules":[{"host":"a.example.com"}]}},
+			{"metadata":{"name":"b"},"spec":{"rules":[{"host":"b.example.com"}]}}
+		]}`
+		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
+		changed, err := rewriteURLInRecord(rec, upper)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed {
+			t.Fatal("want changed=true")
+		}
+		var out map[string]interface{}
+		if err := json.Unmarshal(rec.ResponseBody, &out); err != nil {
+			t.Fatal(err)
+		}
+		items := out["items"].([]interface{})
+		host0 := items[0].(map[string]interface{})["spec"].(map[string]interface{})["rules"].([]interface{})[0].(map[string]interface{})["host"]
+		host1 := items[1].(map[string]interface{})["spec"].(map[string]interface{})["rules"].([]interface{})[0].(map[string]interface{})["host"]
+		if host0 != "a.example.com-ALIASED" || host1 != "b.example.com-ALIASED" {
+			t.Errorf("item hosts = %q, %q", host0, host1)
+		}
+	})
+
+	t.Run("a record with no URL occurrence at all is left untouched", func(t *testing.T) {
+		body := `{"kind":"Namespace","metadata":{"name":"prod"}}`
+		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
+		orig := string(rec.ResponseBody)
+		changed, err := rewriteURLInRecord(rec, upper)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if changed {
+			t.Error("want changed=false")
+		}
+		if string(rec.ResponseBody) != orig {
+			t.Error("body must be byte-identical when nothing was rewritten")
+		}
+	})
+}

--- a/internal/anonymize/walk.go
+++ b/internal/anonymize/walk.go
@@ -1,0 +1,51 @@
+package anonymize
+
+// walkStrings recursively visits every string value in a decoded JSON tree
+// (the map[string]interface{}/[]interface{}/string shape json.Unmarshal
+// produces into interface{}), replacing a string leaf with whatever visit
+// returns when visit reports changed=true. Shared by the IP and URL
+// categories' full-tree safety-net scans (ipmatch.go, urlmatch.go): both
+// need to find a value-shaped string (a valid IP literal; a scheme://host
+// substring) wherever it occurs, not just at a fixed set of field paths —
+// unlike the node/pod/workload categories, which only ever expect their
+// values at specific, known field names (resourcename.go).
+//
+// Mutates map/slice values in place (both are reference types in Go) and
+// returns whether anything changed, so a caller can skip re-marshaling a
+// record whose body wasn't actually touched.
+func walkStrings(node interface{}, visit func(string) (string, bool)) bool {
+	switch v := node.(type) {
+	case map[string]interface{}:
+		changed := false
+		for k, val := range v {
+			if s, ok := val.(string); ok {
+				if newS, ok := visit(s); ok {
+					v[k] = newS
+					changed = true
+				}
+				continue
+			}
+			if walkStrings(val, visit) {
+				changed = true
+			}
+		}
+		return changed
+	case []interface{}:
+		changed := false
+		for i, val := range v {
+			if s, ok := val.(string); ok {
+				if newS, ok := visit(s); ok {
+					v[i] = newS
+					changed = true
+				}
+				continue
+			}
+			if walkStrings(val, visit) {
+				changed = true
+			}
+		}
+		return changed
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## Summary
- Adds the three remaining anonymize categories from #137's design plan, completing the category set: `ip`, `url`, `image`.
- **`ip`** (`internal/anonymize/ipmatch.go`): one full-tree walk (`walk.go`'s new `walkStrings`) over each record body, aliasing any string that parses as a valid `net.IP`. This single mechanism covers every schema-aware location the plan calls out (`status.podIP`, `status.podIPs[*].ip`, `status.hostIP`, `spec.clusterIP(s)`, Node addresses, LB/Endpoints IPs) *and* stray occurrences, with no field allowlist — a valid IP literal is self-evidently a candidate. A CIDR string (e.g. a Node's `podCIDR`) doesn't parse as a bare IP and is out of scope, documented in the code.
- **`url`** (`internal/anonymize/urlmatch.go`): schema-aware whole-value aliasing for fields that are always bare hostnames (Ingress `spec.rules[*].host`/`spec.tls[*].hosts[*]`, Service `spec.externalName`, `CaptureMetadata.ServerAddress`), plus a full-tree regex splice for `scheme://host` substrings anywhere else (webhook URLs, cert-manager/external-dns annotations). Both mechanisms share one alias space and are mutually exclusive by construction (one requires a scheme prefix, the other only touches fields that never have one) — verified in `TestArchive_IPURLImageConsistentAcrossKindsAndPaths` that a hostname reads identically whether it's bare or embedded in a URL.
- **`image`** (`internal/anonymize/imagematch.go`): a generic recursive walk for `containers`/`initContainers`/`ephemeralContainers` (and their status-side counterparts), rewriting only the leading registry host of each image reference per Docker's own "is there an explicit registry" heuristic (Open Question 6) — proven against real per-Kind nesting depth differences (`TestRewriteImageRegistryInRecord`'s Deployment `spec.template.spec` vs. CronJob's one-level-deeper `spec.jobTemplate.spec.template.spec`, both found generically with no hardcoded per-Kind path).
- All three share the existing `collisionTracker`/alias-dispatch plumbing from M2/M3 and are gated the same way by which categories were actually requested (`TestArchive_IPURLImageCategoryGatingRestrictsWhichFieldsChange`).

## Test plan
- [x] `go test ./internal/anonymize/... ./cmd/...` — new unit tests per matcher (`ipmatch_test.go`, `urlmatch_test.go`, `imagematch_test.go`), plus `Archive()` integration tests: cross-record consistency (the same real IP on a Node and a Pod; the same real hostname bare and URL-embedded), category gating, `CaptureMetadata.ServerAddress` splicing, and a real found-not-constructed alias collision for the `url` category (proving the collision tracker generalizes to the new substring-splicing category, not just the whole-value-swap ones)
- [x] `go test -race ./...` — full suite green
- [x] `make lint-ci`, `gofmt -w .`, `go mod tidy` — clean
- [x] `make docs` — `docs/cli-reference.md` regenerated
- [x] Revert-and-reconfirm: manually removed the `ServerAddress` splice block in `Archive()` and confirmed the integration test catches it (wrong host, wrong count) before restoring
- [x] Manual smoke test against `examples/auto-discovery/capture.kshrk` with all seven categories combined — verified via `kshrk query`/`kshrk inspect`/`kshrk diagnose` that: the pod's `status.podIP`/`hostIP` alias independently (genuinely different real values); an image with no explicit registry (`nginx:alpine`) is correctly left untouched; the *resolved* `imageID` (`docker.io/library/nginx@sha256:...`) correctly gets only its `docker.io` registry host aliased, repo/tag/digest untouched; and the mock server's own `ServerAddress` host is spliced consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)