### PR TITLE
fix(anonymize): widen namespace alias encoding from 2 to 3 words (#137)

### DIFF
--- a/internal/anonymize/archive_test.go
+++ b/internal/anonymize/archive_test.go
@@ -402,18 +402,19 @@ func TestArchive_Deterministic(t *testing.T) {
 	}
 }
 
-// A real, found-not-constructed collision: "ns-66" and "ns-106" both alias to
-// "namespace-green-lynx" under this exact salt (found by brute-force search
-// over the namespace category's real HMAC-based Aliaser — it took only ~106
-// draws, consistent with collision.go's birthday-bound math for a
-// 64x64=4096-combination space). This exercises the real, wired-up
-// collisionTracker end to end through Archive(), not just the tracker in
-// isolation (collision_test.go) with an injected colliding function — a bug
-// in how the tracker is *wired into* the two index loops would not
-// necessarily show up there.
+// A real, found-not-constructed collision: "ns-763" and "ns-880" both alias
+// to "namespace-large-cheetah-coral" under this exact salt (found by
+// brute-force search over the namespace category's real HMAC-based Aliaser —
+// it took ~881 draws, consistent with collision.go's birthday-bound math for
+// the namespace category's 64x64x64=262144-combination, 3-word encoding —
+// see #359, which bumped namespace from 2 to 3 words). This exercises the
+// real, wired-up collisionTracker end to end through Archive(), not just the
+// tracker in isolation (collision_test.go) with an injected colliding
+// function — a bug in how the tracker is *wired into* the two index loops
+// would not necessarily show up there.
 const (
-	collidingNamespaceA    = "ns-66"
-	collidingNamespaceB    = "ns-106"
+	collidingNamespaceA    = "ns-763"
+	collidingNamespaceB    = "ns-880"
 	collidingNamespaceSalt = "fixed-test-salt-for-collision-search"
 )
 

--- a/internal/anonymize/collision.go
+++ b/internal/anonymize/collision.go
@@ -8,9 +8,9 @@ import "fmt"
 // name.go's wordsPerCategory), a cluster with 50 same-category resources has
 // roughly a 1-in-4 chance of at least one collision, and 100 roughly 2-in-3,
 // by the ordinary birthday bound (a 3-word, 262,144-combination encoding
-// pushes that same 100-resource case down to roughly 1-in-30 — see #359,
-// which bumped the namespace category from 2 to 3 words for exactly this
-// reason). Silently
+// pushes that same 100-resource case down to roughly 1-in-53 (~1.9%) — see
+// #359, which bumped the namespace category from 2 to 3 words for exactly
+// this reason). Silently
 // proceeding on a collision is not an acceptable failure mode here: it means
 // two distinct source API paths would rewrite to the same destination key,
 // and the archive-rewrite loop's index/watch-index rebuild would silently

--- a/internal/anonymize/collision.go
+++ b/internal/anonymize/collision.go
@@ -4,10 +4,13 @@ import "fmt"
 
 // collisionTracker wraps a category's alias function with collision
 // detection. Two distinct original values landing on the same alias is not
-// astronomically unlikely — for the namespace category's 2-word encoding
-// (4096 combinations, see name.go's wordsPerCategory), a cluster with 50
-// namespaces has roughly a 1-in-4 chance of at least one collision, and 100
-// namespaces roughly 2-in-3, by the ordinary birthday bound. Silently
+// astronomically unlikely — for a 2-word encoding (4096 combinations, see
+// name.go's wordsPerCategory), a cluster with 50 same-category resources has
+// roughly a 1-in-4 chance of at least one collision, and 100 roughly 2-in-3,
+// by the ordinary birthday bound (a 3-word, 262,144-combination encoding
+// pushes that same 100-resource case down to roughly 1-in-30 — see #359,
+// which bumped the namespace category from 2 to 3 words for exactly this
+// reason). Silently
 // proceeding on a collision is not an acceptable failure mode here: it means
 // two distinct source API paths would rewrite to the same destination key,
 // and the archive-rewrite loop's index/watch-index rebuild would silently

