### PR TITLE
feat(anonymize): two-pass full-sweep for any-occurrence recall (#361)

### DIFF
--- a/cmd/anonymize.go
+++ b/cmd/anonymize.go
@@ -32,7 +32,15 @@ Categories available: namespace, node, pod, workload, ip, url, image -- see
 https://github.com/phenixblue/k8shark/issues/137.
 
 Categories and field-path exclusion rules may also be loaded from a config
-file's anonymize block via --config; see docs/config.md.`,
+file's anonymize block via --config; see docs/config.md.
+
+By default, a value is only anonymized at the field paths each category
+already knows to look at. --full-sweep additionally replaces any substring
+occurrence of a discovered namespace/node/pod/workload/ip/url value anywhere
+else in a record's text (an Event message, an escaped-JSON-string
+annotation, an unrecognized CRD's field) -- slower, and opt-in, since
+matching a short or common value as a substring carries a real
+false-positive risk. See https://github.com/phenixblue/k8shark/issues/361.`,
 	Example: `  # Anonymize every namespace name in a capture
   kshrk anonymize capture.kshrk --categories namespace
 
@@ -52,7 +60,10 @@ file's anonymize block via --config; see docs/config.md.`,
   kshrk anonymize capture.kshrk --categories namespace --emit-mapping --encrypt-recipient age1abc...
 
   # Anonymize and write to a chosen path
-  kshrk anonymize capture.kshrk --out safe.kshrk --categories namespace`,
+  kshrk anonymize capture.kshrk --out safe.kshrk --categories namespace
+
+  # Also catch occurrences outside known field paths (slower, opt-in)
+  kshrk anonymize capture.kshrk --categories namespace --categories ip --full-sweep`,
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: completeArchiveArg,
 	RunE:              runAnonymize,
@@ -67,6 +78,7 @@ func init() {
 	anonymizeCmd.Flags().Bool("emit-mapping", false, "write the original-to-alias mapping alongside the output archive")
 	anonymizeCmd.Flags().String("mapping-path", "", "path for the mapping file (default: <out>.mapping.json, or .mapping.json.age when encrypted)")
 	anonymizeCmd.Flags().Bool("emit-mapping-plaintext", false, "allow --emit-mapping to write an unencrypted mapping when no --encrypt-* flag is set (not recommended)")
+	anonymizeCmd.Flags().Bool("full-sweep", false, "also replace any substring occurrence of a discovered namespace/node/pod/workload/ip/url value anywhere in a record's text, not just at known field paths (slower, opt-in; see #361)")
 	_ = anonymizeCmd.MarkFlagFilename("out", captureExt)
 	_ = anonymizeCmd.MarkFlagFilename("config", configExts...)
 	_ = anonymizeCmd.RegisterFlagCompletionFunc("output",
@@ -94,6 +106,19 @@ var supportedAnonymizeCategories = map[anonymize.Category]bool{
 	anonymize.CategoryIP:        true,
 	anonymize.CategoryURL:       true,
 	anonymize.CategoryImage:     true,
+}
+
+// sweepEligibleCategories are the categories --full-sweep actually extends
+// recall for (internal/anonymize/sweep.go's buildSweepCandidates). Image is
+// deliberately absent — see that file's own package doc for why a registry
+// host alias isn't swept for free-standing occurrences.
+var sweepEligibleCategories = map[anonymize.Category]bool{
+	anonymize.CategoryNamespace: true,
+	anonymize.CategoryNode:      true,
+	anonymize.CategoryPod:       true,
+	anonymize.CategoryWorkload:  true,
+	anonymize.CategoryIP:        true,
+	anonymize.CategoryURL:       true,
 }
 
 // parseAnonymizeCategories validates --categories against what this build's
@@ -144,6 +169,7 @@ func runAnonymize(cmd *cobra.Command, args []string) error {
 	emitMapping, _ := cmd.Flags().GetBool("emit-mapping")
 	mappingPath, _ := cmd.Flags().GetString("mapping-path")
 	emitMappingPlaintext, _ := cmd.Flags().GetBool("emit-mapping-plaintext")
+	fullSweep, _ := cmd.Flags().GetBool("full-sweep")
 
 	if outputFormat != "text" && outputFormat != "json" {
 		return fmt.Errorf("--output must be text or json (got %q)", outputFormat)
@@ -164,6 +190,9 @@ func runAnonymize(cmd *cobra.Command, args []string) error {
 		if mappingPath == "" {
 			mappingPath = cfg.Anonymize.MappingPath
 		}
+		if cfg.Anonymize.FullSweep {
+			fullSweep = true
+		}
 	}
 
 	categories, err := parseAnonymizeCategories(categoryFlags)
@@ -171,6 +200,20 @@ func runAnonymize(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	categories = dedupeCategories(categories)
+
+	if fullSweep {
+		eligible := false
+		for _, c := range categories {
+			if sweepEligibleCategories[c] {
+				eligible = true
+				break
+			}
+		}
+		if !eligible {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"warning: --full-sweep has no effect: none of the requested categories (%v) are sweep-eligible (namespace, node, pod, workload, ip, url)\n", categories)
+		}
+	}
 
 	if out == "" {
 		// Trim either the current or the legacy extension so anonymizing a
@@ -252,6 +295,7 @@ func runAnonymize(cmd *cobra.Command, args []string) error {
 		Identities: identities,
 		Recipients: enc.recipients,
 		Rules:      rules,
+		FullSweep:  fullSweep,
 	})
 	if err != nil {
 		return err
@@ -278,6 +322,10 @@ func runAnonymize(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(cmd.OutOrStdout(), "Anonymized %d namespace(s), %d node(s), %d pod(s), %d workload(s), %d IP(s), %d host(s), %d registry host(s) → %s (%d bytes)\n",
 		result.NamespacesRenamed, result.NodesRenamed, result.PodsRenamed, result.WorkloadsRenamed,
 		result.IPsRenamed, result.HostsRenamed, result.RegistriesRenamed, out, result.OutputBytes)
+	if fullSweep {
+		fmt.Fprintf(cmd.OutOrStdout(), "Full sweep found %d additional occurrence(s); skipped %d ambiguous value(s)\n",
+			result.SweepOccurrencesFound, result.SweepAmbiguousSkipped)
+	}
 	if emitMapping {
 		fmt.Fprintf(cmd.OutOrStdout(), "Mapping written to %s\n", mappingPath)
 	}

--- a/cmd/anonymize_test.go
+++ b/cmd/anonymize_test.go
@@ -134,6 +134,7 @@ func newTestAnonymizeCmdCommand(t *testing.T) *cobra.Command {
 	cmd.Flags().Bool("emit-mapping", false, "")
 	cmd.Flags().String("mapping-path", "", "")
 	cmd.Flags().Bool("emit-mapping-plaintext", false, "")
+	cmd.Flags().Bool("full-sweep", false, "")
 	addAnonymizeFlags(cmd)
 	addEncryptFlags(cmd)
 	cmd.Flags().AddFlagSet(cmd.PersistentFlags())
@@ -285,6 +286,7 @@ func TestRunAnonymize_JSONOutput(t *testing.T) {
 	for _, k := range []string{
 		"schema_version", "namespaces_renamed", "nodes_renamed", "pods_renamed",
 		"workloads_renamed", "ips_renamed", "hosts_renamed", "registries_renamed", "output_path",
+		"sweep_occurrences_found", "sweep_ambiguous_skipped",
 	} {
 		if _, ok := raw[k]; !ok {
 			t.Errorf("missing expected top-level key %q; got %s", k, stdout.String())
@@ -493,5 +495,82 @@ func TestRunAnonymize_EmitMappingTightensPreExistingPermissions(t *testing.T) {
 	}
 	if got := fi.Mode().Perm(); got != 0o600 {
 		t.Errorf("mapping file mode = %o, want 0600 (a pre-existing 0644 mode must be tightened, not preserved)", got)
+	}
+}
+
+func TestRunAnonymize_FullSweepFlagIsPlumbedThrough(t *testing.T) {
+	// A namespace mention inside a free-text field the schema-aware
+	// matchers don't know about — only --full-sweep can catch it.
+	in := buildDiffArchive(t, `{"kind":"PodList","items":[
+		{"metadata":{"name":"web-1","namespace":"prod"},"status":{"message":"scheduled onto namespace prod"}}
+	]}`)
+
+	cmd := newTestAnonymizeCmdCommand(t)
+	var stdout strings.Builder
+	cmd.SetOut(&stdout)
+	_ = cmd.Flags().Set("categories", "namespace")
+	_ = cmd.Flags().Set("output", "json")
+	_ = cmd.Flags().Set("full-sweep", "true")
+	_ = cmd.Flags().Set("anonymize-salt-file", writeAnonymizeTestSaltFile(t))
+
+	if err := runAnonymize(cmd, []string{in}); err != nil {
+		t.Fatalf("runAnonymize: %v", err)
+	}
+
+	var result anonymize.Result
+	if err := json.Unmarshal([]byte(stdout.String()), &result); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %s", err, stdout.String())
+	}
+	if result.SweepOccurrencesFound == 0 {
+		t.Error("sweep_occurrences_found = 0, want > 0 — --full-sweep should have caught the free-text mention")
+	}
+}
+
+func TestRunAnonymize_ConfigFileSuppliesFullSweep(t *testing.T) {
+	in := buildDiffArchive(t, `{"kind":"PodList","items":[
+		{"metadata":{"name":"web-1","namespace":"prod"},"status":{"message":"scheduled onto namespace prod"}}
+	]}`)
+	cfgPath := filepath.Join(t.TempDir(), "k8shark.yaml")
+	if err := os.WriteFile(cfgPath, []byte("anonymize:\n  categories: [namespace]\n  fullSweep: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTestAnonymizeCmdCommand(t)
+	var stdout strings.Builder
+	cmd.SetOut(&stdout)
+	_ = cmd.Flags().Set("config", cfgPath)
+	_ = cmd.Flags().Set("output", "json")
+	_ = cmd.Flags().Set("anonymize-salt-file", writeAnonymizeTestSaltFile(t))
+
+	// No --full-sweep flag at all: the config file must enable it on its own.
+	if err := runAnonymize(cmd, []string{in}); err != nil {
+		t.Fatalf("runAnonymize: %v", err)
+	}
+
+	var result anonymize.Result
+	if err := json.Unmarshal([]byte(stdout.String()), &result); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %s", err, stdout.String())
+	}
+	if result.SweepOccurrencesFound == 0 {
+		t.Error("sweep_occurrences_found = 0, want > 0 — anonymize.fullSweep in the config file should have enabled the sweep")
+	}
+}
+
+func TestRunAnonymize_FullSweepWithNoEligibleCategoryWarns(t *testing.T) {
+	in := buildDiffArchive(t, `{"kind":"PodList","items":[{"metadata":{"name":"web-1","namespace":"prod"}}]}`)
+
+	cmd := newTestAnonymizeCmdCommand(t)
+	cmd.SetOut(io.Discard)
+	var stderr strings.Builder
+	cmd.SetErr(&stderr)
+	_ = cmd.Flags().Set("categories", "image")
+	_ = cmd.Flags().Set("full-sweep", "true")
+	_ = cmd.Flags().Set("anonymize-salt-file", writeAnonymizeTestSaltFile(t))
+
+	if err := runAnonymize(cmd, []string{in}); err != nil {
+		t.Fatalf("runAnonymize: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "--full-sweep has no effect") {
+		t.Errorf("stderr = %q, want a warning that --full-sweep has no effect for --categories image", stderr.String())
 	}
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -75,6 +75,14 @@ https://github.com/phenixblue/k8shark/issues/137.
 Categories and field-path exclusion rules may also be loaded from a config
 file's anonymize block via --config; see docs/config.md.
 
+By default, a value is only anonymized at the field paths each category
+already knows to look at. --full-sweep additionally replaces any substring
+occurrence of a discovered namespace/node/pod/workload/ip/url value anywhere
+else in a record's text (an Event message, an escaped-JSON-string
+annotation, an unrecognized CRD's field) -- slower, and opt-in, since
+matching a short or common value as a substring carries a real
+false-positive risk. See https://github.com/phenixblue/k8shark/issues/361.
+
 ```
 kshrk anonymize <capture.kshrk> --categories <category> [--out <anonymized.kshrk>] [flags]
 ```
@@ -102,6 +110,9 @@ kshrk anonymize <capture.kshrk> --categories <category> [--out <anonymized.kshrk
 
   # Anonymize and write to a chosen path
   kshrk anonymize capture.kshrk --out safe.kshrk --categories namespace
+
+  # Also catch occurrences outside known field paths (slower, opt-in)
+  kshrk anonymize capture.kshrk --categories namespace --categories ip --full-sweep
 ```
 
 ### Options
@@ -116,6 +127,7 @@ kshrk anonymize <capture.kshrk> --categories <category> [--out <anonymized.kshrk
       --encrypt-passphrase-file string   read the encryption passphrase from this file (first line) instead of prompting
       --encrypt-recipient stringArray    age recipient public key (age1...) to encrypt to (repeatable); mutually exclusive with passphrase encryption
       --encrypt-recipients-file string   file of age recipient public keys (one per line) to encrypt to
+      --full-sweep                       also replace any substring occurrence of a discovered namespace/node/pod/workload/ip/url value anywhere in a record's text, not just at known field paths (slower, opt-in; see #361)
   -h, --help                             help for anonymize
       --mapping-path string              path for the mapping file (default: <out>.mapping.json, or .mapping.json.age when encrypted)
       --out string                       output archive path (default: <in>-anonymized.kshrk)

--- a/docs/config.md
+++ b/docs/config.md
@@ -570,6 +570,7 @@ Categories and field-path exclusion rules live in a top-level `anonymize` block 
 | `rules` | list | `[]` | Field-path exclusions layered on top of `categories`. See below. |
 | `emitMapping` | bool | `false` | Write the original-to-alias mapping alongside the output archive (same as `--emit-mapping` on the CLI). |
 | `mappingPath` | string | *(computed)* | Override the mapping file's path. |
+| `fullSweep` | bool | `false` | Also replace any substring occurrence of a discovered `namespace`/`node`/`pod`/`workload`/`ip`/`url` value anywhere in a record's text, not just at known field paths — e.g. a name in an Event message, or one embedded in an escaped-JSON-string annotation like `kubectl.kubernetes.io/last-applied-configuration`. Same as `--full-sweep` on the CLI. Slower (a full extra read pass) and opt-in: matching a short or common value as a substring carries a real false-positive risk. A value that's a candidate under more than one category (e.g. a namespace and a pod both named `prod`) is left untouched rather than guessed at. See [#361](https://github.com/phenixblue/k8shark/issues/361). |
 
 ### Anonymize rule fields
 

--- a/internal/anonymize/archive.go
+++ b/internal/anonymize/archive.go
@@ -73,6 +73,15 @@ type Options struct {
 	// must have Exclude set; Archive rejects the whole run otherwise (see
 	// newExcludeMatcher).
 	Rules []config.AnonymizeRule
+	// FullSweep enables a second, opt-in pass (see sweep.go's own doc
+	// comment) that replaces any substring occurrence of an
+	// already-discovered namespace/node/pod/workload/ip/url value with its
+	// alias, anywhere in a record's string content — not just at the known
+	// field paths the schema-aware/full-tree matchers cover. Off by
+	// default: it doubles the archive read cost (a full collection pass
+	// before the normal rewrite pass) and carries a real false-positive
+	// risk for short or common values (see #361).
+	FullSweep bool
 }
 
 // SchemaVersion is the version of the `kshrk anonymize -o json` output
@@ -104,6 +113,23 @@ type Result struct {
 	// RegistriesRenamed counts distinct container-image registry hosts
 	// (the leading host[:port] segment of an image reference).
 	RegistriesRenamed int `json:"registries_renamed"`
+	// SweepOccurrencesFound counts additional occurrences rewritten by the
+	// opt-in full-sweep pass (Options.FullSweep) — a value already caught
+	// by the schema-aware/full-tree matchers above doesn't count again
+	// here; this is purely the substring occurrences those matchers would
+	// have missed (a name in an Event message, a value embedded in an
+	// escaped-JSON-string annotation like
+	// kubectl.kubernetes.io/last-applied-configuration). Always 0 when
+	// FullSweep was not requested.
+	SweepOccurrencesFound int `json:"sweep_occurrences_found"`
+	// SweepAmbiguousSkipped counts distinct original values that were
+	// eligible for the full-sweep pass but excluded from it because the
+	// same literal string was a candidate under more than one category
+	// with a different alias (e.g. a namespace and a pod both named
+	// "prod") — left untouched rather than guessed at, matching this
+	// package's existing collision-detection discipline. Always 0 when
+	// FullSweep was not requested.
+	SweepAmbiguousSkipped int `json:"sweep_ambiguous_skipped"`
 	// OutputPath and OutputBytes are populated by the CLI layer (cmd/anonymize.go),
 	// not by Archive itself — Archive doesn't know its own caller's chosen
 	// output path or need to stat the file it just finished writing.
@@ -140,6 +166,12 @@ type Result struct {
 // proven out risked regressing a shipped, fuzz-tested command for an
 // unproven second caller. Revisit sharing once this package's shape is
 // settled across more categories.
+//
+// Single streaming pass, with one opt-in exception: Options.FullSweep adds
+// a read-only collection pass over the whole archive *before* the write
+// pass below (and before the output archive is even created) — see that
+// pass's own comment for why a sweep can't be done in one pass the way
+// every other category here can.
 func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 	if len(opts.Categories) == 0 {
 		return Result{}, fmt.Errorf("anonymize: no categories requested")
@@ -286,6 +318,125 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 		return nil
 	}
 
+	// applyRecordRewrites runs every requested category's schema-aware/
+	// full-tree matcher against rec, in place. Shared between the two
+	// passes FullSweep needs (see below): pass 1 calls this on a throwaway
+	// record purely for its tracker side effects, pass 2 (rewriteEntryRecords)
+	// calls the identical code on the record that actually gets written —
+	// one list, not two hand-copied ones that could drift apart.
+	applyRecordRewrites := func(rec *capture.Record, apiPath string, seq int) error {
+		if doNamespace {
+			if _, err := rewriteNamespaceInRecord(rec, excluded, namespaceAlias); err != nil {
+				return fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
+			}
+		}
+		if doResourceName {
+			if _, err := rewriteResourceNameInRecord(rec, enabledResource, excluded, resourceAlias); err != nil {
+				return fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
+			}
+		}
+		if doIP {
+			if _, err := rewriteIPInRecord(rec, excluded, ipAlias); err != nil {
+				return fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
+			}
+		}
+		if doURL {
+			if _, err := rewriteURLInRecord(rec, excluded, urlAlias); err != nil {
+				return fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
+			}
+		}
+		if doImage {
+			if _, err := rewriteImageRegistryInRecord(rec, excluded, imageAlias); err != nil {
+				return fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
+			}
+		}
+		return nil
+	}
+
+	// applyPathRewrites is the same namespace-then-resource-name path chain
+	// the main write loop below uses, factored out so FullSweep's
+	// collection pass can trigger the same Alias() calls (for its tracker
+	// side effects) without needing the resulting string for anything.
+	applyPathRewrites := func(apiPath string) (string, error) {
+		newAPIPath := apiPath
+		if doNamespace {
+			if rewritten, ok := rewriteNamespaceInPath(apiPath, namespaceAlias); ok {
+				newAPIPath = rewritten
+			}
+			if err := firstCollisionErr(); err != nil {
+				return "", err
+			}
+		}
+		if doResourceName {
+			if rewritten, ok := rewriteResourceNameInPath(newAPIPath, enabledResource, resourceAlias); ok {
+				newAPIPath = rewritten
+			}
+			if err := firstCollisionErr(); err != nil {
+				return "", err
+			}
+		}
+		return newAPIPath, nil
+	}
+
+	// FullSweep needs the *complete* candidate set (every distinct original
+	// value anywhere in the archive) before it can safely sweep any single
+	// record — a value first seen in record #300 must still be caught in
+	// record #5. This collection-only pass runs the exact same matchers the
+	// write pass below runs, on throwaway record copies, purely for their
+	// tracker side effects — and runs before the output archive is even
+	// created, so a collision found here never leaves a partial file behind.
+	// See sweep.go's own doc comment for what the resulting candidate set is
+	// used for.
+	var sweepCandidates *sweepCandidateSet
+	if opts.FullSweep {
+		for _, apiPath := range sortedKeys(map[string]*capture.IndexEntry(idx)) {
+			entry := idx[apiPath]
+			if _, err := applyPathRewrites(apiPath); err != nil {
+				return Result{}, err
+			}
+			for _, seq := range entry.Seqs {
+				data, err := ar.ReadRecord(apiPath, seq)
+				if err != nil {
+					return Result{}, fmt.Errorf("reading record %s seq %d: %w", apiPath, seq, err)
+				}
+				var rec capture.Record
+				if err := json.Unmarshal(data, &rec); err != nil {
+					return Result{}, fmt.Errorf("parsing record %s seq %d: %w", apiPath, seq, err)
+				}
+				if err := applyRecordRewrites(&rec, apiPath, seq); err != nil {
+					return Result{}, err
+				}
+				if err := firstCollisionErr(); err != nil {
+					return Result{}, err
+				}
+			}
+		}
+		for _, apiPath := range sortedKeys(map[string]*capture.WatchIndexEntry(wi)) {
+			wiEntry := wi[apiPath]
+			if _, err := applyPathRewrites(apiPath); err != nil {
+				return Result{}, err
+			}
+			for _, seq := range wiEntry.Seqs {
+				data, err := ar.ReadRecord(apiPath, seq)
+				if err != nil {
+					return Result{}, fmt.Errorf("reading watch record %s seq %d: %w", apiPath, seq, err)
+				}
+				var rec capture.Record
+				if err := json.Unmarshal(data, &rec); err != nil {
+					return Result{}, fmt.Errorf("parsing watch record %s seq %d: %w", apiPath, seq, err)
+				}
+				if err := applyRecordRewrites(&rec, apiPath, seq); err != nil {
+					return Result{}, err
+				}
+				if err := firstCollisionErr(); err != nil {
+					return Result{}, err
+				}
+			}
+		}
+		sweepCandidates = buildSweepCandidates(namespaceTracker, nodeTracker, podTracker, workloadTracker, ipTracker, urlTracker)
+	}
+	var sweepOccurrences int
+
 	var sw *archive.StreamWriter
 	if len(opts.Recipients) > 0 {
 		sw, err = archive.NewEncryptedStreamWriter(dstPath, opts.Recipients)
@@ -346,29 +497,24 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 				return nil, fmt.Errorf("parsing record %s seq %d: %w", apiPath, seq, err)
 			}
 
-			if doNamespace {
-				if _, err := rewriteNamespaceInRecord(&rec, excluded, namespaceAlias); err != nil {
-					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
-				}
+			if err := applyRecordRewrites(&rec, apiPath, seq); err != nil {
+				return nil, err
 			}
-			if doResourceName {
-				if _, err := rewriteResourceNameInRecord(&rec, enabledResource, excluded, resourceAlias); err != nil {
-					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
+			// Runs after the schema-aware/full-tree matchers above, not
+			// before: by the time the sweep scans a leaf, any occurrence
+			// those matchers already know how to find has already been
+			// replaced with its alias — so the sweep only ever finds and
+			// counts occurrences those matchers didn't already know to
+			// look for (SweepOccurrencesFound stays a clean "additional
+			// recall" number, not inflated by double-counting the same
+			// occurrence twice).
+			if sweepCandidates != nil {
+				changed, occurrences, err := sweepRecord(&rec, sweepCandidates, excluded)
+				if err != nil {
+					return nil, fmt.Errorf("sweeping record %s seq %d: %w", apiPath, seq, err)
 				}
-			}
-			if doIP {
-				if _, err := rewriteIPInRecord(&rec, excluded, ipAlias); err != nil {
-					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
-				}
-			}
-			if doURL {
-				if _, err := rewriteURLInRecord(&rec, excluded, urlAlias); err != nil {
-					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
-				}
-			}
-			if doImage {
-				if _, err := rewriteImageRegistryInRecord(&rec, excluded, imageAlias); err != nil {
-					return nil, fmt.Errorf("anonymizing record %s seq %d: %w", apiPath, seq, err)
+				if changed {
+					sweepOccurrences += occurrences
 				}
 			}
 			// Keep the record's own APIPath field in sync with wherever it's
@@ -570,15 +716,22 @@ func Archive(srcPath, dstPath string, opts Options) (Result, error) {
 		}
 	}
 
+	sweepAmbiguousSkipped := 0
+	if sweepCandidates != nil {
+		sweepAmbiguousSkipped = sweepCandidates.ambiguousSkipped
+	}
+
 	return Result{
-		SchemaVersion:     SchemaVersion,
-		NamespacesRenamed: namespaceTracker.Count(),
-		NodesRenamed:      nodeTracker.Count(),
-		PodsRenamed:       podTracker.Count(),
-		WorkloadsRenamed:  workloadTracker.Count(),
-		IPsRenamed:        ipTracker.Count(),
-		HostsRenamed:      urlTracker.Count(),
-		RegistriesRenamed: imageTracker.Count(),
-		Mapping:           mapping,
+		SchemaVersion:         SchemaVersion,
+		NamespacesRenamed:     namespaceTracker.Count(),
+		NodesRenamed:          nodeTracker.Count(),
+		PodsRenamed:           podTracker.Count(),
+		WorkloadsRenamed:      workloadTracker.Count(),
+		IPsRenamed:            ipTracker.Count(),
+		HostsRenamed:          urlTracker.Count(),
+		RegistriesRenamed:     imageTracker.Count(),
+		SweepOccurrencesFound: sweepOccurrences,
+		SweepAmbiguousSkipped: sweepAmbiguousSkipped,
+		Mapping:               mapping,
 	}, nil
 }

--- a/internal/anonymize/fullsweep_test.go
+++ b/internal/anonymize/fullsweep_test.go
@@ -1,0 +1,328 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/archive"
+	"github.com/phenixblue/k8shark/internal/capture"
+	"github.com/phenixblue/k8shark/internal/config"
+)
+
+// Reproduces #358 against Archive() end-to-end: an unrecognized CRD (a
+// Portworx-style StorageNode, standing in for any vendor's CRD) references a
+// real Node name via a Kind kindCategories doesn't know about, so
+// rewriteResourceNameInObject's schema-aware path can't recognize it — only
+// the full sweep, which doesn't care about field names or Kinds at all, can
+// catch it.
+func TestArchive_FullSweepCatchesUnrecognizedCRDNameReference(t *testing.T) {
+	nodeBody := `{"kind":"Node","apiVersion":"v1","metadata":{"name":"worker-1"}}`
+	// StorageNode is not a Kind kindCategories recognizes (resourcename.go's
+	// own doc comment documents this exact gap), so nothing schema-aware
+	// ever looks at its "name" field.
+	storageNodeBody := `{"kind":"StorageNode","apiVersion":"portworx.io/v1","metadata":{"name":"px-storagenode"},"nodeReference":"worker-1"}`
+	records := []*capture.Record{
+		{ID: "r1", CapturedAt: fixedNow, APIPath: "/api/v1/nodes/worker-1", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(nodeBody)},
+		{ID: "r2", CapturedAt: fixedNow, APIPath: "/apis/portworx.io/v1/storagenodes/px-storagenode", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(storageNodeBody)},
+	}
+	src := buildAnonymizeTestArchive(t, records)
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+	salt := []byte("crd-name-gap-test-salt")
+
+	result, err := Archive(src, dst, Options{
+		Categories: []Category{CategoryNode},
+		Salt:       salt,
+		FullSweep:  true,
+	})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if result.SweepOccurrencesFound == 0 {
+		t.Error("want SweepOccurrencesFound > 0 — the StorageNode's nodeReference should have been caught")
+	}
+
+	wantAlias := NewAliaser(salt).Alias(CategoryNode, "worker-1")
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	defer ar.Close()
+	data, err := ar.ReadRecord("/apis/portworx.io/v1/storagenodes/px-storagenode", 0)
+	if err != nil {
+		t.Fatalf("ReadRecord: %v", err)
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatal(err)
+	}
+	var obj map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+		t.Fatal(err)
+	}
+	if got := obj["nodeReference"]; got != wantAlias {
+		t.Errorf("nodeReference = %v, want %v (the real node name %q must not leak)", got, wantAlias, "worker-1")
+	}
+}
+
+// Reproduces #360 against Archive() end-to-end: a
+// kubectl.kubernetes.io/last-applied-configuration-shaped annotation is an
+// escaped JSON *string*, not real nested structure — invisible to every
+// schema-aware matcher and to the full-tree IP matcher (which only ever
+// replaces a whole leaf value, not a substring of one). Only the sweep,
+// which scans the annotation's string content directly, can catch it.
+func TestArchive_FullSweepCatchesLastAppliedConfigurationLeak(t *testing.T) {
+	// The annotation value is itself a JSON-encoded string containing the
+	// namespace "prod" and the IP "10.1.2.3" — exactly the shape kubectl
+	// apply writes.
+	lastApplied := `{"apiVersion":"v1","kind":"Pod","metadata":{"namespace":"prod"},"status":{"hostIP":"10.1.2.3"}}`
+	lastAppliedJSON, err := json.Marshal(lastApplied)
+	if err != nil {
+		t.Fatal(err)
+	}
+	podBody := `{"kind":"Pod","apiVersion":"v1","metadata":{"name":"web-1","namespace":"prod","annotations":{"kubectl.kubernetes.io/last-applied-configuration":` + string(lastAppliedJSON) + `}},"status":{"podIP":"10.1.2.3"}}`
+	records := []*capture.Record{
+		{ID: "r1", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/prod/pods/web-1", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(podBody)},
+	}
+	src := buildAnonymizeTestArchive(t, records)
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+	salt := []byte("last-applied-config-test-salt")
+
+	result, err := Archive(src, dst, Options{
+		Categories: []Category{CategoryNamespace, CategoryIP},
+		Salt:       salt,
+		FullSweep:  true,
+	})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if result.SweepOccurrencesFound == 0 {
+		t.Error("want SweepOccurrencesFound > 0 — the annotation's embedded namespace and IP should have been caught")
+	}
+
+	nsAlias := NewAliaser(salt).Alias(CategoryNamespace, "prod")
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	defer ar.Close()
+	data, err := ar.ReadRecord("/api/v1/namespaces/"+nsAlias+"/pods/web-1", 0)
+	if err != nil {
+		t.Fatalf("ReadRecord: %v", err)
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatal(err)
+	}
+	var obj map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+		t.Fatal(err)
+	}
+	annotation := obj["metadata"].(map[string]interface{})["annotations"].(map[string]interface{})["kubectl.kubernetes.io/last-applied-configuration"].(string)
+	if annotation == lastApplied {
+		t.Fatal("last-applied-configuration annotation was not touched at all")
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal([]byte(annotation), &decoded); err != nil {
+		t.Fatalf("annotation is no longer valid JSON after sweeping: %v (%q)", err, annotation)
+	}
+	if got := decoded["metadata"].(map[string]interface{})["namespace"]; got != nsAlias {
+		t.Errorf("annotation's embedded namespace = %v, want %v — the real value %q must not leak", got, nsAlias, "prod")
+	}
+	if got := decoded["status"].(map[string]interface{})["hostIP"]; got == "10.1.2.3" {
+		t.Error("annotation's embedded IP was not aliased — the real value must not leak")
+	}
+}
+
+// A namespace and a pod that happen to share the same real name are
+// genuinely ambiguous for the sweep (see buildSweepCandidates) — this must
+// be left untouched by the sweep (not guessed at), while the schema-aware
+// matchers still correctly alias each in its own known field.
+func TestArchive_FullSweepSkipsAmbiguousCrossCategoryValue(t *testing.T) {
+	nsBody := `{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"shared"}}`
+	podBody := `{"kind":"Pod","apiVersion":"v1","metadata":{"name":"shared","namespace":"shared"},"status":{"message":"pod shared is running in namespace shared"}}`
+	records := []*capture.Record{
+		{ID: "r1", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/shared", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(nsBody)},
+		{ID: "r2", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/shared/pods/shared", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(podBody)},
+	}
+	src := buildAnonymizeTestArchive(t, records)
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+	salt := []byte("ambiguous-value-test-salt")
+
+	result, err := Archive(src, dst, Options{
+		Categories: []Category{CategoryNamespace, CategoryPod},
+		Salt:       salt,
+		FullSweep:  true,
+	})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if result.SweepAmbiguousSkipped == 0 {
+		t.Error("want SweepAmbiguousSkipped > 0 — \"shared\" is a candidate under both namespace and pod")
+	}
+
+	nsAlias := NewAliaser(salt).Alias(CategoryNamespace, "shared")
+	podAlias := NewAliaser(salt).Alias(CategoryPod, "shared")
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	defer ar.Close()
+	data, err := ar.ReadRecord("/api/v1/namespaces/"+nsAlias+"/pods/"+podAlias, 0)
+	if err != nil {
+		t.Fatalf("ReadRecord: %v", err)
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatal(err)
+	}
+	var obj map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+		t.Fatal(err)
+	}
+	// The schema-aware matchers still correctly alias the pod's own
+	// metadata.name/namespace (proven by the ReadRecord path above
+	// resolving at all) — only the free-text status.message mention of the
+	// ambiguous value "shared" must be left completely untouched by the
+	// sweep.
+	status := obj["status"].(map[string]interface{})
+	if got := status["message"]; got != "pod shared is running in namespace shared" {
+		t.Errorf("status.message = %q, want the ambiguous value left untouched by the sweep", got)
+	}
+}
+
+// A field-path exclusion rule must still be honored by the sweep, exactly
+// as it already is by every schema-aware/full-tree matcher.
+func TestArchive_FullSweepRespectsExcludeRules(t *testing.T) {
+	podBody := `{"kind":"Pod","apiVersion":"v1","metadata":{"name":"web-1","namespace":"prod"},"status":{"message":"scheduled onto namespace prod"}}`
+	records := []*capture.Record{
+		{ID: "r1", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/prod/pods/web-1", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(podBody)},
+	}
+	src := buildAnonymizeTestArchive(t, records)
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+	salt := []byte("exclude-rule-sweep-test-salt")
+
+	result, err := Archive(src, dst, Options{
+		Categories: []Category{CategoryNamespace},
+		Salt:       salt,
+		FullSweep:  true,
+		Rules: []config.AnonymizeRule{
+			{Category: "namespace", FieldPath: "status.message", Kind: "Pod", Exclude: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if result.SweepOccurrencesFound != 0 {
+		t.Errorf("SweepOccurrencesFound = %d, want 0 — the only sweep-eligible occurrence is excluded", result.SweepOccurrencesFound)
+	}
+
+	nsAlias := NewAliaser(salt).Alias(CategoryNamespace, "prod")
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	defer ar.Close()
+	data, err := ar.ReadRecord("/api/v1/namespaces/"+nsAlias+"/pods/web-1", 0)
+	if err != nil {
+		t.Fatalf("ReadRecord: %v", err)
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatal(err)
+	}
+	var obj map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+		t.Fatal(err)
+	}
+	status := obj["status"].(map[string]interface{})
+	if got := status["message"]; got != "scheduled onto namespace prod" {
+		t.Errorf("status.message = %q, want it left untouched by the excluded sweep rule", got)
+	}
+}
+
+// Running Archive twice with FullSweep and the same source+salt must
+// produce byte-identical output — extends TestArchive_Deterministic's
+// existing coverage to the sweep pass specifically.
+func TestArchive_FullSweepDeterministic(t *testing.T) {
+	records := append(namespaceFixtureRecords(), &capture.Record{
+		ID: "r5", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/prod/configmaps/notes",
+		HTTPMethod: "GET", ResponseCode: 200,
+		ResponseBody: json.RawMessage(`{"kind":"ConfigMap","apiVersion":"v1","metadata":{"name":"notes","namespace":"prod"},"data":{"notes":"reminder: prod namespace is scheduled for maintenance"}}`),
+	})
+	src := buildAnonymizeTestArchive(t, records)
+	dst1 := filepath.Join(t.TempDir(), "out1.kshrk")
+	dst2 := filepath.Join(t.TempDir(), "out2.kshrk")
+	salt := []byte("full-sweep-determinism-test-salt")
+
+	opts := Options{Categories: []Category{CategoryNamespace}, Salt: salt, FullSweep: true}
+	if _, err := Archive(src, dst1, opts); err != nil {
+		t.Fatalf("first Archive run: %v", err)
+	}
+	if _, err := Archive(src, dst2, opts); err != nil {
+		t.Fatalf("second Archive run: %v", err)
+	}
+
+	b1, err := os.ReadFile(dst1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b2, err := os.ReadFile(dst2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(b1) != len(b2) {
+		t.Fatalf("outputs differ in length: %d vs %d bytes", len(b1), len(b2))
+	}
+	for i := range b1 {
+		if b1[i] != b2[i] {
+			t.Fatalf("outputs diverge at byte offset %d", i)
+		}
+	}
+}
+
+// FullSweep defaults to false, and must leave behavior byte-identical to
+// before this feature existed: zero sweep counts, and a free-text mention
+// of a value that only the sweep could catch stays untouched.
+func TestArchive_WithoutFullSweepLeavesFreeTextUntouched(t *testing.T) {
+	podBody := `{"kind":"Pod","apiVersion":"v1","metadata":{"name":"web-1","namespace":"prod"},"status":{"message":"scheduled onto namespace prod"}}`
+	records := []*capture.Record{
+		{ID: "r1", CapturedAt: fixedNow, APIPath: "/api/v1/namespaces/prod/pods/web-1", HTTPMethod: "GET", ResponseCode: 200, ResponseBody: json.RawMessage(podBody)},
+	}
+	src := buildAnonymizeTestArchive(t, records)
+	dst := filepath.Join(t.TempDir(), "out.kshrk")
+	salt := []byte("no-full-sweep-test-salt")
+
+	result, err := Archive(src, dst, Options{Categories: []Category{CategoryNamespace}, Salt: salt})
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if result.SweepOccurrencesFound != 0 || result.SweepAmbiguousSkipped != 0 {
+		t.Errorf("want both sweep counts 0 when FullSweep is false, got SweepOccurrencesFound=%d SweepAmbiguousSkipped=%d",
+			result.SweepOccurrencesFound, result.SweepAmbiguousSkipped)
+	}
+
+	nsAlias := NewAliaser(salt).Alias(CategoryNamespace, "prod")
+	ar, err := archive.Open(dst)
+	if err != nil {
+		t.Fatalf("archive.Open: %v", err)
+	}
+	defer ar.Close()
+	data, err := ar.ReadRecord("/api/v1/namespaces/"+nsAlias+"/pods/web-1", 0)
+	if err != nil {
+		t.Fatalf("ReadRecord: %v", err)
+	}
+	var rec capture.Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatal(err)
+	}
+	var obj map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+		t.Fatal(err)
+	}
+	status := obj["status"].(map[string]interface{})
+	if got := status["message"]; got != "scheduled onto namespace prod" {
+		t.Errorf("status.message = %q, want the free-text mention left untouched without FullSweep", got)
+	}
+}

--- a/internal/anonymize/sweep.go
+++ b/internal/anonymize/sweep.go
@@ -1,0 +1,313 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+// This file implements Options.FullSweep (#361): a second, opt-in pass that
+// replaces any substring occurrence of an already-discovered namespace/
+// node/pod/workload/ip/url value with its alias, anywhere in a record's
+// string content — not just at the field paths the schema-aware/full-tree
+// matchers in namespace.go/resourcename.go/ipmatch.go/urlmatch.go already
+// know to look at. It exists to catch a real value that leaks through an
+// unrecognized CRD's field, an escaped-JSON-string annotation (e.g.
+// kubectl.kubernetes.io/last-applied-configuration), an Event message, or
+// an opaque Table cell — none of which any schema-aware or self-evident-
+// shape matcher can see. See Archive's own FullSweep comment for how this
+// integrates into the two-pass architecture.
+//
+// Image is deliberately not covered: a registry-host alias
+// (aliasRegistryHost) is tied to a specific image-reference field position,
+// not free-standing text, so sweeping for it elsewhere has no clear
+// motivating case the way a name, IP, or hostname leaking into free text
+// does.
+
+// minSweepCandidateLength is a v1 heuristic, not a guarantee (same tone as
+// name.go/collision.go's own sizing comments): a candidate shorter than
+// this is dropped from the sweep entirely, to blunt — not eliminate — the
+// risk of a short, common value (a two-letter namespace, a one-octet-short
+// IP fragment) colliding with ordinary, unrelated text.
+const minSweepCandidateLength = 4
+
+// sweepCandidate is one (original, alias) pair eligible for the sweep.
+type sweepCandidate struct {
+	Category Category
+	Original string
+	Alias    string
+}
+
+// candidateGroup is one compiled alternation of every candidate sharing a
+// boundary predicate, plus the lookup sweepRecord needs to resolve a raw
+// regex match back to its alias and category.
+type candidateGroup struct {
+	re         *regexp.Regexp
+	byOriginal map[string]sweepCandidate
+	// reject reports whether a byte immediately before or after a raw match
+	// disqualifies it — see nameBoundaryReject/ipBoundaryReject.
+	reject func(byte) bool
+}
+
+// sweepCandidateSet is the compiled, ready-to-scan form of every distinct
+// original value the sweep covers, built once per Archive run by
+// buildSweepCandidates after its collection pass has fully populated the
+// trackers.
+type sweepCandidateSet struct {
+	// nameGroup covers namespace/node/pod/workload candidates and any
+	// URL-category candidate that isn't itself an IP literal. ipGroup
+	// covers the IP category plus any URL-category candidate that is an IP
+	// literal (a URL's host position can be a bare IP — see
+	// Result.HostsRenamed's own doc comment). Both are nil when there was
+	// nothing eligible, so sweepRecord can skip the work entirely.
+	nameGroup *candidateGroup
+	ipGroup   *candidateGroup
+	// ambiguousSkipped is the number of distinct original values excluded
+	// from the sweep because the same literal string was a candidate under
+	// more than one category with a different alias (e.g. a namespace and
+	// a pod both named "prod") — see buildSweepCandidates.
+	ambiguousSkipped int
+}
+
+// isAlnum reports whether b is an ASCII letter or digit. Sweep candidates
+// (DNS-1123 names, IP literals, hostnames) are always ASCII, so a
+// byte-level check is enough — no need to decode UTF-8 runes, and any
+// non-ASCII adjacent byte is definitionally not a continuation of one of
+// these candidates regardless of what larger character it's part of.
+func isAlnum(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
+// nameBoundaryReject is the boundary predicate for namespace/node/pod/
+// workload candidates and non-IP-shaped URL candidates. Rejects only
+// alphanumeric adjacency — deliberately NOT '.' or ':' — so a name embedded
+// in a cluster-local FQDN (svc.<namespace>.svc.cluster.local) or a
+// namespace immediately followed by a colon in free text is still caught,
+// not silently missed the way rejecting those characters would cause.
+func nameBoundaryReject(b byte) bool {
+	return isAlnum(b)
+}
+
+// ipBoundaryReject is the boundary predicate for IP-shaped candidates —
+// stricter than nameBoundaryReject on purpose: without also rejecting '.'
+// and ':' adjacency, a short IPv6 literal like "::1" would incorrectly
+// match inside an unrelated, longer address like "fe80::1", and an IPv4
+// literal would incorrectly match as a truncated fragment of a longer
+// dotted-decimal string.
+func ipBoundaryReject(b byte) bool {
+	return isAlnum(b) || b == '.' || b == ':'
+}
+
+// buildSweepCandidates gathers every distinct (original, alias) pair the
+// namespace/node/pod/workload/ip/url trackers discovered — after Archive's
+// collection pass has fully populated them, so every distinct value
+// anywhere in the archive is present regardless of which record it was
+// first seen in — and compiles them into the two boundary-predicate groups
+// sweepRecord scans against.
+//
+// Cross-category ambiguity: the same literal string can legitimately be a
+// candidate under more than one category (a namespace named "prod" and a
+// pod named "prod" are both realistic). A bare mention of "prod" in free
+// text is then genuinely ambiguous about which alias applies — matching
+// this package's existing collision-detection discipline (refuse rather
+// than silently guess), any original value seen under more than one
+// distinct alias is excluded from the sweep entirely, not guessed at.
+func buildSweepCandidates(namespaceTracker, nodeTracker, podTracker, workloadTracker, ipTracker, urlTracker *collisionTracker) *sweepCandidateSet {
+	type firstSeenEntry struct {
+		alias string
+	}
+	firstSeen := make(map[string]firstSeenEntry)
+	ambiguous := make(map[string]bool)
+
+	var all []sweepCandidate
+	add := func(cat Category, mapping map[string]string) {
+		for original, alias := range mapping {
+			all = append(all, sweepCandidate{Category: cat, Original: original, Alias: alias})
+			if prior, ok := firstSeen[original]; ok {
+				if prior.alias != alias {
+					ambiguous[original] = true
+				}
+				continue
+			}
+			firstSeen[original] = firstSeenEntry{alias: alias}
+		}
+	}
+	add(CategoryNamespace, namespaceTracker.Mapping())
+	add(CategoryNode, nodeTracker.Mapping())
+	add(CategoryPod, podTracker.Mapping())
+	add(CategoryWorkload, workloadTracker.Mapping())
+	add(CategoryIP, ipTracker.Mapping())
+	add(CategoryURL, urlTracker.Mapping())
+
+	var nameCands, ipCands []sweepCandidate
+	for _, c := range all {
+		if ambiguous[c.Original] || len(c.Original) < minSweepCandidateLength {
+			continue
+		}
+		if net.ParseIP(c.Original) != nil {
+			ipCands = append(ipCands, c)
+		} else {
+			nameCands = append(nameCands, c)
+		}
+	}
+
+	return &sweepCandidateSet{
+		nameGroup:        buildCandidateGroup(nameCands, nameBoundaryReject),
+		ipGroup:          buildCandidateGroup(ipCands, ipBoundaryReject),
+		ambiguousSkipped: len(ambiguous),
+	}
+}
+
+// buildCandidateGroup compiles cands into one alternation regex, sorted by
+// descending length (then lexicographically, for byte-identical output
+// across runs regardless of Go map iteration order — the same determinism
+// discipline sortedKeys enforces elsewhere in this package). Descending
+// length matters for correctness, not just style: Go's RE2 alternation is
+// leftmost-first, not leftmost-longest, so a shorter candidate that's a
+// prefix of a longer one (e.g. "web" vs. "web-1") would otherwise win
+// arbitrarily depending on list order — sorting longest-first guarantees
+// the more specific candidate is always preferred.
+func buildCandidateGroup(cands []sweepCandidate, reject func(byte) bool) *candidateGroup {
+	if len(cands) == 0 {
+		return nil
+	}
+	sort.Slice(cands, func(i, j int) bool {
+		if len(cands[i].Original) != len(cands[j].Original) {
+			return len(cands[i].Original) > len(cands[j].Original)
+		}
+		return cands[i].Original < cands[j].Original
+	})
+	byOriginal := make(map[string]sweepCandidate, len(cands))
+	parts := make([]string, len(cands))
+	for i, c := range cands {
+		byOriginal[c.Original] = c
+		parts[i] = regexp.QuoteMeta(c.Original)
+	}
+	return &candidateGroup{
+		re:         regexp.MustCompile(strings.Join(parts, "|")),
+		byOriginal: byOriginal,
+		reject:     reject,
+	}
+}
+
+// spliceCandidates replaces every accepted match of group's alternation in
+// s with its candidate's alias. kind/path identify the field being swept,
+// for the excluded(...) check.
+//
+// Matches are found via FindAllStringIndex — deliberately not a pattern
+// with boundary characters baked into the consumed match: Go's RE2 has no
+// lookaround, and consuming a boundary character as part of one match would
+// make it unavailable as the boundary for an immediately-adjacent next
+// match (e.g. two candidates separated by exactly one space). Checking the
+// surrounding bytes manually, without consuming them, avoids that bug
+// entirely — both a rejected and an accepted match leave every byte outside
+// the actual candidate text untouched and available for the next check.
+func spliceCandidates(s string, group *candidateGroup, excluded excludedFunc, kind, path string) (string, bool, int) {
+	if group == nil {
+		return s, false, 0
+	}
+	matches := group.re.FindAllStringIndex(s, -1)
+	if len(matches) == 0 {
+		return s, false, 0
+	}
+	var out strings.Builder
+	last := 0
+	occurrences := 0
+	for _, m := range matches {
+		start, end := m[0], m[1]
+		if start > 0 && group.reject(s[start-1]) {
+			continue
+		}
+		if end < len(s) && group.reject(s[end]) {
+			continue
+		}
+		cand := group.byOriginal[s[start:end]]
+		if excluded(cand.Category, kind, path) {
+			continue
+		}
+		out.WriteString(s[last:start])
+		out.WriteString(cand.Alias)
+		last = end
+		occurrences++
+	}
+	if occurrences == 0 {
+		return s, false, 0
+	}
+	out.WriteString(s[last:])
+	return out.String(), true, occurrences
+}
+
+// sweepRecord applies the full sweep to rec: every string leaf in the
+// decoded body is scanned against candidates' two boundary-predicate
+// groups, splicing in the alias for any accepted match. Runs after the
+// schema-aware/full-tree matchers (see Archive's own ordering comment), so
+// a leaf they already rewrote no longer contains its original value for
+// this pass to re-match — SweepOccurrencesFound stays a clean count of
+// occurrences those matchers would have missed, not inflated by
+// double-counting the same occurrence twice.
+//
+// List-aware exactly like the other matchers in this package: an exclude
+// rule scoped to a Kind applies correctly to a List response's items[], not
+// the List wrapper itself.
+func sweepRecord(rec *capture.Record, candidates *sweepCandidateSet, excluded excludedFunc) (bool, int, error) {
+	if candidates == nil || (candidates.nameGroup == nil && candidates.ipGroup == nil) {
+		return false, 0, nil
+	}
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal(rec.ResponseBody, &obj); err != nil {
+		return false, 0, nil
+	}
+
+	kind, _ := obj["kind"].(string)
+	total := 0
+	sweepItem := func(item map[string]interface{}, itemKind string) bool {
+		return walkStrings(item, "", func(path, s string) (string, bool) {
+			changed := false
+			if out, ok, n := spliceCandidates(s, candidates.nameGroup, excluded, itemKind, path); ok {
+				s, changed, total = out, true, total+n
+			}
+			if out, ok, n := spliceCandidates(s, candidates.ipGroup, excluded, itemKind, path); ok {
+				s, changed, total = out, true, total+n
+			}
+			return s, changed
+		})
+	}
+
+	modified := false
+	if strings.HasSuffix(kind, "List") {
+		items, _ := obj["items"].([]interface{})
+		itemKind := strings.TrimSuffix(kind, "List")
+		for i, itemRaw := range items {
+			item, ok := itemRaw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			ik := itemKind
+			if k, ok := item["kind"].(string); ok && k != "" {
+				ik = k
+			}
+			if sweepItem(item, ik) {
+				items[i] = item
+				modified = true
+			}
+		}
+	} else if sweepItem(obj, kind) {
+		modified = true
+	}
+
+	if !modified {
+		return false, 0, nil
+	}
+	newBody, err := json.Marshal(obj)
+	if err != nil {
+		return false, 0, fmt.Errorf("re-marshaling record: %w", err)
+	}
+	rec.ResponseBody = newBody
+	return true, total, nil
+}

--- a/internal/anonymize/sweep_test.go
+++ b/internal/anonymize/sweep_test.go
@@ -1,0 +1,261 @@
+package anonymize
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/phenixblue/k8shark/internal/capture"
+)
+
+func trackerWith(cat Category, alias func(string) string, originals ...string) *collisionTracker {
+	t := newCollisionTracker(cat, alias)
+	for _, o := range originals {
+		t.Alias(o)
+	}
+	return t
+}
+
+func emptyTracker(cat Category) *collisionTracker {
+	return newCollisionTracker(cat, upper)
+}
+
+func TestBuildSweepCandidates_BasicRouting(t *testing.T) {
+	ns := trackerWith(CategoryNamespace, upper, "production")
+	node := emptyTracker(CategoryNode)
+	pod := emptyTracker(CategoryPod)
+	workload := emptyTracker(CategoryWorkload)
+	ip := trackerWith(CategoryIP, upper, "10.1.2.3")
+	url := trackerWith(CategoryURL, upper, "webhook-svc.default.svc")
+
+	cs := buildSweepCandidates(ns, node, pod, workload, ip, url)
+
+	if cs.nameGroup == nil {
+		t.Fatal("want a non-nil nameGroup for the namespace/url candidates")
+	}
+	if cs.ipGroup == nil {
+		t.Fatal("want a non-nil ipGroup for the IP candidate")
+	}
+	if _, ok := cs.nameGroup.byOriginal["production"]; !ok {
+		t.Error("namespace candidate missing from nameGroup")
+	}
+	if _, ok := cs.nameGroup.byOriginal["webhook-svc.default.svc"]; !ok {
+		t.Error("hostname candidate missing from nameGroup")
+	}
+	if _, ok := cs.ipGroup.byOriginal["10.1.2.3"]; !ok {
+		t.Error("IP candidate missing from ipGroup")
+	}
+	if cs.ambiguousSkipped != 0 {
+		t.Errorf("ambiguousSkipped = %d, want 0", cs.ambiguousSkipped)
+	}
+}
+
+// A URL-category candidate that happens to be a bare IP literal (a URL's
+// host position can be an IP — see Result.HostsRenamed's own doc comment)
+// must route into the IP-boundary group, not the name/host group, even
+// though it came from the URL tracker.
+func TestBuildSweepCandidates_URLCandidateThatIsAnIPRoutesToIPGroup(t *testing.T) {
+	ns := emptyTracker(CategoryNamespace)
+	node := emptyTracker(CategoryNode)
+	pod := emptyTracker(CategoryPod)
+	workload := emptyTracker(CategoryWorkload)
+	ip := emptyTracker(CategoryIP)
+	url := trackerWith(CategoryURL, upper, "10.1.2.3")
+
+	cs := buildSweepCandidates(ns, node, pod, workload, ip, url)
+
+	if cs.nameGroup != nil {
+		t.Error("want nameGroup nil — the only URL candidate is IP-shaped and should route to ipGroup")
+	}
+	if cs.ipGroup == nil {
+		t.Fatal("want a non-nil ipGroup")
+	}
+	if cand, ok := cs.ipGroup.byOriginal["10.1.2.3"]; !ok || cand.Category != CategoryURL {
+		t.Errorf("ipGroup candidate = %+v, ok=%v, want Category=CategoryURL", cand, ok)
+	}
+}
+
+// A namespace named "prod" and a pod also named "prod" produce two
+// different aliases (the category prefix guarantees this) for the same
+// literal original value — genuinely ambiguous for a bare mention in free
+// text, so it must be excluded from the sweep entirely rather than guessed
+// at.
+func TestBuildSweepCandidates_CrossCategoryAmbiguityExcluded(t *testing.T) {
+	// Distinct alias functions, mirroring how the real Aliaser always
+	// prefixes by category (aliasName) — using the same alias function for
+	// both trackers would produce identical aliases and defeat the very
+	// ambiguity this test means to exercise.
+	nsAlias := func(s string) string { return "namespace-" + s }
+	podAlias := func(s string) string { return "pod-" + s }
+	ns := trackerWith(CategoryNamespace, nsAlias, "prod")
+	node := emptyTracker(CategoryNode)
+	pod := trackerWith(CategoryPod, podAlias, "prod")
+	workload := emptyTracker(CategoryWorkload)
+	ip := emptyTracker(CategoryIP)
+	url := emptyTracker(CategoryURL)
+
+	cs := buildSweepCandidates(ns, node, pod, workload, ip, url)
+
+	if cs.nameGroup != nil {
+		t.Fatal("want nameGroup nil — the only candidate is ambiguous and should be fully excluded")
+	}
+	if cs.ambiguousSkipped != 1 {
+		t.Errorf("ambiguousSkipped = %d, want 1", cs.ambiguousSkipped)
+	}
+}
+
+func TestBuildSweepCandidates_ShortCandidatesFiltered(t *testing.T) {
+	ns := trackerWith(CategoryNamespace, upper, "ab") // below minSweepCandidateLength
+	node := emptyTracker(CategoryNode)
+	pod := emptyTracker(CategoryPod)
+	workload := emptyTracker(CategoryWorkload)
+	ip := emptyTracker(CategoryIP)
+	url := emptyTracker(CategoryURL)
+
+	cs := buildSweepCandidates(ns, node, pod, workload, ip, url)
+
+	if cs.nameGroup != nil {
+		t.Error("want nameGroup nil — the only candidate is below minSweepCandidateLength")
+	}
+}
+
+func TestSpliceCandidates_LongestCandidatePreferred(t *testing.T) {
+	cands := []sweepCandidate{
+		{Category: CategoryPod, Original: "web", Alias: "pod-alias"},
+		{Category: CategoryWorkload, Original: "web-1", Alias: "workload-alias"},
+	}
+	group := buildCandidateGroup(cands, nameBoundaryReject)
+
+	out, changed, n := spliceCandidates("connecting to web-1 now", group, noExclusions, "Event", "message")
+	if !changed || n != 1 {
+		t.Fatalf("changed=%v n=%d, want changed=true n=1", changed, n)
+	}
+	if out != "connecting to workload-alias now" {
+		t.Errorf("out = %q, want the full web-1 match replaced by workload-alias, not a truncated web match", out)
+	}
+}
+
+func TestSpliceCandidates_NameBoundaryAllowsFQDNEmbedding(t *testing.T) {
+	cands := []sweepCandidate{{Category: CategoryNamespace, Original: "prod", Alias: "namespace-quiet-otter-fox"}}
+	group := buildCandidateGroup(cands, nameBoundaryReject)
+
+	out, changed, n := spliceCandidates("svc.prod.svc.cluster.local", group, noExclusions, "Pod", "status.message")
+	if !changed || n != 1 {
+		t.Fatalf("changed=%v n=%d, want changed=true n=1", changed, n)
+	}
+	if out != "svc.namespace-quiet-otter-fox.svc.cluster.local" {
+		t.Errorf("out = %q, want the namespace segment aliased inside the FQDN", out)
+	}
+}
+
+func TestSpliceCandidates_NameBoundaryRejectsAlnumAdjacency(t *testing.T) {
+	cands := []sweepCandidate{{Category: CategoryNamespace, Original: "prod", Alias: "ALIASED"}}
+	group := buildCandidateGroup(cands, nameBoundaryReject)
+
+	out, changed, n := spliceCandidates("this is unrelated-prodcuction text", group, noExclusions, "Pod", "status.message")
+	if changed || n != 0 {
+		t.Errorf("changed=%v n=%d out=%q, want no match — \"prod\" here is a substring of \"production\", alnum-adjacent on both sides", changed, n, out)
+	}
+}
+
+// The motivating case for ipBoundaryReject's stricter charset: a short IPv6
+// literal must not match inside an unrelated, longer address.
+func TestSpliceCandidates_IPBoundaryRejectsWithinLongerIPv6Address(t *testing.T) {
+	cands := []sweepCandidate{{Category: CategoryIP, Original: "::1", Alias: "ALIASED"}}
+	group := buildCandidateGroup(cands, ipBoundaryReject)
+
+	out, changed, n := spliceCandidates("connecting to fe80::1 on the link", group, noExclusions, "Event", "message")
+	if changed || n != 0 {
+		t.Errorf("changed=%v n=%d out=%q, want no match — \"::1\" is a colon-adjacent fragment of \"fe80::1\", not the loopback address", changed, n, out)
+	}
+}
+
+func TestSpliceCandidates_IPBoundaryAcceptsGenuineOccurrence(t *testing.T) {
+	cands := []sweepCandidate{{Category: CategoryIP, Original: "10.1.2.3", Alias: "10.99.99.99"}}
+	group := buildCandidateGroup(cands, ipBoundaryReject)
+
+	out, changed, n := spliceCandidates("Pulling image failed, dialing 10.1.2.3 timed out", group, noExclusions, "Event", "message")
+	if !changed || n != 1 {
+		t.Fatalf("changed=%v n=%d, want changed=true n=1", changed, n)
+	}
+	if out != "Pulling image failed, dialing 10.99.99.99 timed out" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestSpliceCandidates_IPBoundaryRejectsPartialOctetMatch(t *testing.T) {
+	cands := []sweepCandidate{{Category: CategoryIP, Original: "10.1.2.3", Alias: "ALIASED"}}
+	group := buildCandidateGroup(cands, ipBoundaryReject)
+
+	for _, s := range []string{"110.1.2.3 is unrelated", "10.1.2.34 is unrelated", "10.1.2.3.4 is unrelated"} {
+		out, changed, n := spliceCandidates(s, group, noExclusions, "Event", "message")
+		if changed || n != 0 {
+			t.Errorf("input %q: changed=%v n=%d out=%q, want no match", s, changed, n, out)
+		}
+	}
+}
+
+func TestSpliceCandidates_ExcludeRuleSkipsMatch(t *testing.T) {
+	cands := []sweepCandidate{{Category: CategoryNamespace, Original: "prod", Alias: "ALIASED"}}
+	group := buildCandidateGroup(cands, nameBoundaryReject)
+	excluded := func(cat Category, kind, path string) bool {
+		return cat == CategoryNamespace && kind == "Event" && path == "message"
+	}
+
+	out, changed, n := spliceCandidates("Namespace prod is active", group, excluded, "Event", "message")
+	if changed || n != 0 {
+		t.Errorf("changed=%v n=%d out=%q, want the excluded rule to leave this occurrence untouched", changed, n, out)
+	}
+}
+
+func TestSweepRecord_ListUsesEachItemsOwnKindForExclusion(t *testing.T) {
+	cands := []sweepCandidate{{Category: CategoryNamespace, Original: "prod", Alias: "ALIASED"}}
+	cs := &sweepCandidateSet{nameGroup: buildCandidateGroup(cands, nameBoundaryReject)}
+
+	body := `{"kind":"EventList","items":[
+		{"kind":"Event","message":"Namespace prod is active"},
+		{"kind":"Event","message":"another mention of prod here"}
+	]}`
+	rec := &capture.Record{ResponseBody: json.RawMessage(body)}
+
+	changed, occurrences, err := sweepRecord(rec, cs, noExclusions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed || occurrences != 2 {
+		t.Fatalf("changed=%v occurrences=%d, want changed=true occurrences=2", changed, occurrences)
+	}
+
+	var out struct {
+		Items []struct {
+			Message string `json:"message"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rec.ResponseBody, &out); err != nil {
+		t.Fatal(err)
+	}
+	for i, item := range out.Items {
+		if item.Message == "" {
+			t.Fatalf("item %d: empty message", i)
+		}
+		if want := "ALIASED"; !strings.Contains(item.Message, want) {
+			t.Errorf("item %d message = %q, want it to contain %q", i, item.Message, want)
+		}
+	}
+}
+
+func TestSweepRecord_NilCandidatesIsNoOp(t *testing.T) {
+	rec := &capture.Record{ResponseBody: json.RawMessage(`{"kind":"Event","message":"Namespace prod is active"}`)}
+	orig := string(rec.ResponseBody)
+
+	changed, occurrences, err := sweepRecord(rec, nil, noExclusions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed || occurrences != 0 {
+		t.Fatalf("changed=%v occurrences=%d, want changed=false occurrences=0", changed, occurrences)
+	}
+	if string(rec.ResponseBody) != orig {
+		t.Error("body must be byte-identical when nothing was swept")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -142,6 +142,13 @@ type AnonymizeConfig struct {
 	EmitMapping bool `mapstructure:"emitMapping"`
 	// MappingPath optionally overrides the mapping sidecar's default path.
 	MappingPath string `mapstructure:"mappingPath"`
+	// FullSweep, when true, enables a second, opt-in pass that replaces any
+	// substring occurrence of an already-discovered original value with its
+	// alias anywhere in a record's string content — not just at the known
+	// field paths the schema-aware/full-tree matchers already cover. See
+	// internal/anonymize/sweep.go's doc comment for the mechanism and its
+	// precision/recall tradeoffs (#361).
+	FullSweep bool `mapstructure:"fullSweep"`
 }
 
 // RedactionConfig is the top-level redaction section of the capture config.


### PR DESCRIPTION
## Summary

Adds `kshrk anonymize --full-sweep`: an opt-in second pass that catches a discovered namespace/node/pod/workload/ip/url value wherever it appears as a substring in a record's text — not just at the field paths the schema-aware/full-tree matchers already know to look at.

Closes the two real gaps found during live-cluster validation of #137:
- **#358** — an unrecognized CRD (e.g. Portworx's `StorageNode`) referencing a real Node/Pod name via a `kind` the schema-aware matchers don't recognize.
- **#360** — `kubectl.kubernetes.io/last-applied-configuration`, an escaped-JSON-*string* annotation invisible to both the schema-aware matchers (no real nested structure) and the full-tree IP matcher (whole-leaf-value only).

## How it works

1. **Collection pass** (read-only, before the output archive is even created): runs the exact same matchers the normal write pass uses, over the whole archive, on throwaway record copies — purely to fully populate each category's alias tracker regardless of which record a value first appears in.
2. **Candidate set**: gathers every distinct (original, alias) pair from the namespace/node/pod/workload/ip/url trackers. A value seen under more than one category with a different alias (e.g. a namespace and a pod both named `prod`) is genuinely ambiguous for free text — excluded from the sweep entirely rather than guessed at (`Result.SweepAmbiguousSkipped`).
3. **Two boundary predicates**, chosen per candidate's own shape (not its category): alnum-adjacency rejection for names/hosts (deliberately *not* rejecting `.`/`:`, so a namespace embedded in a cluster-local FQDN is still caught), and a stricter digit/dot/colon-adjacency rejection for IPs (so a short IPv6 literal like `::1` doesn't falsely match inside `fe80::1`).
4. **Write pass** (existing, unchanged except for one new step): after the normal schema-aware/full-tree rewrites, sweep every string leaf against the candidate set.

Off by default — zero behavior or performance change unless `--full-sweep` is passed. When on, it roughly doubles the archive read cost (a full extra pass) and trades some precision for recall, which is why it's opt-in.

## Test plan

- [x] `go test ./internal/anonymize/... ./cmd/...` — new unit tests for boundary predicates, cross-category ambiguity, minimum-length filtering, longest-candidate-preferred-over-prefix, exclude-rule interaction; end-to-end fixtures reproducing #358 and #360; determinism; a `--full-sweep`-off regression test
- [x] `go test -race ./...` — clean
- [x] `make lint-ci` — clean
- [x] `go mod tidy` / `gofmt -l .` — no drift
- [x] `make docs` — `docs/cli-reference.md` regenerated, `docs/config.md`'s anonymize section updated with `fullSweep`
- [x] Manual: ran `--full-sweep` against `examples/multi-namespace/capture.kshrk` with all six eligible categories — found 2075 additional occurrences, then confirmed via `kshrk query --text` that the real namespace name has zero remaining occurrences anywhere in the output, and `kshrk inspect` confirms the output is structurally valid with all 178 records intact

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)