### PR TITLE
fix(anonymize): alias Event involvedObject.name for Namespace references (#137)

### DIFF
--- a/internal/anonymize/archive_test.go
+++ b/internal/anonymize/archive_test.go
@@ -321,8 +321,13 @@ func TestArchive_EventNamespaceReferenceAliasesName(t *testing.T) {
 		 "involvedObject":{"kind":"Namespace","name":"prod"},
 		 "message":"Namespace prod is active"}
 	]}`
+	// Appended under the *same* path as namespaceFixtureRecords' own events
+	// record (real Kubernetes API paths never have an "events2" resource
+	// type) — buildAnonymizeTestArchive assigns sequence numbers per path,
+	// so this lands as seq 1 alongside the fixture's own seq-0 record, the
+	// same way a real capture accumulates multiple polls of one endpoint.
 	records := append(namespaceFixtureRecords(), &capture.Record{
-		ID: "r5", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/prod/events2",
+		ID: "r5", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/prod/events",
 		HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(eventListBody),
 	})
 	src := buildAnonymizeTestArchive(t, records)
@@ -339,7 +344,7 @@ func TestArchive_EventNamespaceReferenceAliasesName(t *testing.T) {
 		t.Fatalf("archive.Open: %v", err)
 	}
 	defer ar.Close()
-	data, err := ar.ReadRecord("/api/v1/namespaces/"+wantAlias+"/events2", 0)
+	data, err := ar.ReadRecord("/api/v1/namespaces/"+wantAlias+"/events", 1)
 	if err != nil {
 		t.Fatalf("ReadRecord: %v", err)
 	}

--- a/internal/anonymize/archive_test.go
+++ b/internal/anonymize/archive_test.go
@@ -307,6 +307,56 @@ func TestArchive_RoundTripReadableViaStore(t *testing.T) {
 	}
 }
 
+// Found missing against a real cluster capture, not constructed from first
+// principles: a namespace-lifecycle Event's involvedObject.kind is
+// "Namespace", and namespace.go's Event handling previously only ever
+// aliased a reference's "namespace" field, never its "name" field — the
+// one a Namespace reference actually needs, since a Namespace has no
+// membership of its own. This end-to-end-checks the fix through the full
+// Archive() path, not just rewriteNamespaceInObject in isolation
+// (namespace_test.go covers that).
+func TestArchive_EventNamespaceReferenceAliasesName(t *testing.T) {
+	eventListBody := `{"kind":"EventList","apiVersion":"v1","items":[
+		{"metadata":{"name":"prod.abc","namespace":"prod"},
+		 "involvedObject":{"kind":"Namespace","name":"prod"},
+		 "message":"Namespace prod is active"}
+	]}`
+	records := append(namespaceFixtureRecords(), &capture.Record{
+		ID: "r5", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/prod/events2",
+		HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(eventListBody),
+	})
+	src := buildAnonymizeTestArchive(t, records)
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+	salt := []byte("event-namespace-reference-test-salt")
+
+	if _, err := Archive(src, dst, Options{Categories: []Category{CategoryNamespace}, Salt: salt}); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	wantAlias := NewAliaser(salt).Alias(CategoryNamespace, "prod")
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	defer ar.Close()
+	data, err := ar.ReadRecord("/api/v1/namespaces/"+wantAlias+"/events2", 0)
+	if err != nil {
+		t.Fatalf("ReadRecord: %v", err)
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatal(err)
+	}
+	var eventList map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &eventList); err != nil {
+		t.Fatal(err)
+	}
+	involved := eventList["items"].([]interface{})[0].(map[string]interface{})["involvedObject"].(map[string]interface{})
+	if got := involved["name"]; got != wantAlias {
+		t.Errorf("involvedObject.name = %v, want %v — the real bug: this leaked the unaliased namespace name", got, wantAlias)
+	}
+}
+
 // Running Archive twice over the identical source with the identical salt
 // must produce byte-identical output — this is the property the whole
 // single-pass, stateless design in alias.go exists to guarantee. Comparing

--- a/internal/anonymize/namespace.go
+++ b/internal/anonymize/namespace.go
@@ -38,6 +38,16 @@ import (
 // *names* on the parent Event, same Namespace field within. All three are
 // checked unconditionally; whichever ones a given record doesn't have are
 // simply absent from the decoded map and the corresponding check is a no-op.
+//
+// A reference whose own Kind is "Namespace" needs the *opposite* field
+// aliased from every other Kind, mirroring the exact same distinction the
+// top-level object dispatch above makes: the reference's "name" field is
+// that Namespace's own identity (there is no membership to express — a
+// Namespace can't be namespaced), not its "namespace" field. Confirmed
+// missing against a real cluster capture (#137): an Event whose
+// involvedObject.kind is "Namespace" leaked the real namespace name in
+// full through involvedObject.name, even though every other occurrence of
+// that same namespace elsewhere in the archive was correctly aliased.
 func rewriteNamespaceInObject(obj map[string]interface{}, kind string, excluded excludedFunc, alias func(string) string) bool {
 	meta, _ := obj["metadata"].(map[string]interface{})
 	if meta == nil {
@@ -59,6 +69,14 @@ func rewriteNamespaceInObject(obj map[string]interface{}, kind string, excluded 
 		for _, field := range []string{"involvedObject", "regarding", "related"} {
 			ref, ok := obj[field].(map[string]interface{})
 			if !ok {
+				continue
+			}
+			refKind, _ := ref["kind"].(string)
+			if refKind == "Namespace" {
+				if name, ok := ref["name"].(string); ok && name != "" && !excluded(CategoryNamespace, kind, field+".name") {
+					ref["name"] = alias(name)
+					modified = true
+				}
 				continue
 			}
 			if ns, ok := ref["namespace"].(string); ok && ns != "" && !excluded(CategoryNamespace, kind, field+".namespace") {

--- a/internal/anonymize/namespace_test.go
+++ b/internal/anonymize/namespace_test.go
@@ -91,6 +91,34 @@ func TestRewriteNamespaceInObject(t *testing.T) {
 		}
 	})
 
+	// Found missing against a real cluster capture, not a synthetic case:
+	// a Namespace object can't have a "namespace" (membership) field of its
+	// own — its identity IS its name — so a reference whose own Kind is
+	// "Namespace" needs its "name" field aliased, not its "namespace"
+	// field, mirroring the exact distinction the top-level object dispatch
+	// already makes for a Namespace object itself.
+	t.Run("an Event referencing a Namespace object aliases involvedObject.name, not .namespace", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"kind":           "Event",
+			"metadata":       map[string]interface{}{"name": "openshift-cnv.abc", "namespace": "openshift-cnv"},
+			"involvedObject": map[string]interface{}{"kind": "Namespace", "name": "openshift-cnv"},
+		}
+		if !rewriteNamespaceInObject(obj, "Event", noExclusions, alias) {
+			t.Fatal("want modified=true")
+		}
+		meta := obj["metadata"].(map[string]interface{})
+		involved := obj["involvedObject"].(map[string]interface{})
+		if got := meta["namespace"]; got != "openshift-cnv-ALIASED" {
+			t.Errorf("metadata.namespace = %v, want openshift-cnv-ALIASED", got)
+		}
+		if got := involved["name"]; got != "openshift-cnv-ALIASED" {
+			t.Errorf("involvedObject.name = %v, want openshift-cnv-ALIASED — this is the bug found via a real cluster capture: the Namespace's own identity, unaliased, leaked in full", got)
+		}
+		if _, has := involved["namespace"]; has {
+			t.Error("a Namespace reference must not gain a namespace field — it has no membership of its own")
+		}
+	})
+
 	t.Run("cluster-scoped object with no metadata.namespace is left alone", func(t *testing.T) {
 		obj := map[string]interface{}{
 			"kind":     "Node",

--- a/internal/anonymize/resourcename.go
+++ b/internal/anonymize/resourcename.go
@@ -62,6 +62,19 @@ var resourceTypeCategories = func() map[string]Category {
 // generic pattern for "this token is a Kubernetes name" the way there is
 // for an IP literal, so recall would need a candidate set built from these
 // same structured fields first (see #137's plan, Open Question 5).
+//
+// A closely related, confirmed-real instance of that same gap: kindCategories
+// only recognizes built-in Kubernetes Kinds, so an Event whose
+// involvedObject/regarding/related.kind is a CRD that happens to share
+// identity with a real Node/Pod (e.g. Portworx's StorageNode custom
+// resource, conventionally named identically to the Node it represents)
+// leaks that real name in full through the reference's own "name" field,
+// even though the same value is correctly aliased everywhere it occurs as
+// an actual Node. Found against a real cluster capture; recognizing this
+// would need either a cluster/vendor-specific Kind allowlist (fragile, not
+// generalizable) or the same candidate-set approach the free-text gap
+// above needs — deliberately left as a documented limitation rather than
+// silently patched for one vendor's naming convention.
 func rewriteResourceNameInObject(obj map[string]interface{}, kind string, enabled map[Category]bool, excluded excludedFunc, alias func(Category, string) string) bool {
 	modified := false
 


### PR DESCRIPTION
## Summary
Found by running `kshrk anonymize` against a real, live ~76-namespace OpenShift + Portworx cluster (functional validation of #137's now-merged M1–M5 work, not a synthetic test case):

- **Real bug, fixed**: an `Event` whose `involvedObject`/`regarding`/`related.kind` is `"Namespace"` leaked the real namespace name in full through the reference's own `name` field — confirmed on a real event referencing `openshift-cnv`, which leaked completely while every *other* occurrence of that same namespace in the same archive was correctly aliased. `namespace.go`'s Event handling only ever aliased a reference's `namespace` field, but a `Namespace` reference has no membership field of its own — its identity *is* its name, mirroring the exact distinction the top-level object dispatch already makes for a `Namespace` object itself.
- **Documented, out-of-scope limitation**: a related but architecturally different gap found in the same run — a Portworx CRD (`StorageNode`) conventionally named identically to the `Node` it represents isn't recognized by `kindCategories` (which only covers built-in Kinds), so an `Event` referencing one leaks the real node name. This is the same class of problem as the plan's already-documented Open Question 5 (no generic way to recognize an arbitrary Kind's name as "really" a node/pod name) — documented in `resourcename.go` rather than patched with a fragile, vendor-specific allowlist.

## What else was validated on the real cluster
- All 7 categories anonymized consistently across kinds (pod `spec.nodeName` ↔ node's own alias, ReplicaSet `ownerReferences` ↔ Deployment alias, image registry host aliased with repo/tag preserved).
- **Determinism confirmed byte-for-byte**: two independent runs with the same salt produced identical archive bytes.
- **Collision detection worked as designed**: this cluster's 76 namespaces (well within the birthday-bound collision zone for the namespace category's 2-word encoding) hit genuine collisions on most salt attempts, and `Archive()` correctly refused to produce a corrupted archive each time rather than silently dropping a record.
- `-o json` and `--emit-mapping` (0600 permissions) both correct against real data.

## Test plan
- [x] `go test ./...` and `go test -race ./...` — full suite green
- [x] `make lint-ci`, `gofmt -w .`, `go mod tidy`, `make docs` — clean
- [x] New unit test (`namespace_test.go`) reproducing the exact real-world shape (an Event's `involvedObject.kind == "Namespace"`)
- [x] New `Archive()` integration test (`archive_test.go`) checking the fix end-to-end, not just the object-level function in isolation
- [x] Revert-and-reconfirm: manually reverted the fix and confirmed both new tests catch the exact regression found on the real cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)