### PR TITLE
feat(anonymize): M5 — config schema, -o json, mapping output, exclude rules (#137)

### DIFF
--- a/cmd/anonymize.go
+++ b/cmd/anonymize.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 
+	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/anonymize"
 	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +29,10 @@ anonymize replaces every occurrence of a value it recognizes, consistently,
 using a deterministic alias derived from a salt.
 
 Categories available: namespace, node, pod, workload, ip, url, image -- see
-https://github.com/phenixblue/k8shark/issues/137.`,
+https://github.com/phenixblue/k8shark/issues/137.
+
+Categories and field-path exclusion rules may also be loaded from a config
+file's anonymize block via --config; see docs/config.md.`,
 	Example: `  # Anonymize every namespace name in a capture
   kshrk anonymize capture.kshrk --categories namespace
 
@@ -39,6 +45,12 @@ https://github.com/phenixblue/k8shark/issues/137.`,
   # Reproduce the exact same aliases on a re-run
   kshrk anonymize capture.kshrk --categories namespace --anonymize-salt-file salt.txt
 
+  # Categories and exclusion rules from a config file, as JSON output
+  kshrk anonymize capture.kshrk --config k8shark.yaml -o json
+
+  # Emit the original-to-alias mapping, encrypted to a recipient
+  kshrk anonymize capture.kshrk --categories namespace --emit-mapping --encrypt-recipient age1abc...
+
   # Anonymize and write to a chosen path
   kshrk anonymize capture.kshrk --out safe.kshrk --categories namespace`,
 	Args:              cobra.ExactArgs(1),
@@ -50,7 +62,17 @@ func init() {
 	rootCmd.AddCommand(anonymizeCmd)
 	anonymizeCmd.Flags().String("out", "", "output archive path (default: <in>-anonymized.kshrk)")
 	anonymizeCmd.Flags().StringArray("categories", nil, `category to anonymize (repeatable); supported: namespace, node, pod, workload, ip, url, image`)
+	anonymizeCmd.Flags().StringP("output", "o", "text", "output format: text or json")
+	anonymizeCmd.Flags().String("config", "", "capture config file whose anonymize.categories/anonymize.rules block is applied")
+	anonymizeCmd.Flags().Bool("emit-mapping", false, "write the original-to-alias mapping alongside the output archive")
+	anonymizeCmd.Flags().String("mapping-path", "", "path for the mapping file (default: <out>.mapping.json, or .mapping.json.age when encrypted)")
+	anonymizeCmd.Flags().Bool("emit-mapping-plaintext", false, "allow --emit-mapping to write an unencrypted mapping when no --encrypt-* flag is set (not recommended)")
 	_ = anonymizeCmd.MarkFlagFilename("out", captureExt)
+	_ = anonymizeCmd.MarkFlagFilename("config", configExts...)
+	_ = anonymizeCmd.RegisterFlagCompletionFunc("output",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"text", "json"}, cobra.ShellCompDirectiveNoFileComp
+		})
 	addAnonymizeFlags(anonymizeCmd)
 	// Write-side encryption for the anonymized output (read-side --decrypt-*
 	// are persistent flags from the root command, same as redact).
@@ -81,7 +103,7 @@ var supportedAnonymizeCategories = map[anonymize.Category]bool{
 // category should fail loudly, not silently anonymize nothing for it.
 func parseAnonymizeCategories(raw []string) ([]anonymize.Category, error) {
 	if len(raw) == 0 {
-		return nil, fmt.Errorf(`--categories is required; supported categories: namespace, node, pod, workload, ip, url, image (see #137)`)
+		return nil, fmt.Errorf(`--categories is required (or anonymize.categories in a --config file); supported categories: namespace, node, pod, workload, ip, url, image (see #137)`)
 	}
 	out := make([]anonymize.Category, 0, len(raw))
 	for _, c := range raw {
@@ -94,15 +116,61 @@ func parseAnonymizeCategories(raw []string) ([]anonymize.Category, error) {
 	return out, nil
 }
 
+// dedupeCategories drops repeat entries while preserving first-seen order,
+// so combining --categories flags with a config file's anonymize.categories
+// (or simply repeating the same --categories value) doesn't produce a
+// Categories slice with duplicates — harmless to Archive either way, but a
+// clean, deduplicated list is what a --config-and-flags-combined -o json
+// caller would reasonably expect to see echoed back.
+func dedupeCategories(cats []anonymize.Category) []anonymize.Category {
+	seen := make(map[anonymize.Category]bool, len(cats))
+	out := make([]anonymize.Category, 0, len(cats))
+	for _, c := range cats {
+		if seen[c] {
+			continue
+		}
+		seen[c] = true
+		out = append(out, c)
+	}
+	return out
+}
+
 func runAnonymize(cmd *cobra.Command, args []string) error {
 	in := args[0]
 	out, _ := cmd.Flags().GetString("out")
+	outputFormat, _ := cmd.Flags().GetString("output")
 	categoryFlags, _ := cmd.Flags().GetStringArray("categories")
+	cfgFile, _ := cmd.Flags().GetString("config")
+	emitMapping, _ := cmd.Flags().GetBool("emit-mapping")
+	mappingPath, _ := cmd.Flags().GetString("mapping-path")
+	emitMappingPlaintext, _ := cmd.Flags().GetBool("emit-mapping-plaintext")
+
+	if outputFormat != "text" && outputFormat != "json" {
+		return fmt.Errorf("--output must be text or json (got %q)", outputFormat)
+	}
+
+	var rules []config.AnonymizeRule
+	if cfgFile != "" {
+		cfg, err := config.Load(cfgFile)
+		if err != nil {
+			return fmt.Errorf("loading config: %w", err)
+		}
+		warnDeprecatedConfigKeys(cmd.ErrOrStderr(), cfg)
+		categoryFlags = append(categoryFlags, cfg.Anonymize.Categories...)
+		rules = append(rules, cfg.Anonymize.Rules...)
+		if cfg.Anonymize.EmitMapping {
+			emitMapping = true
+		}
+		if mappingPath == "" {
+			mappingPath = cfg.Anonymize.MappingPath
+		}
+	}
 
 	categories, err := parseAnonymizeCategories(categoryFlags)
 	if err != nil {
 		return err
 	}
+	categories = dedupeCategories(categories)
 
 	if out == "" {
 		// Trim either the current or the legacy extension so anonymizing a
@@ -145,24 +213,87 @@ func runAnonymize(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// The mapping is the one genuinely sensitive artifact this command can
+	// produce (see anonymize.Result.Mapping's own doc comment) — resolve
+	// and validate its encryption *before* doing any archive I/O, so a
+	// misconfigured --emit-mapping fails fast rather than after a
+	// potentially expensive anonymize pass.
+	if emitMapping && len(enc.recipients) == 0 && !emitMappingPlaintext {
+		return fmt.Errorf("--emit-mapping would write an unencrypted mapping because no --encrypt-* flag is set; pass --encrypt / --encrypt-recipient (recommended) or --emit-mapping-plaintext to force plaintext output")
+	}
+
 	result, err := anonymize.Archive(in, out, anonymize.Options{
 		Categories: categories,
 		Salt:       salt,
 		Identities: identities,
 		Recipients: enc.recipients,
+		Rules:      rules,
 	})
 	if err != nil {
 		return err
 	}
 
 	fi, _ := os.Stat(out)
-	size := int64(0)
 	if fi != nil {
-		size = fi.Size()
+		result.OutputBytes = fi.Size()
+	}
+	result.OutputPath = out
+
+	if emitMapping {
+		if mappingPath == "" {
+			mappingPath = out + ".mapping.json"
+			if len(enc.recipients) > 0 {
+				mappingPath += ".age"
+			}
+		}
+		if err := writeAnonymizeMapping(mappingPath, result.Mapping, enc.recipients); err != nil {
+			return fmt.Errorf("writing mapping: %w", err)
+		}
 	}
 
-	fmt.Printf("Anonymized %d namespace(s), %d node(s), %d pod(s), %d workload(s), %d IP(s), %d host(s), %d registry host(s) → %s (%d bytes)\n",
+	if outputFormat == "json" {
+		jsonEnc := json.NewEncoder(cmd.OutOrStdout())
+		jsonEnc.SetIndent("", "  ")
+		return jsonEnc.Encode(result)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Anonymized %d namespace(s), %d node(s), %d pod(s), %d workload(s), %d IP(s), %d host(s), %d registry host(s) → %s (%d bytes)\n",
 		result.NamespacesRenamed, result.NodesRenamed, result.PodsRenamed, result.WorkloadsRenamed,
-		result.IPsRenamed, result.HostsRenamed, result.RegistriesRenamed, out, size)
+		result.IPsRenamed, result.HostsRenamed, result.RegistriesRenamed, out, result.OutputBytes)
+	if emitMapping {
+		fmt.Fprintf(cmd.OutOrStdout(), "Mapping written to %s\n", mappingPath)
+	}
 	return nil
+}
+
+// writeAnonymizeMapping JSON-marshals mapping and writes it to path,
+// age-encrypted to recipients when recipients is non-empty. The caller
+// (runAnonymize) has already enforced that an empty recipients list here
+// only happens when the user explicitly opted into plaintext output via
+// --emit-mapping-plaintext.
+func writeAnonymizeMapping(path string, mapping map[anonymize.Category]map[string]string, recipients []age.Recipient) error {
+	data, err := json.MarshalIndent(mapping, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling mapping: %w", err)
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("creating %q: %w", path, err)
+	}
+	defer f.Close()
+
+	if len(recipients) == 0 {
+		_, err := f.Write(data)
+		return err
+	}
+
+	w, err := age.Encrypt(f, recipients...)
+	if err != nil {
+		return fmt.Errorf("encrypting mapping: %w", err)
+	}
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("writing encrypted mapping: %w", err)
+	}
+	return w.Close()
 }

--- a/cmd/anonymize.go
+++ b/cmd/anonymize.go
@@ -215,11 +215,35 @@ func runAnonymize(cmd *cobra.Command, args []string) error {
 
 	// The mapping is the one genuinely sensitive artifact this command can
 	// produce (see anonymize.Result.Mapping's own doc comment) — resolve
-	// and validate its encryption *before* doing any archive I/O, so a
-	// misconfigured --emit-mapping fails fast rather than after a
-	// potentially expensive anonymize pass.
+	// and validate everything about it *before* doing any archive I/O, so
+	// a misconfigured --emit-mapping fails fast rather than after a
+	// potentially expensive anonymize pass, or worse, after silently
+	// truncating an archive (see the path-collision check below).
 	if emitMapping && len(enc.recipients) == 0 && !emitMappingPlaintext {
 		return fmt.Errorf("--emit-mapping would write an unencrypted mapping because no --encrypt-* flag is set; pass --encrypt / --encrypt-recipient (recommended) or --emit-mapping-plaintext to force plaintext output")
+	}
+	if emitMapping {
+		if mappingPath == "" {
+			mappingPath = out + ".mapping.json"
+			if len(enc.recipients) > 0 {
+				mappingPath += ".age"
+			}
+		}
+		// writeAnonymizeMapping creates/truncates mappingPath — an explicit
+		// --mapping-path (or a config file's mappingPath) that happens to
+		// equal the source or destination archive would silently destroy
+		// that archive the moment the mapping is written. The default path
+		// above always differs from out (it appends a suffix), so this can
+		// only fire for an explicit value. rejectSamePath's own error text
+		// ("output path must differ from...") is written for the in/out
+		// pair, so it's deliberately discarded here in favor of a message
+		// that names --mapping-path specifically.
+		if rejectSamePath(in, mappingPath) != nil {
+			return fmt.Errorf("--mapping-path %q must not be the source archive", mappingPath)
+		}
+		if rejectSamePath(out, mappingPath) != nil {
+			return fmt.Errorf("--mapping-path %q must not be the output archive", mappingPath)
+		}
 	}
 
 	result, err := anonymize.Archive(in, out, anonymize.Options{
@@ -240,12 +264,6 @@ func runAnonymize(cmd *cobra.Command, args []string) error {
 	result.OutputPath = out
 
 	if emitMapping {
-		if mappingPath == "" {
-			mappingPath = out + ".mapping.json"
-			if len(enc.recipients) > 0 {
-				mappingPath += ".age"
-			}
-		}
 		if err := writeAnonymizeMapping(mappingPath, result.Mapping, enc.recipients); err != nil {
 			return fmt.Errorf("writing mapping: %w", err)
 		}

--- a/cmd/anonymize.go
+++ b/cmd/anonymize.go
@@ -306,6 +306,14 @@ func writeAnonymizeMapping(path string, mapping map[anonymize.Category]map[strin
 		return fmt.Errorf("creating %q: %w", path, err)
 	}
 	defer f.Close()
+	// OpenFile's mode argument only applies when the file is actually
+	// created — if mappingPath already existed (e.g. a prior run left it
+	// world-readable, before this 0600 discipline existed, or a re-run at
+	// the same path), O_TRUNC alone leaves its existing permissions
+	// untouched. Chmod unconditionally to guarantee 0600 either way.
+	if err := f.Chmod(0o600); err != nil {
+		return fmt.Errorf("setting permissions on %q: %w", path, err)
+	}
 
 	if len(recipients) == 0 {
 		_, err := f.Write(data)

--- a/cmd/anonymize.go
+++ b/cmd/anonymize.go
@@ -277,7 +277,13 @@ func writeAnonymizeMapping(path string, mapping map[anonymize.Category]map[strin
 		return fmt.Errorf("marshaling mapping: %w", err)
 	}
 
-	f, err := os.Create(path)
+	// os.Create leaves permissions up to the process umask (commonly 0644,
+	// world-readable) — this file can hold the original values behind
+	// every alias, so it's created 0600 explicitly rather than trusting
+	// whatever the umask happens to be, matching this codebase's existing
+	// precedent for other sensitive file writes (internal/server/kubeconfig.go,
+	// cmd/controllermanager.go).
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("creating %q: %w", path, err)
 	}

--- a/cmd/anonymize_test.go
+++ b/cmd/anonymize_test.go
@@ -455,3 +455,43 @@ func TestRunAnonymize_EmitMappingRejectsPathCollisions(t *testing.T) {
 		}
 	})
 }
+
+// A pre-existing mapping file left world-readable (e.g. from a build
+// before this 0600 discipline existed, or a re-run at the same path) must
+// end up 0600 after a fresh --emit-mapping run — os.OpenFile's mode
+// argument only applies when the file is actually created, so O_TRUNC
+// alone would silently preserve a pre-existing insecure mode.
+func TestRunAnonymize_EmitMappingTightensPreExistingPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits don't apply on Windows")
+	}
+	in := buildDiffArchive(t, `{"kind":"PodList","items":[{"metadata":{"name":"web-1","namespace":"prod"}}]}`)
+	out := filepath.Join(t.TempDir(), "out.kshrk")
+	mappingPath := out + ".mapping.json"
+
+	// Simulate a pre-existing, world-readable mapping file at the exact
+	// path this run will write to.
+	if err := os.WriteFile(mappingPath, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTestAnonymizeCmdCommand(t)
+	cmd.SetOut(io.Discard)
+	_ = cmd.Flags().Set("categories", "namespace")
+	_ = cmd.Flags().Set("out", out)
+	_ = cmd.Flags().Set("emit-mapping", "true")
+	_ = cmd.Flags().Set("emit-mapping-plaintext", "true")
+	_ = cmd.Flags().Set("anonymize-salt-file", writeAnonymizeTestSaltFile(t))
+
+	if err := runAnonymize(cmd, []string{in}); err != nil {
+		t.Fatalf("runAnonymize: %v", err)
+	}
+
+	fi, err := os.Stat(mappingPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Errorf("mapping file mode = %o, want 0600 (a pre-existing 0644 mode must be tightened, not preserved)", got)
+	}
+}

--- a/cmd/anonymize_test.go
+++ b/cmd/anonymize_test.go
@@ -271,8 +271,29 @@ func TestRunAnonymize_JSONOutput(t *testing.T) {
 	if result.OutputPath == "" {
 		t.Error("output_path is empty")
 	}
-	if strings.Contains(stdout.String(), `"Mapping"`) {
-		t.Error("the mapping must never appear in -o json output, even though Result.Mapping is populated internally")
+
+	// Decode the top-level key set directly, rather than substring-matching
+	// the Go field name "Mapping" — that would miss a regression where a
+	// future retag exposed it under a differently-cased or differently-named
+	// key (e.g. "mapping"). Every legitimate key is checked for presence and
+	// every present key is checked for not looking like the mapping, so
+	// renaming a real field wouldn't silently pass this either.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stdout.String()), &raw); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %s", err, stdout.String())
+	}
+	for _, k := range []string{
+		"schema_version", "namespaces_renamed", "nodes_renamed", "pods_renamed",
+		"workloads_renamed", "ips_renamed", "hosts_renamed", "registries_renamed", "output_path",
+	} {
+		if _, ok := raw[k]; !ok {
+			t.Errorf("missing expected top-level key %q; got %s", k, stdout.String())
+		}
+	}
+	for k := range raw {
+		if strings.Contains(strings.ToLower(k), "mapping") {
+			t.Errorf("-o json output must never contain the mapping under any key; found key %q: %s", k, stdout.String())
+		}
 	}
 }
 
@@ -374,6 +395,63 @@ func TestRunAnonymize_EmitMappingRequiresEncryptionOrAck(t *testing.T) {
 		}
 		if mapping["namespace"]["prod"] == "" {
 			t.Errorf("mapping[namespace][prod] is empty; mapping = %v", mapping)
+		}
+	})
+}
+
+// --mapping-path colliding with the source or destination archive would
+// have writeAnonymizeMapping's create/truncate silently destroy that
+// archive — this must be rejected before any archive I/O runs at all, not
+// discovered after the anonymize pass already succeeded.
+func TestRunAnonymize_EmitMappingRejectsPathCollisions(t *testing.T) {
+	// Each subtest builds its own source archive, deliberately not shared:
+	// if the guard under test ever regressed, the first subtest would
+	// actually corrupt a shared "in" by writing the mapping over it, and
+	// the second subtest would then "pass" for the wrong reason (Archive
+	// failing to open the now-corrupted source) rather than because its
+	// own guard fired.
+	t.Run("--mapping-path equal to the source archive is rejected", func(t *testing.T) {
+		in := buildDiffArchive(t, `{"kind":"PodList","items":[{"metadata":{"name":"web-1","namespace":"prod"}}]}`)
+		out := filepath.Join(t.TempDir(), "out.kshrk")
+		cmd := newTestAnonymizeCmdCommand(t)
+		cmd.SetOut(io.Discard)
+		_ = cmd.Flags().Set("categories", "namespace")
+		_ = cmd.Flags().Set("out", out)
+		_ = cmd.Flags().Set("emit-mapping", "true")
+		_ = cmd.Flags().Set("emit-mapping-plaintext", "true")
+		_ = cmd.Flags().Set("mapping-path", in)
+		_ = cmd.Flags().Set("anonymize-salt-file", writeAnonymizeTestSaltFile(t))
+
+		if err := runAnonymize(cmd, []string{in}); err == nil {
+			t.Fatal("want an error when --mapping-path equals the source archive")
+		}
+		// And the source archive itself must survive untouched — the whole
+		// point of catching this before any archive I/O.
+		fi, statErr := os.Stat(in)
+		if statErr != nil || fi.Size() == 0 {
+			t.Errorf("source archive %q was damaged (or removed): stat err=%v, size=%v", in, statErr, fi)
+		}
+	})
+
+	t.Run("--mapping-path equal to the output archive is rejected", func(t *testing.T) {
+		in := buildDiffArchive(t, `{"kind":"PodList","items":[{"metadata":{"name":"web-1","namespace":"prod"}}]}`)
+		out := filepath.Join(t.TempDir(), "out.kshrk")
+		cmd := newTestAnonymizeCmdCommand(t)
+		cmd.SetOut(io.Discard)
+		_ = cmd.Flags().Set("categories", "namespace")
+		_ = cmd.Flags().Set("out", out)
+		_ = cmd.Flags().Set("emit-mapping", "true")
+		_ = cmd.Flags().Set("emit-mapping-plaintext", "true")
+		_ = cmd.Flags().Set("mapping-path", out)
+		_ = cmd.Flags().Set("anonymize-salt-file", writeAnonymizeTestSaltFile(t))
+
+		if err := runAnonymize(cmd, []string{in}); err == nil {
+			t.Fatal("want an error when --mapping-path equals the output archive")
+		}
+		// The whole point: caught before Archive() ever runs, so no output
+		// file should exist at all — not a truncated one.
+		if _, statErr := os.Stat(out); statErr == nil {
+			t.Error("output archive should not have been written at all; the collision must be caught before any archive I/O")
 		}
 	})
 }

--- a/cmd/anonymize_test.go
+++ b/cmd/anonymize_test.go
@@ -1,9 +1,19 @@
 package cmd
 
 import (
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/anonymize"
+	archivepkg "github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/spf13/cobra"
 )
 
 func TestParseAnonymizeCategories(t *testing.T) {
@@ -90,6 +100,263 @@ func TestParseAnonymizeCategories(t *testing.T) {
 	t.Run("one bad category in a list rejects the whole list", func(t *testing.T) {
 		if _, err := parseAnonymizeCategories([]string{"namespace", "bogus"}); err == nil {
 			t.Error("want an error when any requested category is unsupported")
+		}
+	})
+}
+
+func TestDedupeCategories(t *testing.T) {
+	got := dedupeCategories([]anonymize.Category{
+		anonymize.CategoryNamespace, anonymize.CategoryNode, anonymize.CategoryNamespace,
+	})
+	want := []anonymize.Category{anonymize.CategoryNamespace, anonymize.CategoryNode}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %v, want %v (order must be first-seen)", i, got[i], want[i])
+		}
+	}
+}
+
+// newTestAnonymizeCmdCommand mirrors newTestDecryptCmdCommand's pattern
+// (decrypt_test.go): a standalone command carrying every flag runAnonymize
+// reads, so tests can call runAnonymize directly instead of going through
+// cobra's full command tree / Execute().
+func newTestAnonymizeCmdCommand(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.Flags().String("out", "", "")
+	cmd.Flags().StringArray("categories", nil, "")
+	cmd.Flags().StringP("output", "o", "text", "")
+	cmd.Flags().String("config", "", "")
+	cmd.Flags().Bool("emit-mapping", false, "")
+	cmd.Flags().String("mapping-path", "", "")
+	cmd.Flags().Bool("emit-mapping-plaintext", false, "")
+	addAnonymizeFlags(cmd)
+	addEncryptFlags(cmd)
+	cmd.Flags().AddFlagSet(cmd.PersistentFlags())
+	return cmd
+}
+
+// anonymizeTestSalt is a fixed, valid hex salt used across these tests so
+// runAnonymize doesn't hit resolveAnonymizeSalt's generate-and-warn path,
+// which would print to stderr and make aliases non-reproducible between
+// assertions within one test.
+var anonymizeTestSalt = hex.EncodeToString([]byte("anonymize-cmd-test-salt-32-bytes"))
+
+func writeAnonymizeTestSaltFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "salt.txt")
+	if err := os.WriteFile(path, []byte(anonymizeTestSalt), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestRunAnonymize_ConfigFileSuppliesCategories(t *testing.T) {
+	in := buildDiffArchive(t, `{"kind":"PodList","items":[{"metadata":{"name":"web-1","namespace":"prod"}}]}`)
+	cfgPath := filepath.Join(t.TempDir(), "k8shark.yaml")
+	if err := os.WriteFile(cfgPath, []byte("anonymize:\n  categories: [namespace]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTestAnonymizeCmdCommand(t)
+	cmd.SetOut(io.Discard)
+	_ = cmd.Flags().Set("config", cfgPath)
+	_ = cmd.Flags().Set("anonymize-salt-file", writeAnonymizeTestSaltFile(t))
+
+	// No --categories flag at all: the config file must supply it on its own.
+	if err := runAnonymize(cmd, []string{in}); err != nil {
+		t.Fatalf("runAnonymize: %v", err)
+	}
+
+	wantOut := strings.TrimSuffix(in, ".kshrk") + "-anonymized.kshrk"
+	if fi, err := os.Stat(wantOut); err != nil || fi.Size() == 0 {
+		t.Fatalf("default output %q not created (or empty): %v", wantOut, err)
+	}
+}
+
+func TestRunAnonymize_ConfigFileRuleExcludesFieldPath(t *testing.T) {
+	// "default" matches buildDiffArchive's own hardcoded APIPath namespace
+	// segment, so there is exactly one distinct namespace value in play —
+	// the path itself still gets renamed regardless of the rule (rules
+	// gate only the body's own field-write site, not the path rewrite),
+	// but the body's own metadata.namespace must survive unchanged.
+	in := buildDiffArchive(t, `{"kind":"PodList","items":[{"metadata":{"name":"web-1","namespace":"default"}}]}`)
+	cfgPath := filepath.Join(t.TempDir(), "k8shark.yaml")
+	cfgYAML := "anonymize:\n" +
+		"  categories: [namespace]\n" +
+		"  rules:\n" +
+		"    - category: namespace\n" +
+		"      kind: Pod\n" +
+		"      fieldPath: metadata.namespace\n" +
+		"      exclude: true\n"
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(t.TempDir(), "out.kshrk")
+
+	cmd := newTestAnonymizeCmdCommand(t)
+	cmd.SetOut(io.Discard)
+	_ = cmd.Flags().Set("config", cfgPath)
+	_ = cmd.Flags().Set("out", out)
+	_ = cmd.Flags().Set("anonymize-salt-file", writeAnonymizeTestSaltFile(t))
+
+	if err := runAnonymize(cmd, []string{in}); err != nil {
+		t.Fatalf("runAnonymize: %v", err)
+	}
+
+	ar, err := archivepkg.Open(out)
+	if err != nil {
+		t.Fatalf("opening output archive: %v", err)
+	}
+	defer ar.Close()
+	idx, err := ar.ReadIndex()
+	if err != nil {
+		t.Fatalf("ReadIndex: %v", err)
+	}
+	if len(idx) != 1 {
+		t.Fatalf("index has %d entries, want 1: %v", len(idx), idx)
+	}
+	var onlyPath string
+	for p := range idx {
+		onlyPath = p
+	}
+	data, err := ar.ReadRecord(onlyPath, 0)
+	if err != nil {
+		t.Fatalf("ReadRecord(%q, 0): %v", onlyPath, err)
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatal(err)
+	}
+	var podList map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &podList); err != nil {
+		t.Fatal(err)
+	}
+	gotNS := podList["items"].([]interface{})[0].(map[string]interface{})["metadata"].(map[string]interface{})["namespace"]
+	if gotNS != "default" {
+		t.Errorf("Pod metadata.namespace = %v, want unchanged \"default\" — excluded by the config-supplied rule", gotNS)
+	}
+}
+
+func TestRunAnonymize_JSONOutput(t *testing.T) {
+	// "default" matches buildDiffArchive's own hardcoded APIPath namespace
+	// segment, so there is exactly one distinct namespace value to count.
+	in := buildDiffArchive(t, `{"kind":"PodList","items":[{"metadata":{"name":"web-1","namespace":"default"}}]}`)
+
+	cmd := newTestAnonymizeCmdCommand(t)
+	var stdout strings.Builder
+	cmd.SetOut(&stdout)
+	_ = cmd.Flags().Set("categories", "namespace")
+	_ = cmd.Flags().Set("output", "json")
+	_ = cmd.Flags().Set("anonymize-salt-file", writeAnonymizeTestSaltFile(t))
+
+	if err := runAnonymize(cmd, []string{in}); err != nil {
+		t.Fatalf("runAnonymize: %v", err)
+	}
+
+	var result anonymize.Result
+	if err := json.Unmarshal([]byte(stdout.String()), &result); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %s", err, stdout.String())
+	}
+	if result.SchemaVersion != anonymize.SchemaVersion {
+		t.Errorf("schema_version = %d, want %d", result.SchemaVersion, anonymize.SchemaVersion)
+	}
+	if result.NamespacesRenamed != 1 {
+		t.Errorf("namespaces_renamed = %d, want 1", result.NamespacesRenamed)
+	}
+	if result.OutputPath == "" {
+		t.Error("output_path is empty")
+	}
+	if strings.Contains(stdout.String(), `"Mapping"`) {
+		t.Error("the mapping must never appear in -o json output, even though Result.Mapping is populated internally")
+	}
+}
+
+func TestRunAnonymize_EmitMappingRequiresEncryptionOrAck(t *testing.T) {
+	in := buildDiffArchive(t, `{"kind":"PodList","items":[{"metadata":{"name":"web-1","namespace":"prod"}}]}`)
+
+	t.Run("rejected with neither encryption nor the plaintext ack", func(t *testing.T) {
+		cmd := newTestAnonymizeCmdCommand(t)
+		cmd.SetOut(io.Discard)
+		_ = cmd.Flags().Set("categories", "namespace")
+		_ = cmd.Flags().Set("out", filepath.Join(t.TempDir(), "out.kshrk"))
+		_ = cmd.Flags().Set("emit-mapping", "true")
+		_ = cmd.Flags().Set("anonymize-salt-file", writeAnonymizeTestSaltFile(t))
+
+		if err := runAnonymize(cmd, []string{in}); err == nil {
+			t.Fatal("want an error when --emit-mapping is set with no encryption and no --emit-mapping-plaintext")
+		}
+	})
+
+	t.Run("plaintext ack writes a readable JSON mapping", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "out.kshrk")
+		cmd := newTestAnonymizeCmdCommand(t)
+		cmd.SetOut(io.Discard)
+		_ = cmd.Flags().Set("categories", "namespace")
+		_ = cmd.Flags().Set("out", out)
+		_ = cmd.Flags().Set("emit-mapping", "true")
+		_ = cmd.Flags().Set("emit-mapping-plaintext", "true")
+		_ = cmd.Flags().Set("anonymize-salt-file", writeAnonymizeTestSaltFile(t))
+
+		if err := runAnonymize(cmd, []string{in}); err != nil {
+			t.Fatalf("runAnonymize: %v", err)
+		}
+
+		mappingPath := out + ".mapping.json"
+		data, err := os.ReadFile(mappingPath)
+		if err != nil {
+			t.Fatalf("reading mapping file: %v", err)
+		}
+		var mapping map[string]map[string]string
+		if err := json.Unmarshal(data, &mapping); err != nil {
+			t.Fatalf("mapping file is not valid JSON: %v", err)
+		}
+		if mapping["namespace"]["prod"] == "" {
+			t.Errorf("mapping[namespace][prod] is empty; mapping = %v", mapping)
+		}
+	})
+
+	t.Run("an encryption recipient satisfies the requirement and encrypts the mapping", func(t *testing.T) {
+		id, err := age.GenerateX25519Identity()
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := filepath.Join(t.TempDir(), "out.kshrk")
+		cmd := newTestAnonymizeCmdCommand(t)
+		cmd.SetOut(io.Discard)
+		_ = cmd.Flags().Set("categories", "namespace")
+		_ = cmd.Flags().Set("out", out)
+		_ = cmd.Flags().Set("emit-mapping", "true")
+		_ = cmd.Flags().Set("encrypt-recipient", id.Recipient().String())
+		_ = cmd.Flags().Set("anonymize-salt-file", writeAnonymizeTestSaltFile(t))
+
+		if err := runAnonymize(cmd, []string{in}); err != nil {
+			t.Fatalf("runAnonymize: %v", err)
+		}
+
+		mappingPath := out + ".mapping.json.age"
+		f, err := os.Open(mappingPath)
+		if err != nil {
+			t.Fatalf("opening encrypted mapping file: %v", err)
+		}
+		defer f.Close()
+		r, err := age.Decrypt(f, id)
+		if err != nil {
+			t.Fatalf("age.Decrypt: %v", err)
+		}
+		data, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("reading decrypted mapping: %v", err)
+		}
+		var mapping map[string]map[string]string
+		if err := json.Unmarshal(data, &mapping); err != nil {
+			t.Fatalf("decrypted mapping is not valid JSON: %v", err)
+		}
+		if mapping["namespace"]["prod"] == "" {
+			t.Errorf("mapping[namespace][prod] is empty; mapping = %v", mapping)
 		}
 	})
 }