--- a/internal/anonymize/name.go
+++ b/internal/anonymize/name.go
@@ -11,8 +11,8 @@ package anonymize
 //
 // Namespace was bumped from 2 to 3 words after #359: a real 76-namespace
 // OpenShift cluster hit a same-category collision on 8 of the first 10 salt
-// attempts under the 2-word (64x64=4096-combination) encoding, matching the
-// birthday-bound math below almost exactly. At 3 words (64^3=262,144
+// attempts under the 2-word (64x64=4096-combination) encoding, matching
+// collision.go's own birthday-bound math almost exactly. At 3 words (64^3=262,144
 // combinations), the expected collision count at 76 namespaces drops from
 // ~0.7 to ~0.011 — a first-attempt success becomes the overwhelmingly common
 // case instead of a near coin flip.

--- a/internal/anonymize/name.go
+++ b/internal/anonymize/name.go
@@ -2,11 +2,20 @@ package anonymize
 
 // wordsPerCategory is how many words from the adjective/noun lists are
 // chained together for a category's alias. Categories with realistically
-// high cardinality in a real cluster (pods, workloads) get an extra word to
-// keep the combination space large enough that a same-category collision
-// within one archive stays unlikely; node/namespace counts are realistically
-// much smaller, so two words keeps those aliases shorter and easier to read
-// in the common case without a meaningful collision-risk cost.
+// high cardinality in a real cluster (pods, workloads, namespaces) get an
+// extra word to keep the combination space large enough that a
+// same-category collision within one archive stays unlikely; node counts
+// are realistically much smaller, so two words keeps those aliases shorter
+// and easier to read in the common case without a meaningful collision-risk
+// cost.
+//
+// Namespace was bumped from 2 to 3 words after #359: a real 76-namespace
+// OpenShift cluster hit a same-category collision on 8 of the first 10 salt
+// attempts under the 2-word (64x64=4096-combination) encoding, matching the
+// birthday-bound math below almost exactly. At 3 words (64^3=262,144
+// combinations), the expected collision count at 76 namespaces drops from
+// ~0.7 to ~0.011 — a first-attempt success becomes the overwhelmingly common
+// case instead of a near coin flip.
 //
 // This is a v1 sizing choice, not a correctness guarantee: two different
 // original values can still collide onto the same alias (see Aliaser's doc
@@ -15,7 +24,7 @@ package anonymize
 // cross-record state this package deliberately does not hold).
 var wordsPerCategory = map[Category]int{
 	CategoryNode:      2,
-	CategoryNamespace: 2,
+	CategoryNamespace: 3,
 	CategoryPod:       3,
 	CategoryWorkload:  3,
 	CategoryURL:       2,


### PR DESCRIPTION
## Summary

- Bumps `wordsPerCategory[CategoryNamespace]` from 2 to 3 words (64x64=4096 → 64x64x64=262,144 combinations), matching pod/workload's existing 3-word sizing.
- Updates `name.go`/`collision.go` doc comments to reflect the new sizing and record why (birthday-bound math, real-cluster evidence).
- Re-derives the brute-forced real-collision fixture in `archive_test.go` (`ns-763`/`ns-880` → `namespace-large-cheetah-coral`, found in 881 draws) since the old 2-word pair (`ns-66`/`ns-106`) no longer collides under the wider encoding.

## Why

Found while running `kshrk anonymize` against a real, live 76-namespace OpenShift cluster: the first 8 of 10 salt attempts hit a genuine same-category collision, matching `collision.go`'s own birthday-bound math for a 4096-combination space almost exactly. Collision detection was working exactly as designed (no archive was ever silently corrupted), but requiring several retries to find a working salt is a real, demonstrated usability problem at realistic OpenShift-scale namespace counts — not a rare edge case.

At 3 words, the expected collision count at 76 namespaces drops from ~0.7 to ~0.011, making first-attempt success the overwhelmingly common case. Not a breaking change — this only affects freshly-computed aliases going forward, not the archive format itself.

Closes #359

## Test plan

- [x] `go test ./internal/anonymize/...` — all pass, including the re-derived real-collision fixture
- [x] `go test -race ./...` — clean
- [x] `make lint-ci` — clean
- [x] `go mod tidy` — no drift
- [x] `gofmt -l .` — no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)