--- a/cmd/anonymize_test.go
+++ b/cmd/anonymize_test.go
@@ -317,6 +317,17 @@ func TestRunAnonymize_EmitMappingRequiresEncryptionOrAck(t *testing.T) {
 		if mapping["namespace"]["prod"] == "" {
 			t.Errorf("mapping[namespace][prod] is empty; mapping = %v", mapping)
 		}
+
+		// The mapping holds every original value behind an alias — it must
+		// never be created at the process umask's default (commonly 0644,
+		// world-readable), regardless of platform umask settings.
+		fi, err := os.Stat(mappingPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := fi.Mode().Perm(); got != 0o600 {
+			t.Errorf("mapping file mode = %o, want 0600", got)
+		}
 	})
 
 	t.Run("an encryption recipient satisfies the requirement and encrypts the mapping", func(t *testing.T) {

--- a/cmd/anonymize_test.go
+++ b/cmd/anonymize_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -320,13 +321,18 @@ func TestRunAnonymize_EmitMappingRequiresEncryptionOrAck(t *testing.T) {
 
 		// The mapping holds every original value behind an alias — it must
 		// never be created at the process umask's default (commonly 0644,
-		// world-readable), regardless of platform umask settings.
-		fi, err := os.Stat(mappingPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got := fi.Mode().Perm(); got != 0o600 {
-			t.Errorf("mapping file mode = %o, want 0600", got)
+		// world-readable), regardless of platform umask settings. Unix
+		// permission bits don't apply on Windows (mirrors
+		// internal/archive/crypto_test.go's identical skip for the same
+		// reason).
+		if runtime.GOOS != "windows" {
+			fi, err := os.Stat(mappingPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := fi.Mode().Perm(); got != 0o600 {
+				t.Errorf("mapping file mode = %o, want 0600", got)
+			}
 		}
 	})
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -72,6 +72,9 @@ using a deterministic alias derived from a salt.
 Categories available: namespace, node, pod, workload, ip, url, image -- see
 https://github.com/phenixblue/k8shark/issues/137.
 
+Categories and field-path exclusion rules may also be loaded from a config
+file's anonymize block via --config; see docs/config.md.
+
 ```
 kshrk anonymize <capture.kshrk> --categories <category> [--out <anonymized.kshrk>] [flags]
 ```
@@ -91,6 +94,12 @@ kshrk anonymize <capture.kshrk> --categories <category> [--out <anonymized.kshrk
   # Reproduce the exact same aliases on a re-run
   kshrk anonymize capture.kshrk --categories namespace --anonymize-salt-file salt.txt
 
+  # Categories and exclusion rules from a config file, as JSON output
+  kshrk anonymize capture.kshrk --config k8shark.yaml -o json
+
+  # Emit the original-to-alias mapping, encrypted to a recipient
+  kshrk anonymize capture.kshrk --categories namespace --emit-mapping --encrypt-recipient age1abc...
+
   # Anonymize and write to a chosen path
   kshrk anonymize capture.kshrk --out safe.kshrk --categories namespace
 ```
@@ -100,18 +109,22 @@ kshrk anonymize <capture.kshrk> --categories <category> [--out <anonymized.kshrk
 ```
       --anonymize-salt-file string       read the anonymize salt from this file (first line, hex-encoded) instead of $KSHRK_ANONYMIZE_SALT or generating one
       --categories stringArray           category to anonymize (repeatable); supported: namespace, node, pod, workload, ip, url, image
+      --config string                    capture config file whose anonymize.categories/anonymize.rules block is applied
+      --emit-mapping                     write the original-to-alias mapping alongside the output archive
+      --emit-mapping-plaintext           allow --emit-mapping to write an unencrypted mapping when no --encrypt-* flag is set (not recommended)
       --encrypt                          encrypt the output archive with a passphrase (age); from --encrypt-passphrase-file, $KSHRK_ENCRYPT_PASSPHRASE, or an interactive prompt
       --encrypt-passphrase-file string   read the encryption passphrase from this file (first line) instead of prompting
       --encrypt-recipient stringArray    age recipient public key (age1...) to encrypt to (repeatable); mutually exclusive with passphrase encryption
       --encrypt-recipients-file string   file of age recipient public keys (one per line) to encrypt to
   -h, --help                             help for anonymize
+      --mapping-path string              path for the mapping file (default: <out>.mapping.json, or .mapping.json.age when encrypted)
       --out string                       output archive path (default: <in>-anonymized.kshrk)
+  -o, --output string                    output format: text or json (default "text")
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string                    config file (default: ./config.yaml, then ~/.config/kshrk/config.yaml)
       --decrypt-identity-file string     age identity (key) file to decrypt an encrypted archive
       --decrypt-passphrase-file string   read the passphrase for an encrypted archive from this file (first line)
   -v, --verbose                          enable verbose output

--- a/docs/config.md
+++ b/docs/config.md
@@ -556,6 +556,71 @@ kshrk redact capture.kshrk --out redacted.kshrk --config k8shark.yaml
 
 ---
 
+## Anonymize
+
+`kshrk anonymize` replaces every occurrence of a value it recognizes — a namespace name, a node's IP, an image registry host — with a stable, deterministic alias, consistently across the whole archive. This is different from redaction: redaction replaces one exact field path with a fixed constant; anonymize replaces every occurrence of a *value*, using an alias derived from a salt (never stored in this config — see [Naming convention](#naming-convention) and the CLI's `--anonymize-salt-file` flag).
+
+Categories and field-path exclusion rules live in a top-level `anonymize` block and are applied when running `kshrk anonymize --config`.
+
+### `anonymize` fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `categories` | list of strings | `[]` | Categories to anonymize: `namespace`, `node`, `pod`, `workload`, `ip`, `url`, `image`. Merged with any `--categories` flags. |
+| `rules` | list | `[]` | Field-path exclusions layered on top of `categories`. See below. |
+| `emitMapping` | bool | `false` | Write the original-to-alias mapping alongside the output archive (same as `--emit-mapping` on the CLI). |
+| `mappingPath` | string | *(computed)* | Override the mapping file's path. |
+
+### Anonymize rule fields
+
+Anonymize rules are **exclusions only** — a value's category membership is already determined automatically by where and how it occurs, so there is no separate "include" action. Every rule must set `exclude: true`; `kshrk anonymize` rejects a config where it isn't.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `category` | string | yes | The category this exclusion applies to (`namespace`, `node`, `pod`, `workload`, `ip`, `url`, or `image`). |
+| `fieldPath` | string | yes | The field's path from the object root, e.g. `metadata.name`, `spec.containers[*].image`, `status.podIP`. Every array index is written as the wildcard `[*]` — never a literal index — since a rule targets a kind of occurrence, not one specific array element. |
+| `kind` | string | no | Resource kind to match, e.g. `Pod`, `Node`. Use `*` or omit to match every kind the category applies to. |
+| `exclude` | bool | yes | Must be `true`. |
+
+### Example: unified config with anonymize
+
+```yaml
+duration: 10m
+output: ./capture.kshrk
+kubeconfig: ~/.kube/config
+
+resources:
+  - all: true
+
+anonymize:
+  categories:
+    - namespace
+    - node
+    - ip
+
+  rules:
+    # A known, non-sensitive reserved IP that should stay readable
+    - category: ip
+      kind: Pod
+      fieldPath: status.podIP
+      exclude: true
+
+    # Leave a specific Node's own identity alone, but still alias its
+    # appearance elsewhere (spec.nodeName, Event source.host, ...)
+    - category: node
+      kind: Node
+      fieldPath: metadata.name
+      exclude: true
+```
+
+Apply the same categories and rules to an existing archive:
+
+```bash
+kshrk anonymize capture.kshrk --out safe.kshrk --config k8shark.yaml
+```
+
+---
+
 ## Duration and interval units
 
 Both `duration` and `interval` accept Go duration strings:

--- a/docs/stability-policy.md
+++ b/docs/stability-policy.md
@@ -55,6 +55,7 @@ the exceptions called out [below](#flags-explicitly-not-covered):
 | `query` | JSONPath / text / regex search across an archive |
 | `transitions` | List watch-event (ADDED/MODIFIED/DELETED) history |
 | `redact` | Re-write an archive with Secret/field redaction applied |
+| `anonymize` | Re-write an archive with consistent value/pattern-based aliasing applied |
 | `encrypt` / `decrypt` | Re-write an archive's encryption envelope |
 | `completion` | Generate shell completion scripts |
 | `version` | Print the `kshrk` version |
@@ -112,17 +113,17 @@ command's current successes into exit `1` would break them.
 
 ### Structured output (`-o json` / `-o yaml`)
 
-`inspect`, `diagnose`, `diff`, `query`, and `transitions` all support `-o
-json` (some also support `-o yaml`). **This output is a stable, scriptable
-interface, not an implementation detail** — it follows the same evolution
-rule as the archive format:
+`inspect`, `diagnose`, `diff`, `query`, `transitions`, and `anonymize` all
+support `-o json` (some also support `-o yaml`). **This output is a stable,
+scriptable interface, not an implementation detail** — it follows the same
+evolution rule as the archive format:
 
 - Adding a new field is a minor-version change. Consumers must ignore
   fields they don't recognize.
 - Removing a field, renaming a field, or changing a field's type/meaning is
   a major-version change.
 
-Every one of the five emits a JSON **object** at the top level (never a bare
+Every one of the six emits a JSON **object** at the top level (never a bare
 array) carrying its own `schema_version`, so the envelope can always gain
 fields and a consumer can always tell what shape it's parsing. The versions
 are per-command and independent: `diagnose`'s `schema_version` moving to 2
@@ -136,6 +137,8 @@ carries is emitted even when empty, rather than dropped. The key sets differ
 *between* commands, though — only `inspect`, `diagnose`, and `transitions`
 carry a `capture_id`. `query` doesn't, and `diff` deliberately doesn't, since
 it compares two archives and a single capture ID wouldn't identify either.
+`anonymize` doesn't carry one either, for the same `diff`/`query` reason:
+its per-category counts describe the *rewrite*, not a single capture.
 
 The one deliberately conditional field is `diagnose`'s `at`, present only when
 `--at` was passed.

--- a/internal/anonymize/apipath_test.go
+++ b/internal/anonymize/apipath_test.go
@@ -4,6 +4,11 @@ import "testing"
 
 func upper(s string) string { return s + "-ALIASED" }
 
+// noExclusions is the excludedFunc used by every test that isn't
+// specifically exercising rule-based exclusion — equivalent to an archive
+// run with no configured AnonymizeRule entries.
+func noExclusions(Category, string, string) bool { return false }
+
 func TestRewriteNamespaceInPath(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/internal/anonymize/archive.go
+++ b/internal/anonymize/archive.go
@@ -107,8 +107,14 @@ type Result struct {
 	// OutputPath and OutputBytes are populated by the CLI layer (cmd/anonymize.go),
 	// not by Archive itself — Archive doesn't know its own caller's chosen
 	// output path or need to stat the file it just finished writing.
-	OutputPath  string `json:"output_path,omitempty"`
-	OutputBytes int64  `json:"output_bytes,omitempty"`
+	// Deliberately not omitempty: docs/stability-policy.md's -o json
+	// contract requires every command's top-level key set to be identical
+	// on every run, present even when the value is empty/zero — a stray
+	// omitempty here would silently drop output_path/output_bytes from the
+	// rare case where OutputBytes is legitimately 0 (e.g. os.Stat failed)
+	// or a caller marshals a zero-value Result directly.
+	OutputPath  string `json:"output_path"`
+	OutputBytes int64  `json:"output_bytes"`
 	// Mapping is the original-to-alias mapping, keyed by category, for
 	// every category Options.Categories requested — regardless of whether
 	// the caller actually asked to emit it. Deliberately excluded from the

--- a/internal/anonymize/archive.go
+++ b/internal/anonymize/archive.go
@@ -9,6 +9,7 @@ import (
 	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/config"
 )
 
 // sortedKeys returns m's keys sorted lexicographically, so a caller that
@@ -67,19 +68,31 @@ type Options struct {
 	// Recipients, when non-empty, cause the anonymized output archive to be
 	// written as an age-encrypted envelope. Mirrors redact.Options.Recipients.
 	Recipients []age.Recipient
+	// Rules is a list of field-path exclusions layered on top of
+	// Categories — see config.AnonymizeRule's own doc comment. Every entry
+	// must have Exclude set; Archive rejects the whole run otherwise (see
+	// newExcludeMatcher).
+	Rules []config.AnonymizeRule
 }
+
+// SchemaVersion is the version of the `kshrk anonymize -o json` output
+// shape (Result). Bump on a breaking change to the documented shape, per
+// docs/stability-policy.md's convention for the other -o json commands
+// (internal/query, internal/diagnose, internal/inspect).
+const SchemaVersion = 1
 
 // Result reports how many distinct values were anonymized, per category.
 // Every count is the number of distinct original values encountered, not
 // the number of records touched — a value that appears on 50 records still
 // counts once.
 type Result struct {
-	NamespacesRenamed int
-	NodesRenamed      int
-	PodsRenamed       int
-	WorkloadsRenamed  int
+	SchemaVersion     int `json:"schema_version"`
+	NamespacesRenamed int `json:"namespaces_renamed"`
+	NodesRenamed      int `json:"nodes_renamed"`
+	PodsRenamed       int `json:"pods_renamed"`
+	WorkloadsRenamed  int `json:"workloads_renamed"`
 	// IPsRenamed counts distinct IP literals.
-	IPsRenamed int
+	IPsRenamed int `json:"ips_renamed"`
 	// HostsRenamed counts distinct URL-category values: bare hostnames (an
 	// Ingress host, a Service externalName) and whatever occupies a
 	// scheme://host URL's host position — which is not always a DNS name.
@@ -87,10 +100,25 @@ type Result struct {
 	// through this same category, so an IP literal sitting in a URL's host
 	// position counts here too, not under IPsRenamed — see Archive's own
 	// ServerAddress-rewrite comment for why that's the deliberate choice.
-	HostsRenamed int
+	HostsRenamed int `json:"hosts_renamed"`
 	// RegistriesRenamed counts distinct container-image registry hosts
 	// (the leading host[:port] segment of an image reference).
-	RegistriesRenamed int
+	RegistriesRenamed int `json:"registries_renamed"`
+	// OutputPath and OutputBytes are populated by the CLI layer (cmd/anonymize.go),
+	// not by Archive itself — Archive doesn't know its own caller's chosen
+	// output path or need to stat the file it just finished writing.
+	OutputPath  string `json:"output_path,omitempty"`
+	OutputBytes int64  `json:"output_bytes,omitempty"`
+	// Mapping is the original-to-alias mapping, keyed by category, for
+	// every category Options.Categories requested — regardless of whether
+	// the caller actually asked to emit it. Deliberately excluded from the
+	// -o json output (json:"-"): unlike every other field here, this is the
+	// one genuinely sensitive payload Archive can produce, and #137's own
+	// design explicitly requires it be "never persisted by default" — that
+	// has to hold for accidentally-scripted `-o json | jq` output too, not
+	// just for the default text summary. The CLI layer (cmd/anonymize.go)
+	// only writes this out at all when --emit-mapping was explicitly given.
+	Mapping map[Category]map[string]string `json:"-"`
 }
 
 // Archive reads srcPath, anonymizes it per opts, and writes to dstPath. The
@@ -159,6 +187,11 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 		CategoryWorkload: doWorkload,
 	}
 	doResourceName := doNode || doPod || doWorkload
+
+	excluded, err := newExcludeMatcher(opts.Rules)
+	if err != nil {
+		return Result{}, err
+	}
 
 	ar, err := archive.OpenWithIdentities(srcPath, opts.Identities)
 	if err != nil {
@@ -308,27 +341,27 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 			}
 
 			if doNamespace {
-				if _, err := rewriteNamespaceInRecord(&rec, namespaceAlias); err != nil {
+				if _, err := rewriteNamespaceInRecord(&rec, excluded, namespaceAlias); err != nil {
 					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
 				}
 			}
 			if doResourceName {
-				if _, err := rewriteResourceNameInRecord(&rec, enabledResource, resourceAlias); err != nil {
+				if _, err := rewriteResourceNameInRecord(&rec, enabledResource, excluded, resourceAlias); err != nil {
 					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
 				}
 			}
 			if doIP {
-				if _, err := rewriteIPInRecord(&rec, ipAlias); err != nil {
+				if _, err := rewriteIPInRecord(&rec, excluded, ipAlias); err != nil {
 					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
 				}
 			}
 			if doURL {
-				if _, err := rewriteURLInRecord(&rec, urlAlias); err != nil {
+				if _, err := rewriteURLInRecord(&rec, excluded, urlAlias); err != nil {
 					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
 				}
 			}
 			if doImage {
-				if _, err := rewriteImageRegistryInRecord(&rec, imageAlias); err != nil {
+				if _, err := rewriteImageRegistryInRecord(&rec, excluded, imageAlias); err != nil {
 					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
 				}
 			}
@@ -476,6 +509,17 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	// plaintext source anonymized straight into an encrypted output.
 	meta.Encrypted = len(opts.Recipients) > 0
 
+	// Provenance, mirroring Redacted/SecretsRedacted's identical pattern:
+	// mark the output as anonymized and record which categories were
+	// actually applied, so a later `kshrk inspect`/the UI's capture-info
+	// card can say so without having to guess from the data itself.
+	meta.Anonymized = true
+	anonymizedCategories := make([]string, len(opts.Categories))
+	for i, cat := range opts.Categories {
+		anonymizedCategories[i] = string(cat)
+	}
+	meta.AnonymizedCategories = anonymizedCategories
+
 	// CaptureMetadata.ServerAddress lives on the metadata, not inside any
 	// Record body, so it needs its own rewrite here rather than going
 	// through rewriteEntryRecords — but it's the exact same URL shape
@@ -496,7 +540,32 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	}
 	finished = true
 
+	// Only the requested categories' trackers actually saw any values (an
+	// unrequested category's tracker is wired up but never called), so its
+	// Mapping() would just be an empty map — including it anyway would be
+	// harmless but misleading, implying that category was processed.
+	mapping := make(map[Category]map[string]string, len(opts.Categories))
+	for _, cat := range opts.Categories {
+		switch cat {
+		case CategoryNamespace:
+			mapping[cat] = namespaceTracker.Mapping()
+		case CategoryNode:
+			mapping[cat] = nodeTracker.Mapping()
+		case CategoryPod:
+			mapping[cat] = podTracker.Mapping()
+		case CategoryWorkload:
+			mapping[cat] = workloadTracker.Mapping()
+		case CategoryIP:
+			mapping[cat] = ipTracker.Mapping()
+		case CategoryURL:
+			mapping[cat] = urlTracker.Mapping()
+		case CategoryImage:
+			mapping[cat] = imageTracker.Mapping()
+		}
+	}
+
 	return Result{
+		SchemaVersion:     SchemaVersion,
 		NamespacesRenamed: namespaceTracker.Count(),
 		NodesRenamed:      nodeTracker.Count(),
 		PodsRenamed:       podTracker.Count(),
@@ -504,5 +573,6 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 		IPsRenamed:        ipTracker.Count(),
 		HostsRenamed:      urlTracker.Count(),
 		RegistriesRenamed: imageTracker.Count(),
+		Mapping:           mapping,
 	}, nil
 }

--- a/internal/anonymize/archive_test.go
+++ b/internal/anonymize/archive_test.go
@@ -12,6 +12,7 @@ import (
 	"filippo.io/age"
 	"github.com/phenixblue/k8shark/internal/archive"
 	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/config"
 	"github.com/phenixblue/k8shark/internal/store"
 )
 
@@ -112,6 +113,22 @@ func TestArchive_NamespaceConsistentAcrossKindsAndPaths(t *testing.T) {
 
 	wantAlias := NewAliaser(salt).Alias(CategoryNamespace, "prod")
 
+	t.Run("Result.Mapping carries the same original->alias pair, only for requested categories", func(t *testing.T) {
+		nsMapping, ok := result.Mapping[CategoryNamespace]
+		if !ok {
+			t.Fatal("Mapping has no entry for the requested namespace category")
+		}
+		if got, want := nsMapping["prod"], wantAlias; got != want {
+			t.Errorf(`Mapping[namespace]["prod"] = %q, want %q`, got, want)
+		}
+		if len(nsMapping) != 1 {
+			t.Errorf("Mapping[namespace] has %d entries, want 1", len(nsMapping))
+		}
+		if _, ok := result.Mapping[CategoryPod]; ok {
+			t.Error("Mapping has an entry for CategoryPod, which was never requested")
+		}
+	})
+
 	ar, err := archive.Open(dst)
 	if err != nil {
 		t.Fatalf("opening output archive: %v", err)
@@ -194,6 +211,44 @@ func indexKeys(idx capture.Index) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// The output archive's own metadata must record that it was anonymized,
+// and with which categories — mirroring Redacted/SecretsRedacted's
+// identical provenance pattern (internal/redact) — so a later `kshrk
+// inspect` or the UI's capture-info card can say so without guessing.
+func TestArchive_SetsAnonymizedProvenanceMetadata(t *testing.T) {
+	src := buildAnonymizeTestArchive(t, namespaceFixtureRecords())
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+	if _, err := Archive(src, dst, Options{
+		Categories: []Category{CategoryNamespace, CategoryNode},
+		Salt:       []byte("provenance-test-salt"),
+	}); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	defer ar.Close()
+	meta, err := ar.ReadMetadata()
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if !meta.Anonymized {
+		t.Error("meta.Anonymized = false, want true")
+	}
+	want := []string{"namespace", "node"}
+	if len(meta.AnonymizedCategories) != len(want) {
+		t.Fatalf("AnonymizedCategories = %v, want %v", meta.AnonymizedCategories, want)
+	}
+	for i := range want {
+		if meta.AnonymizedCategories[i] != want[i] {
+			t.Errorf("AnonymizedCategories[%d] = %q, want %q", i, meta.AnonymizedCategories[i], want[i])
+		}
+	}
 }
 
 // The sharpest regression risk named in the design plan: proving the output
@@ -1069,5 +1124,191 @@ func TestArchive_DetectsRealURLCollision(t *testing.T) {
 	}
 	if _, statErr := os.Stat(dst); statErr == nil {
 		t.Error("no (corrupt) output file should be left behind on a detected collision")
+	}
+}
+
+// An AnonymizeRule excluding a Namespace object's own metadata.name must
+// leave that specific occurrence alone while every other namespace
+// occurrence in the same archive still gets aliased normally — proving the
+// exclude wiring reaches all the way from Options.Rules through
+// newExcludeMatcher into rewriteNamespaceInObject's actual field-write
+// site, not just that the matcher itself works in isolation
+// (rules_test.go already covers that). The path rewrite
+// (rewriteNamespaceInPath) is a separate, unconditional mechanism not
+// gated by rules at all — only the body's own metadata.name field is
+// excluded here.
+func TestArchive_RuleExcludesSpecificFieldPath(t *testing.T) {
+	src := buildAnonymizeTestArchive(t, namespaceFixtureRecords())
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+	salt := []byte("rule-exclude-test-salt")
+
+	result, err := Archive(src, dst, Options{
+		Categories: []Category{CategoryNamespace},
+		Salt:       salt,
+		Rules: []config.AnonymizeRule{
+			{Category: "namespace", Kind: "Namespace", FieldPath: "metadata.name", Exclude: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	// The Pod's metadata.namespace and the Event's namespace occurrences are
+	// NOT excluded (different fieldPath/kind), so "prod" is still seen and
+	// counted there — only the Namespace object's own identity is skipped.
+	if result.NamespacesRenamed != 1 {
+		t.Errorf("NamespacesRenamed = %d, want 1 (still counted via the Pod/Event occurrences)", result.NamespacesRenamed)
+	}
+
+	wantAlias := NewAliaser(salt).Alias(CategoryNamespace, "prod")
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatalf("opening output archive: %v", err)
+	}
+	defer ar.Close()
+
+	data, err := ar.ReadRecord("/api/v1/namespaces/"+wantAlias, 0)
+	if err != nil {
+		t.Fatalf("ReadRecord: %v", err)
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatal(err)
+	}
+	var nsObj map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &nsObj); err != nil {
+		t.Fatal(err)
+	}
+	if got := nsObj["metadata"].(map[string]interface{})["name"]; got != "prod" {
+		t.Errorf("Namespace metadata.name = %v, want unchanged prod — excluded by rule", got)
+	}
+
+	// The Pod's metadata.namespace, a different fieldPath, is still aliased.
+	data, err = ar.ReadRecord("/api/v1/namespaces/"+wantAlias+"/pods", 0)
+	if err != nil {
+		t.Fatalf("ReadRecord: %v", err)
+	}
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatal(err)
+	}
+	var podList map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &podList); err != nil {
+		t.Fatal(err)
+	}
+	podNS := podList["items"].([]interface{})[0].(map[string]interface{})["metadata"].(map[string]interface{})["namespace"]
+	if podNS != wantAlias {
+		t.Errorf("Pod metadata.namespace = %v, want %v — not excluded by this rule", podNS, wantAlias)
+	}
+}
+
+// A rule scoped to a Kind that never occurs in the archive must be a
+// complete no-op — proving Kind scoping is exact, not accidentally broad.
+func TestArchive_RuleScopedToWrongKindDoesNotExclude(t *testing.T) {
+	src := buildAnonymizeTestArchive(t, namespaceFixtureRecords())
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+	salt := []byte("rule-wrong-kind-test-salt")
+
+	_, err := Archive(src, dst, Options{
+		Categories: []Category{CategoryNamespace},
+		Salt:       salt,
+		Rules: []config.AnonymizeRule{
+			// Same fieldPath, but scoped to a Kind that never appears —
+			// must not accidentally suppress the real Namespace occurrence.
+			{Category: "namespace", Kind: "ConfigMap", FieldPath: "metadata.name", Exclude: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	wantAlias := NewAliaser(salt).Alias(CategoryNamespace, "prod")
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatalf("opening output archive: %v", err)
+	}
+	defer ar.Close()
+	data, err := ar.ReadRecord("/api/v1/namespaces/"+wantAlias, 0)
+	if err != nil {
+		t.Fatalf("ReadRecord: %v", err)
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatal(err)
+	}
+	var nsObj map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &nsObj); err != nil {
+		t.Fatal(err)
+	}
+	if got := nsObj["metadata"].(map[string]interface{})["name"]; got != wantAlias {
+		t.Errorf("Namespace metadata.name = %v, want %v — the rule's Kind doesn't match, so it must not exclude", got, wantAlias)
+	}
+}
+
+// A rule excluding a full-tree-scanned category's occurrence (IP) by its
+// computed field path, proving the walkStrings path-tracking added for
+// exclusion actually reaches the IP/URL full-tree scans, not just the
+// schema-aware categories' fixed field-write sites.
+func TestArchive_RuleExcludesFullTreeIPOccurrence(t *testing.T) {
+	body := `{"kind":"Pod","metadata":{"name":"web-1"},"status":{"podIP":"10.1.2.3","hostIP":"10.9.9.9"}}`
+	rec := &capture.Record{
+		ID: "r1", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/prod/pods/web-1",
+		HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(body),
+	}
+	src := buildAnonymizeTestArchive(t, []*capture.Record{rec})
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+	salt := []byte("rule-exclude-ip-test-salt")
+
+	_, err := Archive(src, dst, Options{
+		Categories: []Category{CategoryIP},
+		Salt:       salt,
+		Rules: []config.AnonymizeRule{
+			{Category: "ip", Kind: "Pod", FieldPath: "status.podIP", Exclude: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatalf("opening output archive: %v", err)
+	}
+	defer ar.Close()
+	data, err := ar.ReadRecord("/api/v1/namespaces/prod/pods/web-1", 0)
+	if err != nil {
+		t.Fatalf("ReadRecord: %v", err)
+	}
+	var outRec capture.Record
+	if err := json.Unmarshal(data, &outRec); err != nil {
+		t.Fatal(err)
+	}
+	var podObj map[string]interface{}
+	if err := json.Unmarshal(outRec.ResponseBody, &podObj); err != nil {
+		t.Fatal(err)
+	}
+	status := podObj["status"].(map[string]interface{})
+	if got := status["podIP"]; got != "10.1.2.3" {
+		t.Errorf("status.podIP = %v, want unchanged 10.1.2.3 — excluded by rule", got)
+	}
+	if got := status["hostIP"]; got == "10.9.9.9" {
+		t.Error("status.hostIP was not aliased — the exclude rule for status.podIP must not also suppress a different field path")
+	}
+}
+
+func TestArchive_RejectsInvalidRule(t *testing.T) {
+	src := buildAnonymizeTestArchive(t, namespaceFixtureRecords())
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+	_, err := Archive(src, dst, Options{
+		Categories: []Category{CategoryNamespace},
+		Salt:       []byte("s"),
+		Rules: []config.AnonymizeRule{
+			{Category: "namespace", FieldPath: "metadata.name", Exclude: false},
+		},
+	})
+	if err == nil {
+		t.Fatal("want an error for a rule with Exclude: false")
+	}
+	if _, statErr := os.Stat(dst); statErr == nil {
+		t.Error("no output file should be left behind on a rejected rule")
 	}
 }

--- a/internal/anonymize/collision.go
+++ b/internal/anonymize/collision.go
@@ -68,3 +68,15 @@ func (c *collisionTracker) Err() error { return c.err }
 // exactly the bookkeeping Result's per-category counts need, and a
 // byproduct of collision detection rather than separate state to maintain.
 func (c *collisionTracker) Count() int { return len(c.aliasOf) }
+
+// Mapping returns a copy of the original-to-alias mapping accumulated so
+// far, for Options.EmitMapping's benefit (archive.go) — a copy, not the
+// live map, so a caller holding onto it can't observe (or corrupt) this
+// tracker's own state as more values are aliased after the copy is taken.
+func (c *collisionTracker) Mapping() map[string]string {
+	m := make(map[string]string, len(c.aliasOf))
+	for k, v := range c.aliasOf {
+		m[k] = v
+	}
+	return m
+}

--- a/internal/anonymize/imagematch.go
+++ b/internal/anonymize/imagematch.go
@@ -48,13 +48,34 @@ var containerFieldNames = func() map[string]bool {
 // here at all" — see registryHost). The repository path, tag, and digest
 // are left untouched; full OCI reference grammar reconstruction is real,
 // separate parsing work this milestone doesn't attempt.
-func rewriteImageRegistryInRecord(rec *capture.Record, alias func(string) string) (bool, error) {
-	var obj interface{}
+func rewriteImageRegistryInRecord(rec *capture.Record, excluded excludedFunc, alias func(string) string) (bool, error) {
+	var obj map[string]interface{}
 	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
 		return false, nil
 	}
 
-	modified := rewriteContainerImages(obj, alias)
+	kind, _ := obj["kind"].(string)
+	modified := false
+	if strings.HasSuffix(kind, "List") {
+		items, _ := obj["items"].([]interface{})
+		itemKind := strings.TrimSuffix(kind, "List")
+		for i, itemRaw := range items {
+			item, ok := itemRaw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			ik := itemKind
+			if k, ok := item["kind"].(string); ok && k != "" {
+				ik = k
+			}
+			if rewriteContainerImages(item, ik, "", excluded, alias) {
+				items[i] = item
+				modified = true
+			}
+		}
+	} else if rewriteContainerImages(obj, kind, "", excluded, alias) {
+		modified = true
+	}
 
 	if !modified {
 		return false, nil
@@ -68,8 +89,14 @@ func rewriteImageRegistryInRecord(rec *capture.Record, alias func(string) string
 }
 
 // rewriteContainerImages recursively walks node, rewriting "image"/"imageID"
-// string fields inside any container-list-shaped map it finds.
-func rewriteContainerImages(node interface{}, alias func(string) string) bool {
+// string fields inside any container-list-shaped map it finds. kind is the
+// enclosing object's own Kind (e.g. "Deployment") — fixed for the whole
+// recursive descent, unlike path, which grows as the walk goes deeper
+// (e.g. into a Deployment's spec.template.spec). Both are threaded through
+// purely for exclusion-rule matching; nothing else in this function
+// depends on kind at all, since the container-list shape it looks for is
+// the same regardless of which Kind it's nested under.
+func rewriteContainerImages(node interface{}, kind, path string, excluded excludedFunc, alias func(string) string) bool {
 	switch v := node.(type) {
 	case map[string]interface{}:
 		modified := false
@@ -77,6 +104,10 @@ func rewriteContainerImages(node interface{}, alias func(string) string) bool {
 		for _, field := range containerListFields {
 			list, ok := v[field].([]interface{})
 			if !ok {
+				continue
+			}
+			imagePath := joinFieldPath(path, field) + "[*].image"
+			if excluded(CategoryImage, kind, imagePath) {
 				continue
 			}
 			for _, raw := range list {
@@ -97,12 +128,16 @@ func rewriteContainerImages(node interface{}, alias func(string) string) bool {
 			if !ok {
 				continue
 			}
+			base := joinFieldPath(path, field) + "[*]"
 			for _, raw := range list {
 				c, ok := raw.(map[string]interface{})
 				if !ok {
 					continue
 				}
 				for _, imgField := range []string{"image", "imageID"} {
+					if excluded(CategoryImage, kind, base+"."+imgField) {
+						continue
+					}
 					if image, ok := c[imgField].(string); ok && image != "" {
 						if rewritten, changed := rewriteImageRegistryHost(image, alias); changed {
 							c[imgField] = rewritten
@@ -126,15 +161,16 @@ func rewriteContainerImages(node interface{}, alias func(string) string) bool {
 			if containerFieldNames[k] {
 				continue
 			}
-			if rewriteContainerImages(val, alias) {
+			if rewriteContainerImages(val, kind, joinFieldPath(path, k), excluded, alias) {
 				modified = true
 			}
 		}
 		return modified
 	case []interface{}:
 		modified := false
+		childPath := path + "[*]"
 		for _, val := range v {
-			if rewriteContainerImages(val, alias) {
+			if rewriteContainerImages(val, kind, childPath, excluded, alias) {
 				modified = true
 			}
 		}

--- a/internal/anonymize/imagematch_test.go
+++ b/internal/anonymize/imagematch_test.go
@@ -95,7 +95,7 @@ func TestRewriteImageRegistryInRecord(t *testing.T) {
 		body := `{"kind":"Pod","spec":{"containers":[{"name":"app","image":"registry.internal.corp/team/app:v1"}]},
 			"status":{"containerStatuses":[{"name":"app","image":"registry.internal.corp/team/app:v1","imageID":"registry.internal.corp/team/app@sha256:abc"}]}}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
-		changed, err := rewriteImageRegistryInRecord(rec, upper)
+		changed, err := rewriteImageRegistryInRecord(rec, noExclusions, upper)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -125,7 +125,7 @@ func TestRewriteImageRegistryInRecord(t *testing.T) {
 	t.Run("Deployment nested at spec.template.spec", func(t *testing.T) {
 		body := `{"kind":"Deployment","spec":{"template":{"spec":{"containers":[{"name":"app","image":"registry.internal.corp/team/app:v1"}]}}}}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
-		changed, err := rewriteImageRegistryInRecord(rec, upper)
+		changed, err := rewriteImageRegistryInRecord(rec, noExclusions, upper)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -148,7 +148,7 @@ func TestRewriteImageRegistryInRecord(t *testing.T) {
 			"containers":[{"name":"app","image":"registry.internal.corp/team/app:v1"}]
 		}}}}}}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
-		changed, err := rewriteImageRegistryInRecord(rec, upper)
+		changed, err := rewriteImageRegistryInRecord(rec, noExclusions, upper)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -171,7 +171,7 @@ func TestRewriteImageRegistryInRecord(t *testing.T) {
 		body := `{"kind":"Pod","spec":{"containers":[{"name":"app","image":"nginx:1.21"}]}}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
 		orig := string(rec.ResponseBody)
-		changed, err := rewriteImageRegistryInRecord(rec, upper)
+		changed, err := rewriteImageRegistryInRecord(rec, noExclusions, upper)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -187,7 +187,7 @@ func TestRewriteImageRegistryInRecord(t *testing.T) {
 		body := `{"kind":"Namespace","metadata":{"name":"prod"}}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
 		orig := string(rec.ResponseBody)
-		changed, err := rewriteImageRegistryInRecord(rec, upper)
+		changed, err := rewriteImageRegistryInRecord(rec, noExclusions, upper)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/anonymize/ipmatch.go
+++ b/internal/anonymize/ipmatch.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/phenixblue/k8shark/internal/capture"
 )
@@ -39,19 +40,55 @@ import (
 // passes through unrecognized. Splitting a CIDR into its address and
 // prefix-length, aliasing just the address, is real additional work the
 // design plan doesn't call out for this milestone.
-func rewriteIPInRecord(rec *capture.Record, alias func(string) string) (bool, error) {
-	var obj interface{}
+//
+// List-aware, the same way the schema-aware categories are (namespace.go,
+// resourcename.go): an exclude rule can be scoped to a Kind, and IP
+// occurrences inside a List response's items[] belong to each item's own
+// Kind, not the List's — walking the whole record body in one flat pass
+// (as this function did before rule support existed) would have no correct
+// Kind to check exclusion against for a List response at all.
+func rewriteIPInRecord(rec *capture.Record, excluded excludedFunc, alias func(string) string) (bool, error) {
+	var obj map[string]interface{}
 	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
 		return false, nil
 	}
 
-	changed := walkStrings(obj, func(s string) (string, bool) {
-		if net.ParseIP(s) == nil {
-			return "", false
+	kind, _ := obj["kind"].(string)
+	visit := func(node interface{}, itemKind string) bool {
+		return walkStrings(node, "", func(path, s string) (string, bool) {
+			if net.ParseIP(s) == nil {
+				return "", false
+			}
+			if excluded(CategoryIP, itemKind, path) {
+				return "", false
+			}
+			return alias(s), true
+		})
+	}
+
+	modified := false
+	if strings.HasSuffix(kind, "List") {
+		items, _ := obj["items"].([]interface{})
+		itemKind := strings.TrimSuffix(kind, "List")
+		for i, itemRaw := range items {
+			item, ok := itemRaw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			ik := itemKind
+			if k, ok := item["kind"].(string); ok && k != "" {
+				ik = k
+			}
+			if visit(item, ik) {
+				items[i] = item
+				modified = true
+			}
 		}
-		return alias(s), true
-	})
-	if !changed {
+	} else if visit(obj, kind) {
+		modified = true
+	}
+
+	if !modified {
 		return false, nil
 	}
 

--- a/internal/anonymize/ipmatch_test.go
+++ b/internal/anonymize/ipmatch_test.go
@@ -12,7 +12,7 @@ func TestRewriteIPInRecord(t *testing.T) {
 		rec := &capture.Record{
 			ResponseBody: json.RawMessage(`{"kind":"Pod","status":{"podIP":"10.1.2.3"}}`),
 		}
-		changed, err := rewriteIPInRecord(rec, upper)
+		changed, err := rewriteIPInRecord(rec, noExclusions, upper)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -32,7 +32,7 @@ func TestRewriteIPInRecord(t *testing.T) {
 		rec := &capture.Record{
 			ResponseBody: json.RawMessage(`{"kind":"Pod","status":{"podIPs":[{"ip":"10.1.2.3"},{"ip":"fd00::1"}]}}`),
 		}
-		changed, err := rewriteIPInRecord(rec, upper)
+		changed, err := rewriteIPInRecord(rec, noExclusions, upper)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -63,7 +63,7 @@ func TestRewriteIPInRecord(t *testing.T) {
 			ResponseBody: json.RawMessage(`{"kind":"Pod","metadata":{"annotations":{"note":"reachable at 10.1.2.3 for now"}}}`),
 		}
 		orig := string(rec.ResponseBody)
-		changed, err := rewriteIPInRecord(rec, upper)
+		changed, err := rewriteIPInRecord(rec, noExclusions, upper)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -79,7 +79,7 @@ func TestRewriteIPInRecord(t *testing.T) {
 		rec := &capture.Record{
 			ResponseBody: json.RawMessage(`{"kind":"Pod","metadata":{"annotations":{"external-ip":"203.0.113.5"}}}`),
 		}
-		changed, err := rewriteIPInRecord(rec, upper)
+		changed, err := rewriteIPInRecord(rec, noExclusions, upper)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -101,7 +101,7 @@ func TestRewriteIPInRecord(t *testing.T) {
 			ResponseBody: json.RawMessage(`{"kind":"Node","spec":{"podCIDR":"10.244.0.0/16"}}`),
 		}
 		orig := string(rec.ResponseBody)
-		changed, err := rewriteIPInRecord(rec, upper)
+		changed, err := rewriteIPInRecord(rec, noExclusions, upper)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -117,7 +117,7 @@ func TestRewriteIPInRecord(t *testing.T) {
 		body := `{"kind":"Namespace","metadata":{"name":"prod"}}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
 		orig := string(rec.ResponseBody)
-		changed, err := rewriteIPInRecord(rec, upper)
+		changed, err := rewriteIPInRecord(rec, noExclusions, upper)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -137,7 +137,7 @@ func TestRewriteIPInRecord(t *testing.T) {
 		// scalar types decoded generically — walkStrings still visits a
 		// string cell like any other string leaf, so this is caught too,
 		// unlike the schema-aware categories' documented Table-cell gap.
-		changed, err := rewriteIPInRecord(rec, upper)
+		changed, err := rewriteIPInRecord(rec, noExclusions, upper)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/anonymize/json_contract_test.go
+++ b/internal/anonymize/json_contract_test.go
@@ -33,9 +33,14 @@ func TestArchive_JSONContract(t *testing.T) {
 	for _, k := range []string{
 		"schema_version", "namespaces_renamed", "nodes_renamed", "pods_renamed",
 		"workloads_renamed", "ips_renamed", "hosts_renamed", "registries_renamed",
+		// output_path/output_bytes are always zero-valued here (Archive()
+		// itself never sets them — see Result's own doc comment) — that's
+		// exactly the case an accidental omitempty would drop, so their
+		// presence here is a real check, not a formality.
+		"output_path", "output_bytes",
 	} {
 		if _, ok := got[k]; !ok {
-			t.Errorf("missing frozen top-level key %q; got %s", k, b)
+			t.Errorf("missing frozen top-level key %q (must be present even when zero-valued); got %s", k, b)
 		}
 	}
 

--- a/internal/anonymize/json_contract_test.go
+++ b/internal/anonymize/json_contract_test.go
@@ -1,0 +1,55 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+// The `-o json` output is a stable, scriptable interface (see
+// docs/stability-policy.md): adding a top-level key is a minor change,
+// renaming or removing one is a major change. This pins the key set and
+// SchemaVersion against what Archive actually returns, mirroring
+// internal/diagnose/json_contract_test.go's identical pattern for the
+// same reason: a hand-built Result literal would keep passing even if
+// Archive regressed to a zero-value field.
+func TestArchive_JSONContract(t *testing.T) {
+	src := buildAnonymizeTestArchive(t, namespaceFixtureRecords())
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+
+	result, err := Archive(src, dst, Options{Categories: []Category{CategoryNamespace}, Salt: []byte("contract-salt")})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	b, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{
+		"schema_version", "namespaces_renamed", "nodes_renamed", "pods_renamed",
+		"workloads_renamed", "ips_renamed", "hosts_renamed", "registries_renamed",
+	} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("missing frozen top-level key %q; got %s", k, b)
+		}
+	}
+
+	var fields struct {
+		SchemaVersion     int `json:"schema_version"`
+		NamespacesRenamed int `json:"namespaces_renamed"`
+	}
+	if err := json.Unmarshal(b, &fields); err != nil {
+		t.Fatalf("unmarshal fields: %v", err)
+	}
+	if fields.SchemaVersion != SchemaVersion {
+		t.Errorf("schema_version = %d, want %d", fields.SchemaVersion, SchemaVersion)
+	}
+	if fields.NamespacesRenamed != 1 {
+		t.Errorf("namespaces_renamed = %d, want 1", fields.NamespacesRenamed)
+	}
+}

--- a/internal/anonymize/namespace.go
+++ b/internal/anonymize/namespace.go
@@ -38,7 +38,7 @@ import (
 // *names* on the parent Event, same Namespace field within. All three are
 // checked unconditionally; whichever ones a given record doesn't have are
 // simply absent from the decoded map and the corresponding check is a no-op.
-func rewriteNamespaceInObject(obj map[string]interface{}, kind string, alias func(string) string) bool {
+func rewriteNamespaceInObject(obj map[string]interface{}, kind string, excluded excludedFunc, alias func(string) string) bool {
 	meta, _ := obj["metadata"].(map[string]interface{})
 	if meta == nil {
 		return false
@@ -46,11 +46,11 @@ func rewriteNamespaceInObject(obj map[string]interface{}, kind string, alias fun
 
 	modified := false
 	if kind == "Namespace" {
-		if name, ok := meta["name"].(string); ok && name != "" {
+		if name, ok := meta["name"].(string); ok && name != "" && !excluded(CategoryNamespace, kind, "metadata.name") {
 			meta["name"] = alias(name)
 			modified = true
 		}
-	} else if ns, ok := meta["namespace"].(string); ok && ns != "" {
+	} else if ns, ok := meta["namespace"].(string); ok && ns != "" && !excluded(CategoryNamespace, kind, "metadata.namespace") {
 		meta["namespace"] = alias(ns)
 		modified = true
 	}
@@ -61,7 +61,7 @@ func rewriteNamespaceInObject(obj map[string]interface{}, kind string, alias fun
 			if !ok {
 				continue
 			}
-			if ns, ok := ref["namespace"].(string); ok && ns != "" {
+			if ns, ok := ref["namespace"].(string); ok && ns != "" && !excluded(CategoryNamespace, kind, field+".namespace") {
 				ref["namespace"] = alias(ns)
 				modified = true
 			}
@@ -93,7 +93,7 @@ func rewriteNamespaceInObject(obj map[string]interface{}, kind string, alias fun
 // of scope for the archive-rewrite path in this milestone: Table rows have
 // no field names, so it needs a different, value-pattern-based approach
 // layered on top of this schema-aware one, not a fix to this function.
-func rewriteNamespaceInRecord(rec *capture.Record, alias func(string) string) (bool, error) {
+func rewriteNamespaceInRecord(rec *capture.Record, excluded excludedFunc, alias func(string) string) (bool, error) {
 	var obj map[string]interface{}
 	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
 		return false, nil
@@ -114,12 +114,12 @@ func rewriteNamespaceInRecord(rec *capture.Record, alias func(string) string) (b
 			if k, ok := item["kind"].(string); ok && k != "" {
 				ik = k
 			}
-			if rewriteNamespaceInObject(item, ik, alias) {
+			if rewriteNamespaceInObject(item, ik, excluded, alias) {
 				items[i] = item
 				modified = true
 			}
 		}
-	} else if rewriteNamespaceInObject(obj, kind, alias) {
+	} else if rewriteNamespaceInObject(obj, kind, excluded, alias) {
 		modified = true
 	}
 

--- a/internal/anonymize/namespace_test.go
+++ b/internal/anonymize/namespace_test.go
@@ -15,7 +15,7 @@ func TestRewriteNamespaceInObject(t *testing.T) {
 			"kind":     "Namespace",
 			"metadata": map[string]interface{}{"name": "prod"},
 		}
-		if !rewriteNamespaceInObject(obj, "Namespace", alias) {
+		if !rewriteNamespaceInObject(obj, "Namespace", noExclusions, alias) {
 			t.Fatal("want modified=true")
 		}
 		meta := obj["metadata"].(map[string]interface{})
@@ -32,7 +32,7 @@ func TestRewriteNamespaceInObject(t *testing.T) {
 			"kind":     "Pod",
 			"metadata": map[string]interface{}{"name": "web-1", "namespace": "prod"},
 		}
-		if !rewriteNamespaceInObject(obj, "Pod", alias) {
+		if !rewriteNamespaceInObject(obj, "Pod", noExclusions, alias) {
 			t.Fatal("want modified=true")
 		}
 		meta := obj["metadata"].(map[string]interface{})
@@ -50,7 +50,7 @@ func TestRewriteNamespaceInObject(t *testing.T) {
 			"metadata":       map[string]interface{}{"name": "web-1.abc", "namespace": "prod"},
 			"involvedObject": map[string]interface{}{"kind": "Pod", "name": "web-1", "namespace": "prod"},
 		}
-		if !rewriteNamespaceInObject(obj, "Event", alias) {
+		if !rewriteNamespaceInObject(obj, "Event", noExclusions, alias) {
 			t.Fatal("want modified=true")
 		}
 		meta := obj["metadata"].(map[string]interface{})
@@ -75,7 +75,7 @@ func TestRewriteNamespaceInObject(t *testing.T) {
 			"regarding": map[string]interface{}{"kind": "Pod", "name": "web-1", "namespace": "prod"},
 			"related":   map[string]interface{}{"kind": "ReplicaSet", "name": "web-1-rs", "namespace": "prod"},
 		}
-		if !rewriteNamespaceInObject(obj, "Event", alias) {
+		if !rewriteNamespaceInObject(obj, "Event", noExclusions, alias) {
 			t.Fatal("want modified=true")
 		}
 		regarding := obj["regarding"].(map[string]interface{})
@@ -96,7 +96,7 @@ func TestRewriteNamespaceInObject(t *testing.T) {
 			"kind":     "Node",
 			"metadata": map[string]interface{}{"name": "worker-1"},
 		}
-		if rewriteNamespaceInObject(obj, "Node", alias) {
+		if rewriteNamespaceInObject(obj, "Node", noExclusions, alias) {
 			t.Error("want modified=false for an object with no namespace occurrence")
 		}
 		meta := obj["metadata"].(map[string]interface{})
@@ -107,7 +107,7 @@ func TestRewriteNamespaceInObject(t *testing.T) {
 
 	t.Run("object with no metadata at all is left alone, not a crash", func(t *testing.T) {
 		obj := map[string]interface{}{"kind": "Status"}
-		if rewriteNamespaceInObject(obj, "Status", alias) {
+		if rewriteNamespaceInObject(obj, "Status", noExclusions, alias) {
 			t.Error("want modified=false")
 		}
 	})
@@ -120,7 +120,7 @@ func TestRewriteNamespaceInRecord(t *testing.T) {
 		rec := &capture.Record{
 			ResponseBody: json.RawMessage(`{"kind":"Namespace","metadata":{"name":"prod"}}`),
 		}
-		changed, err := rewriteNamespaceInRecord(rec, alias)
+		changed, err := rewriteNamespaceInRecord(rec, noExclusions, alias)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -143,7 +143,7 @@ func TestRewriteNamespaceInRecord(t *testing.T) {
 			{"metadata":{"name":"web-2","namespace":"staging"}}
 		]}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
-		changed, err := rewriteNamespaceInRecord(rec, alias)
+		changed, err := rewriteNamespaceInRecord(rec, noExclusions, alias)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -179,7 +179,7 @@ func TestRewriteNamespaceInRecord(t *testing.T) {
 		body := `{"kind":"Table","apiVersion":"meta.k8s.io/v1","rows":[{"cells":["web-1","Running"]}]}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
 		orig := string(rec.ResponseBody)
-		changed, err := rewriteNamespaceInRecord(rec, alias)
+		changed, err := rewriteNamespaceInRecord(rec, noExclusions, alias)
 		if err != nil {
 			t.Fatalf("Table-format body should not error, got: %v", err)
 		}
@@ -202,7 +202,7 @@ func TestRewriteNamespaceInRecord(t *testing.T) {
 		body := `{"kind":"Node","metadata":{"name":"worker-1"}}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
 		orig := string(rec.ResponseBody)
-		changed, err := rewriteNamespaceInRecord(rec, alias)
+		changed, err := rewriteNamespaceInRecord(rec, noExclusions, alias)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/anonymize/resourcename.go
+++ b/internal/anonymize/resourcename.go
@@ -62,11 +62,11 @@ var resourceTypeCategories = func() map[string]Category {
 // generic pattern for "this token is a Kubernetes name" the way there is
 // for an IP literal, so recall would need a candidate set built from these
 // same structured fields first (see #137's plan, Open Question 5).
-func rewriteResourceNameInObject(obj map[string]interface{}, kind string, enabled map[Category]bool, alias func(Category, string) string) bool {
+func rewriteResourceNameInObject(obj map[string]interface{}, kind string, enabled map[Category]bool, excluded excludedFunc, alias func(Category, string) string) bool {
 	modified := false
 
 	if meta, ok := obj["metadata"].(map[string]interface{}); ok {
-		if cat, ok := kindCategories[kind]; ok && enabled[cat] {
+		if cat, ok := kindCategories[kind]; ok && enabled[cat] && !excluded(cat, kind, "metadata.name") {
 			if name, ok := meta["name"].(string); ok && name != "" {
 				meta["name"] = alias(cat, name)
 				modified = true
@@ -84,7 +84,7 @@ func rewriteResourceNameInObject(obj map[string]interface{}, kind string, enable
 				}
 				ownerKind, _ := ref["kind"].(string)
 				cat, ok := kindCategories[ownerKind]
-				if !ok || !enabled[cat] {
+				if !ok || !enabled[cat] || excluded(cat, kind, "metadata.ownerReferences[*].name") {
 					continue
 				}
 				if name, ok := ref["name"].(string); ok && name != "" {
@@ -95,7 +95,7 @@ func rewriteResourceNameInObject(obj map[string]interface{}, kind string, enable
 		}
 	}
 
-	if kind == "Pod" && enabled[CategoryNode] {
+	if kind == "Pod" && enabled[CategoryNode] && !excluded(CategoryNode, kind, "spec.nodeName") {
 		if spec, ok := obj["spec"].(map[string]interface{}); ok {
 			if nodeName, ok := spec["nodeName"].(string); ok && nodeName != "" {
 				spec["nodeName"] = alias(CategoryNode, nodeName)
@@ -104,7 +104,7 @@ func rewriteResourceNameInObject(obj map[string]interface{}, kind string, enable
 		}
 	}
 
-	if kind == "Node" && enabled[CategoryNode] {
+	if kind == "Node" && enabled[CategoryNode] && !excluded(CategoryNode, kind, "status.addresses[*].address") {
 		if status, ok := obj["status"].(map[string]interface{}); ok {
 			if addrs, ok := status["addresses"].([]interface{}); ok {
 				for _, raw := range addrs {
@@ -133,7 +133,7 @@ func rewriteResourceNameInObject(obj map[string]interface{}, kind string, enable
 			}
 			refKind, _ := ref["kind"].(string)
 			cat, ok := kindCategories[refKind]
-			if !ok || !enabled[cat] {
+			if !ok || !enabled[cat] || excluded(cat, kind, field+".name") {
 				continue
 			}
 			if name, ok := ref["name"].(string); ok && name != "" {
@@ -146,6 +146,9 @@ func rewriteResourceNameInObject(obj map[string]interface{}, kind string, enable
 		// name the event was generated on.
 		if enabled[CategoryNode] {
 			for _, field := range []string{"source", "deprecatedSource"} {
+				if excluded(CategoryNode, kind, field+".host") {
+					continue
+				}
 				src, ok := obj[field].(map[string]interface{})
 				if !ok {
 					continue
@@ -167,7 +170,7 @@ func rewriteResourceNameInObject(obj map[string]interface{}, kind string, enable
 // rewriteNamespaceInRecord's list-handling exactly (see its own doc comment
 // for why a non-JSON or Table/discovery body is left untouched rather than
 // erroring).
-func rewriteResourceNameInRecord(rec *capture.Record, enabled map[Category]bool, alias func(Category, string) string) (bool, error) {
+func rewriteResourceNameInRecord(rec *capture.Record, enabled map[Category]bool, excluded excludedFunc, alias func(Category, string) string) (bool, error) {
 	var obj map[string]interface{}
 	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
 		return false, nil
@@ -188,12 +191,12 @@ func rewriteResourceNameInRecord(rec *capture.Record, enabled map[Category]bool,
 			if k, ok := item["kind"].(string); ok && k != "" {
 				ik = k
 			}
-			if rewriteResourceNameInObject(item, ik, enabled, alias) {
+			if rewriteResourceNameInObject(item, ik, enabled, excluded, alias) {
 				items[i] = item
 				modified = true
 			}
 		}
-	} else if rewriteResourceNameInObject(obj, kind, enabled, alias) {
+	} else if rewriteResourceNameInObject(obj, kind, enabled, excluded, alias) {
 		modified = true
 	}
 

--- a/internal/anonymize/resourcename_test.go
+++ b/internal/anonymize/resourcename_test.go
@@ -25,7 +25,7 @@ func TestRewriteResourceNameInObject(t *testing.T) {
 			"kind":     "Node",
 			"metadata": map[string]interface{}{"name": "worker-1"},
 		}
-		if !rewriteResourceNameInObject(obj, "Node", allResourceCategories, aliasByCategory) {
+		if !rewriteResourceNameInObject(obj, "Node", allResourceCategories, noExclusions, aliasByCategory) {
 			t.Fatal("want modified=true")
 		}
 		meta := obj["metadata"].(map[string]interface{})
@@ -40,7 +40,7 @@ func TestRewriteResourceNameInObject(t *testing.T) {
 			"metadata": map[string]interface{}{"name": "web-1", "namespace": "prod"},
 			"spec":     map[string]interface{}{"nodeName": "worker-1"},
 		}
-		if !rewriteResourceNameInObject(obj, "Pod", allResourceCategories, aliasByCategory) {
+		if !rewriteResourceNameInObject(obj, "Pod", allResourceCategories, noExclusions, aliasByCategory) {
 			t.Fatal("want modified=true")
 		}
 		meta := obj["metadata"].(map[string]interface{})
@@ -58,7 +58,7 @@ func TestRewriteResourceNameInObject(t *testing.T) {
 			"kind":     "Deployment",
 			"metadata": map[string]interface{}{"name": "web", "namespace": "prod"},
 		}
-		if !rewriteResourceNameInObject(obj, "Deployment", allResourceCategories, aliasByCategory) {
+		if !rewriteResourceNameInObject(obj, "Deployment", allResourceCategories, noExclusions, aliasByCategory) {
 			t.Fatal("want modified=true")
 		}
 		meta := obj["metadata"].(map[string]interface{})
@@ -77,7 +77,7 @@ func TestRewriteResourceNameInObject(t *testing.T) {
 				},
 			},
 		}
-		if !rewriteResourceNameInObject(obj, "Pod", allResourceCategories, aliasByCategory) {
+		if !rewriteResourceNameInObject(obj, "Pod", allResourceCategories, noExclusions, aliasByCategory) {
 			t.Fatal("want modified=true")
 		}
 		meta := obj["metadata"].(map[string]interface{})
@@ -99,7 +99,7 @@ func TestRewriteResourceNameInObject(t *testing.T) {
 				},
 			},
 		}
-		if !rewriteResourceNameInObject(obj, "Node", allResourceCategories, aliasByCategory) {
+		if !rewriteResourceNameInObject(obj, "Node", allResourceCategories, noExclusions, aliasByCategory) {
 			t.Fatal("want modified=true")
 		}
 		addrs := obj["status"].(map[string]interface{})["addresses"].([]interface{})
@@ -120,7 +120,7 @@ func TestRewriteResourceNameInObject(t *testing.T) {
 			"involvedObject": map[string]interface{}{"kind": "Pod", "name": "web-1", "namespace": "prod"},
 			"source":         map[string]interface{}{"component": "kubelet", "host": "worker-1"},
 		}
-		if !rewriteResourceNameInObject(obj, "Event", allResourceCategories, aliasByCategory) {
+		if !rewriteResourceNameInObject(obj, "Event", allResourceCategories, noExclusions, aliasByCategory) {
 			t.Fatal("want modified=true")
 		}
 		involved := obj["involvedObject"].(map[string]interface{})
@@ -147,7 +147,7 @@ func TestRewriteResourceNameInObject(t *testing.T) {
 			"related":          map[string]interface{}{"kind": "ReplicaSet", "name": "web-1-rs", "namespace": "prod"},
 			"deprecatedSource": map[string]interface{}{"component": "kubelet", "host": "worker-1"},
 		}
-		if !rewriteResourceNameInObject(obj, "Event", allResourceCategories, aliasByCategory) {
+		if !rewriteResourceNameInObject(obj, "Event", allResourceCategories, noExclusions, aliasByCategory) {
 			t.Fatal("want modified=true")
 		}
 		regarding := obj["regarding"].(map[string]interface{})
@@ -171,7 +171,7 @@ func TestRewriteResourceNameInObject(t *testing.T) {
 			"spec":     map[string]interface{}{"nodeName": "worker-1"},
 		}
 		enabled := map[Category]bool{CategoryPod: true}
-		if !rewriteResourceNameInObject(obj, "Pod", enabled, aliasByCategory) {
+		if !rewriteResourceNameInObject(obj, "Pod", enabled, noExclusions, aliasByCategory) {
 			t.Fatal("want modified=true for the pod name itself")
 		}
 		meta := obj["metadata"].(map[string]interface{})
@@ -189,14 +189,14 @@ func TestRewriteResourceNameInObject(t *testing.T) {
 			"kind":     "Namespace",
 			"metadata": map[string]interface{}{"name": "prod"},
 		}
-		if rewriteResourceNameInObject(obj, "Namespace", allResourceCategories, aliasByCategory) {
+		if rewriteResourceNameInObject(obj, "Namespace", allResourceCategories, noExclusions, aliasByCategory) {
 			t.Error("want modified=false — Namespace is not a node/pod/workload kind")
 		}
 	})
 
 	t.Run("object with no metadata at all is left alone, not a crash", func(t *testing.T) {
 		obj := map[string]interface{}{"kind": "Status"}
-		if rewriteResourceNameInObject(obj, "Status", allResourceCategories, aliasByCategory) {
+		if rewriteResourceNameInObject(obj, "Status", allResourceCategories, noExclusions, aliasByCategory) {
 			t.Error("want modified=false")
 		}
 	})
@@ -207,7 +207,7 @@ func TestRewriteResourceNameInRecord(t *testing.T) {
 		rec := &capture.Record{
 			ResponseBody: json.RawMessage(`{"kind":"Node","metadata":{"name":"worker-1"}}`),
 		}
-		changed, err := rewriteResourceNameInRecord(rec, allResourceCategories, aliasByCategory)
+		changed, err := rewriteResourceNameInRecord(rec, allResourceCategories, noExclusions, aliasByCategory)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -230,7 +230,7 @@ func TestRewriteResourceNameInRecord(t *testing.T) {
 			{"metadata":{"name":"web-2"},"spec":{"nodeName":"worker-2"}}
 		]}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
-		changed, err := rewriteResourceNameInRecord(rec, allResourceCategories, aliasByCategory)
+		changed, err := rewriteResourceNameInRecord(rec, allResourceCategories, noExclusions, aliasByCategory)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -265,7 +265,7 @@ func TestRewriteResourceNameInRecord(t *testing.T) {
 		body := `{"kind":"Namespace","metadata":{"name":"prod"}}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
 		orig := string(rec.ResponseBody)
-		changed, err := rewriteResourceNameInRecord(rec, allResourceCategories, aliasByCategory)
+		changed, err := rewriteResourceNameInRecord(rec, allResourceCategories, noExclusions, aliasByCategory)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/anonymize/rules.go
+++ b/internal/anonymize/rules.go
@@ -1,0 +1,54 @@
+package anonymize
+
+import (
+	"fmt"
+
+	"github.com/phenixblue/k8shark/internal/config"
+)
+
+// excludedFunc reports whether a specific occurrence — a value of category,
+// found on an object of the given kind, at the given field path — should be
+// left alone rather than aliased. Every rewrite call site in this package
+// that's about to write an alias checks this first; a nil excludedFunc (the
+// common case, when Options.Rules is empty) always returns false via
+// newExcludeMatcher's own zero-rule fast path, so no call site needs its
+// own nil check.
+type excludedFunc func(category Category, kind, path string) bool
+
+// newExcludeMatcher builds an excludedFunc from rules. Every rule must have
+// Exclude set: anonymize rules are exclusions only — a value's category
+// membership is already determined automatically by where and how it
+// occurs, so there is no separate "include" action for a rule to request.
+// Category and FieldPath are required; Kind is optional ("" or "*" matches
+// every kind), mirroring RedactionRule.Kind's own convention.
+func newExcludeMatcher(rules []config.AnonymizeRule) (excludedFunc, error) {
+	for i, r := range rules {
+		if !r.Exclude {
+			return nil, fmt.Errorf("anonymize: rule %d (category %q, fieldPath %q): exclude must be true — anonymize rules are exclusions only", i, r.Category, r.FieldPath)
+		}
+		if r.Category == "" {
+			return nil, fmt.Errorf("anonymize: rule %d: category is required", i)
+		}
+		if r.FieldPath == "" {
+			return nil, fmt.Errorf("anonymize: rule %d (category %q): fieldPath is required", i, r.Category)
+		}
+	}
+	if len(rules) == 0 {
+		return func(Category, string, string) bool { return false }, nil
+	}
+	return func(category Category, kind, path string) bool {
+		for _, r := range rules {
+			if Category(r.Category) != category {
+				continue
+			}
+			if r.Kind != "" && r.Kind != "*" && r.Kind != kind {
+				continue
+			}
+			if r.FieldPath != path {
+				continue
+			}
+			return true
+		}
+		return false
+	}, nil
+}

--- a/internal/anonymize/rules.go
+++ b/internal/anonymize/rules.go
@@ -2,9 +2,20 @@ package anonymize
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/phenixblue/k8shark/internal/config"
 )
+
+// fieldPathBracketPattern matches any "[...]" segment of a rule's
+// FieldPath, so newExcludeMatcher can reject one that isn't exactly "[*]"
+// — this package's field-path convention (walk.go, resourcename.go, and
+// every other rewrite site that computes a path to check against
+// excludedFunc) always writes an array index as the wildcard "[*]", never
+// a literal index. A rule written as "spec.containers[0].image" would
+// never match anything a real occurrence's computed path could produce —
+// a silent, hard-to-debug no-op exclusion rather than a loud error.
+var fieldPathBracketPattern = regexp.MustCompile(`\[[^\]]*\]`)
 
 // excludedFunc reports whether a specific occurrence — a value of category,
 // found on an object of the given kind, at the given field path — should be
@@ -21,6 +32,15 @@ type excludedFunc func(category Category, kind, path string) bool
 // occurs, so there is no separate "include" action for a rule to request.
 // Category and FieldPath are required; Kind is optional ("" or "*" matches
 // every kind), mirroring RedactionRule.Kind's own convention.
+//
+// Beyond required-ness, Category and FieldPath are validated for whether
+// the rule could ever actually match anything: an unrecognized category
+// never matches any real occurrence (every category this package can find
+// is listed in archiveCategories, archive.go), and a literal array index in
+// FieldPath never matches this package's own "[*]"-only convention for a
+// computed path. Both are rejected up front rather than accepted as a
+// silently-useless rule — the same reasoning collision detection already
+// uses for a different kind of "wrong but not caught" failure mode.
 func newExcludeMatcher(rules []config.AnonymizeRule) (excludedFunc, error) {
 	for i, r := range rules {
 		if !r.Exclude {
@@ -29,8 +49,16 @@ func newExcludeMatcher(rules []config.AnonymizeRule) (excludedFunc, error) {
 		if r.Category == "" {
 			return nil, fmt.Errorf("anonymize: rule %d: category is required", i)
 		}
+		if !archiveCategories[Category(r.Category)] {
+			return nil, fmt.Errorf("anonymize: rule %d: category %q is not a supported category — it could never match a real occurrence", i, r.Category)
+		}
 		if r.FieldPath == "" {
 			return nil, fmt.Errorf("anonymize: rule %d (category %q): fieldPath is required", i, r.Category)
+		}
+		for _, seg := range fieldPathBracketPattern.FindAllString(r.FieldPath, -1) {
+			if seg != "[*]" {
+				return nil, fmt.Errorf(`anonymize: rule %d (category %q): fieldPath %q must use "[*]" for every array index, not a literal index like %q — a computed occurrence path never contains one`, i, r.Category, r.FieldPath, seg)
+			}
 		}
 	}
 	if len(rules) == 0 {

--- a/internal/anonymize/rules_test.go
+++ b/internal/anonymize/rules_test.go
@@ -1,0 +1,95 @@
+package anonymize
+
+import (
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/config"
+)
+
+func TestNewExcludeMatcher_Validation(t *testing.T) {
+	t.Run("exclude=false is rejected", func(t *testing.T) {
+		_, err := newExcludeMatcher([]config.AnonymizeRule{
+			{Category: "namespace", FieldPath: "metadata.name", Exclude: false},
+		})
+		if err == nil {
+			t.Fatal("want an error for exclude=false")
+		}
+	})
+
+	t.Run("empty category is rejected", func(t *testing.T) {
+		_, err := newExcludeMatcher([]config.AnonymizeRule{
+			{FieldPath: "metadata.name", Exclude: true},
+		})
+		if err == nil {
+			t.Fatal("want an error for an empty category")
+		}
+	})
+
+	t.Run("empty fieldPath is rejected", func(t *testing.T) {
+		_, err := newExcludeMatcher([]config.AnonymizeRule{
+			{Category: "namespace", Exclude: true},
+		})
+		if err == nil {
+			t.Fatal("want an error for an empty fieldPath")
+		}
+	})
+
+	t.Run("no rules is fine — the resulting func always returns false", func(t *testing.T) {
+		excluded, err := newExcludeMatcher(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if excluded(CategoryNamespace, "Pod", "metadata.namespace") {
+			t.Error("want false with no rules configured")
+		}
+	})
+}
+
+func TestExcludeMatcher_Matching(t *testing.T) {
+	rules := []config.AnonymizeRule{
+		{Category: "namespace", Kind: "Pod", FieldPath: "metadata.namespace", Exclude: true},
+		{Category: "ip", FieldPath: "status.podIP", Exclude: true}, // no Kind — matches every kind
+	}
+	excluded, err := newExcludeMatcher(rules)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		category Category
+		kind     string
+		path     string
+		want     bool
+	}{
+		{"exact category/kind/path match", CategoryNamespace, "Pod", "metadata.namespace", true},
+		{"different kind does not match a kind-scoped rule", CategoryNamespace, "Node", "metadata.namespace", false},
+		{"different path does not match", CategoryNamespace, "Pod", "metadata.name", false},
+		{"different category does not match", CategoryPod, "Pod", "metadata.namespace", false},
+		{"kind-less rule matches any kind", CategoryIP, "Pod", "status.podIP", true},
+		{"kind-less rule matches a different kind too", CategoryIP, "Node", "status.podIP", true},
+		{"kind-less rule still requires the right path", CategoryIP, "Pod", "status.hostIP", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := excluded(tc.category, tc.kind, tc.path); got != tc.want {
+				t.Errorf("excluded(%q, %q, %q) = %v, want %v", tc.category, tc.kind, tc.path, got, tc.want)
+			}
+		})
+	}
+
+	t.Run(`Kind: "*" matches any kind, same as omitting it`, func(t *testing.T) {
+		excluded, err := newExcludeMatcher([]config.AnonymizeRule{
+			{Category: "workload", Kind: "*", FieldPath: "metadata.name", Exclude: true},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !excluded(CategoryWorkload, "Deployment", "metadata.name") {
+			t.Error("want true for Deployment")
+		}
+		if !excluded(CategoryWorkload, "ReplicaSet", "metadata.name") {
+			t.Error("want true for ReplicaSet")
+		}
+	})
+}

--- a/internal/anonymize/rules_test.go
+++ b/internal/anonymize/rules_test.go
@@ -34,6 +34,33 @@ func TestNewExcludeMatcher_Validation(t *testing.T) {
 		}
 	})
 
+	t.Run("an unrecognized category is rejected", func(t *testing.T) {
+		_, err := newExcludeMatcher([]config.AnonymizeRule{
+			{Category: "namespac", FieldPath: "metadata.name", Exclude: true}, // typo
+		})
+		if err == nil {
+			t.Fatal("want an error for a category that could never match a real occurrence")
+		}
+	})
+
+	t.Run("a fieldPath with a literal array index is rejected", func(t *testing.T) {
+		_, err := newExcludeMatcher([]config.AnonymizeRule{
+			{Category: "image", FieldPath: "spec.containers[0].image", Exclude: true},
+		})
+		if err == nil {
+			t.Fatal(`want an error for a fieldPath with a literal index instead of "[*]"`)
+		}
+	})
+
+	t.Run("a fieldPath using the wildcard convention is accepted", func(t *testing.T) {
+		_, err := newExcludeMatcher([]config.AnonymizeRule{
+			{Category: "image", FieldPath: "spec.containers[*].image", Exclude: true},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
 	t.Run("no rules is fine — the resulting func always returns false", func(t *testing.T) {
 		excluded, err := newExcludeMatcher(nil)
 		if err != nil {

--- a/internal/anonymize/urlmatch.go
+++ b/internal/anonymize/urlmatch.go
@@ -75,7 +75,7 @@ func spliceURLHosts(s string, alias func(string) string) (string, bool) {
 // not here — these two mechanisms are mutually exclusive by construction
 // (one requires a scheme prefix, the other only ever looks at fields that
 // never have one), so there's no risk of double-aliasing the same value.
-func rewriteURLInObject(obj map[string]interface{}, kind string, alias func(string) string) bool {
+func rewriteURLInObject(obj map[string]interface{}, kind string, excluded excludedFunc, alias func(string) string) bool {
 	modified := false
 
 	spec, ok := obj["spec"].(map[string]interface{})
@@ -85,7 +85,7 @@ func rewriteURLInObject(obj map[string]interface{}, kind string, alias func(stri
 
 	switch kind {
 	case "Ingress":
-		if rules, ok := spec["rules"].([]interface{}); ok {
+		if rules, ok := spec["rules"].([]interface{}); ok && !excluded(CategoryURL, kind, "spec.rules[*].host") {
 			for _, raw := range rules {
 				rule, ok := raw.(map[string]interface{})
 				if !ok {
@@ -97,7 +97,7 @@ func rewriteURLInObject(obj map[string]interface{}, kind string, alias func(stri
 				}
 			}
 		}
-		if tlsEntries, ok := spec["tls"].([]interface{}); ok {
+		if tlsEntries, ok := spec["tls"].([]interface{}); ok && !excluded(CategoryURL, kind, "spec.tls[*].hosts[*]") {
 			for _, raw := range tlsEntries {
 				entry, ok := raw.(map[string]interface{})
 				if !ok {
@@ -118,7 +118,7 @@ func rewriteURLInObject(obj map[string]interface{}, kind string, alias func(stri
 			}
 		}
 	case "Service":
-		if externalName, ok := spec["externalName"].(string); ok && externalName != "" {
+		if externalName, ok := spec["externalName"].(string); ok && externalName != "" && !excluded(CategoryURL, kind, "spec.externalName") {
 			spec["externalName"] = alias(externalName)
 			modified = true
 		}
@@ -129,19 +129,35 @@ func rewriteURLInObject(obj map[string]interface{}, kind string, alias func(stri
 
 // rewriteURLInRecord decodes rec's body and rewrites every URL/hostname
 // occurrence it recognizes: the bare-hostname schema-aware fields
-// (rewriteURLInObject, list-aware the same way rewriteNamespaceInRecord and
-// rewriteResourceNameInRecord are) plus a full-tree walk for
-// scheme://host substrings anywhere in the body (webhook URLs,
-// cert-manager/external-dns annotations, status condition messages).
-func rewriteURLInRecord(rec *capture.Record, alias func(string) string) (bool, error) {
+// (rewriteURLInObject) plus a full-tree walk for scheme://host substrings
+// anywhere else in the body (webhook URLs, cert-manager/external-dns
+// annotations, status condition messages).
+//
+// Both passes run per-item for a List response, using each item's own
+// Kind — not once over the whole record body — so an exclude rule scoped
+// to a Kind applies correctly to a List response's items[] too, the same
+// requirement rewriteIPInRecord has (see its own doc comment).
+func rewriteURLInRecord(rec *capture.Record, excluded excludedFunc, alias func(string) string) (bool, error) {
 	var obj map[string]interface{}
 	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
 		return false, nil
 	}
 
 	kind, _ := obj["kind"].(string)
-	modified := false
+	rewriteItem := func(item map[string]interface{}, itemKind string) bool {
+		itemModified := rewriteURLInObject(item, itemKind, excluded, alias)
+		if walkStrings(item, "", func(path, s string) (string, bool) {
+			if excluded(CategoryURL, itemKind, path) {
+				return "", false
+			}
+			return spliceURLHosts(s, alias)
+		}) {
+			itemModified = true
+		}
+		return itemModified
+	}
 
+	modified := false
 	if strings.HasSuffix(kind, "List") {
 		items, _ := obj["items"].([]interface{})
 		itemKind := strings.TrimSuffix(kind, "List")
@@ -154,18 +170,12 @@ func rewriteURLInRecord(rec *capture.Record, alias func(string) string) (bool, e
 			if k, ok := item["kind"].(string); ok && k != "" {
 				ik = k
 			}
-			if rewriteURLInObject(item, ik, alias) {
+			if rewriteItem(item, ik) {
 				items[i] = item
 				modified = true
 			}
 		}
-	} else if rewriteURLInObject(obj, kind, alias) {
-		modified = true
-	}
-
-	if walkStrings(interface{}(obj), func(s string) (string, bool) {
-		return spliceURLHosts(s, alias)
-	}) {
+	} else if rewriteItem(obj, kind) {
 		modified = true
 	}
 

--- a/internal/anonymize/urlmatch_test.go
+++ b/internal/anonymize/urlmatch_test.go
@@ -104,7 +104,7 @@ func TestRewriteURLInObject(t *testing.T) {
 				},
 			},
 		}
-		if !rewriteURLInObject(obj, "Ingress", upper) {
+		if !rewriteURLInObject(obj, "Ingress", noExclusions, upper) {
 			t.Fatal("want modified=true")
 		}
 		spec := obj["spec"].(map[string]interface{})
@@ -126,7 +126,7 @@ func TestRewriteURLInObject(t *testing.T) {
 			"kind": "Service",
 			"spec": map[string]interface{}{"externalName": "db.upstream.example.com", "type": "ExternalName"},
 		}
-		if !rewriteURLInObject(obj, "Service", upper) {
+		if !rewriteURLInObject(obj, "Service", noExclusions, upper) {
 			t.Fatal("want modified=true")
 		}
 		spec := obj["spec"].(map[string]interface{})
@@ -143,14 +143,14 @@ func TestRewriteURLInObject(t *testing.T) {
 			"kind": "Service",
 			"spec": map[string]interface{}{"clusterIP": "10.0.0.5"},
 		}
-		if rewriteURLInObject(obj, "Service", upper) {
+		if rewriteURLInObject(obj, "Service", noExclusions, upper) {
 			t.Error("want modified=false")
 		}
 	})
 
 	t.Run("an object with no spec at all is left alone, not a crash", func(t *testing.T) {
 		obj := map[string]interface{}{"kind": "Status"}
-		if rewriteURLInObject(obj, "Status", upper) {
+		if rewriteURLInObject(obj, "Status", noExclusions, upper) {
 			t.Error("want modified=false")
 		}
 	})
@@ -161,7 +161,7 @@ func TestRewriteURLInRecord(t *testing.T) {
 		body := `{"kind":"Ingress","metadata":{"annotations":{"cert-manager.io/issuer-url":"https://acme.example.com/directory"}},
 			"spec":{"rules":[{"host":"app.example.com"}]}}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
-		changed, err := rewriteURLInRecord(rec, upper)
+		changed, err := rewriteURLInRecord(rec, noExclusions, upper)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -188,7 +188,7 @@ func TestRewriteURLInRecord(t *testing.T) {
 			{"metadata":{"name":"b"},"spec":{"rules":[{"host":"b.example.com"}]}}
 		]}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
-		changed, err := rewriteURLInRecord(rec, upper)
+		changed, err := rewriteURLInRecord(rec, noExclusions, upper)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -211,7 +211,7 @@ func TestRewriteURLInRecord(t *testing.T) {
 		body := `{"kind":"Namespace","metadata":{"name":"prod"}}`
 		rec := &capture.Record{ResponseBody: json.RawMessage(body)}
 		orig := string(rec.ResponseBody)
-		changed, err := rewriteURLInRecord(rec, upper)
+		changed, err := rewriteURLInRecord(rec, noExclusions, upper)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/anonymize/walk.go
+++ b/internal/anonymize/walk.go
@@ -1,5 +1,17 @@
 package anonymize
 
+// joinFieldPath appends key to base using this package's field-path
+// convention (dot-separated, base=="" for the root), shared by every
+// rewrite function that builds a path to check against excludedFunc —
+// walkStrings' own recursive descent and imagematch.go's container walker
+// alike — so the two can't drift into subtly different notations.
+func joinFieldPath(base, key string) string {
+	if base == "" {
+		return key
+	}
+	return base + "." + key
+}
+
 // walkStrings recursively visits every string value in a decoded JSON tree
 // (the map[string]interface{}/[]interface{}/string shape json.Unmarshal
 // produces into interface{}), replacing a string leaf with whatever visit
@@ -10,37 +22,48 @@ package anonymize
 // unlike the node/pod/workload categories, which only ever expect their
 // values at specific, known field names (resourcename.go).
 //
+// path is the field's dot-notation path from wherever the walk started
+// (typically the decoded object's own root), with every list index written
+// as the literal "[*]" rather than its real index — an exclude rule targets
+// a kind of occurrence (e.g. every annotation value), not one specific
+// array element, so this is the same convention every other rewrite
+// function in this package uses when building a path to check against
+// excludedFunc. The top-level call should pass path="" for the root; walk
+// itself supplies the rest as it descends.
+//
 // Mutates map/slice values in place (both are reference types in Go) and
 // returns whether anything changed, so a caller can skip re-marshaling a
 // record whose body wasn't actually touched.
-func walkStrings(node interface{}, visit func(string) (string, bool)) bool {
+func walkStrings(node interface{}, path string, visit func(path, s string) (string, bool)) bool {
 	switch v := node.(type) {
 	case map[string]interface{}:
 		changed := false
 		for k, val := range v {
+			childPath := joinFieldPath(path, k)
 			if s, ok := val.(string); ok {
-				if newS, ok := visit(s); ok {
+				if newS, ok := visit(childPath, s); ok {
 					v[k] = newS
 					changed = true
 				}
 				continue
 			}
-			if walkStrings(val, visit) {
+			if walkStrings(val, childPath, visit) {
 				changed = true
 			}
 		}
 		return changed
 	case []interface{}:
 		changed := false
+		childPath := path + "[*]"
 		for i, val := range v {
 			if s, ok := val.(string); ok {
-				if newS, ok := visit(s); ok {
+				if newS, ok := visit(childPath, s); ok {
 					v[i] = newS
 					changed = true
 				}
 				continue
 			}
-			if walkStrings(val, visit) {
+			if walkStrings(val, childPath, visit) {
 				changed = true
 			}
 		}

--- a/internal/anonymize/walk_test.go
+++ b/internal/anonymize/walk_test.go
@@ -1,0 +1,90 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+)
+
+func TestWalkStrings_PathConstruction(t *testing.T) {
+	body := `{
+		"metadata": {"name": "web-1", "namespace": "prod"},
+		"spec": {
+			"containers": [
+				{"name": "app", "image": "nginx"},
+				{"name": "sidecar", "image": "envoy"}
+			]
+		},
+		"nested": {"list": [{"deep": {"value": "x"}}]}
+	}`
+	var obj interface{}
+	if err := json.Unmarshal([]byte(body), &obj); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotPaths []string
+	walkStrings(obj, "", func(path, s string) (string, bool) {
+		gotPaths = append(gotPaths, path+"="+s)
+		return "", false
+	})
+	sort.Strings(gotPaths)
+
+	want := []string{
+		"metadata.name=web-1",
+		"metadata.namespace=prod",
+		"nested.list[*].deep.value=x",
+		"spec.containers[*].image=envoy",
+		"spec.containers[*].image=nginx",
+		"spec.containers[*].name=app",
+		"spec.containers[*].name=sidecar",
+	}
+	sort.Strings(want)
+	if len(gotPaths) != len(want) {
+		t.Fatalf("got %d paths, want %d\ngot:  %v\nwant: %v", len(gotPaths), len(want), gotPaths, want)
+	}
+	for i := range want {
+		if gotPaths[i] != want[i] {
+			t.Errorf("path[%d] = %q, want %q", i, gotPaths[i], want[i])
+		}
+	}
+}
+
+func TestWalkStrings_ReplacesAndReportsChanged(t *testing.T) {
+	obj := map[string]interface{}{
+		"a": "keep",
+		"b": "replace-me",
+		"list": []interface{}{
+			"replace-me",
+			"keep",
+		},
+	}
+	changed := walkStrings(obj, "", func(path, s string) (string, bool) {
+		if s == "replace-me" {
+			return "replaced", true
+		}
+		return "", false
+	})
+	if !changed {
+		t.Fatal("want changed=true")
+	}
+	if obj["a"] != "keep" {
+		t.Errorf("a = %v, want unchanged keep", obj["a"])
+	}
+	if obj["b"] != "replaced" {
+		t.Errorf("b = %v, want replaced", obj["b"])
+	}
+	list := obj["list"].([]interface{})
+	if list[0] != "replaced" || list[1] != "keep" {
+		t.Errorf("list = %v, want [replaced keep]", list)
+	}
+}
+
+func TestWalkStrings_NoMatchReportsUnchanged(t *testing.T) {
+	obj := map[string]interface{}{"a": "x"}
+	changed := walkStrings(obj, "", func(path, s string) (string, bool) {
+		return "", false
+	})
+	if changed {
+		t.Error("want changed=false when visit never matches")
+	}
+}

--- a/internal/archive/format/format.go
+++ b/internal/archive/format/format.go
@@ -79,6 +79,14 @@ type CaptureMetadata struct {
 	// ciphertext and so is only readable after decryption). Omitted for
 	// plaintext archives.
 	Encrypted bool `json:"encrypted,omitempty"`
+	// Anonymized and AnonymizedCategories mirror Redacted/SecretsRedacted's
+	// provenance pattern for `kshrk anonymize` (#137): Anonymized is true
+	// for any archive that went through an anonymize pass, and
+	// AnonymizedCategories names which categories (e.g. "namespace", "ip")
+	// were actually applied. Omitted for archives that were never
+	// anonymized.
+	Anonymized           bool     `json:"anonymized,omitempty"`
+	AnonymizedCategories []string `json:"anonymized_categories,omitempty"`
 }
 
 // IndexEntry maps an API path to the ordered list of record sequence numbers.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,6 +101,49 @@ type RedactionRule struct {
 	ValueType string `mapstructure:"valueType"`
 }
 
+// AnonymizeRule describes a single field-path exclusion for `kshrk
+// anonymize`: an occurrence that would otherwise be anonymized, but should
+// be left alone. Anonymize rules are exclusions only — there is no separate
+// "include" action, since a value's category membership is already
+// determined automatically by where and how it occurs (see #137);
+// Exclude must be true, and internal/anonymize rejects a rule where it
+// isn't, rather than silently ignoring an unsupported "include" request.
+type AnonymizeRule struct {
+	// Category restricts the rule to one anonymize category (e.g.
+	// "namespace", "ip", "image"). Required.
+	Category string `mapstructure:"category"`
+	// FieldPath is the field's path from the object root, using the same
+	// dot-notation as RedactionRule.FieldPath, but with every array index
+	// written as the wildcard "[*]" — never a literal index — since an
+	// anonymize rule targets a kind of occurrence (e.g. every container
+	// image), not one specific array element. Required. Examples:
+	// "metadata.name", "spec.containers[*].image", "status.podIP".
+	FieldPath string `mapstructure:"fieldPath"`
+	// Kind restricts the rule to a specific resource kind (e.g. "Pod",
+	// "Node"). Use "*" or omit to match every kind the category applies to.
+	Kind string `mapstructure:"kind"`
+	// Exclude must be true — see the type's own doc comment.
+	Exclude bool `mapstructure:"exclude"`
+}
+
+// AnonymizeConfig is the top-level anonymize section of the capture config,
+// consumed by `kshrk anonymize --config`.
+type AnonymizeConfig struct {
+	// Categories is a list of categories to anonymize, e.g. ["namespace",
+	// "ip"], merged with any --categories flags.
+	Categories []string `mapstructure:"categories"`
+	// Rules is a list of field-path exclusions (see AnonymizeRule) applied
+	// on top of Categories.
+	Rules []AnonymizeRule `mapstructure:"rules"`
+	// EmitMapping, when true, writes the original-to-alias mapping
+	// alongside the anonymized archive (equivalent to --emit-mapping on
+	// the CLI). Never emitted unless explicitly requested here or via the
+	// CLI flag.
+	EmitMapping bool `mapstructure:"emitMapping"`
+	// MappingPath optionally overrides the mapping sidecar's default path.
+	MappingPath string `mapstructure:"mappingPath"`
+}
+
 // RedactionConfig is the top-level redaction section of the capture config.
 type RedactionConfig struct {
 	// RedactSecrets, when true, redacts all Kubernetes Secret data and
@@ -146,6 +189,8 @@ type Config struct {
 	// Redaction holds field-level redaction rules applied during capture and
 	// post-capture redact workflows.
 	Redaction RedactionConfig `mapstructure:"redaction"`
+	// Anonymize holds category and rule settings for `kshrk anonymize`.
+	Anonymize AnonymizeConfig `mapstructure:"anonymize"`
 	// UI holds settings for the `kshrk ui` web explorer. CLI flags override
 	// these when provided.
 	UI UIConfig `mapstructure:"ui"`

--- a/internal/ui/v2/capinfo.go
+++ b/internal/ui/v2/capinfo.go
@@ -11,27 +11,29 @@ import (
 // card. It combines metadata.json with values derived from the index and the
 // archive file on disk.
 type CaptureInfo struct {
-	CaptureID         string    `json:"capture_id"`
-	ServerAddress     string    `json:"server_address,omitempty"`
-	KubernetesVersion string    `json:"kubernetes_version,omitempty"`
-	CapturedAt        time.Time `json:"captured_at"`
-	CapturedUntil     time.Time `json:"captured_until"`
-	DurationSeconds   int       `json:"duration_seconds"`
-	RecordCount       int       `json:"record_count"`
-	DeduplicatedCount int       `json:"deduplicated_count"`
-	CompressedBytes   int64     `json:"compressed_bytes,omitempty"`
-	UncompressedBytes int64     `json:"uncompressed_bytes,omitempty"`
-	ResourcePaths     int       `json:"resource_paths"`
-	ResourceTypes     int       `json:"resource_types"`
-	Namespaces        int       `json:"namespaces"`
-	WatchEvents       int       `json:"watch_events"`
-	AutoDiscovered    bool      `json:"auto_discovered"`
-	WatchEnabled      bool      `json:"watch_enabled"`
-	Intervals         []string  `json:"intervals,omitempty"`
-	Redacted          bool      `json:"redacted"`
-	SecretsRedacted   int       `json:"secrets_redacted,omitempty"`
-	FieldsRedacted    int       `json:"fields_redacted,omitempty"`
-	ArchivePath       string    `json:"archive_path,omitempty"`
+	CaptureID            string    `json:"capture_id"`
+	ServerAddress        string    `json:"server_address,omitempty"`
+	KubernetesVersion    string    `json:"kubernetes_version,omitempty"`
+	CapturedAt           time.Time `json:"captured_at"`
+	CapturedUntil        time.Time `json:"captured_until"`
+	DurationSeconds      int       `json:"duration_seconds"`
+	RecordCount          int       `json:"record_count"`
+	DeduplicatedCount    int       `json:"deduplicated_count"`
+	CompressedBytes      int64     `json:"compressed_bytes,omitempty"`
+	UncompressedBytes    int64     `json:"uncompressed_bytes,omitempty"`
+	ResourcePaths        int       `json:"resource_paths"`
+	ResourceTypes        int       `json:"resource_types"`
+	Namespaces           int       `json:"namespaces"`
+	WatchEvents          int       `json:"watch_events"`
+	AutoDiscovered       bool      `json:"auto_discovered"`
+	WatchEnabled         bool      `json:"watch_enabled"`
+	Intervals            []string  `json:"intervals,omitempty"`
+	Redacted             bool      `json:"redacted"`
+	SecretsRedacted      int       `json:"secrets_redacted,omitempty"`
+	FieldsRedacted       int       `json:"fields_redacted,omitempty"`
+	Anonymized           bool      `json:"anonymized"`
+	AnonymizedCategories []string  `json:"anonymized_categories,omitempty"`
+	ArchivePath          string    `json:"archive_path,omitempty"`
 	// HasConfigMeta is false for archives captured before the config-fact
 	// metadata fields existed; the UI then shows "not recorded" for them.
 	HasConfigMeta bool `json:"has_config_meta"`
@@ -44,21 +46,23 @@ func (h *Handler) serveCaptureInfo(w http.ResponseWriter, r *http.Request) {
 	}
 	m := h.Store.Metadata
 	info := CaptureInfo{
-		CaptureID:         m.CaptureID,
-		ServerAddress:     m.ServerAddress,
-		KubernetesVersion: m.KubernetesVersion,
-		CapturedAt:        m.CapturedAt,
-		CapturedUntil:     m.CapturedUntil,
-		RecordCount:       m.RecordCount,
-		DeduplicatedCount: m.DeduplicatedCount,
-		UncompressedBytes: m.UncompressedBytes,
-		AutoDiscovered:    m.AutoDiscovered,
-		WatchEnabled:      m.WatchEnabled,
-		Intervals:         m.Intervals,
-		Redacted:          m.Redacted,
-		SecretsRedacted:   m.SecretsRedacted,
-		FieldsRedacted:    m.FieldsRedacted,
-		ArchivePath:       h.ArchivePath,
+		CaptureID:            m.CaptureID,
+		ServerAddress:        m.ServerAddress,
+		KubernetesVersion:    m.KubernetesVersion,
+		CapturedAt:           m.CapturedAt,
+		CapturedUntil:        m.CapturedUntil,
+		RecordCount:          m.RecordCount,
+		DeduplicatedCount:    m.DeduplicatedCount,
+		UncompressedBytes:    m.UncompressedBytes,
+		AutoDiscovered:       m.AutoDiscovered,
+		WatchEnabled:         m.WatchEnabled,
+		Intervals:            m.Intervals,
+		Redacted:             m.Redacted,
+		SecretsRedacted:      m.SecretsRedacted,
+		FieldsRedacted:       m.FieldsRedacted,
+		Anonymized:           m.Anonymized,
+		AnonymizedCategories: m.AnonymizedCategories,
+		ArchivePath:          h.ArchivePath,
 	}
 	if m.CapturedUntil.After(m.CapturedAt) {
 		info.DurationSeconds = int(m.CapturedUntil.Sub(m.CapturedAt).Round(time.Second).Seconds())

--- a/internal/ui/v2/capinfo_test.go
+++ b/internal/ui/v2/capinfo_test.go
@@ -5,6 +5,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/phenixblue/k8shark/internal/capture"
 )
 
 func TestServeCaptureInfo(t *testing.T) {
@@ -32,6 +35,41 @@ func TestServeCaptureInfo(t *testing.T) {
 	// Two distinct resource paths (pods, replicasets) were indexed.
 	if info.ResourcePaths != 2 {
 		t.Errorf("ResourcePaths = %d, want 2", info.ResourcePaths)
+	}
+}
+
+func TestServeCaptureInfo_AnonymizedProvenance(t *testing.T) {
+	now := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	podList := `{"apiVersion":"v1","kind":"PodList","items":[]}`
+	recs := []*capture.Record{
+		{ID: "r1", CapturedAt: now, APIPath: "/api/v1/pods", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(podList)},
+	}
+	idx := capture.Index{"/api/v1/pods": {APIPath: "/api/v1/pods", Seqs: []int{0}, Times: []time.Time{now}}}
+	meta := &capture.CaptureMetadata{
+		CaptureID: "v2-anonymized-test", CapturedAt: now.Add(-time.Minute), CapturedUntil: now, RecordCount: 1,
+		Anonymized: true, AnonymizedCategories: []string{"namespace", "ip"},
+	}
+	h := &Handler{Store: buildV2TestStore(t, recs, idx, meta), At: now}
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/api/capture", nil)
+	w := httptest.NewRecorder()
+	h.serveCaptureInfo(w, req)
+
+	var info CaptureInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &info); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !info.Anonymized {
+		t.Error("Anonymized = false, want true")
+	}
+	want := []string{"namespace", "ip"}
+	if len(info.AnonymizedCategories) != len(want) {
+		t.Fatalf("AnonymizedCategories = %v, want %v", info.AnonymizedCategories, want)
+	}
+	for i := range want {
+		if info.AnonymizedCategories[i] != want[i] {
+			t.Errorf("AnonymizedCategories[%d] = %q, want %q", i, info.AnonymizedCategories[i], want[i])
+		}
 	}
 }
 

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -545,11 +545,18 @@
       row('Dynamic discovery', c.auto_discovered ? 'yes' : 'no');
       row('Watch enabled', c.watch_enabled ? 'yes' : 'no');
       if (c.intervals && c.intervals.length) row('Poll interval(s)', c.intervals.join(', '));
-      row('Redaction', c.redacted ? ('yes' + ((c.secrets_redacted || c.fields_redacted) ? ' (' + (c.secrets_redacted || 0) + ' secrets, ' + (c.fields_redacted || 0) + ' fields)' : '')) : 'no');
-      row('Anonymization', c.anonymized ? ('yes' + ((c.anonymized_categories && c.anonymized_categories.length) ? ' (' + c.anonymized_categories.join(', ') + ')' : '')) : 'no');
     } else {
       row('Capture config', 'not recorded (captured before this was tracked)');
     }
+    // Redaction/Anonymization are independent of has_config_meta: both are
+    // written by a later rewrite pass (kshrk redact / kshrk anonymize), not
+    // by the original capture, so an archive captured before the
+    // config-fact fields existed can still be correctly redacted or
+    // anonymized afterward — the rewrite carries the source's own
+    // uncompressed_bytes (and hence has_config_meta) through unchanged, so
+    // gating these two rows on it would hide real provenance data.
+    row('Redaction', c.redacted ? ('yes' + ((c.secrets_redacted || c.fields_redacted) ? ' (' + (c.secrets_redacted || 0) + ' secrets, ' + (c.fields_redacted || 0) + ' fields)' : '')) : 'no');
+    row('Anonymization', c.anonymized ? ('yes' + ((c.anonymized_categories && c.anonymized_categories.length) ? ' (' + c.anonymized_categories.join(', ') + ')' : '')) : 'no');
     row('Archive', c.archive_path);
     return grid;
   }

--- a/internal/ui/v2/static/app.js
+++ b/internal/ui/v2/static/app.js
@@ -546,6 +546,7 @@
       row('Watch enabled', c.watch_enabled ? 'yes' : 'no');
       if (c.intervals && c.intervals.length) row('Poll interval(s)', c.intervals.join(', '));
       row('Redaction', c.redacted ? ('yes' + ((c.secrets_redacted || c.fields_redacted) ? ' (' + (c.secrets_redacted || 0) + ' secrets, ' + (c.fields_redacted || 0) + ' fields)' : '')) : 'no');
+      row('Anonymization', c.anonymized ? ('yes' + ((c.anonymized_categories && c.anonymized_categories.length) ? ' (' + c.anonymized_categories.join(', ') + ')' : '')) : 'no');
     } else {
       row('Capture config', 'not recorded (captured before this was tracked)');
     }


### PR DESCRIPTION
## Summary
Completes #137's config/reporting milestone (M5 of the approved plan):

- **`AnonymizeConfig`/`AnonymizeRule`** (`internal/config/config.go`): categories and field-path exclusion rules loaded via `kshrk anonymize --config`, merged with `--categories` flags. A rule is an *exclusion only* — `Exclude` must be true, rejected otherwise — since a value's category membership is already determined automatically by where it occurs.
- **Exclusion wired through all five matchers**, not just the schema-aware ones: a new `excludedFunc` (`internal/anonymize/rules.go`) is threaded down to every field-write site in namespace.go/resourcename.go/urlmatch.go/ipmatch.go/imagematch.go. `walkStrings` (the shared IP/URL full-tree walker) and imagematch.go's container-walker now track an absolute field path (dot-notation, `[*]` for array indices) as they recurse, so a full-tree-scanned category (IP, URL) can be excluded by path too — this required restructuring those two matchers' entry points to dispatch per-List-item with each item's own Kind, the same way the schema-aware categories already did, so Kind-scoped rules resolve correctly against a List response.
- **`-o json`**: `Result` gains a `SchemaVersion` and JSON tags, following `internal/query`/`internal/diagnose`'s identical contract-test pattern (`internal/anonymize/json_contract_test.go`). `docs/stability-policy.md` updated to list `anonymize` among the `-o json`-covered commands; `Result.Mapping` is explicitly `json:"-"` so the sensitive mapping data can never leak into `-o json` output even by accident.
- **`--emit-mapping`**: the original-to-alias mapping (already tracked per-category internally by each `collisionTracker`) is now exposed via a new `Mapping()` accessor and, when requested, written to a sidecar file — encrypted by default, reusing whatever `--encrypt-*` recipients were set for the main output. Writing it in plaintext requires an explicit `--emit-mapping-plaintext` acknowledgment; `--emit-mapping` with neither encryption nor that flag fails fast, before any archive I/O.
- **`Anonymized`/`AnonymizedCategories` provenance fields** on `CaptureMetadata`, mirroring `Redacted`/`SecretsRedacted` exactly, threaded into `internal/ui/v2/capinfo.go` and the overview page's capture-details card (`app.js`).
- **`docs/config.md`** gains an Anonymize section mirroring the existing Redaction one.

## Test plan
- [x] `go test ./...` and `go test -race ./...` — full suite green
- [x] `make lint-ci`, `gofmt -w .`, `go mod tidy`, `make docs` — clean
- [x] New unit tests: `internal/anonymize/rules_test.go` (exclusion matching + validation), `internal/anonymize/walk_test.go` (path construction), `internal/anonymize/json_contract_test.go` (schema/key-set pinning), plus exclusion-rule coverage added to every matcher's own test file
- [x] New `Archive()` integration tests: a rule excluding a specific field path leaves it unchanged while every other occurrence of the same category still aliases normally; a rule scoped to the wrong Kind is a no-op; a full-tree IP occurrence is excludable by its computed path; an invalid rule (`Exclude: false`) is rejected before any archive I/O; the provenance metadata fields are set correctly
- [x] New `cmd` integration tests (`cmd/anonymize_test.go`, mirroring `decrypt_test.go`'s direct-`runX`-invocation pattern): categories/rules loaded purely from `--config`; `-o json` output round-trips and never contains the mapping; `--emit-mapping` is rejected without encryption or the plaintext ack, succeeds with the ack (plaintext, verified readable), and succeeds with `--encrypt-recipient` (verified it's actually age-encrypted by decrypting it back)
- [x] Revert-and-reconfirm: manually reverted the `Namespace` object's exclusion check in `namespace.go` and confirmed `TestArchive_RuleExcludesSpecificFieldPath` catches it before restoring
- [x] Manual smoke test against `examples/auto-discovery/capture.kshrk`: config-file categories + a rule excluding a Pod's own `metadata.name` — confirmed the Pod's own name field stayed unchanged while the *same* pod name still got aliased consistently via an Event's `involvedObject.name` (a different field path, correctly not covered by the rule); `--emit-mapping --emit-mapping-plaintext` produced a correct, readable mapping file

🤖 Generated with [Claude Code](https://claude.com/claude-code)